### PR TITLE
api: WebHook HMAC SHA-256 instructions + demo

### DIFF
--- a/content/code/reactor/webhook-hmac-sha-256.code
+++ b/content/code/reactor/webhook-hmac-sha-256.code
@@ -1,0 +1,67 @@
+[--- Javascript ---]
+$('#check-hmac-btn').on('click', function() {
+  var stripRegex = /^\s+|\s+$/;
+  var body = $('#webhook-body').val().replace(stripRegex, '');
+  var apiKeyParts = $('#api-key').val().replace(stripRegex, '').split(':');
+
+  if (apiKeyParts.length !== 2) {
+    top.alert("API key is not in valid format such as AppID.KeyID:KeySecret");
+    return;
+  }
+
+  var apiVal = apiKeyParts[0];
+  var apiSecret = apiKeyParts[1];
+
+  $('#result').empty();
+  $('#result').append('<li>Key secret: ' + apiSecret + '</li>');
+  var hmacWordArray = CryptoJS.HmacSHA256(body, apiSecret);
+  var hmacBase64 = CryptoJS.enc.Base64.stringify(hmacWordArray);
+  $('#result').append('<li>X-Ably-Signature: ' + hmacBase64 + '</li>');
+});
+[--- /Javascript ---]
+
+[--- HTML ---]
+<html>
+<head>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/hmac-sha256.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/enc-base64.js"></script>
+  <script src="//cdn.ably.io/lib/ably.js"></script>
+</head>
+<body>
+  <h1><a href="https://www.ably.io" target="_blank"><img src="/images/favicon.png">Ably realtime</a> WebHook HMAC validation example</h1>
+  <p>A simple example demonstrating how to validate the authenticity of a signed WebHook request from Ably.</p>
+  <p>
+    <a href="https://www.ably.io/documentation/general/webhooks#security" target="_blank">See the WebHook security documentation for more information on how this HMAC SHA-256 is generated</a>.
+  </p>
+  <input type="text" placeholder="Insert your API key here" id="api-key" style="width: 80%">
+  <br>
+  <textarea type="text" style="width: 100%; height: 10em" placeholder="Insert your the raw text body of the WebHook request received" id="webhook-body"></textarea>
+  <br>
+  <input type="button" value="Check HMAC" id="check-hmac-btn">
+  <br><br>
+  <ul id="result"></ul>
+</body>
+</html>
+  [--- /HTML ---]
+
+[--- CSS ---]
+h1 {
+  font-family: Arial, Sans Serif;
+  font-size: 18px;
+}
+
+body {
+  font-family: Arial, Sans Serif;
+  font-size: 13px;
+}
+
+a, a:visited, a:active {
+  color: #ed760a;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+[--- /CSS ---]

--- a/content/general/versions/v0.8/webhooks.textile
+++ b/content/general/versions/v0.8/webhooks.textile
@@ -232,6 +232,6 @@ In order to verify the signature, you need to do the following:
 
 * start with the webhook request body. This will be a JSON string encoded with content-encoding @utf-8@;
 * identify the key based on the @keyId@ indicated in the @X-Ably-Key@ header;
-* calculate the HMAC of that request body with algorithm AES256 and the key being the corresponding @keyValue@;
+* calculate the HMAC of that request body with algorithm SHA-256 and the key being the corresponding @keyValue@;
 * encode the resulting HMAC using RFC 3548 base 64;
 * compare that result with the signature value indicated in the @X-Ably-Signature@ header

--- a/content/general/webhooks.textile
+++ b/content/general/webhooks.textile
@@ -244,7 +244,7 @@ h4. Example @channel.message@ JSON payload
 
 Please note that if you are planning to receive messages via WebHooks, it is theoretically very easy to exceed the "transport rate limits":#transport we impose on WebHooks to prevent DoS attacks against your own servers. We recommend you consider "message queues":/general/queues instead as they are far more scalable.
 
-h2. Configuring a WebHook
+h2(#configure). Configuring a WebHook
 
 WebHooks are configured in your "account dashboard":https://support.ably.io/solution/articles/3000048664-how-do-i-access-my-account-dashboard. The following fields are available for each configured WebHook:
 
@@ -286,6 +286,15 @@ In order to verify the signature, you need to do the following:
 
 * start with the webhook request body. This will be a JSON string encoded with content-encoding @utf-8@;
 * identify the key based on the @keyId@ indicated in the @X-Ably-Key@ header;
-* calculate the HMAC of that request body with algorithm AES256 and the key being the corresponding @keyValue@;
+* calculate the HMAC of that request body with algorithm SHA-256 and the key being the corresponding @keyValue@ (the secret part of the key after the "@:@");
 * encode the resulting HMAC using RFC 3548 base 64;
 * compare that result with the signature value indicated in the @X-Ably-Signature@ header
+
+h3. WebHook HMAC SHA-256 signature verification example
+
+If you choose to sign your WebHook requests, we recommend you try the following first:
+
+# "Set up a free RequestBin HTTP endpoint test URL":http://requestb.in/
+# "Configure a WebHook":#configure with the URL set to the RequestBin endpoint and ensure you have chosen a key to sign each WebHook request
+# Trigger an event using the Dev Console in your app dashboard which will generate a WebHook. You should then confirm that the WebHook has been received in your RequestBin
+# Check that the @X-Ably-Signature@ header in your WebHook request matches the HMAC SHA-256 you create using our "Javascript HMAC SHA-256 demo":<%= JsBins.url_for('reactor/webhook-hmac-sha-256') %>

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -23,9 +23,6 @@ jsbin_hash:
   CMyVpRUU+KM5hvED3v4N7b2lOxU=: ocodaf
   ZyIss5caeeJ+cpSaLfIPHFh1e+M=: opapoc
   m5oFFFUyk92pE+/HT+E3vj4eaNI=: ovojij
-  RaOZHWONdQ/SHp9zp1ntVNxy5qQ=: imiyeg
-  "/QODmTZZQOuR+1LnMB4pc0n+Vi0=": oyekah
-  49Jgr0l60h2/tUcDQnos3ZZWleU=: ohidof
   DJMTt2LuCaK3Gy3JUJ1VwhT8I28=: exedir
   Oi423Oq5OQFOuA24IPmrLYdlBo4=: ifokom
   y6nV8eTUT8o9fywImMXZA5GloN8=: efulug
@@ -38,6 +35,7 @@ jsbin_hash:
   zNy+aAFPEDw4u2XTVaE57JQQPsc=: equyip
   "+6+xX3++oxaKA3z5HbC6pvdpKDI=": ekafon
   2BVlKC4nL0eGC29JwK4hfMIjXog=: ewagog
+  pw5duE254r4vCBZRry9w8oUD4A4=: etazid
 jsbin_id:
   client-lib-development-guide/example: urUBwIWkiIJIxLBR/bJCTh1h6x8=
   authentication/basic-auth: K3P/Q3XJhTH3IgjXtLpvms6Oxj4=
@@ -74,3 +72,4 @@ jsbin_id:
   rest/publish-on-behalf-of-client: 12RoaIk5Xe8DZfHn6AlZ5kDcsYY=
   adapters/pubnub-pub-sub: YuO2+EE7oigITwEqrbpZKS6sa38=
   adapters/pusher-pub-sub: jQncq6OcBR6KCAsxnz3q5mit6m4=
+  reactor/webhook-hmac-sha-256: pw5duE254r4vCBZRry9w8oUD4A4=


### PR DESCRIPTION
This PR fixes a typo in our WebHooks docs (we previously incorrectly mentioned AES256 instead of SHA-256 for the HMAC algorithm), and also adds some instructions to test the signature verification to help developers check this themselves more easily in their chosen language.

@paddybyers @SimonWoolf you happy for me to merge in?