### PR TITLE
Consistency in implicit attach and wait for sync on presence#get

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -380,7 +380,7 @@ h3(#realtime-channel). Channel
 ** @(RTL6c)@ Connection state conditions:
 *** @(RTL6c1)@ If the connection is @CONNECTED@ then the messages are published immediately
 *** @(RTL6c2)@ If the connection is @CONNECTING@ or @DISCONNECTED@, and @ClientOptions#queueMessages@ has not been explicitly set to false, then the message will be queued and delivered as soon as the connection state returns to @CONNECTED@
-*** @(RTL6c3)@ Else an exception is raised preventing the message publishing
+*** @(RTL6c3)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTL6d)@ Messages are delivered using a single @ProtocolMessage@ where possible by bundling in all messages for that channel into the @ProtocolMessage#messages@ array. However, a yet to be implemented feature should limit the total number of messages bundled per @ProtocolMessage@ based on the default max message size, and would reject the publish and indicate an error if any single message exceeds that limit
 ** @(RTL6e)@ Unauthenticated clients using basic auth without a @clientId@ (i.e. any @clientId@ is permitted):
 *** @(RTL6e1)@When a @Message@ with a @clientId@ value is published, Ably will accept and publish that message with the provided @clientId@. A test should assert that the @clientId@ of the published @Message@ is populated
@@ -396,7 +396,7 @@ h3(#realtime-channel). Channel
 * @(RTL7)@ @Channel#subscribe@ function:
 ** @(RTL7a)@ Subscribe with no arguments subscribes a listener to all messages
 ** @(RTL7b)@ Subscribe with a single name argument subscribes a listener to only messages whose @name@ member matches the string name
-** @(RTL7c)@ Implicitly attaches the channel if not attached
+** @(RTL7c)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTL7d)@ Messages delivered are automatically decoded based on the @encoding@ attribute; see REST @Channel@ encoding features. If there is an error decoding a message, the message is still delivered, but in addition to sending an error message to the logger, an @ErrorInfo@ error object is emitted as an error on the @Channel@. Tests should exist to publish and subscribe to encoded messages using the "AES 128":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-256.json fixture test data
 ** @(RTL7e)@ If a message cannot be decoded or decrypted successfully, it should be delivered to the listener with the @encoding@ attribute set indicating the residual encoding state, and an error should be emitted on the channel
 ** @(RTL7f)@ A test should exist ensuring published messages are not echoed back to the subscriber when @echoMessages@ is set to false in the @Realtime@ library constructor
@@ -436,7 +436,7 @@ h3(#realtime-presence). Presence
 ** @(RTP8a)@ Enters the current client into this channel, optionally with the data provided
 ** @(RTP8b)@ Optionally a callback can be provided that is called for both success or failure to enter
 ** @(RTP8c)@ A @PRESENCE ProtocolMessage@ with a @PresenceMessage@ with the action @ENTER@ is sent to the Ably service. The @clientId@ attribute of the @PresenceMessage@ must not be present. Entering without an explicit @PresenceMessage#clientId@, implicitly uses the @clientId@ for the current connection
-** @(RTP8d)@ Implicitly attaches to the channel if not attached
+** @(RTP8d)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTP8e)@ Optional data can be included when entering a channel that will be encoded / decoded as with normal messages. A test should exist to ensure data used with enter is encoded & decoded correctly. Also, when data is provided when entering, but no data is provided when leaving, the data attribute should be emitted in the @LEAVE@ event for this client
 ** @(RTP8f)@ Raises an exception if the client library is not authenticated (i.e. no @clientId@ is configured)
 ** @(RTP8g)@ Raises an exception if the channel is @DETACHED@ or @FAILED@
@@ -456,9 +456,9 @@ h3(#realtime-presence). Presence
 ** @(RTP10e)@ In all other ways, this method is identical to @Presence#enter@ and should have matching tests
 * @(RTP11)@ @Presence#get@ function:
 ** @(RTP11a)@ Returns the list of current members on the channel in a callback and, by default, will not wait for the @SYNC@ to be completed
-** @(RTP11b)@ Raises an exception if the channel is @DETACHED@ or @FAILED@
+** @(RTP11b)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTP11c)@ An optional set of params can be provided:
-*** @(RTP11c1)@ @waitForSync@ when true, will wait until @SYNC@ is complete before returning a list of members
+*** @(RTP11c1)@ @waitForSync@ (default @true@). When @true@, method will wait until @SYNC@ is complete before returning a list of members. When @false@, known set of presence members is returned immediately, which may be incomplete if the @SYNC@ is not finished
 *** @(RTP11c2)@ @clientId@ filters members by the provided @clientId@
 *** @(RTP11c3)@ @connectionId@ filters members by the provided @connectionId@
 * @(RTP12)@ @Presence#history@ function:
@@ -477,7 +477,7 @@ h3(#realtime-presence). Presence
 ** @(RTP15b)@ Tests should use @enterClient@, @updateClient@ and @leaveClient@ for many members from one @Realtime@ client and check that the operations are reflected in the presence map and the expected events are emitted on a separate client.
 ** @(RTP15c)@ Tests should also ensure that using these methods has no side effects on a client that has entered normally using @Presence#enter@
 ** @(RTP15d)@ A callback can be provided that will be called upon success or failure
-** @(RTP15e)@ A channel will be implicitly attached when these methods are called
+** @(RTP15e)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTP15f)@ If the client is authenticated and has a configured @clientId@, if the @clientId@ argument does not match the client's @clientId@, then it should indicate an error. The connection and channel remains available for further operations
 
 h3(#eventemitter). EventEmitter mixin / interface

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -455,7 +455,7 @@ h3(#realtime-presence). Presence
 ** @(RTP10d)@ If the client is not currently @ENTERED@ then an exception is raised
 ** @(RTP10e)@ In all other ways, this method is identical to @Presence#enter@ and should have matching tests
 * @(RTP11)@ @Presence#get@ function:
-** @(RTP11a)@ Returns the list of current members on the channel in a callback and, by default, will not wait for the @SYNC@ to be completed
+** @(RTP11a)@ Returns the list of current members on the channel in a callback. By default, will wait for the @SYNC@ to be completed, see "RTP11c1":#RTP11c1
 ** @(RTP11b)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 ** @(RTP11c)@ An optional set of params can be provided:
 *** @(RTP11c1)@ @waitForSync@ (default @true@). When @true@, method will wait until @SYNC@ is complete before returning a list of members. When @false@, known set of presence members is returned immediately, which may be incomplete if the @SYNC@ is not finished

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -428,7 +428,7 @@ h3(#realtime-presence). Presence
 * @(RTP6)@ @Presence#subscribe@ function:
 ** @(RTP6a)@ Subscribe with no arguments subscribes a listener to all presence messages
 ** @(RTP6b)@ Subscribe with a single action argument - such as @ENTER@, @LEAVE@, @UPDATE@ or @PRESENT@ - subscribes a listener to receive only presence messages with that action
-** @(RTP6c)@ Implicitly attaches the channel if not attached
+** @(RTP6c)@ Implicitly attaches the @Channel@. However, if the channel is in the @FAILED@ state, an exception is raised
 * @(RTP7)@ @Presence#unsubscribe@ function:
 ** @(RTP7a)@ Unsubscribe with no arguments unsubscribes the listener if previously subscribed with an action-specific subscription
 ** @(RTP7b)@ Unsubscribe with a single action argument unsubscribes the provided listener to all presence messages for that action


### PR DESCRIPTION
This addresses the proposed clarification of the implicit behaviour in https://github.com/ably/docs/issues/67

@paddybyers @SimonWoolf please review