### PR TITLE
Remove connect callback as not agreed in spec

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -283,7 +283,6 @@ h3(#realtime-connection). Connection
 * @(RTN11)@ @Connection#connect@ function:
 ** @(RTN11a)@ Explicitly connects to the Ably service if not already connected.
 ** @(RTN11b)@ An error will be indicated if the state is @CLOSING@ as the connection must complete the close request before reconnecting
-** @(RTN11c)@ Where the language permits, a callback with a success and failure state can be provided
 * @(RTN12)@ @Connection#close@ function:
 ** @(RTN12a)@ Sends a @CLOSE@ @ProtocolMessage@ to the server, sets the state to @CLOSING@ and waits for a @CLOSED@ @ProtocolMessage@ to be received
 ** @(RTN12b)@ If the @CLOSED@ @ProtocolMessage@ is not received within the "default realtime request timeout":#defaults, the transport will be disconnected and the connection will automatically move to the @CLOSED@ state


### PR DESCRIPTION
See https://github.com/ably/ably-js/issues/43#issuecomment-159657024

As we have not agreed the spec, and it is not a core feature, deferring this until 0.9

@SimonWoolf @paddybyers you happy with this?