### PR TITLE
Add TokenDetails#fromJSON and TokenRequest#fromJSON

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -939,6 +939,7 @@ h4. TokenRequest
 * @(TE3)@ @capability@ is a string attribute containing capabilities JSON stringified
 * @(TE5)@ @timestamp@ long - The timestamp (in milliseconds since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent requests from being replayed
 * @(TE4)@ @ttl@ attribute represents time to live (expiry) of this token in milliseconds
+* @(TE6)@ @TokenRequest::fromJson@ static factory method that accepts either a @JsonObject@ or a string (which should be parsed as a JSON string), and returns a new @TokenRequest@. Statically typed languages (that expect the @authCallback@ to result in a typed @TokenRequest@ object, rather than, say, a hashmap) must implement this; others may at their discretion.
 
 h4. TokenDetails
 
@@ -948,6 +949,7 @@ h4. TokenDetails
 * @(TD4)@ @TokenDetails#issued@ attribute contains the time the token was issued in milliseconds.  Where idiomatic in the language, this can be a Date/Time object
 * @(TD5)@ @TokenDetails#capability@ attribute contains the capability JSON stringified
 * @(TD6)@ @TokenDetails#clientId@ attribute contains the @clientId@ assigned to the token. If @clientId@ is @null@ or omitted, then the token is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the token is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations for this token
+* @(TD7)@ @TokenDetails::fromJson@ static factory method that accepts either a @JsonObject@ or a string (which should be parsed as a JSON string), and returns a new @TokenDetails@. Statically typed languages (that expect the @authCallback@ to result in a typed @TokenDetails@ object, rather than, say, a hashmap) must implement this; others may at their discretion.
 
 h4. AuthDetails
 
@@ -1050,10 +1052,10 @@ h4. ClientOptions
 h4(#token-params). TokenParams
 * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorize@, @Auth#requestToken@ and @Auth#createTokenRequest@
 * @(TK2)@ The attributes of @TokenParams@ consist of:
-* @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds. When omitted, the REST API default of 60 minutes is applied by Ably
-* @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token. When omitted, the REST API default to allow all operations is applied by Ably, with the string value @{"*":["*"]}@
-* @(TK2c)@ @clientId@ string - A @clientId@ string to associate with this token. If @clientId@ is @null@ or omitted, then the token is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the token is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations for this token
-* @(TK2d)@ @timestamp@ long - The timestamp (in milliseconds since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent requests from being replayed. @timestamp@ is a "one-time" value, and is valid in a request, but is not validly a member of any default token params such as @ClientOptions#defaultTokenParams@
+** @(TK2a)@ @ttl@ long - Requested time to live for the token in milliseconds. When omitted, the REST API default of 60 minutes is applied by Ably
+** @(TK2b)@ @capability@ string - Capability requirements JSON stringified for the token. When omitted, the REST API default to allow all operations is applied by Ably, with the string value @{"*":["*"]}@
+** @(TK2c)@ @clientId@ string - A @clientId@ string to associate with this token. If @clientId@ is @null@ or omitted, then the token is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the token is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations for this token
+** @(TK2d)@ @timestamp@ long - The timestamp (in milliseconds since the epoch) of this request. Timestamps, in conjunction with the @nonce@, are used to prevent requests from being replayed. @timestamp@ is a "one-time" value, and is valid in a request, but is not validly a member of any default token params such as @ClientOptions#defaultTokenParams@
 
 h4. AuthOptions
 * @(AO1)@ A class providing configurable authentication options used when authenticating or issuing tokens explicitly. These options are used when invoking @Auth#authorize@, @Auth#requestToken@, @Auth#createTokenRequest@ and @Auth#authorize@
@@ -1192,6 +1194,7 @@ class Auth:
   requestToken(TokenParams?, AuthOptions?) => io TokenDetails // RSA8e
 
 class TokenDetails:
+  +fromJson(String | JsonObject) -> TokenDetails// TD7
   capability: String // TD5
   clientId: String? // TD6
   expires: Time // TD3
@@ -1199,6 +1202,7 @@ class TokenDetails:
   token: String // TD2
 
 class TokenRequest:
+  +fromJson(String | JsonObject) -> TokenRequest // TE6
   capability: String // TE3
   clientId: String? // TE2
   keyName: String // TE2


### PR DESCRIPTION
Fixes https://github.com/ably/docs/issues/192

Name chosen to match [what java lib already uses](https://github.com/ably/ably-java/blob/fb719af9bb21b57429cbc3267a6d654284b1ec7c/lib/src/main/java/io/ably/lib/rest/Auth.java#L231-L233). (In particular, the 'normal' constructor when given a string interprets it as a token string, changing that seemed like an unnecessary break in backwards compatibility, especially as a `fromJSON` static method is more explicit anyway)