### PR TITLE
Fix broken ably-js simple encryption example

### DIFF
--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -222,7 +222,7 @@ blang[java,ruby,objc,swift,csharp].
 h4. Example
 
 ```[jsall]
-  Ably.Realtime.Crypto.generateRandomKey(128, function(err, key) {
+  Ably.Realtime.Crypto.generateRandomKey(256, function(err, key) {
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
@@ -232,30 +232,30 @@ h4. Example
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(128)
+  key = Ably::Util::Crypto.generate_random_key(256)
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {cipher: {key: key}})
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(128);
+  byte[] key = Crypto.generateRandomKey(256);
   ChannelOptions options = ChannelOptions.withCipher(key);
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[csharp]
-  byte[] key = Crypto.GenerateRandomKey(keyLength: 128);
+  byte[] key = Crypto.GenerateRandomKey(keyLength: 256);
   var options = new ChannelOptions(key);
   var channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[objc]
-  NSData *key = [ARTCrypto generateRandomKey:128];
+  NSData *key = [ARTCrypto generateRandomKey:256];
   ARTChannelOptions *options = [[ARTChannelOptions alloc] initWithCipherKey:key];
   ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}" options:options];
 ```
 
 ```[swift]
-let key = ARTCrypto.generateRandomKey(128)
+let key = ARTCrypto.generateRandomKey(256)
 let options = ARTChannelOptions(cipherWithKey: key)
 let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options: options)
 ```

