### PR TITLE
Remove deprecated ProtocolMessage#connectionKey

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -907,7 +907,6 @@ h4. ProtocolMessage
 ** @(TR4b)@ @channel@ string
 ** @(TR4c)@ @channelSerial@ string
 ** @(TR4d)@ @connectionId@ string
-** @(TR4e)@ @connectionKey@ string. Note that this field is soon to be deprecated; when @ConnectionDetails#connectionKey@ is present, it should be considered the definitive @connectionKey@ for the current connection
 ** @(TR4f)@ @connectionSerial@ long
 ** @(TR4o)@ @connectionDetails@ @ConnectionDetails@ object - provides details on the constraints or defaults for the connection such as max message size, client ID or connection state TTL
 ** @(TR4g)@ @count@ integer
@@ -1006,7 +1005,7 @@ h4. ConnectionDetails
 * @(CD1)@ Connection details are optionally passed to the client library in the @CONNECTED@ @ProtocolMessage#connectionDetails@ attribute to inform the client about any constraints it should adhere to, and provide additional metadata about the connection. For example, if a request is made to publish a message that exceeds the @maxMessageSize@, the client library can reject the message immediately, without communicating with the Ably service
 * @(CD2)@ Attributes available in @ConnectionDetails@:
 ** @(CD2a)@ @clientId@ contains the client ID assigned to the token. If @clientId@ is @null@ or omitted, then the client is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the client is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations from this client
-** @(CD2b)@ @connectionKey@ is the connection secret key string that is used to resume a connection and its state. When present, this @connectionKey@ should be considered the definitive @connectionKey@ for the current connection and the soon to be deprecated @ProtocolMessage#connectionKey@ should be ignored
+** @(CD2b)@ @connectionKey@ is the connection secret key string that is used to resume a connection and its state.
 ** @(CD2c)@ @maxMessageSize@ is the maximum individual message size in bytes
 ** @(CD2d)@ @maxFrameSize@ is the maximum size for a single frame of data sent to Ably. This restriction applies to a @ProtocolMessage@ sent over a realtime connection, or the total body size for a REST request
 ** @(CD2e)@ @maxInboundRate@ is the maximum allowable number of requests per second from a client or Ably. In the case of a realtime connection, this restriction applies to the number of @ProtocolMessage@ objects sent, whereas in the case of REST, it is the total number of REST requests per second
@@ -1392,7 +1391,6 @@ class ProtocolMessage:
   channelSerial: String? // TR4c
   connectionDetails: ConnectionDetails? // RSA7b3, RTN19, TR4o
   connectionId: String? // RTN15c1, TR4d
-  connectionKey: String? // TR4e
   connectionSerial: Int? // RTN10c, TR4f
   count: Int? // TR4g
   error: ErrorInfo? // RTN15c2, TR4h


### PR DESCRIPTION
This property is now present in the connectionDetails and 0.9 is a good time to remove.

Matching issue to remove in the product when 0.9 is detected, see https://github.com/ably/realtime/issues/802