### PR TITLE
IDL: Add ChannelEvent enum with ERROR variant.

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -870,12 +870,7 @@ enum ChannelState:
   FAILED
 
 enum ChannelEvent:
-  INITIALIZED
-  ATTACHING
-  ATTACHED
-  DETACHING
-  DETACHED
-  FAILED
+  embeds ChannelState
   ERROR // RTL2c
 
 class ChannelOptions:

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -839,7 +839,7 @@ class RestChannel:
   publish(name: String?, data: Data?, clientId: String) => io // RSL1h
 
 class RealtimeChannel:
-  embeds EventEmitter<ChannelState, ErrorInfo?> // RTL2
+  embeds EventEmitter<ChannelEvent, ErrorInfo?> // RTL2
   errorReason: ErrorInfo? // RTL4e
   state: ChannelState // RTL2b
   presence: RealtimePresence // RTL9
@@ -868,6 +868,15 @@ enum ChannelState:
   DETACHING
   DETACHED
   FAILED
+
+enum ChannelEvent:
+  INITIALIZED
+  ATTACHING
+  ATTACHED
+  DETACHING
+  DETACHED
+  FAILED
+  ERROR // RTL2c
 
 class ChannelOptions:
   cipherParams: CipherParams? // RSL5a, TB2b


### PR DESCRIPTION
This is a requirement of RTL2c that was overlooked in the IDL.

See https://github.com/ably/ably-ios/pull/253#discussion-diff-54078011.