### PR TITLE
Jump to nav is now left aligned so will not ever overlap content

### DIFF
--- a/content/assets/stylesheets/documentation.scss
+++ b/content/assets/stylesheets/documentation.scss
@@ -607,12 +607,10 @@ div.global-lang-container {
 
 nav.jump-to-nav {
   position: fixed;
-  left: 0px;
-  width: 1070px;
-  top: 70px;
+  left: 950px;
+  top: 36px;
   z-index: 100;
   .form {
-    float: right;
     padding: 5px;
     background-color: white;
     border: 1px solid #f30;


### PR DESCRIPTION
@lmars I deployed your changes but then saw that the Jump to nav still overlaps on other pages because it is right aligned to a fixed position.

### Before

![voila_capture 2015-11-09_12-13-19_a m](https://cloud.githubusercontent.com/assets/43789/11023646/ee3d26ba-8676-11e5-92ce-100252299472.png)

### After

![voila_capture 2015-11-09_12-13-38_a m](https://cloud.githubusercontent.com/assets/43789/11023647/f714b564-8676-11e5-963a-2e17d3512ae5.png)
