### PR TITLE
Publish on behalf of a realtime client

### DIFF
--- a/content/code/rest/channel-history.code
+++ b/content/code/rest/channel-history.code
@@ -46,7 +46,7 @@ $('input#history').on('click', getHistory);
 [--- HTML ---]
 <script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
 <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
-<h1>Ably Rest History Example</h1>
+<h1>Ably REST History Example</h1>
 
 <p>In this example, we demonstrate how to easily publish and retrieve message history on a channel over REST. See <a href="https://www.ably.io/documentation/rest/channels-messages">our REST channel documentation</a> for more details.
 

--- a/content/code/rest/channel-publish.code
+++ b/content/code/rest/channel-publish.code
@@ -22,9 +22,9 @@ function show(status, color) {
 [--- HTML ---]
 <script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
 <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
-<h1>Ably Rest Publish Example</h1>
+<h1>Ably REST Publish Example</h1>
 
-<p>In this example, we demonstrate the simplest way to publish a message and receive a callback indicating success or failure to publish the message. See <a href="https://www.ably.io/documentation/rest/channel-messages">our Rest Channel documentation</a> for more details.
+<p>In this example, we demonstrate the simplest way to publish a message and receive a callback indicating success or failure to publish the message. See <a href="https://www.ably.io/documentation/rest/channel-messages">our REST Channel documentation</a> for more details.
 
 <div class="row">
   <input id="publish" type="submit" value="Publish a message">

--- a/content/code/rest/publish-on-behalf-of-client.code
+++ b/content/code/rest/publish-on-behalf-of-client.code
@@ -1,0 +1,83 @@
+[--- Javascript ---]
+var apiKey = '{{API_KEY}}',
+    channelName = '{{RANDOM_CHANNEL_NAME}}',
+    rest = new Ably.Rest({ key: apiKey }),
+    restChannel = rest.channels.get(channelName),
+    clientA = new Ably.Realtime({ key: apiKey, echoMessages: false }),
+    channelA = clientA.channels.get(channelName),
+    clientB = new Ably.Realtime({ key: apiKey }),
+    channelB = clientB.channels.get(channelName);
+
+$('input#publish').on('click', function() {
+  if (clientA.connection.state !== 'connected') {
+    show('client A is not connected, cannot publish on behalf of client A', 'red');
+    return;
+  }
+
+  show('Publishing message over REST on behalf of client A with connection ID "' + clientA.connection.id + '"', 'orange');
+
+  /* Specifying a private (secret) connection key allows a message be published
+     on behalf of that connected client */
+  var msg = { data: 'data', connectionKey: clientA.connection.key };
+
+  restChannel.publish(msg, function(err) {
+    if (err) {
+      show('✗ REST publish failed: ' + err.message, 'red');
+    } else {
+      show('✓ REST publish successful', 'green');
+    }
+  });
+});
+
+clientA.connection.on('connected', function() {
+  show('Client A is connected with connection ID "' + clientA.connection.id + '"<br>Secret connection key is "' + clientA.connection.key + '"', 'green');
+});
+
+clientB.connection.on('connected', function() {
+  show('Client B is connected with connection ID "' + clientB.connection.id + '"', 'green');
+});
+
+channelA.subscribe(function(msg) {
+  show('✗ Client A should not have received any messages as echoMessage is explicitly set to false', 'red');
+});
+
+channelB.subscribe(function(msg) {
+  show('✓ Client B received published message from client A\'s connection ID "' + msg.connectionId + '"', 'green');
+});
+
+function show(status, color) {
+  $('#channel-status').append($('<li>').html(status).css('color', color));
+}
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably: Publishing over REST on behalf of a Realtime client example</h1>
+
+<p>In this example, we demonstrate how it is possible to publish a message over REST on behalf of a connected Realtime client. We create two Realtime clients: client A is the publisher client that the REST client publishes on behalf of, and the other simply subscribes to messages. client A in this example is configured with the client option echoMessages set to false thus preventing the message sent on behalf of itself via the REST library being echoed back to itself. See <a href="https://www.ably.io/documentation/rest/channel-messages#publish-on-behalf">our REST Channel documentation</a> for more details.
+
+<div class="row">
+  <input id="publish" type="submit" value="Publish a message on behalf of client A">
+</div>
+
+<ul class="row" id="channel-status"></ul>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+[--- /CSS ---]

--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -381,6 +381,8 @@ h6(#key). key
 
 A unique private connection key @String@ used to recover or resume a connection, assigned by Ably. When recovering a connection explicitly, the <span lang="default">@recoveryKey@</span><span lang="ruby">@recovery_key@</span> is used in the @recover@ "client options":/realtime/usage#client-options as it contains both the @key@ and the last message @serial@.
 
+This private connection key can also be used by other REST clients to publish on behalf of this client. See the "publishing over REST on behalf of a realtime client documentation":/rest/channels-messages#publish-on-behalf  for more info.
+
 h6(#recovery-key).
   default: recoveryKey
   ruby:    recovery_key

--- a/content/rest-api/index.textile
+++ b/content/rest-api/index.textile
@@ -317,7 +317,10 @@ The request body contains message details and is an object of the form:
 
 bc[json]. {
   name: <event name>,
-  data: <message payload>
+  data: <message payload>,
+  encoding: <optional encoding>,
+  clientId: <optional explicit client identifier>,
+  connectionKey: <optional private connection key>
 }
 
 In JSON format, the accepted types for the @data@ payload are:
@@ -326,6 +329,8 @@ In JSON format, the accepted types for the @data@ payload are:
 * any JSON-encodable Array or Object.
 
 MessagePack additionally "supports byte arrays":https://github.com/msgpack/msgpack/blob/master/spec.md#formats-bin
+
+A message may be published over REST on behalf of an existing realtime connection when a valid @connectionKey@ is present. For example, if you want to publish a message using the REST API so that it appears to come from an existing connected realtime client, then the connection's "private (secret) connection key":/realtime/connection#key must be included. See a "publish on behalf of a realtime client example":<%= JsBins.url_for('rest/publish-on-behalf-of-client') %>.
 
 Example request:
 
@@ -346,7 +351,7 @@ h5. Options
 
 h5. Returns
 
-Nothing
+Nothing when successful, else returns an error.
 
 h3(#message-history). Retrieve message history for a channel
 

--- a/content/rest/channels-messages.textile
+++ b/content/rest/channels-messages.textile
@@ -191,6 +191,12 @@ bc[objc]. [channel publish:@"event" data:@"This is my payload"];
 
 bc[swift]. channel.publish("event", data: "This is my payload")
 
+h4(#publish-on-behalf). Publishing on behalf of realtime connection
+
+Message published using the REST API may be done so on behalf of an existing realtime connection when a valid @connectionKey@ is present in the published message. For example, if you want to publish a message using the REST client library so that it appears to come from an existing connected realtime client, then the connection's "private (secret) connection key":/realtime/connection#key must be included. See a "publish on behalf of a realtime client example":<%= JsBins.url_for('rest/publish-on-behalf-of-client') %>.
+
+If the @connectionKey@ is invalid or belongs to a connection that has since been closed, then the publish operation will fail.
+
 h3(#message-history). Retrieving message history
 
 Channels expose a "@history@":#history method providing a means for clients to obtain messages previously sent on the channel. Channel history can be used to return continuous message history up to the exact point a realtime channel was attached.

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -23,8 +23,6 @@ jsbin_hash:
   RTuR5bolbjcZfpUPC82RwWPlBhQ=: owecul
   e4YmJ77wMyulKC7fEZESiTtDgQo=: agorop
   UWnz6sn5xwMKZMU+OYEWIVKU7CI=: ixowal
-  NzxFADiIFhLWDishg2AyaM5CnQY=: ugobiz
-  6720T/EjK8Qd0VWVcms83Q71lJk=: ojanow
   AJct1KE6KCUVl4KhOuzpLq1AOcM=: awetev
   B+ScmhA8yWIlzybQ7c/72rnyDJw=: inaxoh
   Yb++VD1ZGZ+J77VTPv7GtgOIncs=: uqidub
@@ -32,6 +30,9 @@ jsbin_hash:
   CMyVpRUU+KM5hvED3v4N7b2lOxU=: ocodaf
   ZyIss5caeeJ+cpSaLfIPHFh1e+M=: opapoc
   m5oFFFUyk92pE+/HT+E3vj4eaNI=: ovojij
+  AGG9MKTY97eUnfIerqRaFhXchzM=: anoqir
+  edMQhO4e60q9TU1mOlDyPPsIzJo=: ajevoz
+  0v8Q75y5ANAOFGVY8/BrnVpRVqw=: aqanoy
 jsbin_id:
   client-lib-development-guide/example: urUBwIWkiIJIxLBR/bJCTh1h6x8=
   authentication/basic-auth: K3P/Q3XJhTH3IgjXtLpvms6Oxj4=
@@ -59,9 +60,10 @@ jsbin_id:
   realtime/auth-token-callback: 2G08Z4A2FN9m7c+XknPNWRlL3+Y=
   realtime/auth-client-id: qYYVlE2GZsmEBiXnAwwrurAVtXo=
   realtime/channel-encrypted: B+ScmhA8yWIlzybQ7c/72rnyDJw=
-  rest/channel-history: NzxFADiIFhLWDishg2AyaM5CnQY=
-  rest/channel-publish: 6720T/EjK8Qd0VWVcms83Q71lJk=
+  rest/channel-history: AGG9MKTY97eUnfIerqRaFhXchzM=
+  rest/channel-publish: edMQhO4e60q9TU1mOlDyPPsIzJo=
   rest/stats: AJct1KE6KCUVl4KhOuzpLq1AOcM=
   authentication/capabilities: ekirQX0NX5Z+hMeU4ApXbZCJRCw=
   authentication/auth-callback: CMyVpRUU+KM5hvED3v4N7b2lOxU=
   website-examples/home-page: m5oFFFUyk92pE+/HT+E3vj4eaNI=
+  rest/publish-on-behalf-of-client: 0v8Q75y5ANAOFGVY8/BrnVpRVqw=


### PR DESCRIPTION
A customer has asked how to publish on behalf of a realtime client, a pattern that is often used by Pusher because of their legacy handling of clients typically being receivers only.

This documents how to do that with Ably