### PR TITLE
docs: Add notes on message queue functionality

### DIFF
--- a/content/general/queues.textile
+++ b/content/general/queues.textile
@@ -10,7 +10,7 @@ Using configurable rules, you can ensure that your messages, presence and channe
 
 As each message is delivered exactly once, queues are commonly used by one or more workers to process realtime data published by Ably asynchronously. For example, using workers subscribed to a queue, you could persist each message of a live chat to your own database, start publishing updates once a channel becomes active, or trigger an event if a device has submitted a location that indicates that it has reached its destination.
 
-To find out more about why and when we recommend message queues are used, see the article "Ably message queues — the right way to process and work with realtime data on your servers":https://medium.com/@matt.at.ably/2d15985301f8.
+To find out more about why and when we recommend message queues are used, see the article "Message queues — the right way to process and work with realtime data on your servers":https://blog.ably.io/message-queues-the-right-way-to-process-and-work-with-realtime-data-on-your-servers-2d15985301f8.
 
 To find out more about the data and event types supported by Ably message queues, see the "WebHooks documentation":/general/webhooks which supports the same data and event types.
 

--- a/content/general/queues.textile
+++ b/content/general/queues.textile
@@ -1,0 +1,17 @@
+---
+title: Message Queues
+section: general
+index: 19
+---
+
+Message queues provide a reliable mechanism for customers to process, store, augment or reroute realtime data efficiently and asynchronously by workers.
+
+Using configurable rules, you can ensure that your messages, presence and channel lifecycle events are enqueued on an Ably message queue. Unlike our "channels":/realtime/channels-messages#channels which follow a "pub/sub pattern":https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern where each message is delivered to any number of subscribers, our "message queues":https://en.wikipedia.org/wiki/Message_queue operate on the basis that each messages is delivered to only one subscriber.
+
+As each message is delivered exactly once, queues are commonly used by one or more workers to process realtime data published by Ably asynchronously. For example, using workers subscribed to a queue, you could persist each message of a live chat to your own database, start publishing updates once a channel becomes active, or trigger an event if a device has submitted a location that indicates that it has reached its destination.
+
+To find out more about why and when we recommend message queues are used, see the article "Ably message queues — the right way to process and work with realtime data on your servers":https://medium.com/@matt.at.ably/2d15985301f8.
+
+To find out more about the data and event types supported by Ably message queues, see the "WebHooks documentation":/general/webhooks which supports the same data and event types.
+
+Message queueing is currently in beta and as such only available to our Enterprise customers. If you are interested in using message queues, please "get in touch with us":https://www.ably.io/contact.

--- a/content/general/webhooks.textile
+++ b/content/general/webhooks.textile
@@ -7,19 +7,23 @@ jump_to:
     - Understanding WebHooks#title
     - Channel lifecycle events#channel-lifecycle
     - Presence events#presence
+    - Messages#messages
     - Configuring a WebHook#configure
     - WebHook transport details#transport
     - WebHook security#security
 ---
 
-WebHooks allow your server to be notified via an HTTP request following channel lifecycle events (such as channel creation) and presence events (such as members entering or leaving).
+WebHooks allow your server to be notified via an HTTP request following channel lifecycle events (such as channel creation), presence events (such as members entering or leaving) or messages being published.
 
-Generally, our customers who want to receive events as they happen, use our "realtime client libraries":/realtime and subscribe to events and messages published. However, some customers prefer to be notified over HTTP when events occur such as a user attaching to a channel, or members entering or leaving the presence set on a channel. For example, a customer may want to start pushing content to a channel only when the channel becomes active and there is someone there to receive the data, or they may want to send a welcome message to someone when they first enter a chat channel. A WebHook is useful feature to achieve this in both these scenarios.
+p(tip). WebHooks are "rate limited":#transport and designed for low to medium volumes of updates. If you expect a high volume of events and messages (upwards of 20 per second), then you should consider using our "message queues":#queues instead as they are designed to scale without limits.
 
-Ably currently supports two types of WebHooks:
+Generally, customers who want to receive events as they happen, use our "message queues":/general/queues, or alternatively our "realtime client libraries":/realtime and subscribe to events and messages published. However, some customers prefer to be notified over HTTP when events occur such as a user attaching to a channel, or members entering or leaving the presence set on a channel. For example, a customer may want to start pushing content to a channel only when the channel becomes active and there is someone there to receive the data, or they may want to send a welcome message to someone when they first enter a chat channel. A WebHook is useful feature to achieve this in both these scenarios.
+
+Ably currently supports three types of WebHooks:
 
 * "Channel lifecycle events":#channel-lifecycle - get notified when a channel is created (following the first client attaching to this channel) or discarded (when there are no more clients attached to the channel)
 * "Presence events":#presence - get notified when clients enter, update their data, or leave channels
+* "Messages":#messages - get notified when messages are published on a channel
 
 In order to prevent overloading your servers with requests, Ably batches WebHook data and issues a @POST@ request with @JSON@ data in the body of the request to your servers. WebHook requests are typically published at most once per second per configured WebHook. See "WebHook transport details":#transport below for the specifics on throughput, restrictions and expected behaviour of WebHooks.
 
@@ -183,6 +187,12 @@ h4. Example @channel.presence@ @update@ and @leave@ JSON payload
    ]
 }
 ```
+
+h2(#messages). Messages
+
+Receiving messages via WebHooks is currently in beta. As such, this functionality is currently only available to Enterprise customers. If you are interested in receiving messages via WebHooks, please "get in touch with us":https://www.ably.io/contact.
+
+Please note that if you are plannig to receive messages via WebHooks, it is theoretically very easy to exceed the "transport rate limits":#transport we impose on WebHooks to prevent DoS attacks. We recommend you consider "message queues":/general/queues instead as they are far more scalable.
 
 h2. Configuring a WebHook
 


### PR DESCRIPTION
@paddybyers @SimonWoolf I have added some very high level documentation in regards to our message queue functionality.  I needed this before we publish our blog post about upcoming queue functionality that we will hopefully test soon with DubTrack.

cc @ashleyf1 