### PR TITLE
spec: Allow REST publisher to publish on behalf of another client

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -831,6 +831,7 @@ h4. Message
 ** @(TM2a)@ @id@ string - unique ID for this message
 ** @(TM2b)@ @clientId@ string
 ** @(TM2c)@ @connectionId@ string
+** @(TM2h)@ @connectionKey@ string (note this is only ever populated by a publishing client when "publishing on behalf of another client":/rest/channels-messages#publish-on-behalf, the @connectionKey@ will never be populated for messages received)
 ** @(TM2g)@ @name@ string
 ** @(TM2d)@ @data@ string, buffer or JSON-encodable object or array
 ** @(TM2e)@ @encoding@ string

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -831,7 +831,7 @@ h4. Message
 ** @(TM2a)@ @id@ string - unique ID for this message
 ** @(TM2b)@ @clientId@ string
 ** @(TM2c)@ @connectionId@ string
-** @(TM2h)@ @connectionKey@ string (note this is only ever populated by a publishing client when "publishing on behalf of another client":/rest/channels-messages#publish-on-behalf, the @connectionKey@ will never be populated for messages received)
+** @(TM2h)@ @connectionKey@ string (note this is only ever populated by a publishing client when "publishing on behalf of another client":/rest/channels-messages#publish-on-behalf, the @connectionKey@ will never be populated for messages received. A simple test for this attribute over REST is to populate this with an invalid @connectionKey@ when publishing and expecting a suitable error)
 ** @(TM2g)@ @name@ string
 ** @(TM2d)@ @data@ string, buffer or JSON-encodable object or array
 ** @(TM2e)@ @encoding@ string


### PR DESCRIPTION
See https://www.ably.io/documentation/rest/channels-messages#publish-on-behalf

We need to add `connectionKey` to message definition so that REST clients can publish on behalf of other realtime clients.

@paddybyers I would like to merge this ASAP as it is a blocker for a customer.