### PR TITLE
Update resource name wildcard docs for latest realtime behaviour

### DIFF
--- a/content/general/authentication.textile
+++ b/content/general/authentication.textile
@@ -158,11 +158,12 @@ See "capability operations":#capability-operations below for the complete set of
 
 h4(#wildcards). Resource names and wildcards
 
-Capabilities are a map from resources to a list of "operations":#capability-operations. Each resource can match a single channel e.g. @channel@, or multiple channels using wildcards (@*@). You can only use wildcards to replace one or more segments (delimited by @:@) of the resource name. For example:
+Capabilities are a map from resources to a list of "operations":#capability-operations. Each resource can match a single channel e.g. @channel@, or multiple channels using wildcards (@*@). Wildcard can only replace whole segments (segments are delimited by @:@) of the resource name. A wildcard at the end of the name can replace arbitrarily many segments. For example:
 
 * A resource of @*@ will match any channel
 * A resource of @namespace:*@ will match any channel in the @namespace@ namespace, including @namespace:channel@, and @namespace:channel:other@
-* A resource of @foo:*:baz@ will match @foo:bar:baz@, @foo:bar:bam:baz@, etc
+* A resource of @foo:*:baz@ will match @foo:bar:baz@, but not @foo:bar:bam:baz@
+* A resource of @foo:*@ will match @foo:bar@, @foo:bar:bam@, @foo:bar:bam:baz@ etc., as the wildcard as at the end
 * A resource of @foo*@ (without a colon!) will only match the single channel literally called @foo*@, which probably isn't what you want
 
 A resource can also be a queue, in which case it will start with @[queue]@, e.g. @[queue]appid-queuename@. (This is unambiguous as channel names may not begin with a @[@). Similar wildcard rules apply, e.g. @[queue]*@ will match all queues.

--- a/content/general/versions/v0.8/authentication.textile
+++ b/content/general/versions/v0.8/authentication.textile
@@ -145,11 +145,12 @@ See "capability operations":#capability-operations below for the complete set of
 
 h4(#wildcards). Resource names and wildcards
 
-Capabilities are a map from resources to a list of "operations":#capability-operations. Each resource can match a single channel e.g. @channel@, or multiple channels using wildcards (@*@). You can only use wildcards to replace one or more segments (delimited by @:@) of the resource name. For example:
+Capabilities are a map from resources to a list of "operations":#capability-operations. Each resource can match a single channel e.g. @channel@, or multiple channels using wildcards (@*@). Wildcard can only replace whole segments (segments are delimited by @:@) of the resource name. A wildcard at the end of the name can replace arbitrarily many segments. For example:
 
 * A resource of @*@ will match any channel
 * A resource of @namespace:*@ will match any channel in the @namespace@ namespace, including @namespace:channel@, and @namespace:channel:other@
-* A resource of @foo:*:baz@ will match @foo:bar:baz@, @foo:bar:bam:baz@, etc
+* A resource of @foo:*:baz@ will match @foo:bar:baz@, but not @foo:bar:bam:baz@
+* A resource of @foo:*@ will match @foo:bar@, @foo:bar:bam@, @foo:bar:bam:baz@ etc., as the wildcard as at the end
 * A resource of @foo*@ (without a colon!) will only match the single channel literally called @foo*@, which probably isn't what you want
 
 A resource can also be a queue, in which case it will start with @[queue]@, e.g. @[queue]appid-queuename@. (This is unambiguous as channel names may not begin with a @[@). Similar wildcard rules apply, e.g. @[queue]*@ will match all queues.


### PR DESCRIPTION
Wildcards now only match multiple segments if at the end of a resource name, see https://github.com/ably/realtime/pull/1027#issuecomment-297261069