### PR TITLE
Proofread of how-ably-works draft

### DIFF
--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -15,17 +15,17 @@ Ably's global realtime service enables Internet enabled devices, such as a brows
 
 h2. Key concepts
 
-At its simplest, Ably can be described as a cloud-based "pub/sub":https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern Platform-as-a-Service ensuring any device publishing messages to Ably will be received in real time by any number of subscribing devices. However, in reality, Ably makes it possible for developers to build apps and infrastructure that can communicate in realtime without the worries of managing scale, latency, data durability, integrity and storage, seamless connection recovery, device interopability, network outages, encryption, security and authentication, throttling and denial of service attacks, to name a few.
+At its simplest, Ably is a cloud-based "pub/sub":https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern Platform-as-a-Service ensuring any device publishing messages to Ably will be received in real time by any number of subscribing devices. But it is more than that. Ably makes it possible for developers to build apps and infrastructure that can communicate in realtime without the worries of managing scale, latency, data durability, integrity and storage, seamless connection recovery, device interopability, network outages, encryption, security and authentication, throttling, and denial of service attacks, to name a few.
 
 In order to understand how Ably works, and why "pub/sub":https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern is only one part of the problem we solve for developers, we have have broken down the key concepts as follows:
 
 h3(#channels). Channels
 
-The Ably service organises the traffic within any application into named channels. Clients connected to Ably can either be publishers (they push messages with data to Ably), subscribers (they wait for messages to be pushed from Ably to them) or both. Messages are always published over a named channel, and Ably routes messages to subscribers based on the channels are subscribed to. Channels are most often used to filter messages, so whilst billions of messages may be delivered by Ably, subscribers will only receive the messages on the channels they subscribe to.
+The Ably service organises the traffic within any application into named channels. Clients connected to Ably can either be publishers (they push messages with data to Ably), subscribers (they wait for messages to be pushed from Ably to them), or both. Messages are always published over a named channel. Channels are used to filter messages, so whilst billions of messages may be delivered by Ably, subscribers will only receive the messages on the channels they subscribe to.
 
-Channels are uniquely identified by a string specified when publishing to or attaching to a channel. Publishers and subscribers are completely decoupled; a publisher can publish a message without any subscribers on the channel; subscribers can listen on channels that don't yet have publishers; theoretically an infinite number of subscribers can receive a single message published on a channel.
+Channels are uniquely identified by a string specified when publishing to or attaching to a channel. Publishers and subscribers are completely decoupled: a publisher can publish a message without any subscribers on the channel; subscribers can listen on channels that don't yet have publishers; arbitrarily many subscribers can receive a single message published on a channel.
 
-A channel within the Ably service supports one-to-many (fan-out), many-to-one (fan-in), and many-to-many.
+In other words, Ably channels support one-to-many (fan-out), many-to-one (fan-in), and many-to-many.
 
 The following diagram illustrates a very simple use case for channels. The server and vehicle are publishers and publish messages on channels without any knowledge of the subscribers. One mobile device is both a subscriber and publisher by publishing its location and also subscribing for alerts. All other devices are subscribed to just one channel.
 
@@ -39,7 +39,7 @@ Ably supports two forms of authentication.
 
 h4. Basic Authentication
 
-Basic authentication is the simplest form of authentication using an app's private API key to connect to Ably. Private API keys and their capabilities (permissions) are managed within an "app's dashboard":http://support.ably.io/support/solutions/articles/3000030053-how-do-i-access-my-app-dashboard. In most cases, we do not recommend that basic authentication is used as it requires that you share your private API key with the client that is connecting to Ably. Our recommendation is to only use basic authentication on your trusted servers when communicating with Ably over TLS.
+Basic authentication is the simplest form of authentication. Clients connect to Ably using an app's private API key directly. Private API keys and their capabilities (permissions) are managed within an "app's dashboard":http://support.ably.io/support/solutions/articles/3000030053-how-do-i-access-my-app-dashboard. In most cases, we do not recommend that basic authentication is used as it requires that you share your private API key with the client that is connecting to Ably. Our recommendation is to only use basic authentication on your trusted servers when communicating with Ably over TLS.
 
 h4. Token Authentication
 
@@ -65,9 +65,9 @@ A token request is sent directly from your server to Ably, a token is returned, 
 
 h5. Client identity and access control
 
-A client using token authentication is either anonymous, or identified if a client ID exists in the token. All messages, presence state and connection state for identified clients contains the trusted client ID and is accessible by other clients. As a private key is needed to generate a token for a client with a client ID, the client ID can be trusted by other clients.
+A client using token authentication is either anonymous, or identified if a client ID exists in the token. All messages, presence state and connection state for identified clients contain the trusted client ID and are accessible by other clients. As a private key is needed to generate a token for a client with a client ID, the client ID can be trusted by other clients.
 
-When tokens are created, they are limited to the capabilities of the API key used to create the token. When requesting a token, the capabilities may be limited further using fine-grained permissions using a combination of the operation (such as publish, subscribe, presence) and the channel(s).
+Tokens are limited to the capabilities of the API key used to create the token. When requesting a token, the capabilities may be limited further using fine-grained permissions using a combination of the operation (such as publish, subscribe, presence) and the channel(s).
 
 
 h3. Global message routing

--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -39,7 +39,7 @@ Ably supports two forms of authentication.
 
 h4. Basic Authentication
 
-Basic authentication is the simplest form of authentication. Clients connect to Ably using an app's private API key directly. Private API keys and their capabilities (permissions) are managed within an "app's dashboard":http://support.ably.io/support/solutions/articles/3000030053-how-do-i-access-my-app-dashboard. In most cases, we do not recommend that basic authentication is used as it requires that you share your private API key with the client that is connecting to Ably. Our recommendation is to only use basic authentication on your trusted servers when communicating with Ably over TLS.
+Basic authentication is the simplest form of authentication, allowing clients to communicate with Ably by including the complete private API key within the URL or request headers. To mitigate the risks of sending a private key over the Internet, basic authentication is only permitted over an encrypted "TLS":https://en.wikipedia.org/wiki/Transport_Layer_Security connection. Private API keys and their capabilities (permissions) are managed within an "app's dashboard":http://support.ably.io/support/solutions/articles/3000030053-how-do-i-access-my-app-dashboard. In most cases, we do not recommend that basic authentication is used as it requires that you share your private API key with the client that is connecting to Ably. Our recommendation is to only use basic authentication on your trusted servers.
 
 h4. Token Authentication
 


### PR DESCRIPTION
Looks good. Couple of trivial style tweaks. (also for the auth diagrams: second one seems to have much smaller arrowheads than the first)

Minor concern: we don't give any guidance on whether to use server-signed token requests or server-requested tokens. I'd guess most devs probably just want to be told 'do it this way except in circumstances X,Y,Z'? (If we really don't want to have a preferred one, should we maybe just pick one for the 'how ably works' page to keep it simple, relegate the other to an "Alternatively, ..." paragraph with no diagram?)