### PR TITLE
Allow usage of this the docs repo as a Gem to avoid need to use submodules

### DIFF
--- a/docs.gemspec
+++ b/docs.gemspec
@@ -1,0 +1,18 @@
+Gem::Specification.new do |spec|
+  spec.name          = 'ably-docs'
+  spec.version       = '0.8.0'
+  spec.authors       = ["Matthew O'Riordan"]
+  spec.email         = ['matt@ably.io']
+  spec.description   = %q{Documentation repository Gem for Ably}
+  spec.summary       = %q{Allows the Ably documentation Textile files to be accessed by other Ruby applications}
+  spec.homepage      = 'http://github.com/ably/docs'
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = []
+  spec.test_files    = []
+  spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'RedCloth', '~> 4.2'
+  spec.add_runtime_dependency 'jsbin-client'
+end

--- a/lib/ably-docs.rb
+++ b/lib/ably-docs.rb
@@ -1,0 +1,22 @@
+require 'redcloth'
+
+# AblyDocs is only used by other apps that load in this repo as a Gem and need paths to the files
+#
+class AblyDocs
+  class << self
+    def content_path
+      File.expand_path("../content", File.dirname(__FILE__))
+    end
+
+    def lib_path
+      File.expand_path("../lib", File.dirname(__FILE__))
+    end
+
+    def data_path
+      File.expand_path("../data", File.dirname(__FILE__))
+    end
+  end
+end
+
+# Full path is required to YAML files when loaded as Gem
+YAML_PATH = File.join(AblyDocs.data_path, 'jsbins.yaml')


### PR DESCRIPTION
Please see https://github.com/ably/website/pull/309

This needs to be merged into `#source` branch, and then the Gemfile in the website needs to reference `#source` instead of this working branch `#gem`.
