### PR TITLE
api: All libs default to 256 bits for Crypto

### DIFF
--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -206,7 +206,7 @@ This call obtains a randomly-generated binary key of the specified key length.
 
 h4. Parameters
 
-- <span lang="default">keyLength</span><span lang="ruby,python">key_length</span> := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to <span language="default">256</span><span language="java">128</span>.
+- <span lang="default">keyLength</span><span lang="ruby,python">key_length</span> := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to 256.
 
 - <div lang="csharp">mode</div> := Optional AES @CipherMode@ which is used when the key is generated
 - <div lang="jsall">callback</div> := is a function of the form @function(err, key)@ which is called upon completion

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -216,7 +216,7 @@ This call obtains a randomly-generated binary key of the specified key length<sp
 
 h4. Parameters
 
-- <span lang="default">keyLength</span><span lang="ruby,python">key_length</span> := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to <span language="default">256</span><span language="java">128</span>.
+- <span lang="default">keyLength</span><span lang="ruby,python">key_length</span> := Optional @Int@ with the length of key to generate. For AES, this should be either 128 or 256. If unspecified, defaults to 256.
 
 - <div lang="csharp">mode</div> := Optional AES @CipherMode@ which is used when the key is generated
 - <div lang="jsall">callback</div> := is a function of the form @function(err, key)@ which is called upon completion

--- a/content/types/_cipher_params.textile
+++ b/content/types/_cipher_params.textile
@@ -10,7 +10,7 @@ h4.
 - <div lang="jsall,ruby,objc,swift,csharp"><span lang="default">key</span><span lang="csharp">Key</span><span lang="ruby">:key</span></div> := A binary (<span lang="java,csharp">@byte[]@</span><span lang="javascript">@ArrayBuffer@ or @WordArray@</span><span lang="nodejs">@Buffer@</span><span lang="ruby">byte array</span><span lang="objc,swift">@NSData@</span>) containing the secret key used for encryption and decryption
 
 - <span lang="default">algorithm</span><span lang="ruby">:algorithm</span><span lang="csharp">Algorithm</span> := _AES_ The name of the algorithm in the default system provider, or the lower-cased version of it; eg "aes" or "AES"<br>__Type: @String@__
-- <span lang="python">key_length</span><span lang="ruby">:key_length</span><span lang="default">keyLength</span><span lang="csharp">KeyLength</span> := <span lang="default">_256_</span><span lang="java">_128_</span> The key length in bits of the cipher, either 128 or 256<br>__Type: @Integer@__
+- <span lang="python">key_length</span><span lang="ruby">:key_length</span><span lang="default">keyLength</span><span lang="csharp">KeyLength</span> := _256_ The key length in bits of the cipher, either 128 or 256<br>__Type: @Integer@__
 - <span lang="default">mode</span><span lang="ruby">:mode</span><span lang="csharp">Mode</span> := _CBC_ The cipher mode<br>__Type: <span lang="default">@String@</span><span lang="csharp">@CipherMode@</span>__
 
 - <div lang="java">keySpec</div> := A @KeySpec@ for the cipher key<br>__Type: @SecretKeySpec@__


### PR DESCRIPTION
See https://github.com/ably/ably-java/pull/329

I have no idea why we left Java with a different default, this fixes that change in the docs.