### PR TITLE
Use fog creds from key 'ably', rather than 'default'

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -6,11 +6,11 @@ module Ably
     JSBIN_API_KEY = "readonly"
 
     def aws_access_key_id
-      fog_yaml['default']['aws_access_key_id']
+      fog_yaml['ably']['aws_access_key_id']
     end
 
     def aws_secret_access_key
-      fog_yaml['default']['aws_secret_access_key']
+      fog_yaml['ably']['aws_secret_access_key']
     end
 
     def s3_bucket


### PR DESCRIPTION
Tried deploying docs.ably.io just now, noticed this repo expects fog creds to be under a 'default' key. Since the infrastructure repo expects ably fog creds to be under an 'ably' key, no point in duplicating them