### PR TITLE
docs: Remove duplicate items() method on PaginatedResult

### DIFF
--- a/content/types/_paginated_result.textile
+++ b/content/types/_paginated_result.textile
@@ -6,7 +6,7 @@ h4.
   ruby:    Attributes
   python:  Attributes
 
-- <span lang="default">items</span><span lang="csharp">Items</span> := contains a page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python">__Type: @List <Message, Presence, Stats>@__</span>
+- <span lang="default">items</span><span lang="csharp">Items</span> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python,csharp">__Type: @List <Message, Presence, Stats>@__</span>
 
 - <div lang="javascript,nodejs,java,swift,objc">isLast</div> := @true@ if this page is the last page<br>__Type: @Boolean@__
 - <div lang="ruby">last?</div> := @true@ if this page is the last page<br>__Type: @Boolean@__
@@ -36,20 +36,6 @@ bq(definition).
   swift,objc: first(callback: (ARTPaginatedResult?, ARTErrorInfo?) -> Void)
 
 Returns a new @PaginatedResult@ for the first page of results. <span lang="ruby">When using the Realtime library, the @first@ method returns a "Deferrable":/realtime/types#deferrable and yields a "PaginatedResult":/realtime/types#paginated-result.</span><span lang="csharp">The method is asynchronous and returns a Task which needs to be awaited to get the "PaginatedResult":/realtime/types#paginated-result.</span>
-
-h6.
-  default: items
-  csharp: Items
-
-bq(definition).
-  default:  Object[] items()
-  python:   List items()
-  ruby:     Object[] items
-  java:     Object[] items()
-  csharp:   List<T> Items
-  swift, objc: items: [AnyObject]
-
-Returns the current page of results as <span lang="default">an Array</span><span lang="csharp">a List</span><span lang="python">a @List@</span>. The type of the objects in the <span lang="default">array</span><span lang="python,csharp">list</span> is determined by the operation that provided the @PaginatedResult@. For example, a "<span lang="default">Message.history()</span><span lang="csharp">Message.History()</span>":/realtime/channels-messages#history request will return <span lang="default">an array</span><span lang="python,csharp">a list</span> of @Message@ objects.
 
 h6.
   default: next


### PR DESCRIPTION
Fixes https://github.com/ably/docs/issues/185

Before merging I will ensure this is not a method in any of the libs