### PR TITLE
Fixes some iOS Swift docs (handles renames)

### DIFF
--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -77,7 +77,7 @@ bc[objc]. ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 }];
 
 bc[swift]. let realtime = ARTRealtime(key: "{{API_KEY}}")
-realtime.connection.on(.Connected) { change in
+realtime.connection.on(.connected) { change in
     print("Connected, that was easy")
 }
 

--- a/content/realtime/push/activate-subscribe.textile
+++ b/content/realtime/push/activate-subscribe.textile
@@ -109,7 +109,7 @@ You should now have a couple of methods: <span lang="swift">"@application(_:didR
 ```[swift]
 // In your UIApplicationDelegate class:
 func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    ARTPush.didRegisterForRemoteNotificationsWithDeviceToken(deviceToken, realtime: self.getAblyRealtime())
+    ARTPush.didRegisterForRemoteNotifications(withDeviceToken: deviceToken, realtime: self.getAblyRealtime())
 }
 
 func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {


### PR DESCRIPTION
Looks like the Swift docs were slightly out of date?
(certainly not an iOS expert here)