### PR TITLE
Fix type of authCallback in IDL.

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1169,7 +1169,7 @@ class ClientOptions:
   httpMaxRetryDuration: Duration default 10s // TO315
 
 class AuthOptions: // RSA8e
-  authCallback: (String | TokenDetails | TokenRequest) ->? // RSC14c, RSA4, TO3j5, AO2b
+  authCallback: (() -> io (String | TokenDetails | TokenRequest))? // RSC14c, RSA4, TO3j5, AO2b
   authHeaders: [(String, String)]? // RSA8c3, TO3j8, AO2e
   authMethod: .GET | .POST default .GET // RSA8c, TO3j7, AO2d
   authParams: [String: [String]]? // RSA8c3, RSA8c1, TO3j9, AO2f


### PR DESCRIPTION
It was a function taking a TokenDetails, TokenRequest or String, but it should be a function that takes nothing and IO-returns a TokenDetails, TokenRequest or String.

IO-returning functions can always fail in a unspecified but platform-consistent manner, so it's relevant for the ongoing #194.