### PR TITLE
Token default for clientId is Null

### DIFF
--- a/content/assets/javascripts/application.js
+++ b/content/assets/javascripts/application.js
@@ -104,7 +104,7 @@ $(function() {
     var addTryItButton = function() {
       if ($(this).hasClass('prettyprint')) {
         var binId = $(this).attr('class').match(/open-jsbin-(\w+)/i)[1],
-            btn = $('<a href="//jsbin.ably.io/' + binId + '/latest/edit?javascript,live" target="_blank" class="try-it-button">Try it</a>');
+            btn = $('<a href="//jsbin.ably.io/' + binId + '/1/edit?javascript,live" target="_blank" class="try-it-button">Try it</a>');
         $(this).append(btn);
       } else {
         setTimeout(addTryItButton, 500);

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -99,6 +99,7 @@ h3(#rest-auth). Auth
 *** @(RSA7a1)@ All operations (such as message publishing or presence) will have an implicit @clientId@. The Ably service automatically updates the @clientId@ attribute (when empty) for all @Message@ and @PresenceMessage@ messages received from that authenticated client, and any messages then published from the Ably service, will have the @clientId@ attribute populated. It is therefore expected that Ably client libraries do not explicitly set the @clientId@ field on messages published when @clientId@ is implicit in the connection or authentication scheme
 *** @(RSA7a2)@ If @clientId@ is provided in @ClientOptions@, and an API key is provided along with no other means to generate a token, the client library will authenticate with Ably and obtain a token using the provided @clientId@ ensuring the token is restricted to operations for that @clientId@
 *** @(RSA7a3)@ @Auth#clientId@ attribute returns a string value for the authenticated client's @clientId@
+*** @(RSA7a4)@ When a @clientId@ value is provided in both @ClientOptions#clientId@ and @ClientOptions#defaultTokenParams@, the @ClientOptions#clientId@ takes precendence and is used for all Auth operations
 ** @(RSA12)@ @Auth#clientId@ attribute is @null@, when following authentication, the @clientId@ attribute of the @TokenDetails@ is a wildcard @'*'@, indicating that any @clientId@ can be used by this client
 ** @(RSA7b)@ @Auth#clientId@ is not @null@ when:
 *** @(RSA7b1)@ A @clientId@ is provided in the @ClientOptions@. @clientId@ should be a string

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -92,8 +92,8 @@ h3(#rest-auth). Auth
 ** @(RSA15a)@ Any @clientId@ provided in @ClientOptions@ must match any non wildcard (@'*'@) @clientId@ value in @TokenDetails@ or @connectionDetails@ of the @CONNECTED@ @ProtocolMessage@, where applicable
 ** @(RSA15b)@ If the @clientId@ from @TokenDetails@ or @connectionDetails@ contains only a wildcard string @'*'@, then the client is permitted to be either unauthenticated (i.e. anonymous without a @clientId@) or authenticated by providing a @clientId@ when communicating with Ably
 ** @(RSA15c)@ Following an auth request which uses a @TokenDetails@ or @TokenRequest@ object that contains an incompatible @clientId@, the library should in the case of Realtime change the connection state to @FAILED@ and emit an error, and in the case of REST raise an exception
-* @(RSA5)@ TTL for new tokens is specified in milliseconds (default is 1 hour, see "TK2a":#TK2a)
-* @(RSA6)@ The @capability@ for new tokens is JSON stringified (defaults to allow all @{"*":["*"]}@, see "TK2b":#TK2b)
+* @(RSA5)@ TTL for new tokens is specified in milliseconds (REST API default is 1 hour, see "TK2a":#TK2a)
+* @(RSA6)@ The @capability@ for new tokens is JSON stringified (REST API default is allow all @{"*":["*"]}@, see "TK2b":#TK2b)
 * @(RSA7)@ @clientId@ and authenticated clients:
 ** @(RSA7a)@ If a @clientId@ is provided in the @ClientOptions@, or is present in the current authentication token, then the client is considered to be authenticated (it has a @clientId@ that is implicit in all operations). Note that an authentication token @clientId@ wildcard value of @'*'@ is the exception where the client is not necessarily authenticated and any @clientId@ is permitted. The following applies to authenticated clients:
 *** @(RSA7a1)@ All operations (such as message publishing or presence) will have an implicit @clientId@. The Ably service automatically updates the @clientId@ attribute (when empty) for all @Message@ and @PresenceMessage@ messages received from that authenticated client, and any messages then published from the Ably service, will have the @clientId@ attribute populated. It is therefore expected that Ably client libraries do not explicitly set the @clientId@ field on messages published when @clientId@ is implicit in the connection or authentication scheme
@@ -646,8 +646,8 @@ h4. ClientOptions
 h4(#token-params). TokenParams
 * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorise@, @Auth#requestToken@ and @Auth#createTokenRequest@
 * @(TK2)@ The attributes of @TokenParams@ consist of:
-* @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds. The default set by the client library is 60 minutes
-* @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token. The default set by the client library allows all operations with the string value @{"*":["*"]}@
+* @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds. When omitted, the REST API default of 60 minutes is applied by Ably
+* @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token. When omitted, the REST API default to allow all operations is applied by Ably, with the string value @{"*":["*"]}@
 * @(TK2c)@ @clientId@ string - A @clientId@ string to associate with this token. If @clientId@ is @null@ or omitted, then the token is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the token is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations for this token
 * @(TK2d)@ @timestamp@ long - The timestamp (in milliseconds since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent requests from being replayed
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -89,8 +89,8 @@ h3(#rest-auth). Auth
 * @(RSA4)@ Token Auth is used if @useTokenAuth@ is set to true, or if @useTokenAuth@ is unspecified and any one of the following conditions cause token auth to be selected as the default: a @clientId@ is specified; @authUrl@ or @authCallback@ is provided; an explicit @token@ or @TokenDetails@ is provided
 * @(RSA14)@ If Token Auth is selected, an exception will be raised if a token is not provided or there is no means to generate a token. For example, if only the option @useTokenAuth@ is specified, and a @key@ is not provided, then the client library is unable to authenticate or issue a token
 * @(RSA15)@ If Token Auth is selected and @clientId@ has been set in the @ClientOptions@ when the library was instanced:
-** @(RSA15a)@ Any @clientId@ provided in @ClientOptions@ must match any non @null@ @clientId@ value in @TokenDetails@ or @connectionDetails@ of the @CONNECTED@ @ProtocolMessage@, where applicable
-** @(RSA15b)@ If the @clientId@ from @TokenDetails@ or @connectionDetails@ contains only a wildcard string @'*'@, then the client is permitted to be either unauthenticated (effectively anonymous without a @clientId@) or authenticated providing a @clientId@ when communicating with Ably
+** @(RSA15a)@ Any @clientId@ provided in @ClientOptions@ must match any non wildcard (@'*'@) @clientId@ value in @TokenDetails@ or @connectionDetails@ of the @CONNECTED@ @ProtocolMessage@, where applicable
+** @(RSA15b)@ If the @clientId@ from @TokenDetails@ or @connectionDetails@ contains only a wildcard string @'*'@, then the client is permitted to be either unauthenticated (i.e. anonymous without a @clientId@) or authenticated by providing a @clientId@ when communicating with Ably
 ** @(RSA15c)@ Following an auth request which uses a @TokenDetails@ or @TokenRequest@ object that contains an incompatible @clientId@, the library should in the case of Realtime change the connection state to @FAILED@ and emit an error, and in the case of REST raise an exception
 * @(RSA5)@ TTL for new tokens is specified in milliseconds (default is 1 hour, see "TK2a":#TK2a)
 * @(RSA6)@ The @capability@ for new tokens is JSON stringified (defaults to allow all @{"*":["*"]}@, see "TK2b":#TK2b)
@@ -98,14 +98,14 @@ h3(#rest-auth). Auth
 ** @(RSA7a)@ If a @clientId@ is provided in the @ClientOptions@, or is present in the current authentication token, then the client is considered to be authenticated (it has a @clientId@ that is implicit in all operations). Note that an authentication token @clientId@ wildcard value of @'*'@ is the exception where the client is not necessarily authenticated and any @clientId@ is permitted. The following applies to authenticated clients:
 *** @(RSA7a1)@ All operations (such as message publishing or presence) will have an implicit @clientId@. The Ably service automatically updates the @clientId@ attribute (when empty) for all @Message@ and @PresenceMessage@ messages received from that authenticated client, and any messages then published from the Ably service, will have the @clientId@ attribute populated. It is therefore expected that Ably client libraries do not explicitly set the @clientId@ field on messages published when @clientId@ is implicit in the connection or authentication scheme
 *** @(RSA7a2)@ If @clientId@ is provided in @ClientOptions@, and an API key is provided along with no other means to generate a token, the client library will authenticate with Ably and obtain a token using the provided @clientId@ ensuring the token is restricted to operations for that @clientId@
-*** @(RSA7a3)@ @Auth#clientId@ attribute returns a string value for the authenticated client's @clientId@
 *** @(RSA7a4)@ When a @clientId@ value is provided in both @ClientOptions#clientId@ and @ClientOptions#defaultTokenParams@, the @ClientOptions#clientId@ takes precendence and is used for all Auth operations
-** @(RSA12)@ @Auth#clientId@ attribute is @null@, when following authentication, the @clientId@ attribute of the @TokenDetails@ is a wildcard @'*'@, indicating that any @clientId@ can be used by this client
+** @(RSA12)@ @Auth#clientId@ attribute returns @null@, when following authentication, the @clientId@ attribute of the @TokenDetails@ (or @ConnectionDetails@ where applicable) is @null@ indicating that a @clientId@ identity cannot be assumed by this client i.e. the client is anonymous for all operations
 ** @(RSA7b)@ @Auth#clientId@ is not @null@ when:
 *** @(RSA7b1)@ A @clientId@ is provided in the @ClientOptions@. @clientId@ should be a string
-*** @(RSA7b2)@ Token authentication is being used, and the @TokenRequest@ or @TokenDetails@ object, used for authentication, has a @clientId@ value that is not @null@ or a wildcard string @'*'@
-*** @(RSA7b3)@ Following a realtime connection being established, if the @CONNECTED@ @ProtocolMessages@ contains a @clientId@ that is both not @null@ and not a wildcard string @'*'@. @clientId@ is an attribute of @ProtocolMessage#connectionDetails@ within a @CONNECTED@ @ProtocolMessage@
-** @(RSA7c)@ A @clientId@ provided in the @ClientOptions@ when instancing the library must be either @null@ or a string, and cannot contain only a wilcard @'*'@ value which is reserved
+*** @(RSA7b2)@ Token authentication is being used, and the @TokenRequest@ or @TokenDetails@ object, used for authentication, has a @clientId@ value that is not @null@
+*** @(RSA7b3)@ Following a realtime connection being established, if the @CONNECTED@ @ProtocolMessages@ contains a @clientId@ that is not @null@. @clientId@ is an attribute of @ProtocolMessage#connectionDetails@ within a @CONNECTED@ @ProtocolMessage@
+*** @(RSA7b4)@ When a wildcard string @'*'@ is present in the @TokenRequest@, @TokenDetails@, or @ProtocolMessage#connectionDetails@ object, then the client does not have a @clientId@ but is allowed to assume any identity performing operations with Ably. As such, @Auth#clientId@ should contain the string value @'*'@ indicating that the current client is allowed to perform operations on behalf of any @clientId@
+** @(RSA7c)@ A @clientId@ provided in the @ClientOptions@ when instancing the library must be either @null@ or a string, and cannot contain only a wilcard @'*'@ string value as that client ID value is reserved
 * @(RSA8)@ @Auth#requestToken@ function:
 ** @(RSA8e)@ Method signature is @requestToken(TokenParams, AuthOptions)@. @TokenParams@ and @AuthOptions@ are optional. When provided, the values supersede matching client library configured params and options.
 ** @(RSA8a)@ Implicitly creates a @TokenRequest@ if required, and requests a token from Ably if required. Returns a @TokenDetails@ object
@@ -120,7 +120,7 @@ h3(#rest-auth). Auth
 ** @(RSA8f)@ A test should exist for the following:
 *** @(RSA8f1)@ Request a token with a @null@ value @clientId@, authenticate a client with the token, publish a message without an explicit @clientId@, and ensure the message published does not have a @clientId@. Check that @Auth#clientId@ is @null@
 *** @(RSA8f2)@ Request a token with a @null@ value @clientId@, authenticate a client with the token, publish a message with an explicit @clientId@ value, and ensure that the message is rejected
-*** @(RSA8f3)@ Request a token with a wildcard @'*'@ value @clientId@, authenticate a client with the token, publish a message without an explicit @clientId@, and ensure the message published does not have a @clientId@. Check that @Auth#clientId@ is @null@
+*** @(RSA8f3)@ Request a token with a wildcard @'*'@ value @clientId@, authenticate a client with the token, publish a message without an explicit @clientId@, and ensure the message published does not have a @clientId@. Check that @Auth#clientId@ is a string with value @'*'@
 *** @(RSA8f4)@ Request a token with a wildcard @'*'@ value @clientId@, authenticate a client with the token, publish a message with an explicit @clientId@ value, and ensure that the message published has the provided @clientId@
 * @(RSA9)@ @Auth#createTokenRequest@ function:
 ** @(RSA9h)@ Method signature is @createTokenRequest(TokenParams, AuthOptions)@. @TokenParams@ and @AuthOptions@ are optional. When provided, the values supersede any client library configured params and options.
@@ -236,7 +236,7 @@ h3(#realtimeclient). RealtimeClient
 * @(RTC2)@ @RealtimeClient#connection@ attribute provides access to the underlying @Connection@ object
 * @(RTC3)@ @RealtimeClient#channels@ attribute provides access to the underlying @Channels@ object
 * @(RTC4)@ @RealtimeClient#auth@ attribute provides access to the @Auth@ object that was instanced with the @ClientOptions@ provided in the @RealtimeClient@ constructor
-** @(RTC4a)@ Unlike the stateless REST client library, the @Auth#clientId@ may be populated when the connection is established.  The @CONNECTED@ @ProtocolMessage@ may contain a @clientId@ that notifies the @RealtimeClient@ that all further operations are implicitly for that @clientId@, and operations for any other @clientId@ are no longer permitted. See @RSA7b@ for complete details
+** @(RTC4a)@ Unlike the stateless REST client library, the @Auth#clientId@ may be populated when the connection is established.  The @CONNECTED@ @ProtocolMessage@ may contain a @clientId@ that notifies the @RealtimeClient@ that all further operations are implicitly for that @clientId@, and operations for any other @clientId@ are no longer permitted. See "@RSA7b@":#RSA7b for complete details
 * @(RTC5)@ @RealtimeClient#stats@ function:
 ** @(RTC5a)@ Proxy to @RestClient#stats@ presented with an async or threaded interface as appropriate
 ** @(RTC5b)@ Accepts all the same params as @RestClient#stats@ and provides all the same functionality

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -92,8 +92,8 @@ h3(#rest-auth). Auth
 ** @(RSA15a)@ Any @clientId@ provided in @ClientOptions@ must match any non @null@ @clientId@ value in @TokenDetails@ or @connectionDetails@ of the @CONNECTED@ @ProtocolMessage@, where applicable
 ** @(RSA15b)@ If the @clientId@ from @TokenDetails@ or @connectionDetails@ contains only a wildcard string @'*'@, then the client is permitted to be either unauthenticated (effectively anonymous without a @clientId@) or authenticated providing a @clientId@ when communicating with Ably
 ** @(RSA15c)@ Following an auth request which uses a @TokenDetails@ or @TokenRequest@ object that contains an incompatible @clientId@, the library should in the case of Realtime change the connection state to @FAILED@ and emit an error, and in the case of REST raise an exception
-* @(RSA5)@ TTL for new tokens is specified in milliseconds and defaults to the REST API default (1 hour)
-* @(RSA6)@ The @capability@, if not specified, defaults to allow all operations permitted for the key associated with the token
+* @(RSA5)@ TTL for new tokens is specified in milliseconds (default is 1 hour, see "TK2a":#TK2a)
+* @(RSA6)@ The @capability@ for new tokens is JSON stringified (defaults to allow all @{"*":["*"]}@, see "TK2b":#TK2b)
 * @(RSA7)@ @clientId@ and authenticated clients:
 ** @(RSA7a)@ If a @clientId@ is provided in the @ClientOptions@, or is present in the current authentication token, then the client is considered to be authenticated (it has a @clientId@ that is implicit in all operations). Note that an authentication token @clientId@ wildcard value of @'*'@ is the exception where the client is not necessarily authenticated and any @clientId@ is permitted. The following applies to authenticated clients:
 *** @(RSA7a1)@ All operations (such as message publishing or presence) will have an implicit @clientId@. The Ably service automatically updates the @clientId@ attribute (when empty) for all @Message@ and @PresenceMessage@ messages received from that authenticated client, and any messages then published from the Ably service, will have the @clientId@ attribute populated. It is therefore expected that Ably client libraries do not explicitly set the @clientId@ field on messages published when @clientId@ is implicit in the connection or authentication scheme
@@ -627,6 +627,7 @@ h4. ClientOptions
 *** @(TO3j8)@ @authHeaders@ - Headers to be included in any request made by the library to the @authUrl@
 *** @(TO3j9)@ @authParams@ - Additional params to be included in any request made by the library to the @authUrl@, either as query params added to the URL in the case of @GET@, or form-encoded in the body in the case of @POST@
 *** @(TO3j10)@ @queryTime@ - If true, the library will query the Ably system for the current time instead of relying on a locally-available time of day
+*** @(TO3j11)@ @defaultTokenParams@ - When a "TokenParams":#token-params object is provided, it will override the client library defaults described in "TokenParams":#token-params
 ** @(TO3k)@ Development environment attributes:
 *** @(TO3k1)@ @environment@ string - for development environments only; allows a non-default Ably environment to be used such as @sandbox@
 *** @(TO3k2)@ @restHost@ string - for development environments only; allows a non-default Ably REST host to be specified
@@ -641,13 +642,13 @@ h4. ClientOptions
 *** @(TO3l5)@ @httpMaxRetryCount@ integer - default 3. Max number of fallback host retries for HTTP requests that fail due to network issues or server problems
 *** @(TO3l6)@ @httpMaxRetryDuration@ integer - default 10,000 (10s). Max elapsed time in which fallback host retries for HTTP requests will be attempted i.e. if the first default host attempt takes 5s, and then the subsequent fallback retry attempt takes 7s, no further fallback host attempts will be made as the total elapsed time of 12s exceeds the default 10s limit
 
-h4. TokenParams
+h4(#token-params). TokenParams
 * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorise@, @Auth#requestToken@ and @Auth#createTokenRequest@
 * @(TK2)@ The attributes of @TokenParams@ consist of:
-* @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds
-* @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token.
+* @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds. The default set by the client library is 60 minutes
+* @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token. The default set by the client library allows all operations with the string value @{"*":["*"]}@
 * @(TK2c)@ @clientId@ string - A @clientId@ string to associate with this token. If @clientId@ is @null@ or omitted, then the token is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the token is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations for this token
-* @(TK2d)@ @timestamp@ long - The timestamp (in millis since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent n requests from being replayed
+* @(TK2d)@ @timestamp@ long - The timestamp (in milliseconds since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent requests from being replayed
 
 h4. AuthOptions
 * @(AO1)@ A class providing configurable authentication options used when authenticating or issuing tokens explicitly. These options are used when invoking @Auth#authorise@, @Auth#requestToken@ and @Auth#createTokenRequest@

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -105,7 +105,7 @@ h3(#rest-auth). Auth
 *** @(RSA7b2)@ Token authentication is being used, and the @TokenRequest@ or @TokenDetails@ object, used for authentication, has a @clientId@ value that is not @null@
 *** @(RSA7b3)@ Following a realtime connection being established, if the @CONNECTED@ @ProtocolMessages@ contains a @clientId@ that is not @null@. @clientId@ is an attribute of @ProtocolMessage#connectionDetails@ within a @CONNECTED@ @ProtocolMessage@
 *** @(RSA7b4)@ When a wildcard string @'*'@ is present in the @TokenRequest@, @TokenDetails@, or @ProtocolMessage#connectionDetails@ object, then the client does not have a @clientId@ but is allowed to assume any identity performing operations with Ably. As such, @Auth#clientId@ should contain the string value @'*'@ indicating that the current client is allowed to perform operations on behalf of any @clientId@
-** @(RSA7c)@ A @clientId@ provided in the @ClientOptions@ when instancing the library must be either @null@ or a string, and cannot contain only a wilcard @'*'@ string value as that client ID value is reserved
+** @(RSA7c)@ A @clientId@ provided in the @ClientOptions@ when instancing the library must be either @null@ or a string, and cannot contain only a wildcard @'*'@ string value as that client ID value is reserved
 * @(RSA8)@ @Auth#requestToken@ function:
 ** @(RSA8e)@ Method signature is @requestToken(TokenParams, AuthOptions)@. @TokenParams@ and @AuthOptions@ are optional. When provided, the values supersede matching client library configured params and options.
 ** @(RSA8a)@ Implicitly creates a @TokenRequest@ if required, and requests a token from Ably if required. Returns a @TokenDetails@ object

--- a/content/code/website-examples/backbone-todo.code
+++ b/content/code/website-examples/backbone-todo.code
@@ -27,9 +27,10 @@ var ToDoList = Backbone.Collection.extend({
         // Subscribe to add and remove events
         channel.subscribe('add', function(msg) {
           if (msg.data && msg.data.id) {
+            msg.data.timestamp = msg.timestamp;
             if (!collection.get(msg.data.id)) collection.add([msg.data]);
           } else if (msg.data) { // REST post with simple string payload
-            collection.add([{ id: msg.id, title: msg.data }]);
+            collection.add([{ id: msg.id, title: msg.data.title, from: msg.data.from, timestamp: msg.timestamp }]);
           }
         });
         channel.subscribe('remove', function(msg) {
@@ -48,7 +49,8 @@ var ToDoRowView = Backbone.View.extend({
     this.model.on('remove', this.remove, this); // replicate model remove events to this view
   },
   render: function() {
-    return this.$el.text(this.model.get('title'));
+    var template = _.template($('#todo-item-template').html());
+    return this.$el.html(template({ title: this.model.get('title'), from: this.model.get('from'), timestamp: this.model.get('timestamp') }));
   },
   destroy: function() {
     this.model.collection.remove(this.model);
@@ -67,7 +69,6 @@ var ToDosView = Backbone.View.extend({
       .on('add', this.addToDoToView, this)
       .on('connectedToAbly', function() {
         view.$('button').text('Add').addClass('enabled').removeAttr('disabled');
-        view.$('label').text('Enter something to do here');
       });
   },
   render: function() {
@@ -79,7 +80,7 @@ var ToDosView = Backbone.View.extend({
     this.$("ul").prepend(view.render());
   },
   add: function() {
-    this.options.collection.add([{ title: this.$('input').val() }]);
+    this.options.collection.add([{ title: this.$('input').val(), from: this.options.position }]);
     this.$('input').val('');
   },
   keyPress: function(e) {
@@ -89,10 +90,7 @@ var ToDosView = Backbone.View.extend({
 
 // Create the left and right side Backbone To Do List views and collections
 $(function() {
-  // jQuery helper for labels over input fields
-  $("label").inFieldLabels();
-
-  _(['left','right']).each(function(side) {
+  _(['Jack','Jill']).each(function(side) {
     var toDoListView = new ToDosView({ position: side, collection: new ToDoList() });
     $('#lists').append(toDoListView.render());
   });
@@ -106,7 +104,7 @@ $(function() {
     <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
     <script src="//jsbin-files.ably.io/js/underscore-min.js"></script>
     <script src="//jsbin-files.ably.io/js/backbone-min.js"></script>
-    <script src="//jsbin-files.ably.io/js/jquery.infieldlabel.min.js"></script>
+    <script src="//jsbin-files.ably.io/js/moment.min.js"></script>
     <script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
     <meta charset=utf-8 />
   </head>
@@ -121,16 +119,15 @@ $(function() {
   <p class="instructions">
     Both To-Do lists are built with <a href="http://backbonejs.org/">Backbone.js</a>, each connected in real-time via <a href="https://www.ably.io">Ably realtime messaging</a>.
     <br><br>
-    When you add/update a To-Do list item, a message is published to Ably using its connection. The other To-Do list is subsequently updated when it receives a message on its connection.
+    When you add, or remove by clicking a To-Do list item, a message is published to Ably using its connection. The other To-Do list is subsequently updated when it receives a message on its connection.
     <br><br>
-    Enter a new to do item to see how quickly a message is sent from from your browser to Ably and back to your browser. Alternatively, send a message in your terminal via the <a href="https://www.ably.io/documentation/rest-api" target="_blank">Ably REST API</a>:
+    Enter a new to do item to see how quickly a message is sent from from your browser to Ably and back to your browser's other connection. Alternatively, send a message in your terminal via the <a href="https://www.ably.io/documentation/rest-api" target="_blank">Ably REST API</a>:
   </p>
 
   <pre id="curl"><code>curl -X POST https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/messages \
   -u "{{DEMO_API_KEY}}" \
   -H "Content-Type: application/json" \
-  --data '{ "name": "add", "data": "added by curl" }'
-  </code></pre>
+  --data '{ "name": "add", "data": { "title": "Do X via curl", "from": "John" } }'</code></pre>
 
   <p class="copyright">
     <a href="https://www.ably.io">Copyright Ably</a>
@@ -142,12 +139,17 @@ $(function() {
     <div class="container">
       <h2>Real-time To-do list (<%= position %>)</h2>
       <div class="entry">
-        <label for="new_to_do<%= position %>">Please wait, connecting to Ably...</label>
-        <input class="add" type="text" value="" id="new_to_do<%= position %>"><button class="add" disabled="true">connecting...</button>
+        <input class="add" type="text" placeholder="Enter a message here" id="new_to_do<%= position %>"><button class="add" disabled="true">connecting...</button>
       </div>
       <ul class="todo-list"></ul>
     </div>
   </div>
+</script>
+
+<script type="text/template" id="todo-item-template">
+  <%= title %>
+  <div class="from"><%= from %></div>
+  <div class="time"><%= moment(timestamp).format('h:mm:ss a') %></div>
 </script>
 
 </html>
@@ -201,11 +203,11 @@ h2 {
   margin-top: 0;
 }
 
-#left {
+#Jack {
   width: 48%;
   float: left;
 }
-#right {
+#Jill {
   margin-left: 52%;
 }
 
@@ -235,12 +237,6 @@ input[type=text] {
   text-align: left;
   border-bottom: 3px solid rgba(255,255,255,0.2);
 }
-.entry label  {
-  position:absolute;
-  top: 2px;
-  left: 25px;
-  font-size: 14px;
-}
 
 button {
   border: 1px solid #CCC;
@@ -268,16 +264,27 @@ li {
   margin: 0;
   padding: 5px 10px;
   list-style: none;
-  background: #EEE url(//jsbin-files.ably.io/images/bg/cream_dust.png);
+  background: #EEE;
   font-weight: bold;
   text-align: left;
 }
 
-li:before {
+li:hover {
+  background-color: #DDD;
+}
+
+li .from {
   color: #999;
-  content: 'Task:';
   padding-right: 10px;
   font-weight: normal;
+  width: 3em;
+  float: left;
+}
+
+li .time {
+  color: #999;
+  font-weight: normal;
+  float: right;
 }
 
 li:first-child {
@@ -296,6 +303,7 @@ li:last-child:first-child {
 
 li:hover:after {
   content: '(click to delete)';
+  padding-right: 10px;
   float: right;
   color: #A00;
   font-weight: normal

--- a/content/code/website-examples/ember-todo.code
+++ b/content/code/website-examples/ember-todo.code
@@ -6,10 +6,15 @@ var channelName = '{{RANDOM_CHANNEL_NAME}}';
 // Ember To Do model definition
 App.ToDo = Ember.Object.extend({
   title: null,
+  from: null,
+  timestamp: null,
   init: function() {
     if (!this.get('id')) { this.set('id', Math.random()); }
     this._super();
-  }
+  },
+  timeFormatted: function() {
+    return moment(this.get('timestamp')).format('h:mm:ss a');
+  }.property('timestamp')
 });
 
 // Ember To Do List model collection as Array Proxy definition
@@ -29,10 +34,11 @@ App.ToDoList = Ember.ArrayProxy.extend({
     this.get('channel').subscribe('add', function(msg) {
       if (msg.data && msg.data.id) {
         if (!model.get('content').find(function(item) { return item.id === msg.data.id; })) {
+          msg.data.timestamp = msg.timestamp;
           model.unshiftObject(App.ToDo.create(msg.data));
         }
       } else if (msg.data) { // REST post with simple string payload
-        model.unshiftObject(App.ToDo.create({ id: msg.id, title: msg.data }));
+        model.unshiftObject(App.ToDo.create({ id: msg.id, title: msg.data.title, from: msg.data.from, timestamp: msg.timestamp }));
       }
     });
     this.get('channel').subscribe('remove', function(msg) {
@@ -61,8 +67,8 @@ App.ToDoList = Ember.ArrayProxy.extend({
 // Ember model representing a collection of 2 separate To Do Lists, each with their own Ably connection
 App.toDoLists = Ember.ArrayProxy.create({
   content: Ember.A([
-    App.ToDoList.create({ side: 'left', content: Ember.A([]) }),
-    App.ToDoList.create({ side: 'right', content: Ember.A([]) })
+    App.ToDoList.create({ side: 'Jack', content: Ember.A([]) }),
+    App.ToDoList.create({ side: 'Jill', content: Ember.A([]) })
   ])
 });
 
@@ -72,7 +78,7 @@ App.ToDoListView = Ember.View.extend({
   templateName: "todo-container",
   addToDo: function() {
     if (this.get('newToDoTextValue')) {
-      this.get('content').unshiftObject(App.ToDo.create({ title: this.get('newToDoTextValue') }));
+      this.get('content').unshiftObject(App.ToDo.create({ title: this.get('newToDoTextValue'), from: this.get('elementId'), timestamp: new Date().getTime() }));
       this.set('newToDoTextValue', '');
     }
   }
@@ -108,6 +114,7 @@ App.CreateToDoButtonView = Ember.Button.extend({
   <head>
     <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
     <script src="//jsbin-files.ably.io/js/ember-0.9.8.1.min.js"></script>
+    <script src="//jsbin-files.ably.io/js/moment.min.js"></script>
     <script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
     <meta charset=utf-8 />
   </head>
@@ -124,7 +131,7 @@ App.CreateToDoButtonView = Ember.Button.extend({
   <p class="instructions">
     Both To-do lists are built with <a href="http://emberjs.com/">Ember.js</a>, each connected in real-time via <a href="https://www.ably.io">Ably realtime messaging</a>.
     <br><br>
-    When you add/update a To-Do list item, a message is published to Ably using its connection. The other To-Do list is subsequently updated when it receives a message on its connection.
+    When you add, or remove by clicking a To-Do list item, a message is published to Ably using its connection. The other To-Do list is subsequently updated when it receives a message on its connection.
     <br><br>
     Enter a new to do item to see how quickly a message is sent from from your browser to Ably and back to your browser. Alternatively, send a message in your terminal via the <a href="https://www.ably.io/documentation/rest-api" target="_blank">Ably REST API</a>:
   </p>
@@ -132,8 +139,7 @@ App.CreateToDoButtonView = Ember.Button.extend({
   <pre id="curl"><code>curl -X POST https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/messages \
   -u "{{DEMO_API_KEY}}" \
   -H "Content-Type: application/json" \
-  --data '{ "name": "add", "data": "added by curl" }'
-  </code></pre>
+  --data '{ "name": "add", "data": { "title": "Do X via curl", "from": "John" } }'</code></pre>
 
   <p class="copyright">
     <a href="https://www.ably.io">Copyright Ably</a>
@@ -152,7 +158,9 @@ App.CreateToDoButtonView = Ember.Button.extend({
 </script>
 
 <script type="text/x-handlebars" data-template-name="todo">
-{{content.title}}
+  {{content.title}}
+  <div class="from">{{content.from}}</div>
+  <div class="time">{{content.timeFormatted}}</div>
 </script>
 
 </html>
@@ -206,11 +214,11 @@ h2 {
   margin-top: 0;
 }
 
-#left {
+#Jack {
   width: 48%;
   float: left;
 }
-#right {
+#Jill {
   margin-left: 52%;
 }
 
@@ -240,12 +248,6 @@ input[type=text] {
   text-align: left;
   border-bottom: 3px solid rgba(255,255,255,0.2);
 }
-.entry label  {
-  position:absolute;
-  top: 2px;
-  left: 25px;
-  font-size: 14px;
-}
 
 button {
   border: 1px solid #CCC;
@@ -273,16 +275,27 @@ li {
   margin: 0;
   padding: 5px 10px;
   list-style: none;
-  background: #EEE url(//jsbin-files.ably.io/images/bg/cream_dust.png);
+  background: #EEE;
   font-weight: bold;
   text-align: left;
 }
 
-li:before {
+li:hover {
+  background-color: #DDD;
+}
+
+li .from {
   color: #999;
-  content: 'Task:';
   padding-right: 10px;
   font-weight: normal;
+  width: 3em;
+  float: left;
+}
+
+li .time {
+  color: #999;
+  font-weight: normal;
+  float: right;
 }
 
 li:first-child {
@@ -301,6 +314,7 @@ li:last-child:first-child {
 
 li:hover:after {
   content: '(click to delete)';
+  padding-right: 10px;
   float: right;
   color: #A00;
   font-weight: normal

--- a/content/code/website-examples/simple-chat.code.erb
+++ b/content/code/website-examples/simple-chat.code.erb
@@ -2,17 +2,22 @@
 $(function() {
   var channelName = '{{RANDOM_CHANNEL_NAME}}';
 
-  function setupChat($root) {
+  function setupChat(userName) {
+    var $root = $('#' + userName);
     var ably = new Ably.Realtime('{{DEMO_API_KEY}}'),
         channel = ably.channels.get(channelName),
         textField = $root.find('input[type=text]'),
         sendMessage = function() {
-          channel.publish('chat', textField.val());
+          channel.publish('chat', { msg: textField.val(), from: userName });
           textField.val('');
+          textField.blur();
         };
 
     channel.subscribe('chat', function(message) {
-      var li = $('<li></li>').text(message.data).append('<div class="time">' + moment().format('h:mm:ss a') + '</div>');
+      var li = $('<li></li>').
+                  text(message.data.msg).
+                  append('<div class="from">' + message.data.from + '</div>').
+                  append('<div class="time">' + moment(message.timestamp).format('h:mm:ss a') + '</div>');
       $root.find('ul.messages').prepend(li);
     });
 
@@ -24,11 +29,8 @@ $(function() {
     $root.find('button').on('click', sendMessage);
   }
 
-  setupChat($('#left'));
-  setupChat($('#right'));
-
-  // jQuery helper for labels in input fields
-  $("label").inFieldLabels();
+  setupChat('Jack');
+  setupChat('Jill');
 });
 [--- /Javascript ---]
 
@@ -37,7 +39,6 @@ $(function() {
 <html>
   <head>
     <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
-    <script src="//jsbin-files.ably.io/js/jquery.infieldlabel.min.js"></script>
     <script src="//jsbin-files.ably.io/js/moment.min.js"></script>
     <script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
     <meta charset=utf-8 />
@@ -48,19 +49,17 @@ $(function() {
     <h1>Simple Chat Example</h1>
 
     <div id="chat-windows">
-      <div id="left">
-        <h2>Simple chat (left)</h2>
+      <div id="Jack">
+        <h2>Simple chat (Jack)</h2>
         <div class="entry">
-          <label for="new_message_left">Enter a message here</label>
-          <input class="add" type="text" value="" id="new_message_left"><button class="add" disabled="true">connecting...</button>
+          <input class="add" type="text" placeholder="Enter a message here" id="new_message_left"><button class="add" disabled="true">connecting...</button>
         </div>
         <ul class="messages"></ul>
       </div>
-      <div id="right">
-        <h2>Simple chat (right)</h2>
+      <div id="Jill">
+        <h2>Simple chat (Jill)</h2>
         <div class="entry">
-          <label for="new_message_left">Enter a message here</label>
-          <input class="add" type="text" value="" id="new_message_left"><button class="add" disabled="true">connecting...</button>
+          <input class="add" type="text" placeholder="Enter a message here"  id="new_message_right"><button class="add" disabled="true">connecting...</button>
         </div>
         <ul class="messages"></ul>
       </div>
@@ -78,8 +77,7 @@ $(function() {
     <pre id="curl"><code>curl -X POST https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/messages \
   -u "{{DEMO_API_KEY}}" \
   -H "Content-Type: application/json" \
-  --data '{ "name": "chat", "data": "hello from curl" }'
-</code></pre>
+  --data '{ "name": "chat", "data": { "msg": "hello via curl", "from": "John" } }'</code></pre>
 
     <p class="copyright">
       <a href="https://www.ably.io">Copyright Ably</a>
@@ -135,11 +133,11 @@ h2 {
   margin-top: 0;
 }
 
-#left {
+#Jack {
   width: 48%;
   float: left;
 }
-#right {
+#Jill {
   margin-left: 52%;
 }
 
@@ -166,12 +164,6 @@ input[type=text] {
   padding: 0 10px 0 20px;
   position: relative;
   text-align: left;
-}
-.entry label  {
-  position:absolute;
-  top: 2px;
-  left: 25px;
-  font-size: 14px;
 }
 
 button {
@@ -205,11 +197,12 @@ li {
   text-align: left;
 }
 
-li:before {
+li .from {
   color: #999;
-  content: 'Message:';
   padding-right: 10px;
   font-weight: normal;
+  width: 3em;
+  float: left;
 }
 
 li:first-child {

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -3,13 +3,13 @@ jsbin_hash:
   urUBwIWkiIJIxLBR/bJCTh1h6x8=: ogegab
   YvDsA1HS12MBySmD7/ZXQjTm6rQ=: iyiset
   MOFYarJp01R0dM2T3KHJiZ245+M=: ipilet
-  C5j5CZscVO7B5CnoZr0q6XEErKY=: inarel
-  nuNoE897h3Tcl4S47w3fj8RnKdo=: uhoqoj
-  MbuwtFJ57oDqc+LJW0xZiXst3eY=: ojicaz
+  5gADz397Tl8xkXJq3GX12AM6lWg=: adajuf
+  pK8R+f//DnOWuTqvvE+fEsQBKeE=: ovanum
+  AXXToyikTq4KfezSAsaywUt1/xY=: itaxux
 jsbin_id:
   quick-start-guide/send-message: MOFYarJp01R0dM2T3KHJiZ245+M=
   quick-start-guide/connect: YvDsA1HS12MBySmD7/ZXQjTm6rQ=
   client-lib-development-guide/example: urUBwIWkiIJIxLBR/bJCTh1h6x8=
-  website-examples/simple-chat: nuNoE897h3Tcl4S47w3fj8RnKdo=
-  website-examples/backbone-todo: C5j5CZscVO7B5CnoZr0q6XEErKY=
-  website-examples/ember-todo: MbuwtFJ57oDqc+LJW0xZiXst3eY=
+  website-examples/simple-chat: pK8R+f//DnOWuTqvvE+fEsQBKeE=
+  website-examples/backbone-todo: 5gADz397Tl8xkXJq3GX12AM6lWg=
+  website-examples/ember-todo: AXXToyikTq4KfezSAsaywUt1/xY=

--- a/lib/jsbins.rb
+++ b/lib/jsbins.rb
@@ -23,7 +23,7 @@ class JsBins
           path: path,
           hash: hash,
           jsbin_id: data.fetch('jsbin_hash').fetch(hash),
-          jsbin_url: jsbin_client.url_for(data.fetch('jsbin_hash').fetch(hash))
+          jsbin_url: jsbin_url_for(data.fetch('jsbin_hash').fetch(hash))
         }
       end
     end
@@ -59,11 +59,15 @@ class JsBins
 
       {
         id: id,
-        url: jsbin_client.url_for(id).gsub(/latest/, '1')
+        url: jsbin_url_for(id)
       }
     end
 
     private
+      def jsbin_url_for(id)
+        jsbin_client.url_for(id).gsub(/latest/, '1')
+      end
+
       def hash(content)
         Digest::SHA1.base64digest(content)
       end


### PR DESCRIPTION
The current spec presents an issue for developers that want to authenticate with a wildcard clientId and want the client library to automatically perform this auth for them.

For example, when instancing a library, if specifying `useTokenAuth: true`, the client will currently always be either an anonymous client (if we assumed `clientId` defaults to `null`), or a wildcard client (assuming `clientId` defaults to `*`).  I do not think we should be encouraging people to use a wildcard `clientId` by default, so I propose we:

* Default `clientId` to `null` (anonymous) unless specfied
* We allow the developer to configure the default `TokenParams` for the client library in the `ClientOptions`

@paddybyers @SimonWoolf WDYT?