### PR TITLE
heartbeat timeout proposal

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -327,10 +327,11 @@ h3(#realtime-connection). Connection
 ** @(RTN12c)@ If the transport is abruptly closed following a @CLOSE@ @ProtocolMessage@ being sent, then the connection will automatically move to the @CLOSED@ state
 ** @(RTN12d)@ If the connection state is @DISCONNECTED@ or @SUSPENDED@, aborts the retry process described in "RTN14d":#RTN14d and "RTN14e":#RTN14e and moves the connection immediately to the @CLOSED@ state
 * @(RTN13)@ @Connection#ping@ function:
-** @(RTN13c)@ If the connection state is @CONNECTING@ or @DISCONNECTED@, do the operation once the connection state is @CONNECTED@
+** @(RTN13d)@ If the connection state is @CONNECTING@ or @DISCONNECTED@, do the operation once the connection state is @CONNECTED@
 ** @(RTN13a)@ Will send a @ProtocolMessage@ with action @HEARTBEAT@ the Ably service when connected and expects a @HEARTBEAT@ message in response. If the client library language supports callbacks, then the callback will be called with the response time or error
 ** @(RTN13b)@ Will indicate an error if in, or has moved to, the @INITIALIZED@, @SUSPENDED@, @CLOSING@, @CLOSED@ or @FAILED@ state
 ** @(RTN13c)@ Will fail if a @HEARTBEAT@ @ProtocolMessage@ is not received within the "default realtime request timeout":#defaults
+** @(RTN13e)@ The @ProtocolMessage@ sent should include an @id@ property, with value a random string. If so, only a @HEARTBEAT@ response which includes an @id@ property with the same value should be considered a response to that ping, in order to disambiguate from normal heartbeats and other pings.
 * @(RTN14)@ @Connection@ opening failures:
 ** @(RTN14a)@ If an API key is invalid, then the connection will enter the @FAILED@ state and the @Connection#errorReason@ will be set on the @Connection@ object as well as the emitted @ConnectionStateChange@
 ** @(RTN14b)@ If a connection request fails due to an @ERROR@ @ProtocolMessage@ being received by the client containing a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) and an empty @channel@ attribute, then if the token is renewable, the error should not be emitted, a single attempt to create a new token will be made and a new connection attempt will be initiated using the newly created token. If the attempt to create a new token fails, or the subsequent connection attempt fails due to another token error, then the connection will transition to the @FAILED@ state and the @Connection#errorReason@ will be set

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -374,6 +374,9 @@ h3(#realtime-connection). Connection
 ** @(RTN19a)@ Any @ProtocolMessage@ that is awaiting an @ACK@/@NACK@ on the old transport will not receive the @ACK@/@NACK@ on the new transport. The client library must therefore resend any @ProtocolMessage@ that is awaiting a @ACK@/@NACK@ to Ably in order to receive the expected @ACK@/@NACK@ for that message. The Ably service is responsible for keeping track of messages, ignoring duplicates and responding with suitable @ACK@/@NACK@ messages
 ** @(RTN19b)@ If there are any pending channels i.e. in the @ATTACHING@ or @DETACHING@ state, the respective @ATTACH@ or @DETACH@ message should be resent to Ably
 ** @(RTN19b)@ If a @SYNC@ is underway, ensure the client library adheres to @RTP3@
+* @(RTN21)@ Heartbeats
+** @(RTN21a)@ If a transport does not receive any indication of activity on a transport for a period greater than the sum of the @maxIdleInterval@ (which will be sent in the @connectionDetails@ of the most recent @CONNECTED@ message received on that transport) and the @realtimeRequestTimeout@, that transport should be disconnected. This requirement is not mandatory; in deciding whether to implement, client library developers should take into account whether the transport in question is susceptible to undetected dropped connections. Any message (or non-message indicator, see @RTN21b@) received counts as an indication of activity and should reset the timer, not merely heartbeat messages. However, it must be received (that is, sent from the server to the client); client-sent data does count.
+** @(RTN21b)@ When initiating a connection, the client may send a @heartbeat@ param in the querystring, with value @true@ or @false@. If the value is true, the server will use Ably protocol messages (for example, a message with a @HEARTBEAT@ action) to satisfy the @maxIdleInterval@ requirement. If it is false or unspecified, the server is permitted to use any transport-level mechanism (for example, websocket ping frames) to satisfy this. So for example, for websocket transports, if the client is able to observe websocket pings, then it should send @heartbeats=false@. If not, it should send @heartbeats=true@.
 
 h3(#realtime-channels). Channels
 
@@ -965,6 +968,7 @@ h4. ConnectionDetails
 ** @(CD2e)@ @maxInboundRate@ is the maximum allowable number of requests per second from a client or Ably. In the case of a realtime connection, this restriction applies to the number of @ProtocolMessage@ objects sent, whereas in the case of REST, it is the total number of REST requests per second
 ** @(CD2f)@ @connectionStateTtl@ is the duration that Ably will persist the connection state when a Realtime client is abruptly disconnected
 ** @(CD2g)@ @serverId@ string is a unique identifier for the front-end server that the client has connected to. This server ID is only used for the purposes of debugging
+** @(CD2h)@ @maxIdleInterval@ is the maximum length of time milliseconds that the server will allow no activity to occur in the server->client direction. After such a period of inactivity, the server will send a @HEARTBEAT@ or transport-level ping to the client. If the value is 0, the server will allow arbitrarily-long levels of inactivity.
 
 h3(#options). Option types
 
@@ -1302,6 +1306,7 @@ class ConnectionDetails:
   maxInboundRate: Int // CD2e
   maxMessageSize: Int // CD2c
   serverId: String // CD2g
+  maxIdleInterval: Int // CD2h
 
 class Message:
   constructor(name: String?, data: Data?) // TM2


### PR DESCRIPTION
Per discussion https://github.com/ably/ably-js/issues/155#issuecomment-233481789

Only realtime change needed for now is sending `heartbeatPeriod: config.realtime.heartbeatTimer` in connectionDetails. Honouring qs-param-requested alternate periods is optional & low-priority so can be postponed