### PR TITLE
Apply maxMessageSize limit to protocolmessages, not messages, and firm up the definition

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -185,10 +185,11 @@ h3(#rest-channel). Channel
 * @(RSL1)@ @Channel#publish@ function:
 ** @(RSL1a)@ Expects either an array of @Message@ objects or a @name@ string and @data@ payload
 ** @(RSL1b)@ When @name@ and @data@ is provided, a single message is published to Ably
-** @(RSL1c)@ When an array of @Message@ objects is provided, a single request is made to Ably. When publishing multiple messages, this approach is more efficient. However, a yet to be implemented feature should limit the total number of messages bundled in a single POST based on the default max request size, and would reject the publish and indicate an error if any single message exceeds that limit
+** @(RSL1c)@ When an array of @Message@ objects is provided, a single request is made to Ably
 ** @(RSL1d)@ Indicates an error if the message was not successfully published to Ably
 ** @(RSL1e)@ Allows @name@ and or @data@ to be @null@.  If any of the values are @null@, then key is not sent to Ably i.e. a payload with a @null@ value for @data@ would be sent as follows @{ "name": "click" }@
 ** @(RSL1f)@ Unidentified clients using "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication (i.e. any @clientId@ is permitted as no @clientId@ specified):
+** @(RSL1g)@ If the total size of the message or (if publishing an array) messages, calculated per "TO3l7":#TO3l7, exceeds the @maxMessageSize@, then the client library should reject the publish and indicate an error
 *** @(RSL1f1)@ When a @Message@ with a @clientId@ value is published, Ably will accept and publish that message with the provided @clientId@. A test should assert via the history API that the @clientId@ of the published @Message@ is populated
 ** @(RSL1g)@ Identified clients with a @clientId@ (as a result of either an explicitly configured @clientId@ in @ClientOptions@, or implicitly through Token Auth):
 *** @(RSL1g1)@ When publishing a @Message@ with the @clientId@ attribute set to @null@:
@@ -452,18 +453,20 @@ h3(#realtime-channel). Channel
 ** @(RTL5f)@ Once a @DETACH@ @ProtocolMessage@ is sent, if a @DETACHED@ @ProtocolMessage@ is not received within the "default realtime request timeout":#defaults, the detach request should be treated as though it has failed and the channel will return to its previous state
 ** @(RTL5e)@ If the language permits, a callback can be provided that is called when the channel is detached successfully or the detach fails and the @ErrorInfo@ error is passed as an argument to the callback
 * @(RTL6)@ @Channel#publish@ function:
-** @(RTL6a)@ Messages are encoded in the same way as the REST @Channel#publish@ method
+** @(RTL6a)@ Messages are encoded in the same way as the REST @Channel#publish@ method, and "RSL1g":#RSL1g (size limit) applies similarly
 ** @(RTL6b)@ An optional callback can be provided to the @#publish@ method that is called when the message is successfully delivered or upon failure with the appropriate @ErrorInfo@ error. A test should exist to publish lots of messages on a few connections to ensure all message success callbacks are called for all messages published
 ** @(RTL6i)@ Expects either an array of @Message@ objects or a @name@ string and @data@ payload:
 *** @(RTL6i1)@ When @name@ and @data@ is provided, a single @ProtocolMessage@ containing one @Message@ is published to Ably
-*** @(RTL6i2)@ When an array of @Message@ objects is provided, a single @ProtocolMessage@ is used to publish all @Message@ objects in the array. However, a yet to be implemented feature should limit the total number of messages bundled in a single ProtocolMessage based on the default max message size
+*** @(RTL6i2)@ When an array of @Message@ objects is provided, a single @ProtocolMessage@ is used to publish all @Message@ objects in the array.
 *** @(RTL6i3)@ Allows @name@ and or @data@ to be @null@.  If any of the values are @null@, then key is not sent to Ably i.e. a payload with a @null@ value for @data@ would be sent as follows @{ "name": "click" }@
 ** @(RTL6c)@ Connection and channel state conditions:
 *** @(RTL6c1)@ If the connection is @CONNECTED@ and the channel is @INITIALIZED@, @ATTACHED@, @DETACHED@, @ATTACHING@, or @DETACHING@ then the messages are published immediately
 *** @(RTL6c2)@ If the connection is @INITIALIZED@, @CONNECTING@ or @DISCONNECTED@, and @ClientOptions#queueMessages@ has not been explicitly set to false, then the message will be queued and delivered as soon as the connection is @CONNECTED@ and the channel is in a state in which publishing is permitted per @RTL6c1@
 *** @(RTL6c4)@ If the connection is @SUSPENDED@, @CLOSING@, @CLOSED@, or @FAILED@, or the channel is @SUSPENDED@ or @FAILED@, the operation will result in an error
 *** @(RTL6c5)@ A publish should not trigger an implicit attach (in contrast to earlier version of this spec)
-** @(RTL6d)@ Messages are delivered using a single @ProtocolMessage@ where possible by bundling in all messages for that channel into the @ProtocolMessage#messages@ array. However, a yet to be implemented feature should limit the total number of messages bundled per @ProtocolMessage@ based on the default max message size, and would reject the publish and indicate an error if any single message exceeds that limit
+** @(RTL6d)@ Messages for a single channel that have been queued may be sent in a single @ProtocolMessage@ by bundling them into the @ProtocolMessage#messages@ array, subject to the following constraints:
+*** @(RTL6d1)@ The resulting @ProtocolMesssage@ must not exceed the @maxMessageSize@
+*** @(RTL6d2)@ Messages with differing @clientId@ values must not be bundled together
 ** @(RTL6e)@ Unidentified clients using "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication (i.e. any @clientId@ is permitted as no @clientId@ specified):
 *** @(RTL6e1)@ When a @Message@ with a @clientId@ value is published, Ably will accept and publish that message with the provided @clientId@. A test should assert that the @clientId@ of the published @Message@ is populated
 ** @(RTL6g)@ Identified clients with a @clientId@ (as a result of either an explicitly configured @clientId@ in @ClientOptions@, or implicitly through Token Auth):
@@ -1119,8 +1122,8 @@ h4. ConnectionDetails
 * @(CD2)@ Attributes available in @ConnectionDetails@:
 ** @(CD2a)@ @clientId@ contains the client ID assigned to the token. If @clientId@ is @null@ or omitted, then the client is prohibited from assuming a @clientId@ in any operations, however if @clientId@ is a wildcard string @'*'@, then the client is permitted to assume any @clientId@. Any other string value for @clientId@ implies that the @clientId@ is both enforced and assumed for all operations from this client
 ** @(CD2b)@ @connectionKey@ is the connection secret key string that is used to resume a connection and its state.
-** @(CD2c)@ @maxMessageSize@ is the maximum individual message size in bytes
-** @(CD2d)@ @maxFrameSize@ is the maximum size for a single frame of data sent to Ably. This restriction applies to a @ProtocolMessage@ sent over a realtime connection, or the total body size for a REST request
+** @(CD2c)@ @maxMessageSize@ overrides the default @maxMessageSize@ ("TO3l7":#TO3l7)
+** @(CD2d)@ @maxFrameSize@ overrides the default @maxFrameSize@ ("TO3l8":#TO3l8)
 ** @(CD2e)@ @maxInboundRate@ is the maximum allowable number of requests per second from a client or Ably. In the case of a realtime connection, this restriction applies to the number of @ProtocolMessage@ objects sent, whereas in the case of REST, it is the total number of REST requests per second
 ** @(CD2f)@ @connectionStateTtl@ is the duration that Ably will persist the connection state when a Realtime client is abruptly disconnected
 ** @(CD2g)@ @serverId@ string is a unique identifier for the front-end server that the client has connected to. This server ID is only used for the purposes of debugging
@@ -1174,6 +1177,13 @@ h4. ClientOptions
 *** @(TO3l4)@ @httpRequestTimeout@ integer - default 10,000 (10s). Timeout for any single HTTP request and response
 *** @(TO3l5)@ @httpMaxRetryCount@ integer - default 3. Max number of fallback hosts to use as a fallback when an HTTP request to the primary host is unreachable or indicates that it is unserviceable
 *** @(TO3l6)@ @httpMaxRetryDuration@ integer - default 15,000 (15s). Max elapsed time in which fallback host retries for HTTP requests will be attempted i.e. if the first default host attempt takes 7s, and then the subsequent fallback retry attempt takes 10s, no further fallback host attempts will be made as the total elapsed time of 17s exceeds the default 15s limit
+*** @(TO3l7)@ @maxMessageSize@ integer - default 65536 (64kB). The maximum size of messages that can be published in one go. That is, the size of the @ProtocolMessage.messages@ or @ProtocolMessage.presence@ array for a realtime publish or presence action, or the message or array of messages being published for a REST publish. For realtime publishes, the default will be overridden by the @maxMessageSize@ in the @connectionDetails@, see "CD2c":#CD2c
+**** @(TO3l7a)@ The size is defined as the sum over all messages being published of the message @name@, @data@, @clientId@, and @extras@
+**** @(TO3l7b)@ The size of an @Object@ or @Array@ @data@ property is its string length after being JSON-stringified
+**** @(TO3l7c)@ The size of a @binary@ @data@ property is its size in bytes (of the actual binary, not the base64 representation, regardless of whether the binary protocol is in use)
+**** @(TO3l7d)@ The size of the @extras@ property is the string length of its JSON representation
+**** @(TO3l7e)@ The size of a @null@ or omitted property is zero
+*** @(TO3l8)@ @maxFrameSize@ integer - default 524288 (512kB). The maximum size of a single POST body or WebSocket frame. This is mostly only relevant for `Rest#request` (e.g. for batch publishes), since publishes will hit the @maxMessageSize@ limit before this
 
 h4(#token-params). TokenParams
 * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorize@, @Auth#requestToken@ and @Auth#createTokenRequest@
@@ -1310,13 +1320,15 @@ class ClientOptions:
   useBinaryProtocol: Bool default true // TO3f
   transportParams: [String: Stringifiable]? // RTC1f
   // configurable retry and failure defaults
-  disconnectedRetryTimeout: Duration default 15s // TO311
-  suspendedRetryTimeout: Duration default 30s // RTN14d, TO312
+  disconnectedRetryTimeout: Duration default 15s // TO3l1
+  suspendedRetryTimeout: Duration default 30s // RTN14d, TO3l2
   channelRetryTimeout: Duration default 15s // RTL13b, TO3l7
-  httpOpenTimeout: Duration default 4s // TO313
-  httpRequestTimeout: Duration default 10s // TO314
-  httpMaxRetryCount: Int default 3 // TO315
-  httpMaxRetryDuration: Duration default 15s // TO315
+  httpOpenTimeout: Duration default 4s // TO3l3
+  httpRequestTimeout: Duration default 10s // TO3l4
+  httpMaxRetryCount: Int default 3 // TO3l5
+  httpMaxRetryDuration: Duration default 15s // TO3l6
+  maxMessageSize: Int default 65536 // TO3l7
+  maxFrameSize: Int default 524288 // TO3l8
 
 class AuthOptions: // RSA8e
   authCallback: (() -> io (String | TokenDetails | TokenRequest))? // RSA4a, RSA4, TO3j5, AO2b


### PR DESCRIPTION
Context: https://github.com/ably/wiki/issues/222#issuecomment-334567652