### PR TITLE
Make it clear that the same-url logic is just an example

### DIFF
--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -344,16 +344,30 @@ h4(#connection-state-recover-options). Connection state recover options
 In @recover@ mode it is necessary to request recovery mode in the "client options":/realtime/usage#client-options when instancing the library. Recovery requires that the library knows the previous connection's "<span lang="default">@recoveryKey@</span><span lang="ruby">@recovery_key@</span><span lang="csharp">@RecoveryKey@</span>":#recovery-key value (which includes both the private unique "<span lang="default">@Connection#key@</span><span lang="csharp">@Connection#Key@</span>":#key and the last message serial received on that connection). As the recovery key is never shared with any other clients, it allows Ably to safely resend message backlogs to the original client.
 
 blang[javascript].
-  In the browser environment, if a callback is provided in the @recover@ option, when the @window.beforeunload@ event fires, the connection details, including the "@recoveryKey@":#recovery-key, are stored in the "browser's sessionStorage":https://www.w3.org/TR/webstorage/. The provided @recover@ callback is then invoked whenever the connection state can be recovered and just before a connection is established, passing in the "@LastConnectionDetails@":#last-connection-details. The callback is then responsible for confirming whether the connection state should be recovered or not. For example, it is common to recover connection state when the page is reloaded but not for different pages the user has navigated to. The callback allows the developer to decide if the connection should be recovered or not at the time the new connection is established by inspecting the "@LastConnectionDetails@":#last-connection-details and evaluating that against any other application state. Below is a straightforward example:
+  In the browser environment, if a callback is provided in the @recover@ option, when the @window.beforeunload@ event fires, the connection details, including the "@recoveryKey@":#recovery-key, are stored in the "browser's sessionStorage":https://www.w3.org/TR/webstorage/. The provided @recover@ callback is then invoked whenever the connection state can be recovered and just before a connection is established, passing in the "@LastConnectionDetails@":#last-connection-details. The callback is then responsible for confirming whether the connection state should be recovered or not. For example, it is common to recover connection state when the page is reloaded but not for different pages the user has navigated to. The callback allows the developer to decide if the connection should be recovered or not at the time the new connection is established by inspecting the "@LastConnectionDetails@":#last-connection-details and evaluating that against any other application state. Below are two examples:
+
+  * **Always recover** - always recover the previous connection state if possible
+
+  ```[jsall]
+    var ably = new Ably.Realtime({
+      authUrl: '/obtainToken',
+      recover: function(_, cb) { cb(true); }
+    });
+  ```
+
+  * **Sometimes recover** - recover the previous connection state conditionally based on some logic
 
   ```[jsall]
     var ably = new Ably.Realtime({
       authUrl: '/obtainToken',
       recover: function(lastConnectionDetails, cb) {
+        /* Only recover if the current path hasn't changed, start a
+         * fresh connection if it has. This is just an example, you
+         * can use whatever logic your app requires */
         if (lastConnectionDetails.location.href === document.location.href) {
-          cb(true); /* recover connection as user has reloaded page */
+          cb(true); /* recover connection */
         } else {
-          cb(false); /* do not recover connection as URL has changed */
+          cb(false); /* do not recover connection */
         }
       }
     });


### PR DESCRIPTION
The trouble with code examples is people ignore the text, assume the code is a recommended pattern and copy and paste it.

e.g. [this intercom conversation](https://app.intercom.io/a/apps/ua39m1ld/respond/inbox/all/conversations/11471199775) just now with a customer who thought that connection state recovery wasn't working because they copied our example code for connection state recovery, which uses an example of only recovering if the url doesn't change, and their url was changing.

This tries to make that clearer, and gives an explicit copyable example for always attempting a recovery.