--- a/content/realtime/versions/v0.8/encryption.textile
+++ b/content/realtime/versions/v0.8/encryption.textile
@@ -220,7 +220,7 @@ blang[java,ruby,objc,swift,csharp].
 h4. Example
 
 ```[jsall]
-  Ably.Realtime.Crypto.generateRandomKey(128, function(err, key) {
+  Ably.Realtime.Crypto.generateRandomKey(256, function(err, key) {
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
@@ -230,30 +230,30 @@ h4. Example
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(128)
+  key = Ably::Util::Crypto.generate_random_key(256)
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {cipher: {key: key}})
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(128);
+  byte[] key = Crypto.generateRandomKey(256);
   ChannelOptions options = ChannelOptions.withCipher(key);
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[csharp]
-  byte[] key = Crypto.GenerateRandomKey(keyLength: 128);
+  byte[] key = Crypto.GenerateRandomKey(keyLength: 256);
   var options = new ChannelOptions(key);
   var channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[objc]
-  NSData *key = [ARTCrypto generateRandomKey:128];
+  NSData *key = [ARTCrypto generateRandomKey:256];
   ARTChannelOptions *options = [[ARTChannelOptions alloc] initWithCipherKey:key];
   ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}" options:options];
 ```
 
 ```[swift]
-let key = ARTCrypto.generateRandomKey(128)
+let key = ARTCrypto.generateRandomKey(256)
 let options = ARTChannelOptions(cipherWithKey: key)
 let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}", options: options)
 ```

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -31,10 +31,11 @@ h2(#getting-started). Getting started
 "Channels":/rest/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
 
 ```[jsall]
-  var key = Crypto.generateRandomKey();
-  var channelOpts = { cipher: { key: key } };
-  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
-  channel.publish('unencrypted', 'encrypted secret payload');
+  Ably.Rest.Crypto.generateRandomKey(function(err, key) {
+    var channelOpts = { cipher: { key: key } };
+    var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
+    channel.publish('unencrypted', 'encrypted secret payload');
+  });
 ```
 
 ```[ruby]

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -232,7 +232,7 @@ blang[java,ruby,objc,swift,php,python,csharp].
 h4. Example
 
 ```[jsall]
-  Ably.Rest.Crypto.generateRandomKey(128, function(err, key) {
+  Ably.Rest.Crypto.generateRandomKey(256, function(err, key) {
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
@@ -242,40 +242,40 @@ h4. Example
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(128)
+  key = Ably::Util::Crypto.generate_random_key(256)
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', { cipher: {key: key}})
 ```
 
 ```[python]
-  cipher_params = ably.util.crypto.generate_random_key(128)
+  cipher_params = ably.util.crypto.generate_random_key(256)
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', cipher={'key': key})
 ```
 
 ```[php]
-  $key = Ably\Utils\Crypto->generateRandomKey(128);
+  $key = Ably\Utils\Crypto->generateRandomKey(256);
   $channel = $rest->channels->get('{{RANDOM_CHANNEL_NAME}}', array('cipher' => array('key' => $key)));
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(128);
+  byte[] key = Crypto.generateRandomKey(256);
   ChannelOptions options = ChannelOptions.withCipher(key);
   Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[csharp]
-  byte[] key = Crypto.GenerateRandomKey(128);
+  byte[] key = Crypto.GenerateRandomKey(256);
   ChannelOptions options = new ChannelOptions(key);
   var channel = rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[objc]
-  NSData *key = [ARTCrypto generateRandomKey:128];
+  NSData *key = [ARTCrypto generateRandomKey:256];
   ARTChannelOptions *options = [[ARTChannelOptions alloc] initWithCipherKey:key];
   ARTRealtimeChannel *channel = [rest.channels get:@"{{RANDOM_CHANNEL_NAME}}" options:options];
 ```
 
 ```[swift]
-let key = ARTCrypto.generateRandomKey(128)
+let key = ARTCrypto.generateRandomKey(256)
 let options = ARTChannelOptions(cipherWithKey: key)
 let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options: options)
 ```

--- a/content/rest/versions/v0.8/encryption.textile
+++ b/content/rest/versions/v0.8/encryption.textile
@@ -21,10 +21,11 @@ h2(#getting-started). Getting started
 "Channels":/rest/channels-messages can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
 
 ```[jsall]
-  var key = Crypto.generateRandomKey();
-  var channelOpts = { cipher: { key: key } };
-  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
-  channel.publish('unencrypted', 'encrypted secret payload');
+  Ably.Rest.Crypto.generateRandomKey(function(err, key) {
+    var channelOpts = { cipher: { key: key } };
+    var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOpts);
+    channel.publish('unencrypted', 'encrypted secret payload');
+  });
 ```
 
 ```[ruby]

--- a/content/rest/versions/v0.8/encryption.textile
+++ b/content/rest/versions/v0.8/encryption.textile
@@ -222,7 +222,7 @@ blang[java,ruby,objc,swift,php,python,csharp].
 h4. Example
 
 ```[jsall]
-  Ably.Rest.Crypto.generateRandomKey(128, function(err, key) {
+  Ably.Rest.Crypto.generateRandomKey(256, function(err, key) {
     if(err) {
       console.log("Key generation failed: " + err.toString());
     } else {
@@ -232,40 +232,40 @@ h4. Example
 ```
 
 ```[ruby]
-  key = Ably::Util::Crypto.generate_random_key(128)
+  key = Ably::Util::Crypto.generate_random_key(256)
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', { cipher: {key: key}})
 ```
 
 ```[python]
-  cipher_params = ably.util.crypto.generate_random_key(128)
+  cipher_params = ably.util.crypto.generate_random_key(256)
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}', cipher={'key': key})
 ```
 
 ```[php]
-  $key = Ably\Utils\Crypto->generateRandomKey(128);
+  $key = Ably\Utils\Crypto->generateRandomKey(256);
   $channel = $rest->channels->get('{{RANDOM_CHANNEL_NAME}}', array('cipher' => array('key' => $key)));
 ```
 
 ```[java]
-  byte[] key = Crypto.generateRandomKey(128);
+  byte[] key = Crypto.generateRandomKey(256);
   ChannelOptions options = ChannelOptions.withCipher(key);
   Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[csharp]
-  byte[] key = Crypto.GenerateRandomKey(128);
+  byte[] key = Crypto.GenerateRandomKey(256);
   ChannelOptions options = new ChannelOptions(key);
   var channel = rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", options);
 ```
 
 ```[objc]
-  NSData *key = [ARTCrypto generateRandomKey:128];
+  NSData *key = [ARTCrypto generateRandomKey:256];
   ARTChannelOptions *options = [[ARTChannelOptions alloc] initWithCipherKey:key];
   ARTRealtimeChannel *channel = [rest.channels get:@"{{RANDOM_CHANNEL_NAME}}" options:options];
 ```
 
 ```[swift]
-let key = ARTCrypto.generateRandomKey(128)
+let key = ARTCrypto.generateRandomKey(256)
 let options = ARTChannelOptions(cipherWithKey: key)
 let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options: options)
 ```


### PR DESCRIPTION
generateRandomKey() doesn't return a value, it takes a callback.
Plus convert the examples from 128-bit to 256-bit keys