### PR TITLE
Proposed encryption changes

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -880,13 +880,13 @@ enum ChannelState:
   FAILED
 
 class ChannelOptions:
-  +withCipherKey(key: Binary)? -> ChannelOptions // TB3
+  +withCipherKey(key: Binary | String)? -> ChannelOptions // TB3
   cipher: (CipherParams | Params)? // RSL5a, TB2b
 
 class CipherParams:
   algorithm: String default "AES" // TZ2a
-  key: String // TZ2d
-  keyLength: Int? // TZ2b
+  key: Binary // TZ2d
+  keyLength: Int // TZ2b
   mode: String default "CBC" // TZ2c
 
 class Crypto:

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -229,11 +229,11 @@ h3(#rest-encryption). Encryption
 * @(RSE1)@ @Crypto::getDefaultParams@ function:
 ** @(RSE1a)@ Returns a complete @CipherParams@ instance, using the default values for any field not supplied
 ** @(RSE1b)@ Takes a hashmap (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@
-** @(RSE1c)@ The @key@ must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string. If the key is a string, the function should base64-decode it into a binary. Since the conversion to base64 is not under Ably control, this should be done liberally -- in particular, it should work with 'url-safe base64' (which uses @-@ and @_@ instead of @+@ and @/@) in addition to standard base64
+** @(RSE1c)@ The @key@ must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string. If the key is a string, the function should base64-decode it into a binary. Since the conversion to base64 is not under Ably control, this should be done leniently -- in particular, it should work with base64url (RFC 4648 s.5, which uses @-@ and @_@ instead of @+@ and @/@) as well as base64 (RFC 4648 s.4)
 ** @(RSE1d)@ Calculates a @keyLength@ from the key (its size in bits).
-** @(RSE1e)@ Checks that the provided options are valid and self-consistent as best it can, raises an exception if not. At a minimum, this should include checking the calculated keyLength is a valid key length for the encryption algorithm (for example, 128 or 256 for @AES@)
+** @(RSE1e)@ Checks that the provided options are valid and self-consistent as best it can, raises an exception if not. At a minimum, this should include checking the calculated @keyLength@ is a valid key length for the encryption algorithm (for example, 128 or 256 for @AES@)
 * @(RSE2)@ @Crypto::generateRandomKey@ function
-** @(RSE2a)@ Takes an optional keyLength parameter, which is the length in bits of the key to be generated. If unspecified, this is equal to the default keyLength of the default algorithm: for @AES@, 256 bits.
+** @(RSE2a)@ Takes an optional @keyLength@ parameter, which is the length in bits of the key to be generated. If unspecified, this is equal to the default @keyLength@ of the default algorithm: for @AES@, 256 bits.
 ** @(RSE2b)@ Returns (or calls back with, if the language cryptographic randomness primitives are blocking or async) the key as a binary (e.g. a byte array, depending on the language)
 
 h2(#realtime). Realtime client library features
@@ -699,9 +699,9 @@ h4. ChannelOptions
 
 h4. CipherParams
 * @(TZ1)@ params to configure encryption for a channel, see "Java CipherParams class":https://github.com/ably/ably-java/blob/8a151b4edfa228ddef806fa10d2f9ce2be1ac09c/lib/src/main/java/io/ably/lib/util/Crypto.java as a reference
-* @(TZ2)@ The attributes of @CipherParams@ consist of anything necessary to implement the supported algorithms (eg iv), in addition to the following standardised attributes:
+* @(TZ2)@ The attributes of @CipherParams@ consist of anything necessary to implement the supported algorithms, in addition to the following standardised attributes:
 ** @(TZ2a)@ @algorithm@ string - Default is @AES@. Optionally specify the algorithm to use for encryption, currently only @AES@ is supported
-** @(TZ2b)@ @keyLength@ integer - the size in bits of the @key@
+** @(TZ2b)@ @keyLength@ integer - the length in bits of the @key@
 ** @(TZ2d)@ @key@ binary - private key used to encrypt and decrypt payloads
 ** @(TZ2c)@ @mode@ string - Default is @CBC@. Optionally specify cipher mode, currently only @CBC@ is supported
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -202,7 +202,7 @@ h3(#rest-channel). Channel
 *** @(RSL4d3)@ a JSON Message payload is stringified either as a JSON Object or Array and represented as a JSON string and the @encoding@ attribute is set to "json"
 *** @(RSL4d4)@ All messages received will be decoded based on the @encoding@ field and deliver payloads in the format they were sent in i.e. binary, string, or a structured type containing the parsed JSON
 * @(RSL5)@ Message payload encryption
-** @(RSL5a)@ When a @Channel@ is instanced with the option @encrypted@ true (or no such option and a @cipher@ option present), message payloads will be automatically encrypted when sent to Ably and decrypted when received on this channel. The cipher configuration is set with the @cipher@
+** @(RSL5a)@ When a @Channel@ is instanced with a (non-null) @cipher@ channelOption, message payloads will be automatically encrypted when sent to Ably and decrypted when received on this channel, using the @cipher@ configuration
 ** @(RSL5b)@ AES 256 and 128 CBC encryption must be supported
 ** @(RSL5c)@ Tests must exist that encrypt and decrypt the following fixture data for "AES 128":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-256.json to ensure the client library encryption is compatible across libraries
 * @(RSL6)@ Message decoding
@@ -231,7 +231,7 @@ h3(#rest-encryption). Encryption
 ** @(RSE1b)@ Takes a hashmap (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@
 ** @(RSE1c)@ The @key@ must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string. If the key is a string, the function should base64-decode it into a binary. Since the conversion to base64 is not under Ably control, this should be done liberally -- in particular, it should work with 'url-safe base64' (which uses @-@ and @_@ instead of @+@ and @/@) in addition to standard base64
 ** @(RSE1d)@ Calculates a @keyLength@ from the key (its size in bits).
-** @(RSE1e)@ Checks that the provided options are valid and self-consistent as best it can, raises an exception if not. At a mininum, this should include checking the calculated keyLength is a valid key length for the (provided if provided else default) encryption algorithm (for example, 128 or 256 for @AES@)
+** @(RSE1e)@ Checks that the provided options are valid and self-consistent as best it can, raises an exception if not. At a minimum, this should include checking the calculated keyLength is a valid key length for the encryption algorithm (for example, 128 or 256 for @AES@)
 * @(RSE2)@ @Crypto::generateRandomKey@ function
 ** @(RSE2a)@ Takes an optional keyLength parameter, which is the length in bits of the key to be generated. If unspecified, this is equal to the default keyLength of the default algorithm: for @AES@, 256 bits.
 ** @(RSE2b)@ Returns (or calls back with, if the language cryptographic randomness primitives are blocking or async) the key as a binary (e.g. a byte array, depending on the language)
@@ -692,8 +692,7 @@ h4. AuthOptions
 h4. ChannelOptions
 * @(TB1)@ options provided when instancing a channel, see "Java ChannelOptions":https://github.com/ably/ably-java/blob/master/src/io/ably/types/ChannelOptions.java as a reference
 * @(TB2)@ The attributes of @ChannelOptions@ consist of:
-** @(TB2a)@ @encrypted@ boolean - when true, enables automatic encryption & decryption of all messages. If not present it defaults to true if the @cipher@ attribute is present, false if not.
-** @(TB2b)@ @cipher@ - This is required if @encrypted@ is true. It consists of either:
+** @(TB2b)@ @cipher@, which is either:
 *** @(TB2b1)@ A @CipherParams@ instance, or
 *** @(TB2b2)@ an options hash (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@. In this case, the client library should call `getDefaultParams`, passing it the options hash, to obtain a @CipherParams@ instance
 * @(TB3)@ The client lib may optionally provide an alternative constructor @withCipherKey@ for ChannelOptions that takes a @key@ only. (This must be differentiated from the normal constructor such that it is clear that the value being passed in is a key). (This is intended for languages where requiring a hash map is unidiomatic)
@@ -883,7 +882,6 @@ enum ChannelState:
 class ChannelOptions:
   +withCipherKey(key: Binary)? -> ChannelOptions // TB3
   cipher: (CipherParams | Params)? // RSL5a, TB2b
-  encrypted: Bool? // RSL5a, TB2a
 
 class CipherParams:
   algorithm: String default "AES" // TZ2a

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -202,7 +202,7 @@ h3(#rest-channel). Channel
 *** @(RSL4d3)@ a JSON Message payload is stringified either as a JSON Object or Array and represented as a JSON string and the @encoding@ attribute is set to "json"
 *** @(RSL4d4)@ All messages received will be decoded based on the @encoding@ field and deliver payloads in the format they were sent in i.e. binary, string, or a structured type containing the parsed JSON
 * @(RSL5)@ Message payload encryption
-** @(RSL5a)@ When a @Channel@ is instanced with the option @encrypted@ true, message payloads will be automatically encrypted when sent to Ably and decrypted when received on this channel. The cipher configuration is set with the @cipherParams@
+** @(RSL5a)@ When a @Channel@ is instanced with the option @encrypted@ true (or no such option and a @cipher@ option present), message payloads will be automatically encrypted when sent to Ably and decrypted when received on this channel. The cipher configuration is set with the @cipher@
 ** @(RSL5b)@ AES 256 and 128 CBC encryption must be supported
 ** @(RSL5c)@ Tests must exist that encrypt and decrypt the following fixture data for "AES 128":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-256.json to ensure the client library encryption is compatible across libraries
 * @(RSL6)@ Message decoding
@@ -227,11 +227,11 @@ h3(#rest-presence). Presence
 
 h3(#rest-encryption). Encryption
 * @(RSE1)@ @Crypto::getDefaultParams@ function:
-** @(RSE1a)@ Returns a complete @CipherParams@ instance
-** @(RSE1b)@ Takes a mandatory key parameter, which must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string
-** @(RSE1c)@ If the key is a string, base64-decodes it into a binary. Since the conversion to base64 is not under Ably control, this should be done liberally -- in particular, it should work with 'url-safe base64' (which uses @-@ and @_@ instead of @+@ and @/@) in addition to standard base64
-** @(RSE1d)@ Calculates a @keyLength@ from the key (its size in bits)
-** @(RSE1e)@ Raises an exception if the calculated keyLength is not a valid key length for the default encryption algorithm (currently: 128 or 256)
+** @(RSE1a)@ Returns a complete @CipherParams@ instance, using the default values for any field not supplied
+** @(RSE1b)@ Takes a hashmap (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@
+** @(RSE1c)@ The @key@ must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string. If the key is a string, the function should base64-decode it into a binary. Since the conversion to base64 is not under Ably control, this should be done liberally -- in particular, it should work with 'url-safe base64' (which uses @-@ and @_@ instead of @+@ and @/@) in addition to standard base64
+** @(RSE1d)@ Calculates a @keyLength@ from the key (its size in bits).
+** @(RSE1e)@ Checks that the provided options are valid and self-consistent as best it can, raises an exception if not. At a mininum, this should include checking the calculated keyLength is a valid key length for the (provided if provided else default) encryption algorithm (for example, 128 or 256 for @AES@)
 * @(RSE2)@ @Crypto::generateRandomKey@ function
 ** @(RSE2a)@ Takes an optional keyLength parameter, which is the length in bits of the key to be generated. If unspecified, this is equal to the default keyLength of the default algorithm: for @AES@, 256 bits.
 ** @(RSE2b)@ Returns (or calls back with, if the language cryptographic randomness primitives are blocking or async) the key as a binary (e.g. a byte array, depending on the language)
@@ -692,10 +692,11 @@ h4. AuthOptions
 h4. ChannelOptions
 * @(TB1)@ options provided when instancing a channel, see "Java ChannelOptions":https://github.com/ably/ably-java/blob/master/src/io/ably/types/ChannelOptions.java as a reference
 * @(TB2)@ The attributes of @ChannelOptions@ consist of:
-** @(TB2a)@ @encrypted@ boolean - when true, enables automatic encryption & decryption of all messages
-** @(TB2b)@ @cipherParams@ - This is required if @encrypted@ is true. It consists of either:
+** @(TB2a)@ @encrypted@ boolean - when true, enables automatic encryption & decryption of all messages. If not present it defaults to true if the @cipher@ attribute is present, false if not.
+** @(TB2b)@ @cipher@ - This is required if @encrypted@ is true. It consists of either:
 *** @(TB2b1)@ A @CipherParams@ instance, or
-*** @(TB2b2)@ an options hash (or language equivalent) consisting of the key @key@ with value a key. In this case, the client library should call `getDefaultParams`, passing it the key, to obtain a @CipherParams@ instance
+*** @(TB2b2)@ an options hash (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@. In this case, the client library should call `getDefaultParams`, passing it the options hash, to obtain a @CipherParams@ instance
+* @(TB3)@ The client lib may optionally provide an alternative constructor @withCipherKey@ for ChannelOptions that takes a @key@ only. (This must be differentiated from the normal constructor such that it is clear that the value being passed in is a key). (This is intended for languages where requiring a hash map is unidiomatic)
 
 h4. CipherParams
 * @(TZ1)@ params to configure encryption for a channel, see "Java CipherParams class":https://github.com/ably/ably-java/blob/8a151b4edfa228ddef806fa10d2f9ce2be1ac09c/lib/src/main/java/io/ably/lib/util/Crypto.java as a reference
@@ -880,8 +881,9 @@ enum ChannelState:
   FAILED
 
 class ChannelOptions:
-  cipherParams: CipherParams? // RSL5a, TB2b
-  encrypted: Bool // RSL5a, TB2a
+  +withCipherKey(key: Binary)? -> ChannelOptions // TB3
+  cipher: (CipherParams | Params)? // RSL5a, TB2b
+  encrypted: Bool? // RSL5a, TB2a
 
 class CipherParams:
   algorithm: String default "AES" // TZ2a
@@ -890,8 +892,8 @@ class CipherParams:
   mode: String default "CBC" // TZ2c
 
 class Crypto:
-  +getDefaultParams(key: binary) -> CipherParams // RSE1
-  +generateRandomKey(keyLength: Int?) => io binary // RSE2
+  +getDefaultParams(Params) -> CipherParams // RSE1
+  +generateRandomKey(keyLength: Int?) => io Binary // RSE2
 
 class RestPresence:
   get(

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -202,7 +202,7 @@ h3(#rest-channel). Channel
 *** @(RSL4d3)@ a JSON Message payload is stringified either as a JSON Object or Array and represented as a JSON string and the @encoding@ attribute is set to "json"
 *** @(RSL4d4)@ All messages received will be decoded based on the @encoding@ field and deliver payloads in the format they were sent in i.e. binary, string, or a structured type containing the parsed JSON
 * @(RSL5)@ Message payload encryption
-** @(RSL5a)@ When a @Channel@ is instanced with the option @encrypted@ true, message payloads will be automtically encrypted when sent to Ably and decrypted when received on this channel. The cipher configuration is set with the @cipherParams@
+** @(RSL5a)@ When a @Channel@ is instanced with the option @encrypted@ true, message payloads will be automatically encrypted when sent to Ably and decrypted when received on this channel. The cipher configuration is set with the @cipherParams@
 ** @(RSL5b)@ AES 256 and 128 CBC encryption must be supported
 ** @(RSL5c)@ Tests must exist that encrypt and decrypt the following fixture data for "AES 128":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/master/test-resources/crypto-data-256.json to ensure the client library encryption is compatible across libraries
 * @(RSL6)@ Message decoding
@@ -224,6 +224,17 @@ h3(#rest-presence). Presence
 *** @(RSP4b2)@ @direction@ backwards or forwards; if unspecified defaults to the REST API default (backwards)
 *** @(RSP4b3)@ @limit@ supports up to 1,000 items; if unspecified defaults to the REST API default (100)
 * @(RSP5)@ Presence Messages retrieved are decoded in the same way that messages are decoded
+
+h3(#rest-encryption). Encryption
+* @(RSE1)@ @Crypto::getDefaultParams@ function:
+** @(RSE1a)@ Returns a complete @CipherParams@ instance
+** @(RSE1b)@ Takes a mandatory key parameter, which must be either a binary (e.g. a byte array, depending on the language), or a base64-encoded string
+** @(RSE1c)@ If the key is a string, base64-decodes it into a binary. Since the conversion to base64 is not under Ably control, this should be done liberally -- in particular, it should work with 'url-safe base64' (which uses @-@ and @_@ instead of @+@ and @/@) in addition to standard base64
+** @(RSE1d)@ Calculates a @keyLength@ from the key (its size in bits)
+** @(RSE1e)@ Raises an exception if the calculated keyLength is not a valid key length for the default encryption algorithm (currently: 128 or 256)
+* @(RSE2)@ @Crypto::generateRandomKey@ function
+** @(RSE2a)@ Takes an optional keyLength parameter, which is the length in bits of the key to be generated. If unspecified, this is equal to the default keyLength of the default algorithm: for @AES@, 256 bits.
+** @(RSE2b)@ Returns (or calls back with, if the language cryptographic randomness primitives are blocking or async) the key as a binary (e.g. a byte array, depending on the language)
 
 h2(#realtime). Realtime client library features
 
@@ -682,18 +693,17 @@ h4. ChannelOptions
 * @(TB1)@ options provided when instancing a channel, see "Java ChannelOptions":https://github.com/ably/ably-java/blob/master/src/io/ably/types/ChannelOptions.java as a reference
 * @(TB2)@ The attributes of @ChannelOptions@ consist of:
 ** @(TB2a)@ @encrypted@ boolean - when true, enables automatic encryption & decryption of all messages
-** @(TB2b)@ @cipherParams@ @CipherParams@ - when encrypted is true, the cipher params are required
+** @(TB2b)@ @cipherParams@ - This is required if @encrypted@ is true. It consists of either:
+*** @(TB2b1)@ A @CipherParams@ instance, or
+*** @(TB2b2)@ an options hash (or language equivalent) consisting of the key @key@ with value a key. In this case, the client library should call `getDefaultParams`, passing it the key, to obtain a @CipherParams@ instance
 
 h4. CipherParams
 * @(TZ1)@ params to configure encryption for a channel, see "Java CipherParams class":https://github.com/ably/ably-java/blob/8a151b4edfa228ddef806fa10d2f9ce2be1ac09c/lib/src/main/java/io/ably/lib/util/Crypto.java as a reference
-* @(TZ2)@ The attributes of @CipherParams@ consist of anything necessary to implement the supported algorithms (eg key and iv), in addition to the following standardised attributes:
+* @(TZ2)@ The attributes of @CipherParams@ consist of anything necessary to implement the supported algorithms (eg iv), in addition to the following standardised attributes:
 ** @(TZ2a)@ @algorithm@ string - Default is @AES@. Optionally specify the algorithm to use for encryption, currently only @AES@ is supported
-** @(TZ2b)@ @keyLength@ integer - An integer, from an algorithm-dependent range of possible values. If unspecified, an algorithm-dependent default is used. For AES the allowed values at least include 128 and 256, with a default of 128
-** @(TZ2d)@ @key@ string / byte array - private key used to encrypt and decrypt payloads
+** @(TZ2b)@ @keyLength@ integer - the size in bits of the @key@
+** @(TZ2d)@ @key@ binary - private key used to encrypt and decrypt payloads
 ** @(TZ2c)@ @mode@ string - Default is @CBC@. Optionally specify cipher mode, currently only @CBC@ is supported
-* @(TZ3)@ @Crypto#getDefaultParams@ function
-** @(TZ3a)@ returns a complete @CipherParams@ instance with randomly generated key and iv
-** @(TZ3b)@ takes an optional key parameter, returning a @CipherParams@ instance created with that key and with a keyLength calculated from that key
 
 h3(#defaults). Client Library defaults
 
@@ -880,7 +890,8 @@ class CipherParams:
   mode: String default "CBC" // TZ2c
 
 class Crypto:
-  +getDefaultParams(key: String?) -> CipherParams // TZ3
+  +getDefaultParams(key: binary) -> CipherParams // RSE1
+  +generateRandomKey(keyLength: Int?) => io binary // RSE2
 
 class RestPresence:
   get(

--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -50,7 +50,7 @@ h2(#getting-started). Getting started
   channel.publish("example", "message data");
 ```
 
-Note that the @key@ should not be a password, but a cryptographic key - randomly generated, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a password (for example, one inputted by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
+Note that the @key@ should not be a passphrase, but a cryptographic key - generated from a secure random source, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a passphrase (for example, one entered by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
 
 h2. Understanding encryption
 

--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -21,7 +21,7 @@ h2(#getting-started). Getting started
 "Channels":/realtime/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/realtime/types#channel-options. Below is a simple example:
 
 ```[jsall](code-editor:realtime/channel-encrypted)
-  var channelOpts = { encrypted: true, cipher: { key: <key> } };
+  var channelOpts = { cipher: { key: <key> } };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
   channel.subscribe(function(message) {
     alert('Decrypted data: ' + message.data);
@@ -30,7 +30,7 @@ h2(#getting-started). Getting started
 ```
 
 ```[ruby]
-  channel_opts = { encrypted: true, cipher: { key: <key> } }
+  channel_opts = { cipher: { key: <key> } }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
   channel.subscribe do |message|
     puts "Decrypted data: #{message.data}"
@@ -110,13 +110,13 @@ h4. Example
 
 ```[jsall](code-editor:realtime/channel-encrypted)
   var cipherParams = Ably.Realtime.Crypto.getDefaultParams({key: <key>});
-  var channelOpts = { encrypted: true, cipher: cipherParams };
+  var channelOpts = { cipher: cipherParams };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
 ```
 
 ```[ruby]
   cipher_params = Ably::Util::Crypto.get_default_params({key: <key>})
-  channel_opts = { encrypted: true, cipher: cipher_params }
+  channel_opts = { cipher: cipher_params }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
 ```
 
@@ -162,14 +162,14 @@ h4. Example
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
-      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}});
+      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {cipher: {key: key}});
     }
   });
 ```
 
 ```[ruby]
   key = Ably::Util::Crypto.generate_random_key(128)
-  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}})
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {cipher: {key: key}})
 ```
 
 ```[java]

--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -8,6 +8,7 @@ jump_to:
     - Understanding encryption#encryption
   API Reference:
     - getDefaultParams#get-default-params
+    - generateRandomKey#generate-random-key
   Related types:
     - Channel Options
     - CipherParams#cipher-params
@@ -20,7 +21,7 @@ h2(#getting-started). Getting started
 "Channels":/realtime/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/realtime/types#channel-options. Below is a simple example:
 
 ```[jsall](code-editor:realtime/channel-encrypted)
-  var channelOpts = { encrypted: true, cipherParams: { key: 'A__SECRET__KEY__' } };
+  var channelOpts = { encrypted: true, cipherParams: { key: <key> } };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
   channel.subscribe(function(message) {
     alert('Decrypted data: ' + message.data);
@@ -29,7 +30,7 @@ h2(#getting-started). Getting started
 ```
 
 ```[ruby]
-  channel_opts = { encrypted: true, cipher_params: { key: 'A__SECRET__KEY__' } }
+  channel_opts = { encrypted: true, cipher_params: { key: <key> } }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
   channel.subscribe do |message|
     puts "Decrypted data: #{message.data}"
@@ -38,7 +39,7 @@ h2(#getting-started). Getting started
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams("A__SECRET__KEY__");
+  CipherParams params = Crypto.getDefaultParams(<key>);
   ChannelOptions options = new ChannelOptions();
   options.encrypted = true;
   options.cipherParams = params;
@@ -51,6 +52,8 @@ h2(#getting-started). Getting started
   end
   channel.publish("example", "message data");
 ```
+
+Note that the @key@ should not be a password, but a cryptographic key - randomly generated, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a password (for example, one inputted by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
 
 h2. Understanding encryption
 
@@ -75,6 +78,7 @@ inline-toc.
   Crypto reference:
     - Methods:
       - getDefaultParams#get-default-params
+      - generateRandomKey#generate-random-key
     - Related types:
       - Channel Options
       - CipherParams#cipher-params
@@ -88,44 +92,91 @@ h6(#get-default-params).
   ruby:     get_default_params
 
 bq(definition).
-  default: Crypto.getDefaultParams(String key?, callback("ErrorInfo":/realtime/types#error-info err, "CipherParams":#cipher-params cipherParams))
-  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(String key?)
-  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(String key?)
+  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(ArrayBuffer/String key)
+  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Buffer/String key)
+  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Array/String key)
+  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(byte[]/String key)
 
-This call obtains a "@CipherParams@":#cipher-params object with default values for the implementation, either taking a supplied cipher key or generating a secure random key.
+  This call obtains a "@CipherParams@":#cipher-params object with default values for the implementation using the specified key. You will rarely need to call this yourself, since if you specify a key when initialising the channel (as in the example "at the top":#getting-started)<span lang="jsall"> or when setting channel options with @channel#setOptions@,</span>, the client library will do this for you.
 
 h4. Parameters
 
-- key := an optional <span lang="java">@byte[]@</span><span lang=default>@String@</span> containing the secret key. If not provided, a secure random key is generated
+- key := The secret key. This can be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
 
-- <div lang="jsall">callback</div> := is a function of the form @function(err, cipherParams)@ which is called upon completion
+h4. Returns
 
-blang[jsall].
-  h4. Callback result
-
-  On successfully creating default cipher params, the callback is called with the default "@CipherParams@":#cipher-params object and @err@ is @null@. On failure to create default cipher params, @err@ contains an "@ErrorInfo@":#error-info object describing the failure reason.
-
-blang[java,ruby].
-  h4. Returns
-
-  On success, the method returns the default "@CipherParams@":#cipher-params. Failure to create default cipher params will raise an "@AblyException@":/realtime/types/#ably-exception
+  On success, the method returns a complete "@CipherParams@":#cipher-params object. Failure to create default cipher params will raise an <span lang="ruby,java">"@AblyException@":/realtime/types/#ably-exception </span><span lang="jsall">exception</span>.
 
 h4. Example
 
 ```[jsall](code-editor:realtime/channel-encrypted)
-  var cipherParams = Ably.Realtime.Crypto.getDefaultParams('A__SECRET__KEY__');
+  var cipherParams = Ably.Realtime.Crypto.getDefaultParams(<key>);
   var channelOpts = { encrypted: true, cipherParams: cipherParams };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
 ```
 
 ```[ruby]
-  cipher_params = Ably::Util::Crypto.get_default_params('A__SECRET__KEY__')
+  cipher_params = Ably::Util::Crypto.get_default_params(<key>)
   channel_opts = { encrypted: true, cipher_params: cipher_params }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams("A__SECRET__KEY__");
+  CipherParams params = Crypto.getDefaultParams(<key>);
+  ChannelOptions options = new ChannelOptions();
+  options.encrypted = true;
+  options.cipherParams = params;
+  Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+```
+
+
+h6(#generate-random-key).
+  default:  generateRandomKey
+  ruby:     generate_random_key
+
+bq(definition).
+  default: Crypto.generateRandomKey(Int keyLength?, callback("ErrorInfo":/realtime/types#error-info err, @Buffer@ key))
+  ruby:    byte array Crypto.generate_random_key(Int key_length?)
+  java:    @byte[]@ Crypto.generateRandomKey(Int keyLength?)
+
+This call obtains a randomly-generated binary key of the specified key length.
+
+h4. Parameters
+
+- keyLength := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to 256.
+
+- <div lang="jsall">callback</div> := is a function of the form @function(err, key)@ which is called upon completion
+
+blang[jsall].
+  h4. Callback result
+
+  On successfully generating a key, the callback is called with that key as a <span lang=javascript>@WordArray@</span><span lang=nodejs>@Buffer@</span>, and @err@ is @null@. On failure to create a key, @err@ contains an "@ErrorInfo@":#error-info object describing the failure reason.
+
+blang[java,ruby].
+  h4. Returns
+
+  On success, the method returns the generated key as a <span lang="java">@byte[]@ array</span><span lang=ruby>byte array</span>. Failure will raise an "@AblyException@":/realtime/types/#ably-exception .
+
+h4. Example
+
+```[jsall]
+  Ably.Realtime.Crypto.generateRandomKey(128, function(err, key) {
+    if(err) {
+      console.log("Key generation failed: " + err.toString());
+    } else {
+      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}});
+    }
+  });
+```
+
+```[ruby]
+  key = Ably::Util::Crypto.generate_random_key(<key>)
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}})
+```
+
+```[java]
+  byte[] key = Crypto.generateRandomKey(<key>);
+  CipherParams params = Crypto.getDefaultParams(key);
   ChannelOptions options = new ChannelOptions();
   options.encrypted = true;
   options.cipherParams = params;

--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -21,7 +21,7 @@ h2(#getting-started). Getting started
 "Channels":/realtime/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/realtime/types#channel-options. Below is a simple example:
 
 ```[jsall](code-editor:realtime/channel-encrypted)
-  var channelOpts = { encrypted: true, cipherParams: { key: <key> } };
+  var channelOpts = { encrypted: true, cipher: { key: <key> } };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
   channel.subscribe(function(message) {
     alert('Decrypted data: ' + message.data);
@@ -30,7 +30,7 @@ h2(#getting-started). Getting started
 ```
 
 ```[ruby]
-  channel_opts = { encrypted: true, cipher_params: { key: <key> } }
+  channel_opts = { encrypted: true, cipher: { key: <key> } }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
   channel.subscribe do |message|
     puts "Decrypted data: #{message.data}"
@@ -39,10 +39,7 @@ h2(#getting-started). Getting started
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams(<key>);
-  ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
+  ChannelOptions options = ChannelOptions.withCipherKey(<key>);
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
   channel.subscribe(new MessageListener() {
     @Override
@@ -92,40 +89,41 @@ h6(#get-default-params).
   ruby:     get_default_params
 
 bq(definition).
-  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(ArrayBuffer/String key)
-  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Buffer/String key)
-  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Array/String key)
-  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(byte[]/String key)
+  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(Object params)
+  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Object params)
+  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Hash params)
+  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(Param[] params)
 
-  This call obtains a "@CipherParams@":#cipher-params object with default values for the implementation using the specified key. You will rarely need to call this yourself, since if you specify a key when initialising the channel (as in the example "at the top":#getting-started)<span lang="jsall"> or when setting channel options with @channel#setOptions@,</span>, the client library will do this for you.
+  This call obtains a "@CipherParams@":#cipher-params object using the values passed in (which must be a subset of @CipherParams@ fields that at a minimum includes a @key@), filling in any unspecified fields with default values, and checks that the result is a valid and self-consistent.
+
+You will rarely need to call this yourself, since the client library will handle it for you if you specify @cipher@ params when initialising a channel (as in the example "at the top":#getting-started)<span lang="jsall"> or when setting channel options with @channel#setOptions@</span>.
 
 h4. Parameters
 
-- key := The secret key. This can be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
+- params := The cipher params that you want to specify. It must at a minimum include a @key@, which should be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
 
 h4. Returns
 
-  On success, the method returns a complete "@CipherParams@":#cipher-params object. Failure to create default cipher params will raise an <span lang="ruby,java">"@AblyException@":/realtime/types/#ably-exception </span><span lang="jsall">exception</span>.
+  On success, the method returns a complete "@CipherParams@":#cipher-params object. Failure will raise an <span lang="ruby,java">"@AblyException@":/realtime/types/#ably-exception </span><span lang="jsall">exception</span>.
 
 h4. Example
 
 ```[jsall](code-editor:realtime/channel-encrypted)
-  var cipherParams = Ably.Realtime.Crypto.getDefaultParams(<key>);
-  var channelOpts = { encrypted: true, cipherParams: cipherParams };
+  var cipherParams = Ably.Realtime.Crypto.getDefaultParams({key: <key>});
+  var channelOpts = { encrypted: true, cipher: cipherParams };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
 ```
 
 ```[ruby]
-  cipher_params = Ably::Util::Crypto.get_default_params(<key>)
-  channel_opts = { encrypted: true, cipher_params: cipher_params }
+  cipher_params = Ably::Util::Crypto.get_default_params({key: <key>})
+  channel_opts = { encrypted: true, cipher: cipher_params }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams(<key>);
+  CipherParams params = Crypto.getDefaultParams(new Param[]{ new Param("key", <key>) });
   ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
+  options.cipher = params;
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
@@ -164,22 +162,19 @@ h4. Example
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
-      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}});
+      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}});
     }
   });
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(<key>)
-  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}})
+  key = Ably::Util::Crypto.generate_random_key(128)
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}})
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(<key>);
-  CipherParams params = Crypto.getDefaultParams(key);
-  ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
+  byte[] key = Crypto.generateRandomKey(128);
+  ChannelOptions options = ChannelOptions.withCipher(key);
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -4,104 +4,74 @@ section: rest
 index: 70
 jump_to:
   Help with:
-    - encryption#title
+    - Getting started#getting-started
+    - Understanding encryption#encryption
   API Reference:
     - getDefaultParams#get-default-params
+    - generateRandomKey#generate-random-key
   Related types:
+    - Channel Options
     - CipherParams#cipher-params
-    - CipherData#cipher-data
 ---
 
-Ably client libraries support encryption of message content, making it easier to build apps that encrypt content fully end-to-end.
+Ably client libraries support built-in symmetrical encryption of message content, making it easier to build apps that encrypt content fully end-to-end. Whilst "TLS is enabled by default":https://support.ably.io/solution/articles/3000045208-are-messages-sent-to-and-received-from-ably-sent-securely-using-tls and ensures that data is securely sent to and received from Ably, messages are not encrypted within the Ably system. Using the encryption feature of our client libraries ensures that message payloads are opaque, can never be decrypted by Ably, and can only be decrypted by other clients that share your secret key.
 
-h2. Objectives and Scope
+h2(#getting-started). Getting started
+
+"Channels":/rest/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
+
+```[jsall](code-editor:rest/channel-encrypted)
+  var channelOpts = { encrypted: true, cipherParams: { key: <key> } };
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
+  channel.publish('example', 'secret payload');
+```
+
+```[ruby]
+  channel_opts = { encrypted: true, cipher_params: { key: <key> } }
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
+  channel.publish 'example', 'secret payload'
+```
+
+```[java]
+  CipherParams params = Crypto.getDefaultParams(<key>);
+  ChannelOptions options = new ChannelOptions();
+  options.encrypted = true;
+  options.cipherParams = params;
+  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+  channel.publish("example", "message data");
+```
+
+Note that the @key@ should not be a password, but a cryptographic key - randomly generated, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a password (for example, one inputted by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
+
+h2. Understanding encryption
 
 The libraries support encryption purely as a convenience; the libraries ensure interoperability between environments by having compatible implementations of encryption algorithms and by making common choices on format, mode, padding etc. However,  Ably intentionally does not manage the distribution of keys between clients, and end-to-end encryption is enabled without exposing keys to the Ably service at all. This has the advantage that Ably demonstrably has no access to the unencrypted contents of your messages, but also means that each app is responsible for enabling the distribution of keys to clients independently of Ably.
 
-The client library support for encryption supports symmetric encryption only, and requires each participating client to each specify the correct secret key when creating a @Channel@ instance. Clients that do not specify a key will be delivered the still-encrypted message payloads that they may then still wish to decrypt offline.
+The client library support for encryption supports symmetric encryption only, and requires each participating client to each specify the correct @cipherParams@ secret @key@ when creating a @Channel@ instance. Clients that do not specify a key will be delivered the still-encrypted message payloads that they may then still wish to decrypt offline.
 
 The client libraries are designed to be extensible, but initially only support the AES algorithm (with a default key length of 128 bits) and CBC mode. These defaults are intended to ensure that encryption support can be provided in all target environments and platforms.
 
-Encryption is supported for both REST and Realtime publish operations. Decryption is supported in Realtime message subscriptions and in REST and Realtime history operations.
+Encryption is supported for the @data@ attribute (payload) of "published messages":/rest/types#messages and "presence member messages":/rest/types#presence-message on a channel, over both REST and realtime publish operations. Decryption is supported in realtime "message":/realtime/channels-messages and "presence message":/realtime/presence subscriptions and in "REST history":/rest/history, "REST presence get":/rest/get", and "REST presence history":/rest/presence#history operations.
 
-The key in use at any given time is known the client library, but the Ably service has no visibility of the key; it knows only that a given message payload was encrypted. When accessing messages via the history API, it is the caller's responsibility to ensure that the correct key is used for the requested interval.
+All other attributes of "messages":/rest/types#messages and "presence messages":/rest/types#presence-message, such as event @name@ or <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span> remain unencrypted. All sensitive data, when using the library's symmetrical encryption, must be placed in the @data@ attribute to ensure it is encypted before it is transmitted to Ably.
 
-Encryption options (algorithm, key, etc) are specified on a per-channel basis; it is expected that apps will wish to have both unencrypted and encrypted channels on a single connection.
+The key in use at any given time is known by the client library, but the Ably service has no visibility of the key; it knows only that a given message payload was encrypted. When accessing messages via the "history API":/rest/history, it is the caller's responsibility to ensure that the correct key is configured for the channel before the history request is made.
 
-h2. Encrypted message format
+Encryption options (algorithm, key, etc) are specified on a per-channel basis; it is expected that apps may wish to have both unencrypted and encrypted channels on a single connection.
 
-h3. Message representation
 
-Ably messages contain a typed @data@ member, with various supported data types. Encrypted messages carry the same type information - which is the type of the plaintext data - but the data payload is a buffer (ie a byte array containing binary data) containing the ciphertext. A given encrypted message can be exchanged using either the binary (Thrift) or JSON protocol and encryption and decryption are interoperable between the environments.
-
-In the Thrift encoding, an encrypted message is a Thrift-encoded version of the following @TMessage@:
-
-<pre>{
-	name: <name>,
-	timestamp: <timestamp>,
-	data: {
-		type: <TType for unencrypted data value>,
-		cipherData: <binary data for ciphertext>
-	}
-}
-
-</pre>
-
-In the JSON encoding, an encrypted message is represented as follows:
-
-<pre>{
-	name: <name>,
-	timestamp: <timestamp>,
-	"data": <string containing base64-encoded representation of ciphertext>,
-	"type": <TType ordinal value of unencrypted data value>,
-	"encoding": "cipher+base64"
-}
-
-</pre>
-
-h3. Plaintext
-
-Each possible data value type is canonically converted to a byte array before being encrypted, as follows:
-
-- INT32 := the 4-byte array containing the big-endian representation of the int32 value;
-
-- INT64 := the 8-byte array containing the big-endian representation of the int64 value;
-
-- DOUBLE := the 8-byte array containing the big-endian representation of the IEEE754 int64-encoded value;
-
-- STRING := the utf8-encoding of the string, without any trailing null byte;
-
-- BUFFER := the unmodified buffer contents;
-
-- JSONOBJECT := the utf8-encoding of the JSON-stringified value of the object;
-
-- JSONARRAY := the utf8-encoding of the JSON-stringified value of the array;.
-
-Note that Boolean values, having a type only and no value member, are unencrypted.
-
-h3. Conversion to ciphertext
-
-Conversion from plaintext to ciphertext requires the following steps:
-
-* Obtain an initialisation vector (IV). This can be obtained from a local secure random source or might be sourced externally and provided by the caller. In the Ably client libraries, an initial IV is obtained from a local Secure Random source, and IVs for subsequent messages in a channel are obtained by taking a snapshop of intermediate cipher state.
-
-* Pad the plaintext. The plaintext is padded to be a multiple of 16 bytes (the AES block length) using PKCS#7 ("RFC 5652":http://tools.ietf.org/html/rfc5652#section-6.3).
-
-* Encrypt the plaintext. This is performed using AES-CBC using the IV and padded plaintext.
-
-* Construct the ciphertext message payload. This is the concatenation of the 16-byte IV followed by the ciphertext bytes.
-
-By including the IV explicitly in each message, the client library can decrypt any message independently, knowing only the secret key; it is not necessary to know any earlier message. However, the entire sequence, from the point of view of the sender, is effectively encrypted as a stream, avoiding the need to obtain new entropy for the IV for each message, which would risk entropy exhaustion when there are high message volumes originating from a single sender.
-
-h1. API Reference
+h1. Crypto API Reference
 
 inline-toc.
-  Encryption reference:
+  Crypto reference:
     - Methods:
       - getDefaultParams#get-default-params
+      - generateRandomKey#generate-random-key
     - Related types:
+      - Channel Options
       - CipherParams#cipher-params
-      - CipherData#cipher-data
+
+The <span lang="default">@Ably.Rest.@</span><span lang="ruby">@Ably::Util::@</span><span lang="java">@io.ably.lib.util.@</span>@Crypto@ object exposes the following public methods:
 
 h2(#methods). Methods
 
@@ -110,40 +80,111 @@ h6(#get-default-params).
   ruby:     get_default_params
 
 bq(definition).
-  default:  Crypto.getDefaultParams([key, ]callback)
-  ruby:     Crypto.get_default_params(options) → CipherParams
-  java:     Crypto.getDefaultParams() → CipherParams
+  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(ArrayBuffer/String key)
+  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Buffer/String key)
+  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Array/String key)
+  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(byte[]/String key)
 
-This call obtains a @CipherParams@ instance with default values for the implementation, either taking a supplied cipher key or generating a key.
-
-A non-default key length may be specified by passing in a caller-generated key of the desired key length.
+  This call obtains a "@CipherParams@":#cipher-params object with default values for the implementation using the specified key. You will rarely need to call this yourself, since if you specify a key when initialising the channel (as in the example "at the top":#getting-started )<span lang="jsall"> or when setting channel options with @channel#setOptions@,</span>, the client library will do this for you.
 
 h4. Parameters
 
-- key := an optional <span lang="java">byte[]</span><span lang=default>buffer</span> containing the secret key.
+- key := The secret key. This can be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
 
-- <div lang="nodejs">callback</div> := a callback with callback signature (@err@, @CipherParams@).
+- <div lang="jsall">callback</div> := is a function of the form @function(err, cipherParams)@ which is called upon completion
 
-h2(#cipher-params). CipherParams
+  h4. Returns
 
-A @CipherParams@ contains configuration options for a channel cipher, including algorithm, mode, key length and key. Ably client libraries current support AES with CBC, PKCS#7 with a default key length of 128 bits. All implementations also support AES256.
+  On success, the method returns the default "@CipherParams@":#cipher-params. Failure to create default cipher params will raise an <span lang="ruby,java">"@AblyException@":/rest/types/#ably-exception </span><span lang="jsall">exception</span>.
 
-Individual client libraries may support the client instancing a @CipherParams@ directly, but as a minimum are expected to enable a @CipherParams@ with default values to be obtained via "Crypto.getDefaultParams()":#getdefaultparams.
+h4. Example
 
-A @CipherParams@ includes the following members.
+```[jsall](code-editor:rest/channel-encrypted)
+  var cipherParams = Ably.Rest.Crypto.getDefaultParams(<key>);
+  var channelOpts = { encrypted: true, cipherParams: cipherParams };
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
+```
 
-- <span lang="java">public String</span>algorithm := The name of the algorithm in the default system provider, or the lower-cased version of it; eg "aes" or "AES".
-- <div lang="java">public SecretKeySpec</div> := A @KeySpec@ for the cipher key.
-- <div lang="default">key</div> := A buffer containing the cipher key.
-- <div lang="java">public IvParameterSpec</div> := A @IvParameterSpec@ for the cipher IV.
-- <div lang="default">iv</div> := A buffer containing the cipher IV.
+```[ruby]
+  cipher_params = Ably::Util::Crypto.get_default_params(<key>)
+  channel_opts = { encrypted: true, cipher_params: cipher_params }
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
+```
 
-h2(#cipher-data). CipherData
+```[java]
+  CipherParams params = Crypto.getDefaultParams(<key>);
+  ChannelOptions options = new ChannelOptions();
+  options.encrypted = true;
+  options.cipherParams = params;
+  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+```
 
-A @CipherData@ instance contains an encrypted message payload. It is presented to a client if it is received on a channel and no cipher has been specified locally on that channel.
 
-A @CipherData@ contains the following members.
+h6(#generate-random-key).
+  default:  generateRandomKey
+  ruby:     generate_random_key
 
-- <span lang="java">public TType</span>type := the type of the unencrypted value, specified as a @TType@ <span lang="default>ordinal</span><span lang="java">enum</span>.
+bq(definition).
+  default: Crypto.generateRandomKey(Int keyLength?, callback("ErrorInfo":/rest/types#error-info err, @Buffer@ key))
+  ruby:    byte array Crypto.generate_random_key(Int key_length?)
+  java:    @byte[]@ Crypto.generateRandomKey(Int keyLength?)
 
-- <span lang="java">publiv byte[]</span>buffer := the encrypted text (comprising the concatenated IV and , specified as a @TType@ <span lang="default>ordinal</span><span lang="java">enum</span>.
+This call obtains a randomly-generated binary key of the specified key length.
+
+h4. Parameters
+
+- keyLength := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to 256.
+
+- <div lang="jsall">callback</div> := is a function of the form @function(err, key)@ which is called upon completion
+
+blang[jsall].
+  h4. Callback result
+
+  On successfully generating a key, the callback is called with that key as a <span lang=javascript>@WordArray@</span><span lang=nodejs>@Buffer@</span>, and @err@ is @null@. On failure to create a key, @err@ contains an "@ErrorInfo@":#error-info object describing the failure reason.
+
+blang[java,ruby].
+  h4. Returns
+
+  On success, the method returns the generated key as a <span lang="java">@byte[]@ array</span><span lang=ruby>byte array</span>. Failure will raise an "@AblyException@":/rest/types/#ably-exception .
+
+h4. Example
+
+```[jsall]
+  Ably.Rest.Crypto.generateRandomKey(128, function(err, key) {
+    if(err) {
+      console.log("Key generation failed: " + err.toString());
+    } else {
+      var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}});
+    }
+  });
+```
+
+```[ruby]
+  key = Ably::Util::Crypto.generate_random_key(<key>)
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}})
+```
+
+```[java]
+  byte[] key = Crypto.generateRandomKey(<key>);
+  CipherParams params = Crypto.getDefaultParams(key);
+  ChannelOptions options = new ChannelOptions();
+  options.encrypted = true;
+  options.cipherParams = params;
+  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+```
+
+h2(#related-types). Related types
+
+h3(#channel-options).
+  default:   ChannelOptions Object
+  ruby:      ChannelOptions Hash
+  java:      io.ably.lib.types.ClientOptions
+
+<%= partial 'types/_channel_options' %>
+
+h3(#cipher-params).
+  default: CipherParams
+  ruby:    CipherParams Hash
+  java:    io.ably.lib.util.Crypto.CipherParams
+
+<%= partial 'types/_cipher_params' %>

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -20,23 +20,20 @@ h2(#getting-started). Getting started
 
 "Channels":/rest/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
 
-```[jsall](code-editor:rest/channel-encrypted)
-  var channelOpts = { encrypted: true, cipherParams: { key: <key> } };
+```[jsall]
+  var channelOpts = { encrypted: true, cipher: { key: <key> } };
   var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
   channel.publish('example', 'secret payload');
 ```
 
 ```[ruby]
-  channel_opts = { encrypted: true, cipher_params: { key: <key> } }
+  channel_opts = { encrypted: true, cipher: { key: <key> } }
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
   channel.publish 'example', 'secret payload'
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams(<key>);
-  ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
+  ChannelOptions options = ChannelOptions.withCipherKey(<key>);
   Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
   channel.publish("example", "message data");
 ```
@@ -80,43 +77,42 @@ h6(#get-default-params).
   ruby:     get_default_params
 
 bq(definition).
-  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(ArrayBuffer/String key)
-  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Buffer/String key)
-  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Array/String key)
-  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(byte[]/String key)
+  javascript: "CipherParams":#cipher-params Crypto.getDefaultParams(Object params)
+  nodejs: "CipherParams":#cipher-params Crypto.getDefaultParams(Object params)
+  ruby:    "CipherParams":#cipher-params Crypto.get_default_params(Hash params)
+  java:    public "CipherParams":#cipher-params Crypto.getDefaultParams(Param[] params)
 
-  This call obtains a "@CipherParams@":#cipher-params object with default values for the implementation using the specified key. You will rarely need to call this yourself, since if you specify a key when initialising the channel (as in the example "at the top":#getting-started )<span lang="jsall"> or when setting channel options with @channel#setOptions@,</span>, the client library will do this for you.
+  This call obtains a "@CipherParams@":#cipher-params object using the values passed in (which must be a subset of @CipherParams@ fields that at a minimum includes a @key@), filling in any unspecified fields with default values, and checks that the result is a valid and self-consistent.
+
+You will rarely need to call this yourself, since the client library will handle it for you if you specify @cipher@ params when initialising a channel (as in the example "at the top":#getting-started)<span lang="jsall"> or when setting channel options with @channel#setOptions@</span>.
 
 h4. Parameters
 
-- key := The secret key. This can be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
+- params := The cipher params that you want to specify. It must at a minimum include a @key@, which should be either a binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) or a base64-encoded @String@.
 
-- <div lang="jsall">callback</div> := is a function of the form @function(err, cipherParams)@ which is called upon completion
+h4. Returns
 
-  h4. Returns
-
-  On success, the method returns the default "@CipherParams@":#cipher-params. Failure to create default cipher params will raise an <span lang="ruby,java">"@AblyException@":/rest/types/#ably-exception </span><span lang="jsall">exception</span>.
+  On success, the method returns a complete "@CipherParams@":#cipher-params object. Failure will raise an <span lang="ruby,java">"@AblyException@":/realtime/types/#ably-exception </span><span lang="jsall">exception</span>.
 
 h4. Example
 
-```[jsall](code-editor:rest/channel-encrypted)
-  var cipherParams = Ably.Rest.Crypto.getDefaultParams(<key>);
-  var channelOpts = { encrypted: true, cipherParams: cipherParams };
-  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
+```[jsall](code-editor:realtime/channel-encrypted)
+  var cipherParams = Ably.Realtime.Crypto.getDefaultParams({key: <key>});
+  var channelOpts = { encrypted: true, cipher: cipherParams };
+  var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
 ```
 
 ```[ruby]
-  cipher_params = Ably::Util::Crypto.get_default_params(<key>)
-  channel_opts = { encrypted: true, cipher_params: cipher_params }
-  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
+  cipher_params = Ably::Util::Crypto.get_default_params({key: <key>})
+  channel_opts = { encrypted: true, cipher: cipher_params }
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
 ```
 
 ```[java]
-  CipherParams params = Crypto.getDefaultParams(<key>);
+  CipherParams params = Crypto.getDefaultParams(new Param[]{ new Param("key", <key>) });
   ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
-  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+  options.cipher = params;
+  Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 
@@ -150,27 +146,24 @@ blang[java,ruby].
 h4. Example
 
 ```[jsall]
-  Ably.Rest.Crypto.generateRandomKey(128, function(err, key) {
+  Ably.Realtime.Crypto.generateRandomKey(128, function(err, key) {
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
-      var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}});
+      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}});
     }
   });
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(<key>)
-  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipherParams: {key: key}})
+  key = Ably::Util::Crypto.generate_random_key(128)
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}})
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(<key>);
-  CipherParams params = Crypto.getDefaultParams(key);
-  ChannelOptions options = new ChannelOptions();
-  options.encrypted = true;
-  options.cipherParams = params;
-  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+  byte[] key = Crypto.generateRandomKey(128);
+  ChannelOptions options = ChannelOptions.withCipher(key);
+  Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 h2(#related-types). Related types

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -21,13 +21,13 @@ h2(#getting-started). Getting started
 "Channels":/rest/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
 
 ```[jsall]
-  var channelOpts = { encrypted: true, cipher: { key: <key> } };
+  var channelOpts = { cipher: { key: <key> } };
   var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
   channel.publish('example', 'secret payload');
 ```
 
 ```[ruby]
-  channel_opts = { encrypted: true, cipher: { key: <key> } }
+  channel_opts = { cipher: { key: <key> } }
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
   channel.publish 'example', 'secret payload'
 ```
@@ -98,13 +98,13 @@ h4. Example
 
 ```[jsall](code-editor:realtime/channel-encrypted)
   var cipherParams = Ably.Realtime.Crypto.getDefaultParams({key: <key>});
-  var channelOpts = { encrypted: true, cipher: cipherParams };
+  var channelOpts = { cipher: cipherParams };
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
 ```
 
 ```[ruby]
   cipher_params = Ably::Util::Crypto.get_default_params({key: <key>})
-  channel_opts = { encrypted: true, cipher: cipher_params }
+  channel_opts = { cipher: cipher_params }
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channel_opts)
 ```
 
@@ -150,14 +150,14 @@ h4. Example
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
-      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}});
+      var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {cipher: {key: key}});
     }
   });
 ```
 
 ```[ruby]
   key = Ably::Util::Crypto.generate_random_key(128)
-  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {encrypted: true, cipher: {key: key}})
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {true, cipher: {key: key}})
 ```
 
 ```[java]

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -38,7 +38,7 @@ h2(#getting-started). Getting started
   channel.publish("example", "message data");
 ```
 
-Note that the @key@ should not be a password, but a cryptographic key - randomly generated, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a password (for example, one inputted by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
+Note that the @key@ should not be a passphrase, but a cryptographic key - generated from a secure random source, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a passphrase (for example, one entered by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.
 
 h2. Understanding encryption
 

--- a/content/rest/presence.textile
+++ b/content/rest/presence.textile
@@ -48,7 +48,7 @@ System.out.println("There are " + members.length + " members present");
 bc[ruby]. members = channel.presence.get
 puts "There are #{members.size} members present"
 
-In the REST client library this method directly queries the REST presence "history":/rest-api/presence#history API. No presence state is cached in the library itself, unlike in the Realtime client library.
+In the REST client library this method directly queries the REST presence "history":/rest/presence#history API. No presence state is cached in the library itself, unlike in the Realtime client library.
 
 h3. Retrieving presence history
 
@@ -104,7 +104,7 @@ h6(#get)[default]. get()
 
 h6(#get)[java]. public PresenceMessage[] get()
 
-Get the current presence set for this channel. This call queries the REST "@/channels/<channel id>/presence@":/rest-api/presence#get API.
+Get the current presence set for this channel. This call queries the REST "@/channels/<channel id>/presence@":/rest/presence#get API.
 
 h6(#history). history
 

--- a/content/types/_channel_options.textile
+++ b/content/types/_channel_options.textile
@@ -14,9 +14,7 @@ h4.
   java:    Members
   ruby:    Attributes
 
-- <span lang="ruby">@:@</span>@encrypted@ := Requests encryption for this channel when true. Will default to true if @cipher@ is specified, else false<br>__Type: Boolean__
-
-- <span lang="default">@cipher@</span><span lang="ruby">@:cipher_params@</span> := Specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an example":/realtime/encryption#getting-started<br>__Type: either "@CipherParams@":/realtime/encryption#cipher-params<span lang="ruby,jsall">, or <span lang="jsall">an options object</span><span lang="java">a Param[] list</span><span lang="ruby">an options hash</span> containing at a minimum a @key@ key</span>__
+- <span lang="default">@cipher@</span><span lang="ruby">@:cipher_params@</span> := Requests encryption for this channel when not null, and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an example":/realtime/encryption#getting-started<br>__Type: either "@CipherParams@":/realtime/encryption#cipher-params<span lang="ruby,jsall">, or <span lang="jsall">an options object</span><span lang="java">a Param[] list</span><span lang="ruby">an options hash</span> containing at a minimum a @key@ key</span>__
 
 <div lang="java">
 h4. Static methods

--- a/content/types/_channel_options.textile
+++ b/content/types/_channel_options.textile
@@ -16,4 +16,4 @@ h4.
 
 - <span lang="ruby">@:@</span>@encrypted@ := Requests encryption for this channel when true<br>__Type: Boolean__
 
-- <span lang="default">@cipherParams@</span><span lang="ruby">@:cipher_params@</span> := Specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an encryption example using @CipherParams@":/realtime/encryption#get-default-params<br>__Type: "@CipherParams@":/realtime/encryption#cipher-params__
+- <span lang="default">@cipherParams@</span><span lang="ruby">@:cipher_params@</span> := Specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an encryption example using @CipherParams@":/realtime/encryption#get-default-params<br>__Type: "@CipherParams@":/realtime/encryption#cipher-params<span lang="ruby,jsall">, or options <span lang="jsall">object</span><span lang="ruby">hash</span> containing a @key@ key</span>__

--- a/content/types/_channel_options.textile
+++ b/content/types/_channel_options.textile
@@ -1,3 +1,5 @@
+Currently the supported channel options are only used for "configuring encryption":/realtime/encryption.
+
 blang[jsall].
   @ChannelOptions@, a plain Javascript object, may optionally be specified when instancing a "@Channel@":/realtime/channels-messages, and this may be used to specify channel-specific options. The following attributes can be defined on the object:
 
@@ -7,13 +9,29 @@ blang[ruby].
 blang[java].
   @io.ably.lib.types.ChannelOptions@ may optionally be specified when instancing a "@Channel@":/realtime/channels-messages, and this may be used to specify channel-specific options.
 
-Currently the supported channel options are only used for "configuring encryption":/realtime/encryption.
-
 h4.
   default: Properties
   java:    Members
   ruby:    Attributes
 
-- <span lang="ruby">@:@</span>@encrypted@ := Requests encryption for this channel when true<br>__Type: Boolean__
+- <span lang="ruby">@:@</span>@encrypted@ := Requests encryption for this channel when true. Will default to true if @cipher@ is specified, else false<br>__Type: Boolean__
 
-- <span lang="default">@cipherParams@</span><span lang="ruby">@:cipher_params@</span> := Specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an encryption example using @CipherParams@":/realtime/encryption#get-default-params<br>__Type: "@CipherParams@":/realtime/encryption#cipher-params<span lang="ruby,jsall">, or options <span lang="jsall">object</span><span lang="ruby">hash</span> containing a @key@ key</span>__
+- <span lang="default">@cipher@</span><span lang="ruby">@:cipher_params@</span> := Specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an example":/realtime/encryption#getting-started<br>__Type: either "@CipherParams@":/realtime/encryption#cipher-params<span lang="ruby,jsall">, or <span lang="jsall">an options object</span><span lang="java">a Param[] list</span><span lang="ruby">an options hash</span> containing at a minimum a @key@ key</span>__
+
+<div lang="java">
+h4. Static methods
+
+h6(#with-cipher-key). withCipherKey
+
+bq(definition). public static ChannelOptions.withCipherKey(Byte[] or String key)
+
+A helper method to generate a @ChannelOptions@ for the simple case where you only specify a key.
+
+h4. Parameters
+
+- key := A binary @Byte[]@ array or a base64-encoded @String@.
+
+h4. Returns
+
+On success, the method returns a complete @ChannelOptions@ object. Failure will raise an "@AblyException@":/realtime/types/#ably-exception.
+</div>

--- a/content/types/_cipher_params.textile
+++ b/content/types/_cipher_params.textile
@@ -1,6 +1,6 @@
 A @CipherParams@ contains configuration options for a channel cipher, including algorithm, mode, key length and key. Ably client libraries currently support AES with CBC, PKCS#7 with a default key length of 256 bits. All implementations also support AES128.
 
-Individual client libraries may support either instancing a @CipherParams@ directly, using <span lang="default">"@Crypto.getDefaultParams()@":/realtime/encryption#get-default-params</span><span lang="ruby">"@Crypto.get_default_params()@":/realtime/encryption#get-default-params</span>, or generating one automatically from a key when initialising a channel, as in "this example":/realtime/encryption#getting-started.
+Individual client libraries may support either instancing a @CipherParams@ directly, using <span lang="default">"@Crypto.getDefaultParams()@":/realtime/encryption#get-default-params</span><span lang="ruby">"@Crypto.get_default_params()@":/realtime/encryption#get-default-params</span>, or generating one automatically when initialising a channel, as in "this example":/realtime/encryption#getting-started.
 
 h4.
   default: Properties

--- a/content/types/_cipher_params.textile
+++ b/content/types/_cipher_params.textile
@@ -1,16 +1,16 @@
-A @CipherParams@ contains configuration options for a channel cipher, including algorithm, mode, key length and key. Ably client libraries currently support AES with CBC, PKCS#7 with a default key length of 128 bits. All implementations also support AES256.
+A @CipherParams@ contains configuration options for a channel cipher, including algorithm, mode, key length and key. Ably client libraries currently support AES with CBC, PKCS#7 with a default key length of 256 bits. All implementations also support AES128.
 
-Individual client libraries may support the client instancing a @CipherParams@ directly, using the default values obtained from a <span lang="default">"@Crypto.getDefaultParams()@":/realtime/encryption#get-default-params</span><span lang="ruby">"@Crypto.get_default_params()@":/realtime/encryption#get-default-params</span>, or relying on the defaults provided a channel when encryption is enabled.
+Individual client libraries may support either instancing a @CipherParams@ directly, using <span lang="default">"@Crypto.getDefaultParams()@":/realtime/encryption#get-default-params</span><span lang="ruby">"@Crypto.get_default_params()@":/realtime/encryption#get-default-params</span>, or generating one automatically from a key when initialising a channel, as in "this example":/realtime/encryption#getting-started.
 
 h4.
   default: Properties
   java:    Members
   ruby:    Attributes
 
-- <div lang="jsall,ruby"><span lang="ruby">:</span>key</div> := A string <span lang="jsall">or buffer</span>containing the secret key used for encryption and decryption
+- <div lang="jsall,ruby"><span lang="ruby">:</span>key</div> := A binary (<span lang="java">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span>) containing the secret key used for encryption and decryption
 
 - <span lang="ruby">:</span>algorithm := _AES_ The name of the algorithm in the default system provider, or the lower-cased version of it; eg "aes" or "AES"<br>__Type: String__
-- <span lang="ruby">:key_length</span><span lang="default">keyLength</span> := _128_ The key length of the cipher, either 128 or 256<br>__Type: Integer__
+- <span lang="ruby">:key_length</span><span lang="default">keyLength</span> := _128_ The key length in bits of the cipher, either 128 or 256<br>__Type: Integer__
 - <span lang="ruby">:</span>mode := _CBC_ The cipher mode<br>__Type: String__
 
 - <div lang="java">keySpec</div> := A @KeySpec@ for the cipher key<br>__Type: SecretKeySpec__


### PR DESCRIPTION
Changes to spec and docs resulting from encryption discussion yesterday

Summary of changes:
- Crypto::getDefaultParams always takes a key, and is always synchronous. Generating a random key is split out into Crypto::generateRandomKey(keyLength), which can be async
- key arg must be either a language-dependent binary type or a string. If a string it must be base64-encoded.
- getDefaultParams must validate key is the correct length
- can initialize a channel with `{encrypted: true, cipherParams: {key: key}}`

The documentation changes assume that ably-js and ably-ruby have implemented all the changes, and ably-java has implemented all except the last (I don't know java, but get the impression it seems to like having all options-hash-type things be explicitly-created dedicated objects, so not sure if the last would be idiomatic java..?)

I also moved the Crypto functions in the spec to their own section in Rest rather than being bolted on to the end of Types > Option types > CipherParams.

Rest#encryption page was very old -- all the improvements had been made to the realtime page only -- so I just copied the realtime page over and tweaked as appropriate. IIRC Matt mentioned changes he has planned to reduce rest/realtime docs duplication, so didn't want to do anything that might conflict - if not could easily eg extract most of it to a partial