### PR TITLE
Changed .on to .subscribe

### DIFF
--- a/content/realtime/presence.textile
+++ b/content/realtime/presence.textile
@@ -144,12 +144,12 @@ In addition to the <span lang="default">"@clientId@":/realtime/usage#client-id</
 
 ```[jsall]
 /* Subscribe to presence enter events */
-channel.presence.on('enter', function(member) {
+channel.presence.subscribe('enter', function(member) {
   console.log(member.data); // => not moving
 });
 
 /* Subscribe to presence update events */
-channel.presence.on('update', function(member) {
+channel.presence.subscribe('update', function(member) {
   console.log(member.data); // => travelling North
 });
 


### PR DESCRIPTION
Using .on throws a warning of eminent depreciation, which can be concerning for new users (see https://app.intercom.io/a/apps/ua39m1ld/inbox/inbox/all/conversations/14795960096). Changed to .subscribe.