### PR TITLE
Various gramatical changes to the token auth tutorial

### DIFF
--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -236,7 +236,7 @@ blang[java].
     }
   ```
 
-  Finally you'll add the following method to your @Example.java@ class:
+  Finally you need to add the following method to your @Example.java@ class:
 
   ```[java]
   @RestController
@@ -262,7 +262,7 @@ blang[java].
 blang[nodejs,android].
   "Express.js":https://expressjs.com/ is a very popular and simple web framework for Node.js. You'll need to get this setup:
 
-  First you'll need to add the @express@ NPM module and create a @package.json@ file:
+  Firstly you need to add the @express@ NPM module and create a @package.json@ file:
 
   ```[json]
   {
@@ -282,7 +282,7 @@ blang[nodejs,android].
   }
   ```
 
-  Then you'll need to set up a vanilla HTTP Express.js server in @server.js@:
+  Then you need to set up a vanilla HTTP Express.js server in @server.js@:
 
   ```[nodejs]
     const express = require('express'),
@@ -416,10 +416,10 @@ Token requests, unlike tokens, are created and signed by your server without hav
 
 Therefore, as it is possible to issue token requests without any communication with Ably (in the form of an HTTP request), we recommend that when a client needs to authenticate, you provide a signed token request. This approach minimizes the amount of work your server needs to do by distributing the task of obtaining a token from the Ably service using the token request to your clients instead.
 
-In this step you will get the local web server ready to respond to authentication requests by issuing a token request to the requesting client.
+In this step we will get the local web server ready to respond to authentication requests by issuing a token request to the requesting client.
 
 blang[java].
-  By adding the following route to the @Example.java@ class, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following route to the @Example.java@ class, it will be ready to service clients wanting to authenticate with Ably.
 
   ```[java]
     @RequestMapping("/auth")
@@ -454,7 +454,7 @@ blang[java].
   "See this step in Github":https://github.com/ably/tutorials/commit/4828df8
 
 blang[nodejs,android].
-  By adding the following route to your Express.js server, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following route to your Express.js server, it will be ready to service clients wanting to authenticate with Ably.
 
   ```[nodejs]
     /* Issue token requests to clients sending a request to the /auth endpoint */
@@ -489,7 +489,7 @@ blang[android].
   "See this step in Github":https://github.com/ably/tutorials/commit/2614bfe
 
 blang[ruby].
-  By adding the following route to your server, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following route to your server, it will be ready to service clients wanting to authenticate with Ably.
 
   ```[ruby]
     require 'json'
@@ -517,7 +517,7 @@ blang[ruby].
   "See this step in Github":https://github.com/ably/tutorials/commit/5575d73
 
 blang[python].
-  By adding the following class and route to your urls, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following class and route to your urls, it will be ready to service clients wanting to authenticate with Ably.
 
   ```[python]
     import json
@@ -551,7 +551,7 @@ blang[python].
   "See this step in Github":https://github.com/ably/tutorials/commit/7841d7e
 
 blang[php].
-  By adding the following script, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following script, it will be ready to service clients wanting to authenticate with Ably.
 
   Create @auth.php@ script:
 
@@ -582,20 +582,20 @@ h2.
   android: Step 5 – Setting up environment and client to use token authentication
   swift: Step 5 - Setup an Xcode project and prepare the client to use token authentication
 
-Now that you have a web server running and an authentication endpoint, you are ready to set up the Ably Realtime client that uses token auth.
+Now that we have a web server running and an authentication endpoint, we are ready to set up the Ably Realtime client that uses token auth.
 
 blang[java].
-  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the @src/main/webapp@ folder:
+  Firstly you need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the @src/main/webapp@ folder:
 blang[android].
-  First you'll need to create a simple Android project that will be served by the web server. To build your own Android Project, please visit the "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with the steps necessary to set up your own application. When the project is ready, open your application's module and modify its @build.gradle@ file like this:
+  Firstly you need to create a simple Android project that will be served by the web server. To build your own Android Project, please visit the "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with the steps necessary to set up your own application. When the project is ready, open your application's module and modify its @build.gradle@ file like this:
 blang[nodejs].
-  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.js@:
+  Firstly you need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.js@:
 blang[ruby].
-  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.rb@:
+  Firstly you need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.rb@:
 blang[php].
-  First you'll need to set up a simple HTML page that will be served by the web server. Replace the contents of @index.php@ with the code below:
+  Firstly you need to set up a simple HTML page that will be served by the web server. Replace the contents of @index.php@ with the code below:
 blang[python].
-  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.py@:
+  Firstly you need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.py@:
 blang[nodejs,ruby,php,python,java].
   ```[html]
   <html>
@@ -618,7 +618,7 @@ blang[android].
   }
   ```
 
-  In the above example a specific version of the library is referenced, however we recommend you check which is the latest stable version and always use that. Follow link to get the latest stable release for "Android":https://bintray.com/ably-io/ably/ably-android.
+  In the above example a specific version of the library is referenced, however we recommend you check which is the "latest stable version for Android":https://bintray.com/ably-io/ably/ably-android and always use that.
 
   After you add necessary dependencies, you can import the AblyRealtime class into your @ExampleActivity@ and initialize it.
 
@@ -673,7 +673,7 @@ blang[java].
   Try restarting your server again and visit "http://localhost:3000/":http://localhost:3000/ to ensure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[nodejs,android].
-  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @get '/' do ... end@) with the following:
+  Now you need to serve a static home page. Replace the code that responds to the @/@ route (look for @get '/' do ... end@) with the following:
 
   ```[nodejs]
     app.use('/', express.static(__dirname));
@@ -781,9 +781,9 @@ blang[php].
   ```
 
 blang[php,ruby,nodejs,python,java].
-  Time to see what happens now. Restart the local server and refresh the page. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
+  Time for us to see what happens now. Restart the local server and refresh the page. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 blang[android].
-  Time to see what happens now. Restart the local server and rerun your application. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
+  Time for us to see what happens now. Restart the local server and rerun your application. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
 blang[android].
   "See this step in Github":http://github.com/ably/tutorials/commit/ae636ad
@@ -850,7 +850,7 @@ blang[swift].
   ```
 
   Now it's time to set up a Realtime client that uses token authentication.
-  First you'll need to create a new method that will try to connect us to Ably.
+  Firstly you need to create a new method that will try to connect us to Ably.
   By using @authCallback@ you don't have to worry if the user already has a clientId.
 
   ```[swift]
@@ -923,24 +923,24 @@ blang[swift].
     <img src="/images/tutorials/tutorials-swift-info.plist.png" style="width: 100%" alt="info.plist">
   </a>
 
-  Time to see what happens now. Execute the code in a simulator. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
+  Time for us to see what happens now. Execute the code in a simulator. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
   "See this step in Github":https://github.com/ably/tutorials/commit/6498081
 
-You've now covered the basics of client-server token authentication and your client has a means to renew the token whenever it needs one.
+We've now covered the basics of client-server token authentication and your client has a means to renew the token whenever it needs one.
 
 h2. Step 6 - Authenticating logged in users
 
 In the previous step we saw how easy it is to issue a token request from your server for clients that need to authenticate with Ably. However, the example is quite contrived in that it is unlikely you would want to issue tokens to anonymous users with a full set of capabilities. At present, the token issued allows all users to publish, subscribe, be present, retrieve stats and history across all channels.
 
 blang[android].
-  In this step you'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your mobile app, you will be implementing a trivial and clearly flawed authentication system so that you can keep superfluous unrelated code to a minimum.
+  In this step we'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your mobile app, we will be implementing a trivial and clearly flawed authentication system so that we can keep superfluous unrelated code to a minimum.
 
 blang[java,php,nodejs,python,ruby].
-  n this step you'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your website, you will be implementing a trivial and clearly flawed authentication system so that you can keep superfluous unrelated code to a minimum.
+  In this step we'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your website, we will be implementing a trivial and clearly flawed authentication system so that we can keep superfluous unrelated code to a minimum.
 
 blang[android].
-  Time to get started. First you will add an EditText element and a Button element into our layout, creating simple login form. Add the following into the @activity_example.xml@ file:
+  Time to get started. Firstly you will add an EditText element and a Button element into our layout, creating simple login form. Add the following into the @activity_example.xml@ file:
 
   ```[xml]
     <?xml version="1.0" encoding="utf-8"?>
@@ -981,7 +981,7 @@ blang[android].
   ```
 
 blang[nodejs,ruby,python,java].
-  Time to get started. First you will add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.html@ file:
+  Time to get started. Firstly you will add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.html@ file:
 
   ```[html]
     <div id="panel-anonymous">
@@ -997,7 +997,7 @@ blang[nodejs,ruby,python,java].
   ```
 
 blang[php].
-  Time to get started. First you'll need to add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
+  Time to get started. Firstly you will need to add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
 
   ```[html]
     <div id="panel-anonymous">
@@ -1013,7 +1013,7 @@ blang[php].
   ```
 
 blang[java].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll need to create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @Example.java@ file.
+  Now we need to enable the login and logout functionality in your web server. In order to keep this tutorial simple, when a user logs in we'll create a cookie, and when they log out we'll clear the cookie. Add the following routes to your @Example.java@ file.
 
   ```[java]
     @RequestMapping(value = "/login", method = RequestMethod.GET)
@@ -1040,7 +1040,7 @@ blang[java].
   ```
 
 blang[nodejs].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll need to create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @server.js@ file.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll need to create a cookie, and when they log out we'll clear the cookie. Add the following routes to your @server.js@ file.
 
   ```[nodejs]
     /* Set a cookie when the user logs in */
@@ -1064,7 +1064,7 @@ blang[nodejs].
   ```
 
 blang[android].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, you'll add a @username@ query parameter to the @/auth@ route. If it exists, it means user wants to log in, and if it doesn't they want to log out. Modify @/auth@ route in you @server.js@ file.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, you'll add a @username@ query parameter to the @/auth@ route. If it exists, it means user wants to log in, and if it doesn't they want to log out. Modify the @/auth@ route in you @server.js@ file.
 
   ```[nodejs]
     var tokenParams;
@@ -1081,7 +1081,7 @@ blang[android].
   ```
 
 blang[ruby].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
 
   You'll need to add cookie support to Sinatra, so add the following to your @Gemfile@ and @bundle install@:
 
@@ -1116,7 +1116,7 @@ blang[ruby].
   ```
 
 blang[python].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
 
   Add the following classes to your @server.py@ file.
 
@@ -1147,7 +1147,7 @@ blang[python].
   ```
 
 blang[php].
-  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
 
   You'll need to create two scripts that will serve as your login and logout functionality.
 
@@ -1173,7 +1173,7 @@ blang[php].
   ```
 
 blang[android].
-  Let's add logged in and logged out states for our layout. To switch between them, you'll need to add logic into our @ExampleActivity@. Add the following inside your class:
+  Let's add logged in and logged out states for our layout. To switch between them, you'll need to add logic into your @ExampleActivity@. Add the following inside your class:
 
   ```[java]
     private TextView tvCapabilities;
@@ -1331,7 +1331,7 @@ blang[nodejs].
     }
   ```
 
-  Unfortunately Express.js is very lightweight and does not support cookie parsing out of the box. You'll need to add the @cookie-parser@ NPM module to Express.js. Add the following to your @package.json@ file:
+  Unfortunately Express.js is very lightweight and does not support cookie parsing out of the box. You need to add the @cookie-parser@ NPM module to Express.js. Add the following to your @package.json@ file:
 
   ```[json]
   {
@@ -1461,13 +1461,13 @@ blang[nodejs,python,java,php,ruby].
   ```
 
 blang[android].
-  Ok, you're ready to see all of this in action. Restart the local server @node server.js@ and then rerun your application. You should receive a Toast message to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server @node server.js@ and then rerun your application. You should receive a Toast message to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[java].
-  Ok, you're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[swift].
-  Time to get started. You will need to check if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
+  Time to get started. We will need to check if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
 
   ```[ruby]
     # Issue token requests to clients sending a request to the /auth endpoint
@@ -1493,9 +1493,9 @@ blang[swift].
       end
   ```
 
-  Now you will need to customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
+  Now we will need to customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
 
-  First you will need to add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
+  Firstly we will need to add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
 
   <a href="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" style="width: 100%" alt="Bind action">
@@ -1520,7 +1520,7 @@ blang[swift].
 
   To define the flow between the @ExampleViewController@ and the @LogoutViewController@ you will need to use segues. If you are not familiar with them, please refer to the "Apple developer guide":https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html on how they work.
 
-  First in your @Storyboard@ add a new "Present Modally" action segue. Name it "logoutSegue".
+  Firstly in your @Storyboard@ add a new "Present Modally" action segue. Name it "logoutSegue".
 
   <a href="/images/tutorials/tutorials-swift-create-segue.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-create-segue.gif" style="width: 60%" alt="Create segue">
@@ -1534,7 +1534,7 @@ blang[swift].
     }
   ```
 
-  Then you'll need to change the action that is performed when the user clicks on "OK" when the alert is shown. Change this line:
+  Now you need to change the action that is performed when the user clicks on "OK" when the alert is shown. Change this line:
 
   ```[swift]
     alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil)
@@ -1552,7 +1552,7 @@ blang[swift].
                   }))
   ```
 
-  Now, you'll need to change the method that connects us to Ably. If the user doesn't provide their username then you shouldn't pass any parameters to your server. Equally when the textfield is filled you'll need to its contents as the username.
+  Now you need to change the method that connects us to Ably. If the user doesn't provide their username then you shouldn't pass any parameters to your server. Equally when the textfield is filled you'll need to use its contents as the username.
 
   ```[swift]
     private func connectToAbly() {
@@ -1593,7 +1593,7 @@ blang[swift].
     }
   ```
 
-  You will also need to update the @getTokenRequest@ method so that it will use the correct URL request:
+  You also need to update the @getTokenRequest@ method so that it will use the correct URL request:
 
   ```[swift]
     func getTokenRequest(params: NSURL, completion: (NSDictionary?, ErrorType?) -> ())  {
@@ -1649,19 +1649,19 @@ blang[swift].
         }
   ```
 
-  You're now ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then restart your simulation. Now when you tap on login you should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  We're now ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then restart your simulation. Now when you tap on login you should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[nodejs].
-  Ok, you're ready to see all of this in action. Restart the local server @node server.js@ and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server @node server.js@ and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[ruby].
-  Ok, you're ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then refresh the page at "http://localhost:4567/":http://localhost:4567/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then refresh the page at "http://localhost:4567/":http://localhost:4567/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[python].
-  Ok, you're ready to see all of this in action. Restart the local server @python server.py@ and then refresh the page at "http://localhost:8080/":http://localhost:8080/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server @python server.py@ and then refresh the page at "http://localhost:8080/":http://localhost:8080/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[php].
-  Ok, you're ready to see all of this in action. Restart the local server @php -S 0.0.0.0:8000@ and then refresh the page at "http://localhost:8000/":http://localhost:8000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
+  Ok, we're ready to see all of this in action. Restart the local server @php -S 0.0.0.0:8000@ and then refresh the page at "http://localhost:8000/":http://localhost:8000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 blang[java,nodejs,php,python,ruby].
   <a href="/images/tutorials/token-authentication-anonymous.png" target="_blank">
     <img src="/images/tutorials/token-authentication-anonymous.png" style="width: 457px" alt="Token auth details for anonymous">
@@ -1706,7 +1706,7 @@ blang[php].
 blang[swift].
   "See this step in Github":https://github.com/ably/tutorials/commit/439a0a8
 
-You've covered a lot of ground in this tutorial. However authentication is one of the more challenging aspects to understand as it requires you to have a good overall understanding of how it all works. We strongly recommend you check out the links below for essential further reading to help you understand authentication in more detail for use in your servers and apps.
+We've covered a lot of ground in this tutorial. However authentication is one of the more challenging aspects to understand as it requires you to have a good overall understanding of how it all works. We strongly recommend you check out the links below for essential further reading to help you understand authentication in more detail for use in your servers and apps.
 
 h2. Download tutorial source code
 

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -2,15 +2,23 @@
 title: Client & Server Token Authentication Tutorial
 section: tutorials
 index: 50
+languages:
+  - java
+  - android
+  - python
+  - php
+  - ruby
+  - nodejs
+  - swift
 ---
 
 Ably supports two types of authentication schemes. Basic authentication uses one of your private API keys and is the simplest scheme designed for use by your servers. Token authentication is mostly used by your device and browser clients whereby a short-lived secure token is issued to them by your servers.
 
-Most of our "other tutorials":/tutorials demonstrate the use of the simple "basic authentication scheme":/general/authentication#basic-authentication. In this tutorial we are focussing how you can use the recommended "token authentication scheme":/general/authentication#token-authentication for your un-trusted clients.
+Most of our "other tutorials":/tutorials demonstrate the use of the simple "basic authentication scheme":/general/authentication#basic-authentication. In this tutorial we are focusing on how you can use the recommended "token authentication scheme":/general/authentication#token-authentication for your untrusted clients.
 
-It is important to bear in mind that when using token authentication, unlike with basic authentication, the client should not be given a token at time is instanced. This is because the token will expire. Instead, the client should be configured with a means to obtain a token whenever it needs to authenticate with Ably. As tokens typically expire every hour, which minimises the impact of compromise on a client device or browser, it is necessary that the client can obtain a new token to authenticate whenever the token expires or needs refreshing.
+Tokens typically expire within an hour of creation, which helps reduce the impact of a compromised client device or browser by restricting how long it is authenticated. This means that the client should not be provided with a token simply at the time of instancing, but rather be configured with a means to obtain a token whenever it needs to authenticate with Ably.
 
-Let's get started and show you a typical client server architecture using token authentication.
+Let's get started and show you a typical client-server architecture using token authentication.
 
 <%= partial 'tutorials/_step-1-setup-free-account' %>
 
@@ -31,7 +39,7 @@ blang[java].
 
   In the above example a specific version of the library is referenced, however we recommend you check which is the latest stable version and always use that. Follow link to get the latest stable release for "Java":https://bintray.com/ably-io/ably/ably-java.
 
-  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where risk of compromise of your API key credentials is low.
+  The server-client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where the risk of compromise of your API key credentials is low.
 
   Add the following to a file named @Example.java@ to instance the Ably library inside your Node.js server:
 
@@ -62,7 +70,7 @@ blang[nodejs,android].
     npm install ably
   ```
 
-  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where risk of compromise of your API key credentials is low.
+  The server-client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where the risk of compromise of your API key credentials is low.
 
   Add the following to a file named @server.js@ to instance the Ably library inside your Node.js server:
 
@@ -88,9 +96,9 @@ blang[ruby].
     gem 'ably'
   ```
 
-  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where risk of compromise of your API key credentials is low.
+  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where the risk of compromise of your API key credentials is low.
 
-  As we do not need asynchronous access to the realtime API for this tutorial, we'll be using the simpler "REST client library":/rest.
+  As you do not need asynchronous access to the realtime API for this tutorial, you'll be using the simpler "REST client library":/rest.
 
   ```[ruby]
     require 'ably'
@@ -113,24 +121,24 @@ blang[python].
     client = AblyRest(api_key)
   ```
 
-  For the purpose of this tutorial let's create @server.py@ file with the code above, we'll be using this file as base later on.
+  For the purpose of this tutorial, create a file called @server.py@ containing the code above. You'll be using this file later on.
 
   h4. Note on string encodings
 
-  Since Ably supports both string and binary payloads, to avoid ambiguity, we recommend that strings passed to the library for publishing to Ably (eg as an event name or payload data) should be unicode strings. In Python 3 this is the normal string type, but in Python 2 it is not, so we suggest you prefix string literals with @u@ prefix (eg @u'eventname'@ - or alternatively, use @from __future__ import unicode_literals@, which will make this automatic), and to explicitly decode any user input (eg @raw_input().decode(sys.stdin.encoding@).
+  Since Ably supports both string and binary payloads, we recommend that strings passed to the library for publishing to Ably be unicode strings (e.g. event names or payload data). This is to avoid ambiguity regarding the type of payload. In Python 3 this is the normal string type, but in Python 2 it is not, so we suggest you prefix string literals with the @u@ prefix (eg @u'eventname'@ - or alternatively, use @from __future__ import unicode_literals@, which will make this automatic), and to explicitly decode any user input (e.g. @raw_input().decode(sys.stdin.encoding@).
 
   "See this step in Github":https://github.com/ably/tutorials/commit/aff9d58
 
 blang[php].
-  To start using Ably you first need to install "composer package on packagist":https://packagist.org/packages/ably/ably-php into your composer.
+  To start using Ably you first need to install the "composer package on packagist":https://packagist.org/packages/ably/ably-php into your composer.
 
   ```[sh]
     composer require ably/ably-php --update-no-dev
   ```
 
-  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where risk of compromise of your API key credentials is low.
+  The server-client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where the risk of compromise of your API key credentials is low.
 
-  Create @public@ directory, it will serve as document root. Add the following to a file named @ably.php@ to instance the Ably library inside your php script:
+  Create a directory called @public@, which will serve as the document root. Add the following to a file named @ably.php@ to instance the Ably library inside your php script:
 
   ```[php]
     require_once __DIR__ . '/../vendor/autoload.php';
@@ -140,7 +148,7 @@ blang[php].
   "See this step in Github":https://github.com/ably/tutorials/commit/cd12634
 
 blang[swift].
-  For this Swift example, we need a web server to generate token requests. We will be using Ruby for the server in this tutorial. To start using Ably with Ruby, you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
+  For this Swift example, you need a web server to generate token requests. You will be using Ruby for the server in this tutorial. To start using Ably with Ruby, you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
 
   ```[sh]
     gem install ably
@@ -152,9 +160,9 @@ blang[swift].
     gem 'ably'
   ```
 
-  The server client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where risk of compromise of your API key credentials is low.
+  The server-client library must be instanced with the private API key you copied in Step 1. This will ensure that the "basic authentication scheme":/general/authentication#basic-authentication is used, which is almost always the right choice for your own trusted servers where the risk of compromise of your API key credentials is low.
 
-  As we do not need asynchronous access to the realtime API for this tutorial, we'll be using the simpler "REST client library":/rest.
+  As you do not need asynchronous access to the realtime API for this tutorial, you'll be using the simpler "REST client library":/rest.
 
   ```[ruby]
     require 'ably'
@@ -165,14 +173,14 @@ blang[swift].
 
 h2. Step 3 - Set up your web server
 
-Before a client connects to Ably, it will check if it has suitable credentials to authenticate with Ably. As we'll be using the recommended "token authentication scheme":/general/authentication#token-authentication in the client for this demo, when the client starts up and attempt to connect to Ably, it will request a token immediately so that it can then authenticate with Ably.
+Before a client connects to Ably, it will check if it has suitable credentials to authenticate with Ably. As you'll be using the recommended "token authentication scheme":/general/authentication#token-authentication in the client for this demo, when the client starts up and attempts to connect to Ably, it will request a token immediately so that it can then authenticate with Ably.
 
-As tokens are typically issued from your own web servers, we'll set up a simple web server now for this tutorial.
+As tokens are typically issued from your own web servers, you'll set up a simple web server now for this tutorial.
 
 blang[java].
-  "Spring Boot":https://spring.io/guides/gs/spring-boot/ is a very popular and simple web framework for Java. Let's get this setup:
+  "Spring Boot":https://spring.io/guides/gs/spring-boot/ is a very popular and simple web framework for Java. You'll need to get this set up:
 
-  First we'll add following configuration to @build.gradle@ file:
+  First you'll add following configuration to the @build.gradle@ file:
 
   ```[groovy]
     buildscript {
@@ -212,7 +220,7 @@ blang[java].
     }
   ```
 
-  Then we'll add an @Application.java@ class for initializing our web application.
+  Then you'll add an @Application.java@ class for initializing your web application.
 
   ```[java]
     import org.springframework.boot.SpringApplication;
@@ -228,7 +236,7 @@ blang[java].
     }
   ```
 
-  Finally we'll add following method to our @Example.java@ class:
+  Finally you'll add the following method to your @Example.java@ class:
 
   ```[java]
   @RestController
@@ -252,9 +260,9 @@ blang[java].
   "See this step in Github":https://github.com/ably/tutorials/commit/6d7ce69
 
 blang[nodejs,android].
-  "Express.js":https://expressjs.com/ is a very popular and simple web framework for Node.js. Let's get this setup:
+  "Express.js":https://expressjs.com/ is a very popular and simple web framework for Node.js. You'll need to get this setup:
 
-  First we'll add the @express@ NPM module and create a @package.json@:
+  First you'll need to add the @express@ NPM module and create a @package.json@ file:
 
   ```[json]
   {
@@ -274,7 +282,7 @@ blang[nodejs,android].
   }
   ```
 
-  Then we'll set up a vanilla HTTP Express.js server in @server.js@:
+  Then you'll need to set up a vanilla HTTP Express.js server in @server.js@:
 
   ```[nodejs]
     const express = require('express'),
@@ -296,15 +304,15 @@ blang[android].
   "See this step in Github":https://github.com/ably/tutorials/commit/19a0345
 
 blang[ruby].
-  "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in @routes.rb@, add the code to a controller, and then add the HTML to a view.
+  "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in the @routes.rb@ file, add the code to a controller, and then add the HTML to a view.
 
-  Let's get going with a simple Sinatra web server now. Add the @sinatra@ RubyGem to your @Gemfile@ and then run @bundle install@:
+  You'll get going with a simple Sinatra web server. Add the @sinatra@ RubyGem to your @Gemfile@ and then run @bundle install@:
 
   ```[ruby]
     gem 'sinatra'
   ```
 
-  Now set up a vanilla Sinatra server in @server.rb@:
+  Now set up a vanilla Sinatra server in the @server.rb@ file:
 
   ```[ruby]
     require 'sinatra'
@@ -320,7 +328,7 @@ blang[ruby].
 blang[python].
   "web.py":http://webpy.org/ is a simple web framework for Python. Django is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill.
 
-  Let's get going with a simple web.py web server now. Install @web.py@ using @pip@:
+  You'll get going with a simple web.py web server now. Install @web.py@ using @pip@:
 
   ```[sh]
     pip install web.py
@@ -346,16 +354,16 @@ blang[python].
         app.run()
   ```
 
-  In @web.py@ each resource is mapped to a class, which in turn takes action depending on HTTP method used. In this case it's main domain @'/'@, that will be handled by @index@ class, and it will support HTTP @GET@.
+  In the @web.py@ file each resource is mapped to a class, which in turn takes action depending on the HTTP method used. In this case its main domain is @'/'@, which will be handled by the @index@ class, and will support HTTP @GET@.
 
-  If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Hello, I am a very simple server". If you would like to change port, on which your site will be available, simply add it after command ieg. @python server.py 1234@ for port @1234@.
+  If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Hello, I am a very simple server". If you would like to change the port from which your site is available, simply add the port after the command (e.g. @python server.py 1234@ for port @1234@).
 
   "See this step in Github":https://github.com/ably/tutorials/commit/91ec78e
 
 blang[php].
-  PHP has built-in web server that allows to serve php scripts, and it's excellent for the purpose of this tutorial.
+  PHP has built-in web server functionality which allows it to serve php scripts, making it excellent for the purpose of this tutorial.
 
-  Create @index.php@:
+  Create the file @index.php@:
 
   ```[php]
     <?php
@@ -367,7 +375,7 @@ blang[php].
   "See this step in Github":https://github.com/ably/tutorials/commit/2314a18
 
 blang[swift].
-  "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in @routes.rb@, add the code to a controller, and then add the HTML to a view.
+  "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in the file @routes.rb@, add the code to a controller, and then add the HTML to a view.
 
   Let's get going with a simple Sinatra web server now. Add the @sinatra@ RubyGem to your @Gemfile@ and then run @bundle install@:
 
@@ -390,28 +398,28 @@ blang[swift].
 
 h2. Step 4 - Respond to authentication requests
 
-Before we move onto the client, let's first make sure the web server is capable of issuing token request to clients that need to authenticate with Ably. However, instead of jumping into code, lets quickly talk about how token authentication works and what the difference is between a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details and "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request is.
+Before you move onto the client, you'll need to first make sure the web server is capable of issuing token requests to clients that need to authenticate with Ably. However, instead of jumping into code, let's quickly talk about how token authentication works and what the difference is between a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details and "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request is.
 
-When a client needs to authenticate, it will automatically send a request to the authentication URL you provide, which is normally a URL on your server. Alternatively if you provide a callback instead of an authentication URL, it will invoke your callback and wait for it to respond with token details. See the "auth options documentation":https://www.ably.io/documentation/realtime/authentication#auth-options for more info on the options available.
+When a client needs to authenticate, it will automatically send a request to the authentication URL you provide, which is normally a URL on your server. Alternatively, if you provide a callback instead of an authentication URL, it will invoke your callback and wait for it to respond with token details. See the "auth options documentation":https://www.ably.io/documentation/realtime/authentication#auth-options for more information on the options available.
 
-Your web server or callback, following an authentication request, is then responsible for providing the client library with a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details or a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request. The token can contain permissions (we call then capabilities) and an identity for the client, but we'll look at that functionality later.
+Your web server or callback, following an authentication request, is then responsible for providing the client library with a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details or a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request. The token can contain permissions (we call then capabilities) and an identity for the client, but you'll look at that functionality later in this tutorial.
 
 For now you need to understand how token requests and tokens differ and why in most cases we recommend you issue token requests as opposed to tokens.
 
 h4. Tokens
 
-All clients authenticating with Ably must use either an API key or a token. Tokens are obtained by sending a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request containing the required token spec to the Ably service.  The token may include a set of capabilities (permissions such as subscribe access to a specific channel), an identity (such as logged-in user's unique ID) or a TTL (the time before it expires).
+All clients authenticating with Ably must use either an API key or a token. Tokens are obtained by sending a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request containing the required token spec to the Ably service.  The token may include a set of capabilities (permissions such as subscribe access to a specific channel), an identity (such as the logged-in user's unique ID) or a TTL (the time before the token expires).
 
 h4. Token Requests
 
-Token requests, unlike tokens, are created and signed by your server without having to communicate with Ably. A token request is simply a JSON object that contains a pre-authorization from your servers for a client, effectively stating "Ably, with this signed token, I authorize you to issue a token according to the permissions, ID and TTL specied, to whoever hands this to you". Ably is then able to inspect the signature to ensure the token request is indeed from the your server and signed with your private API key, and issue a token to the client requesting the token. Ably ensures that token requests can only be used soon after creation and can only be used once.
+Token requests, unlike tokens, are created and signed by your server without having to communicate with Ably. A token request is simply a JSON object that contains a pre-authorization from your servers for a client, effectively stating "Ably, with this signed token, I authorize you to issue a token according to the permissions, ID and TTL specified, to whoever hands this to you". Ably is then able to inspect the signature to ensure that the token request is indeed from your server and signed with your private API key. Ably will then issue a token to the client requesting the token. Ably ensures that token requests can only be used soon after creation and can only be used once.
 
-Therefore, as it is possible to issue token requests without any communication to Ably (in the form of an HTTP request), we recommend that when a client needs to authenticate, you should provide a signed token request. This approach minimises the amount of work your servers need to do by distributing the task of obtaining a token from the Ably service using the token request to your clients instead.
+Therefore, as it is possible to issue token requests without any communication with Ably (in the form of an HTTP request), we recommend that when a client needs to authenticate, you provide a signed token request. This approach minimizes the amount of work your servers needs to do by distributing the task of obtaining a token from the Ably service using the token request to your clients instead.
 
-In this step we will get the local web server ready to respond to authentication requests by issuing a token request to the requesting client.
+In this step you will get the local web server ready to respond to authentication requests by issuing a token request to the requesting client.
 
 blang[java].
-  By adding the following route to @Example.java@ class, it is now ready to service clients wanting to authenticate with Ably.
+  By adding the following route to the @Example.java@ class, it is now ready to service clients wanting to authenticate with Ably.
 
   ```[java]
     @RequestMapping("/auth")
@@ -430,7 +438,7 @@ blang[java].
     }
   ```
 
-  Try resetting your server again with and visiting http://localhost:3000/auth and you should see a JSON token request in the form:
+  Try resetting your server again, then visit http://localhost:3000/auth to see a JSON token request in the form:
 
   ```[json]
   {
@@ -463,7 +471,7 @@ blang[nodejs,android].
     });
   ```
 
-  Try running your server again with @node server.js@ and visiting "http://localhost:3000/auth":http://localhost:3000/auth and you should see a JSON token request in the form:
+  Try running your server again with @node server.js@, then visit "http://localhost:3000/auth":http://localhost:3000/auth to see a JSON token request in the form:
 
   ```[json]
   {
@@ -493,7 +501,7 @@ blang[ruby].
     end
   ```
 
-  Try running your server again with @bundle exec ruby server.rb@ and visiting "http://localhost:4567/auth":http://localhost:4567/auth and you should see a JSON token request in the form:
+  Try running your server again with @bundle exec ruby server.rb@, then visit "http://localhost:4567/auth":http://localhost:4567/auth to see a JSON token request in the form:
 
   ```[json]
   {
@@ -527,7 +535,7 @@ blang[python].
     )
   ```
 
-  Try running your server again with @python server.py@ and visiting "http://localhost:8080/auth":http://localhost:8080/auth and you should see a JSON token request in the form:
+  Try running your server again with @python server.py@, then visit "http://localhost:8080/auth":http://localhost:8080/auth to see a JSON token request in the form:
 
   ```[json]
   {
@@ -554,7 +562,7 @@ blang[php].
     echo json_encode($ably->auth->createTokenRequest()->toArray());
   ```
 
-  Try running your server again with @php -S 0.0.0.0:8000@ (if it's not up already) and visiting "http://localhost:8000/auth.php":http://localhost:8000/auth.php and you should see a JSON token request in the form:
+  Try running your server again with @php -S 0.0.0.0:8000@ (if it's not up already), then visit "http://localhost:8000/auth.php":http://localhost:8000/auth.php to see a JSON token request in the form:
 
   ```[json]
   {
@@ -574,21 +582,20 @@ h2.
   android: Step 5 – Setting up environment and client to use token authentication
   swift: Step 5 - Setup an Xcode project and prepare the client to use token authentication
 
-
-Now that we have a web server running and an authentication endpoint, we are ready to setup the Ably Realtime client that uses token auth.
+Now that you have a web server running and an authentication endpoint, you are ready to set up the Ably Realtime client that uses token auth.
 
 blang[java].
-  First we need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the @src/main/webapp@ folder:
+  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the @src/main/webapp@ folder:
 blang[android].
-  First we need to create a simple Android project that will be served by the web server. To build your own Android Project, please visit "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with steps necessary to set up your own application. When the project is ready, open your application's module and modify it's @build.gradle@ file like this:
+  First you'll need to create a simple Android project that will be served by the web server. To build your own Android Project, please visit the "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with the steps necessary to set up your own application. When the project is ready, open your application's module and modify its @build.gradle@ file like this:
 blang[nodejs].
-  First we need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.js@:
+  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.js@:
 blang[ruby].
-  First we need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.rb@:
+  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.rb@:
 blang[php].
-  First we need to set up a simple HTML page that will be served by the web server. Replace contents of @index.php@ with code below:
+  First you'll need to set up a simple HTML page that will be served by the web server. Replace the contents of @index.php@ with the code below:
 blang[python].
-  First we need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.py@:
+  First you'll need to set up a simple HTML page that will be served by the web server. Create the following HTML file named @index.html@ in the same folder as @server.py@:
 blang[nodejs,ruby,php,python,java].
   ```[html]
   <html>
@@ -613,7 +620,7 @@ blang[android].
 
   In the above example a specific version of the library is referenced, however we recommend you check which is the latest stable version and always use that. Follow link to get the latest stable release for "Android":https://bintray.com/ably-io/ably/ably-android.
 
-  After you add necessary dependencies, you can import AblyRealtime class into your @ExampleActivity@ and initialize it.
+  After you add necessary dependencies, you can import the AblyRealtime class into your @ExampleActivity@ and initialize it.
 
   ```[java]
   public class ExampleActivity extends AppCompatActivity {
@@ -646,7 +653,7 @@ blang[android].
   ```
 
 blang[java].
-  Now we need to serve a static home page. Let's delete @index@ method in @Example.java@ class, open @Application.java@ file and add following code:
+  Now you need to serve a static home page. You should delete the @index@ method in the @Example.java@ class, then open the @Application.java@ file and add following code:
 
   ```[java]
   import org.springframework.context.annotation.Configuration;
@@ -663,19 +670,19 @@ blang[java].
   }
   ```
 
-  Try restarting your server again and visiting "http://localhost:3000/":http://localhost:3000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try restarting your server again and visit "http://localhost:3000/":http://localhost:3000/ to make ensure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[nodejs,android].
-  Now we need to serve a static home page. Let's replace the code that responds to the @/@ route (look for @get '/' do ... end@) with the following:
+  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @get '/' do ... end@) with the following:
 
   ```[nodejs]
     app.use('/', express.static(__dirname));
   ```
 
-  Try running your server again with @node server.js@ and visiting "http://localhost:3000/":http://localhost:3000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try running your server again with @node server.js@ and visit "http://localhost:3000/":http://localhost:3000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[ruby].
-  Now we need to serve a static home page. Let's replace the code that responds to the @/@ route (look for @app.get('/', ...@) with the following:
+  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @app.get('/', ...@) with the following:
 
   ```[ruby]
     get '/' do
@@ -683,10 +690,10 @@ blang[ruby].
     end
   ```
 
-  Try running your server again with @bundle exec ruby server.rb@ and visiting "http://localhost:4567/":http://localhost:4567/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try running your server again with @bundle exec ruby server.rb@ and visit "http://localhost:4567/":http://localhost:4567/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[python].
-  Now we need to serve a static home page. Let's replace the code that responds to the @/@ route (look for @index@ class) with the following:
+  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @index@ class) with the following:
 
   ```[python]
     class index:
@@ -695,10 +702,10 @@ blang[python].
             return html.read()
   ```
 
-  Try running your server again with @python server.py@ and visiting "http://localhost:8080/":http://localhost:8080/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try running your server again with @python server.py@ and visit "http://localhost:8080/":http://localhost:8080/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[php].
-  Try running your server again with @php -S 0.0.0.0:8000@ (if it's not up already) and visiting "http://localhost:8000/":http://localhost:8000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try running your server again with @php -S 0.0.0.0:8000@ (if it's not up already) and visit "http://localhost:8000/":http://localhost:8000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[android].
   Add the following into the @ExampleAcitivity#initAbly@ method:
@@ -732,7 +739,7 @@ blang[swift].
     end
   ```
 
-  Try running your server again with @bundle exec ruby server.rb@ and visiting "http://localhost:4567/auth":http://localhost:4567/auth and you should see a JSON token request in the form:
+  Try running your server again with @bundle exec ruby server.rb@ and visit "http://localhost:4567/auth":http://localhost:4567/auth to see a JSON token request in the form:
 
   ```[json]
   {
@@ -774,9 +781,9 @@ blang[php].
   ```
 
 blang[php,ruby,nodejs,python,java].
-  So let's see what happens now. Restart the local server and refresh the page. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client, the client has then obtained a token from Ably with the token request, it has subsequently authenticated and finally connected.
+  Time to see what happens now. Restart the local server and refresh the page. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 blang[android].
-  So let's see what happens now. Restart the local server and rerun your application. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client, the client has then obtained a token from Ably with the token request, it has subsequently authenticated and finally connected.
+  Time to see what happens now. Restart the local server and rerun your application. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
 blang[android].
   "See this step in Github":http://github.com/ably/tutorials/commit/ae636ad
@@ -797,17 +804,23 @@ blang[php].
   "See this step in Github":https://github.com/ably/tutorials/commit/f949bcf
 
 blang[swift].
-  First we need to set up an Xcode project that will serve as our client.
-  To build your own Xcode Project in Swift visit "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to setup your own application.
-  When you setup your application delete the default @ViewController.swift@ add new File -> New -> File... and choose @Cocoa Touch Class@.
+  Firstly you'll need to set up an Xcode project that will serve as your client.
+
+  To build your own Xcode Project in Swift visit the "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to set up your own application.
+  When you set up your application delete the default @ViewController.swift@, then add a new file by going through File -> New -> File... and choose @Cocoa Touch Class@.
+
   <a href="/images/tutorials/tutorials-swift-CTC.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-CTC.png" style="width: 100%" alt="Create new Cocoa Touch Class">
   </a>
+
   Name your new class "ExampleViewController" and choose @Swift@ as language:
+
   <a href="/images/tutorials/tutorials-swift-ExampleClass.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-ExampleClass.png" style="width: 100%" alt="Name new Cocoa Touch Class">
   </a>
-  After that navigate to @Main.storyboard@ in your project, click on the @ViewController@ that has already been added by default during project creation and from the @Utilities@ that are located on the right choose @Identity Inspector@. Find the field labeled "Class" and select "ExampleViewController".
+
+  After that navigate to @Main.storyboard@ in your project, click on the @ViewController@ that has already been added by default during the project creation. In the @Utilities@ that are located on the right select @Identity Inspector@. Find the field labeled "Class" and select "ExampleViewController".
+
   <a href="/images/tutorials/tutorials-swift-IB-class.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
@@ -828,17 +841,17 @@ blang[swift].
 
   bc[sh]. pod install
 
-  To learn more about using CocoaPods in your project visit "official CocoaPods guide":https://guides.cocoapods.org/using/using-cocoapods.html.
+  To learn more about using CocoaPods in your project visit the "official CocoaPods guide":https://guides.cocoapods.org/using/using-cocoapods.html.
 
-  Then in your files in which you will be using Ably import:
+  Then within your files which will be using Ably import:
 
   ```[swift]
     import Ably
   ```
 
   Now it's time to set up a Realtime client that uses token authentication.
-  First we will create a new method that will try to connect us to Ably.
-  By using @authCallback@ we don't have to worry if the user already has a clientId.
+  First you will create a new method that will try to connect us to Ably.
+  By using @authCallback@ you don't have to worry if the user already has a clientId.
 
   ```[swift]
     private func connectToAbly() {
@@ -872,7 +885,7 @@ blang[swift].
     }
   ```
 
-  Now add @getTokenRequest@ method. This method is responsible for making a server request and obtaining a JSON response.
+  Now add the @getTokenRequest@ method. This method is responsible for making a server request and obtaining a JSON response.
 
   ```[swift]
     func getTokenRequest(completion: (NSDictionary?, ErrorType?) -> ())  {
@@ -904,30 +917,30 @@ blang[swift].
     connectToAbly()
   ```
 
-  There is one more thing to do before you will be able to test this code. By default Apple forces it's developers to use secure connections but the server in this tutorial is a really simple and we use simple HTTP. Because of that the code above won't work if we don't change the default behavior to allow arbitrary loads. In @Project Navigator@ choose your project then in the view that will appear click on your target. Next, click on @Info@ tab and under "Custom iOS Target Properties" add a new row by right-clicking on the table and picking "Add Row". Type "App Transport Security Settings" then click on the @+@ type "Allow Arbitrary Loads" and change it's value to "YES". If you have problems with these steps - see the image below:
+  There is one more thing to do before you will be able to test this code. By default Apple forces its developers to use secure connections, but the server in this tutorial is really simple and will be using HTTP. Because of that the code above won't work if you don't change the default behavior to allow arbitrary loads. In the @Project Navigator@ choose your project, then in the view that will appear click on your target. Next, click on the @Info@ tab and under "Custom iOS Target Properties" add a new row by right-clicking on the table and picking "Add Row". Type "App Transport Security Settings" then click on the @+@ type "Allow Arbitrary Loads" and change its value to "YES". If you have problems with these steps - see the image below:
+
   <a href="/images/tutorials/tutorials-swift-info.plist.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-info.plist.png" style="width: 100%" alt="info.plist">
   </a>
 
-  So let's see what happens now. Execute the code in a simulator. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client, the client has then obtained a token from Ably with the token request, it has subsequently authenticated and finally connected.
+  Time to see what happens now. Execute the code in a simulator. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
   "See this step in Github":https://github.com/ably/tutorials/commit/6498081
 
-
-You've now covered the basics of client / server token authentication and your client has a means to renew the token whenever it needs one.
+You've now covered the basics of client-server token authentication and your client has a means to renew the token whenever it needs one.
 
 h2. Step 6 - Authenticating logged in users
 
-In the previous step we demonstrated how easy it is to issue a token request from your server for clients that need to authenticate with Ably. However, the example is quite contrived in that it is unlikely you would want to issue tokens to anonymous users with a full set of capabilities. At present, the token issued allows all users to publish, subscribe, be present, retrieve stats and history across all channels.
+In the previous step you demonstrated how easy it is to issue a token request from your server for clients that need to authenticate with Ably. However, the example is quite contrived in that it is unlikely you would want to issue tokens to anonymous users with a full set of capabilities. At present, the token issued allows all users to publish, subscribe, be present, retrieve stats and history across all channels.
 
 blang[android].
-  In this step we'll show you how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not demonstrate how to build an authentication system for your mobile app, we have implemented a trivial and clearly flawed authentication system so that we can keep superfluous unrelated code to a minimum.
+  In this step you'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your mobile app, you will be implementing a trivial and clearly flawed authentication system so that you can keep superfluous unrelated code to a minimum.
 
 blang[java,php,nodejs,python,ruby].
-  In this step we'll show you how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not demonstrate how to build an authentication system for your website, we have implemented a trivial and clearly flawed authentication system so that we can keep superfluous unrelated code to a minimum.
+  n this step you'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your website, you will be implementing a trivial and clearly flawed authentication system so that you can keep superfluous unrelated code to a minimum.
 
 blang[android].
-  Let's get started. First we will add EditText and Button into our layout, creating simple login form. Add the following into @activity_example.xml@ file:
+  Time to get started. First you will add an EditText element and a Button element into our layout, creating simple login form. Add the following into the @activity_example.xml@ file:
 
   ```[xml]
     <?xml version="1.0" encoding="utf-8"?>
@@ -968,7 +981,7 @@ blang[android].
   ```
 
 blang[nodejs,ruby,python,java].
-  Let's get started. First we will add two panels, one that contains a simple login form, and the other with log out link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.html@ file:
+  Time to get started. First you will add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.html@ file:
 
   ```[html]
     <div id="panel-anonymous">
@@ -984,7 +997,7 @@ blang[nodejs,ruby,python,java].
   ```
 
 blang[php].
-  Let's get started. First we will add two panels, one that contains a simple login form, and the other with log out link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
+  Time to get started. First you'll need to add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
 
   ```[html]
     <div id="panel-anonymous">
@@ -1000,7 +1013,7 @@ blang[php].
   ```
 
 blang[java].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie. Add the following routes to your @Example.java@ file.
+  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @Example.java@ file.
 
   ```[java]
     @RequestMapping(value = "/login", method = RequestMethod.GET)
@@ -1027,7 +1040,7 @@ blang[java].
   ```
 
 blang[nodejs].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie. Add the following routes to your @server.js@ file.
+  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @server.js@ file.
 
   ```[nodejs]
     /* Set a cookie when the user logs in */
@@ -1051,7 +1064,7 @@ blang[nodejs].
   ```
 
 blang[android].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, we'll add a @username@ query parameter to @/auth@ route. If it exists, user wants to log in, if it doesn't he/she wants to log out. Modify @/auth@ route in you @server.js@ file.
+  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, you'll add a @username@ query parameter to the @/auth@ route. If it exists, it means user wants to log in, and if it doesn't they want to log out. Modify @/auth@ route in you @server.js@ file.
 
   ```[nodejs]
     var tokenParams;
@@ -1068,9 +1081,9 @@ blang[android].
   ```
 
 blang[ruby].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
+  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
-  We need to add cookie support to Sinatra, so add the following to your @Gemfile@ and @bundle install@:
+  You'll need to add cookie support to Sinatra, so add the following to your @Gemfile@ and @bundle install@:
 
   ```[ruby]
     gem 'sinatra-contrib'
@@ -1103,7 +1116,7 @@ blang[ruby].
   ```
 
 blang[python].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
+  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
   Add the following classes to your @server.py@ file.
 
@@ -1134,11 +1147,11 @@ blang[python].
   ```
 
 blang[php].
-  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll set a cookie, and when they log out we'll clear the cookie.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
-  We'll create two scripts that will serve as our login and logout functionality.
+  You'll create two scripts that will serve as your login and logout functionality.
 
-  First create @login.php@:
+  First, create a @login.php@ file containing:
 
   ```[php]
     <?php
@@ -1151,7 +1164,7 @@ blang[php].
     }
   ```
 
-  Second script will serve as logout, create @logout.php@:
+  Secondly, create a @logout.php@ file to deal with logging out:
 
   ```[php]
     <?php
@@ -1160,7 +1173,7 @@ blang[php].
   ```
 
 blang[android].
-  Let's add logged in and logged out states for our layout. To switch between them, we need to add logic into our @ExampleActivity@. Add the following inside your class:
+  Let's add logged in and logged out states for our layout. To switch between them, you'll need to add logic into our @ExampleActivity@. Add the following inside your class:
 
   ```[java]
     private TextView tvCapabilities;
@@ -1250,12 +1263,12 @@ blang[android].
     }
   ```
 
-  Remember that from your Android emulator, the localhost address is @10.0.2.2@. If you want to access your server from physical device, just research setting up a @public IP address@.
+  Remember that from your Android emulator, the localhost address is @10.0.2.2@. If you want to access your server from a physical device, just research setting up a @public IP address@.
 
 blang[nodejs,ruby,python,java].
-  Both the logged in and anonymous HTML panels will currently show on the HTML page, let's add quickly hide or show them based on the cookie set above. Add the following just before the final @</script>@ tag in @index.html@
+  Both the logged in and anonymous HTML panels will currently show on the HTML page. You should now add hide or show functionality based on the cookie set above. Add the following just before the final @</script>@ tag in @index.html@
 blang[php].
-  Both the logged in and anonymous HTML panels will currently show on the HTML page, let's add quickly hide or show them based on the cookie set above. Add the following just before the final @</script>@ tag in @index.php@
+  Both the logged in and anonymous HTML panels will currently show on the HTML page. You should now add hide or show functionality based on the cookie set above. Add the following just before the final @</script>@ tag in @index.php@
 
 blang[nodejs,ruby,python,php,java].
   ```[javascript]
@@ -1267,7 +1280,7 @@ blang[nodejs,ruby,python,php,java].
   ```
 
 blang[java].
-  Now that we have a means to determine if a user is logged in or logged out using the session cookie, we can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @Example#auth@ method body with the following:
+  Now that you have the means to determine if a user is logged in or logged out using the session cookie, you can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @Example#auth@ method body with the following:
 
   ```[java]
   String username = null;
@@ -1297,7 +1310,7 @@ blang[java].
   ```
 
 blang[nodejs].
-  Now that we have a means to determine if a user is logged in or logged out using the session cookie, we can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @var tokenParams = {};@ code in your @server.js@ with the following:
+  Now that you have the means to determine if a user is logged in or logged out using the session cookie, you can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @var tokenParams = {};@ code in your @server.js@ with the following:
 
   ```[nodejs]
     var tokenParams;
@@ -1318,7 +1331,7 @@ blang[nodejs].
     }
   ```
 
-  Unfortunately Express.js is very lightweight and does not support cookie parsing out of the box. We need to add the @cookie-parser@ NPM module to Express.js. Add the following to your @package.json@ file:
+  Unfortunately Express.js is very lightweight and does not support cookie parsing out of the box. You'll need to add the @cookie-parser@ NPM module to Express.js. Add the following to your @package.json@ file:
 
   ```[json]
   {
@@ -1339,7 +1352,7 @@ blang[nodejs].
   ```
 
 blang[ruby].
-  Now that we have a means to determine if a user is logged in or logged out using the session cookie, we can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
+  Now that you have a means to determine if a user is logged in or logged out using the session cookie, you can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
 
   ```[ruby]
     require 'sinatra/cookies'
@@ -1371,7 +1384,7 @@ blang[ruby].
   ```
 
 blang[python].
-  Now that we have a means to determine if a user is logged in or logged out using the session cookie, we can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the code for @auth@ class with the following:
+  Now that you have the means to determine if a user is logged in or logged out using the session cookie, you can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the code for @auth@ class with the following:
 
   ```[python]
     class auth:
@@ -1395,7 +1408,7 @@ blang[python].
   ```
 
 blang[php].
-  Now that we have a means to determine if a user is logged in or logged out using the session cookie, we can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the code in your @auth.php@ with the following:
+  Now that you have the means to determine if a user is logged in or logged out using the session cookie, you can issue restricted subscribe-only token requests for anonymous users and publish and subscribe token requests for logged in users. Replace the code in your @auth.php@ with the following:
 
   ```[php]
     <?php
@@ -1424,7 +1437,7 @@ blang[php].
   ```
 
 blang[android].
-  Finally, before we test this new functionality, let's update the Toast message so that it shows the authentication details after it connects to Ably. Replace current Toast message with the following:
+  Finally, before you test this new functionality, update the Toast message so that it shows the authentication details after it connects to Ably. Replace the current Toast message with the following:
 
   ```[java]
     String user = ablyRealtime.auth.getTokenAuth().getTokenDetails().clientId;
@@ -1435,7 +1448,7 @@ blang[android].
   ```
 
 blang[nodejs,python,java,php,ruby].
-  Finally, before we test this new functionality, let's update the alert so that it shows the authentication details after it connects to Ably. Replace @alert("We're connected...@ with the following:
+  Finally, before you test this new functionality, update the alert so that it shows the authentication details after it connects to Ably. Replace @alert("We're connected...@ with the following:
 
   ```[javascript]
     var user = realtime.auth.tokenDetails.clientId || 'anonymous';
@@ -1448,13 +1461,13 @@ blang[nodejs,python,java,php,ruby].
   ```
 
 blang[android].
-  Ok, we're ready to see all of this in action. Restart the local server @node server.js@ and then rerun your application. You should receive an Toast message to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server @node server.js@ and then rerun your application. You should receive a Toast message to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[java].
-  Ok, we're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[swift].
-  Let's get started. We will distinguish if the user provided his username and based on that issue right capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
+  Time to get started. You will distinguish if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
 
   ```[ruby]
     # Issue token requests to clients sending a request to the /auth endpoint
@@ -1480,28 +1493,40 @@ blang[swift].
       end
   ```
 
-  Now we will customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
-  First we will add a Login button and a textfield so that user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
+  Now you will customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
+
+  First you will add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
+
   <a href="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" style="width: 100%" alt="Bind action">
   </a>
-  In a similar fashion add one @UILabel@ and change it's text to "Username:". Then add @UITextField@ and connect it. Name it "usernameText".
+
+  In a similar fashion add one @UILabel@ and change its text to "Username:", then add @UITextField@ and connect it. Name it "usernameText".
   Your @ExampleViewController@ should look similar to this view:
+
   <a href="/images/tutorials/tutorials-swift-token-auth-login-screen.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-token-auth-login-screen.png" style="width: 100%" alt="Login view">
   </a>
-  Now add another @ViewController@ form @Object Library@. Create new @Cocoa Touch Class@ named @LogoutViewController@ just like you did for @ExampleViewController@.
-  In this view controller add one @UILabel@ with a message that user is logged in and one @UIButton@ but don't connect it to any @IBAction@.
+
+  Now add another @ViewController@ form to @Object Library@. Create a new @Cocoa Touch Class@ named @LogoutViewController@ just like you did for @ExampleViewController@.
+
+  In this view controller add one @UILabel@ with a message that the user is logged in. In addition, add a @UIButton@, but don't connect it to any @IBAction@.
+
   Your @LogoutViewController@ should look similar to this view:
+
   <a href="/images/tutorials/tutorials-swift-token-auth-logout-screen.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-token-auth-logout-screen.png" style="width: 60%" alt="Logout view">
   </a>
-  To define the flow between the @ExampleViewController@ and the @LogoutViewController@ we will use segues. If you are not familiar with them, please refer to "Apple developer guide":https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html on how they work.
-  First in your @Storyboard@ add new "Present Modally" action segue. Name it "logoutSegue".
+
+  To define the flow between the @ExampleViewController@ and the @LogoutViewController@ you will use segues. If you are not familiar with them, please refer to the "Apple developer guide":https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html on how they work.
+
+  First in your @Storyboard@ add a new "Present Modally" action segue. Name it "logoutSegue".
+
   <a href="/images/tutorials/tutorials-swift-create-segue.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-create-segue.gif" style="width: 60%" alt="Create segue">
   </a>
-  In your @ExampleViewController@ class add a mathod that will make out view controller perform the segue:
+
+  In your @ExampleViewController@ class add a method that will make our view controller perform the segue:
 
   ```[swift]
     private func performSegue() {
@@ -1509,7 +1534,7 @@ blang[swift].
     }
   ```
 
-  Then we need to change the action that is performed when the user clicks on "OK" when the alert is shown. Change this line:
+  Then you'll need to change the action that is performed when the user clicks on "OK" when the alert is shown. Change this line:
 
   ```[swift]
     alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil)
@@ -1527,7 +1552,7 @@ blang[swift].
                   }))
   ```
 
-  Now, let's change the method that connects us to Ably. If the user doesn't provide his username then we won't pass any parameters to our server and when the textfield won't be empty then we will pass it's contents as username.
+  Now, you'll need to change the method that connects us to Ably. If the user doesn't provide their username then you shouldn't pass any parameters to your server. Equally when the textfield is filled you'll need to its contents as the username.
 
   ```[swift]
     private func connectToAbly() {
@@ -1568,7 +1593,7 @@ blang[swift].
     }
   ```
 
-  We will also update @getTokenRequest@ method so that it will use correct URL request:
+  You will also update the @getTokenRequest@ method so that it will use the correct URL request:
 
   ```[swift]
     func getTokenRequest(params: NSURL, completion: (NSDictionary?, ErrorType?) -> ())  {
@@ -1613,7 +1638,7 @@ blang[swift].
       }
   ```
 
-  Last thing we need to do is perform a logout action. We didn't connect the logout button to an action because we will connect it to a segue right now. In your @Storyboard@ hold ctrl and right-click the button and drag it to @ExampleViewController@ just like the earlier segue. Name it "toLoginSegue". When user taps the logout button, before the segue is performed we will close the connection to ably and nullify the instance. All the actions that should be done before performing the segue can be done in @prepareForSegue@ method in your @LogoutViewController@:
+  The last thing you'll need to do is perform a logout action. You didn't connect the logout button to an action because you will connect it to a segue right now. In your @Storyboard@ hold ctrl and right-click the button and drag it to @ExampleViewController@ just like the earlier segue. Name it "toLoginSegue". When the user taps the logout button, before the segue is performed you'll need to close the connection to Ably and nullify the instance. All the actions that should be done before performing the segue can be done in the @prepareForSegue@ method in your @LogoutViewController@:
 
   ```[swift]
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
@@ -1624,25 +1649,25 @@ blang[swift].
         }
   ```
 
-  Ok, we're ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then restart your simulation. Now when you tap on login you should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  You're now ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then restart your simulation. Now when you tap on login you should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[nodejs].
-  Ok, we're ready to see all of this in action. Restart the local server @node server.js@ and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server @node server.js@ and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[ruby].
-  Ok, we're ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then refresh the page at "http://localhost:4567/":http://localhost:4567/. You should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server @bundle exec ruby server.rb@ and then refresh the page at "http://localhost:4567/":http://localhost:4567/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[python].
-  Ok, we're ready to see all of this in action. Restart the local server @python server.py@ and then refresh the page at "http://localhost:8080/":http://localhost:8080/. You should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server @python server.py@ and then refresh the page at "http://localhost:8080/":http://localhost:8080/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[php].
-  Ok, we're ready to see all of this in action. Restart the local server @php -S 0.0.0.0:8000@ and then refresh the page at "http://localhost:8000/":http://localhost:8000/. You should receive an alert to confirm that you're connected as an anonymous with limited capabilities as follows:
+  Ok, you're ready to see all of this in action. Restart the local server @php -S 0.0.0.0:8000@ and then refresh the page at "http://localhost:8000/":http://localhost:8000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 blang[java,nodejs,php,python,ruby].
   <a href="/images/tutorials/token-authentication-anonymous.png" target="_blank">
     <img src="/images/tutorials/token-authentication-anonymous.png" style="width: 457px" alt="Token auth details for anonymous">
   </a>
 
-  Now enter a username and click "login", and you should receive an alert confirming you are authenticated with Ably as an identified user with additional privileges to subscribe and publish on all channels as follows:
+  Now enter a username and click "login", and you should receive an alert confirming that you are authenticated with Ably as an identified user with additional privileges to subscribe and publish on all channels as follows:
   <a href="/images/tutorials/token-authentication-mike.png" target="_blank">
     <img src="/images/tutorials/token-authentication-mike.png" style="width: 429px" alt="Token auth details for logged in user Mike">
   </a>
@@ -1652,7 +1677,7 @@ blang[android].
     <img src="/images/tutorials/token-authentication-android-anonymous.png" style="width: 457px" alt="Token auth details for anonymous">
   </a>
 
-  Now enter a username and click "Login", and you should receive an alert confirming you are authenticated with Ably as an identified user with additional privileges to subscribe and publish on all channels as follows:
+  Now enter a username and click "Login", and you should receive an alert confirming that you are authenticated with Ably as an identified user with additional privileges to subscribe and publish on all channels as follows:
   <a href="/images/tutorials/token-authentication-android-mike.png" target="_blank">
     <img src="/images/tutorials/token-authentication-android-mike.png" style="width: 429px" alt="Token auth details for logged in user Mike">
   </a>
@@ -1681,7 +1706,7 @@ blang[php].
 blang[swift].
   "See this step in Github":https://github.com/ably/tutorials/commit/439a0a8
 
-We've covered a lot of ground in this tutorial. However authentication is one of the more challenging parts to understand as it requires you to have a good overall understanding of how it all works. We strongly recommend you see below for essential further reading to help you understand authentication in more detail for use in your servers and apps.
+You've covered a lot of ground in this tutorial. However authentication is one of the more challenging aspects to understand as it requires you to have a good overall understanding of how it all works. We strongly recommend you check out the links below for essential further reading to help you understand authentication in more detail for use in your servers and apps.
 
 h2. Download tutorial source code
 

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -997,7 +997,7 @@ blang[nodejs,ruby,python,java].
   ```
 
 blang[php].
-  Time to get started. Firstly you will need to add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
+  Time to get started. Firstly you will add two panels, one that contains a simple login form, and the other with a logout link to the HTML page. Add the following beneath the @</h1>@ tag in your @index.php@ file:
 
   ```[html]
     <div id="panel-anonymous">
@@ -1013,7 +1013,7 @@ blang[php].
   ```
 
 blang[java].
-  Now we need to enable the login and logout functionality in your web server. In order to keep this tutorial simple, when a user logs in we'll create a cookie, and when they log out we'll clear the cookie. Add the following routes to your @Example.java@ file.
+  Now we need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in we'll create a cookie, and when they log out we'll clear the cookie. Add the following routes to your @Example.java@ file.
 
   ```[java]
     @RequestMapping(value = "/login", method = RequestMethod.GET)
@@ -1467,7 +1467,7 @@ blang[java].
   Ok, we're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[swift].
-  Time to get started. We will need to check if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
+  Time to get started. We need to check if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
 
   ```[ruby]
     # Issue token requests to clients sending a request to the /auth endpoint
@@ -1495,7 +1495,7 @@ blang[swift].
 
   Now we will need to customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
 
-  Firstly we will need to add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
+  Firstly, add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
 
   <a href="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" style="width: 100%" alt="Bind action">

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -306,7 +306,7 @@ blang[android].
 blang[ruby].
   "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in the @routes.rb@ file, add the code to a controller, and then add the HTML to a view.
 
-  You'll get going with a simple Sinatra web server. Add the @sinatra@ RubyGem to your @Gemfile@ and then run @bundle install@:
+  You'll need to get going with a simple Sinatra web server. Add the @sinatra@ RubyGem to your @Gemfile@ and then run @bundle install@:
 
   ```[ruby]
     gem 'sinatra'
@@ -328,7 +328,7 @@ blang[ruby].
 blang[python].
   "web.py":http://webpy.org/ is a simple web framework for Python. Django is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill.
 
-  You'll get going with a simple web.py web server now. Install @web.py@ using @pip@:
+  You'll need to get going with a simple web.py web server. Install @web.py@ using @pip@:
 
   ```[sh]
     pip install web.py
@@ -361,7 +361,7 @@ blang[python].
   "See this step in Github":https://github.com/ably/tutorials/commit/91ec78e
 
 blang[php].
-  PHP has built-in web server functionality which allows it to serve php scripts, making it excellent for the purpose of this tutorial.
+  PHP has a built-in web server functionality which allows it to serve php scripts, making it excellent for the purpose of this tutorial.
 
   Create the file @index.php@:
 
@@ -398,11 +398,11 @@ blang[swift].
 
 h2. Step 4 - Respond to authentication requests
 
-Before you move onto the client, you'll need to first make sure the web server is capable of issuing token requests to clients that need to authenticate with Ably. However, instead of jumping into code, let's quickly talk about how token authentication works and what the difference is between a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details and "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request is.
+Before we move onto the client, you'll need to first make sure the web server is capable of issuing token requests to clients that need to authenticate with Ably. However, instead of jumping into code, let's quickly talk about how token authentication works and what the difference is between a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details and "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request is.
 
 When a client needs to authenticate, it will automatically send a request to the authentication URL you provide, which is normally a URL on your server. Alternatively, if you provide a callback instead of an authentication URL, it will invoke your callback and wait for it to respond with token details. See the "auth options documentation":https://www.ably.io/documentation/realtime/authentication#auth-options for more information on the options available.
 
-Your web server or callback, following an authentication request, is then responsible for providing the client library with a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details or a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request. The token can contain permissions (we call then capabilities) and an identity for the client, but you'll look at that functionality later in this tutorial.
+Your web server or callback, following an authentication request, is then responsible for providing the client library with a "@Token@":https://www.ably.io/documentation/realtime/authentication#token-details or a "@TokenRequest@":https://www.ably.io/documentation/realtime/authentication#token-request. The token can contain permissions (we call them capabilities) and an identity for the client, but this functionality will be discussed later in this tutorial.
 
 For now you need to understand how token requests and tokens differ and why in most cases we recommend you issue token requests as opposed to tokens.
 
@@ -412,9 +412,9 @@ All clients authenticating with Ably must use either an API key or a token. Toke
 
 h4. Token Requests
 
-Token requests, unlike tokens, are created and signed by your server without having to communicate with Ably. A token request is simply a JSON object that contains a pre-authorization from your servers for a client, effectively stating "Ably, with this signed token, I authorize you to issue a token according to the permissions, ID and TTL specified, to whoever hands this to you". Ably is then able to inspect the signature to ensure that the token request is indeed from your server and signed with your private API key. Ably will then issue a token to the client requesting the token. Ably ensures that token requests can only be used soon after creation and can only be used once.
+Token requests, unlike tokens, are created and signed by your server without having to communicate with Ably. A token request is simply a JSON object that contains a pre-authorization from your server for a client, effectively stating "Ably, with this signed token, I authorize you to issue a token according to the permissions, ID and TTL specified, to whoever hands this to you". Ably is then able to inspect the signature to ensure that the token request is indeed from your server and signed with your private API key. Ably will then issue a token to the client requesting the token. Ably ensures that token requests can only be used soon after creation and can only be used once.
 
-Therefore, as it is possible to issue token requests without any communication with Ably (in the form of an HTTP request), we recommend that when a client needs to authenticate, you provide a signed token request. This approach minimizes the amount of work your servers needs to do by distributing the task of obtaining a token from the Ably service using the token request to your clients instead.
+Therefore, as it is possible to issue token requests without any communication with Ably (in the form of an HTTP request), we recommend that when a client needs to authenticate, you provide a signed token request. This approach minimizes the amount of work your server needs to do by distributing the task of obtaining a token from the Ably service using the token request to your clients instead.
 
 In this step you will get the local web server ready to respond to authentication requests by issuing a token request to the requesting client.
 
@@ -670,7 +670,7 @@ blang[java].
   }
   ```
 
-  Try restarting your server again and visit "http://localhost:3000/":http://localhost:3000/ to make ensure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
+  Try restarting your server again and visit "http://localhost:3000/":http://localhost:3000/ to ensure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[nodejs,android].
   Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @get '/' do ... end@) with the following:
@@ -682,7 +682,7 @@ blang[nodejs,android].
   Try running your server again with @node server.js@ and visit "http://localhost:3000/":http://localhost:3000/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[ruby].
-  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @app.get('/', ...@) with the following:
+  Now you need to serve a static home page. Replace the code that responds to the @/@ route (look for @app.get('/', ...@) with the following:
 
   ```[ruby]
     get '/' do
@@ -693,7 +693,7 @@ blang[ruby].
   Try running your server again with @bundle exec ruby server.rb@ and visit "http://localhost:4567/":http://localhost:4567/ to make sure the new static home page is being served up correctly. If you can see the static page, then it's time to set up a Realtime client that uses token authentication.
 
 blang[python].
-  Now you'll need to serve a static home page. Replace the code that responds to the @/@ route (look for @index@ class) with the following:
+  Now you need to serve a static home page. Replace the code that responds to the @/@ route (look for @index@ class) with the following:
 
   ```[python]
     class index:
@@ -843,14 +843,14 @@ blang[swift].
 
   To learn more about using CocoaPods in your project visit the "official CocoaPods guide":https://guides.cocoapods.org/using/using-cocoapods.html.
 
-  Then within your files which will be using Ably import:
+  Inside any files which will be using Ably add the following import:
 
   ```[swift]
     import Ably
   ```
 
   Now it's time to set up a Realtime client that uses token authentication.
-  First you will create a new method that will try to connect us to Ably.
+  First you'll need to create a new method that will try to connect us to Ably.
   By using @authCallback@ you don't have to worry if the user already has a clientId.
 
   ```[swift]
@@ -917,7 +917,7 @@ blang[swift].
     connectToAbly()
   ```
 
-  There is one more thing to do before you will be able to test this code. By default Apple forces its developers to use secure connections, but the server in this tutorial is really simple and will be using HTTP. Because of that the code above won't work if you don't change the default behavior to allow arbitrary loads. In the @Project Navigator@ choose your project, then in the view that will appear click on your target. Next, click on the @Info@ tab and under "Custom iOS Target Properties" add a new row by right-clicking on the table and picking "Add Row". Type "App Transport Security Settings" then click on the @+@ type "Allow Arbitrary Loads" and change its value to "YES". If you have problems with these steps - see the image below:
+  There is one more thing to do before you can test this code. By default Apple forces its developers to use secure connections, but the server in this tutorial is really simple and will be using HTTP. Because of that the code above won't work if you don't change the default behavior to allow arbitrary loads. In the @Project Navigator@ choose your project, then in the view that will appear click on your target. Next, click on the @Info@ tab and under "Custom iOS Target Properties" add a new row by right-clicking on the table and picking "Add Row". Type "App Transport Security Settings" then click on the @+@ type "Allow Arbitrary Loads" and change its value to "YES". If you have problems with these steps - see the image below:
 
   <a href="/images/tutorials/tutorials-swift-info.plist.png" target="_blank">
     <img src="/images/tutorials/tutorials-swift-info.plist.png" style="width: 100%" alt="info.plist">
@@ -931,7 +931,7 @@ You've now covered the basics of client-server token authentication and your cli
 
 h2. Step 6 - Authenticating logged in users
 
-In the previous step you demonstrated how easy it is to issue a token request from your server for clients that need to authenticate with Ably. However, the example is quite contrived in that it is unlikely you would want to issue tokens to anonymous users with a full set of capabilities. At present, the token issued allows all users to publish, subscribe, be present, retrieve stats and history across all channels.
+In the previous step we saw how easy it is to issue a token request from your server for clients that need to authenticate with Ably. However, the example is quite contrived in that it is unlikely you would want to issue tokens to anonymous users with a full set of capabilities. At present, the token issued allows all users to publish, subscribe, be present, retrieve stats and history across all channels.
 
 blang[android].
   In this step you'll see how to issue subscribe only tokens limited to a single channel for anonymous users, and issue publish and subscribe tokens for logged in users. As the purpose of this tutorial is not to demonstrate how to build an authentication system for your mobile app, you will be implementing a trivial and clearly flawed authentication system so that you can keep superfluous unrelated code to a minimum.
@@ -1013,7 +1013,7 @@ blang[php].
   ```
 
 blang[java].
-  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @Example.java@ file.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll need to create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @Example.java@ file.
 
   ```[java]
     @RequestMapping(value = "/login", method = RequestMethod.GET)
@@ -1040,7 +1040,7 @@ blang[java].
   ```
 
 blang[nodejs].
-  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @server.js@ file.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll need to create a cookie, and when they log out you'll clear the cookie. Add the following routes to your @server.js@ file.
 
   ```[nodejs]
     /* Set a cookie when the user logs in */
@@ -1064,7 +1064,7 @@ blang[nodejs].
   ```
 
 blang[android].
-  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, you'll add a @username@ query parameter to the @/auth@ route. If it exists, it means user wants to log in, and if it doesn't they want to log out. Modify @/auth@ route in you @server.js@ file.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, you'll add a @username@ query parameter to the @/auth@ route. If it exists, it means user wants to log in, and if it doesn't they want to log out. Modify @/auth@ route in you @server.js@ file.
 
   ```[nodejs]
     var tokenParams;
@@ -1081,7 +1081,7 @@ blang[android].
   ```
 
 blang[ruby].
-  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
   You'll need to add cookie support to Sinatra, so add the following to your @Gemfile@ and @bundle install@:
 
@@ -1116,7 +1116,7 @@ blang[ruby].
   ```
 
 blang[python].
-  Now you'll need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
+  Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
   Add the following classes to your @server.py@ file.
 
@@ -1149,7 +1149,7 @@ blang[python].
 blang[php].
   Now you need to enable the login and logout functionality in the web server. In order to keep this tutorial simple, when a user logs in you'll set a cookie, and when they log out you'll clear the cookie.
 
-  You'll create two scripts that will serve as your login and logout functionality.
+  You'll need to create two scripts that will serve as your login and logout functionality.
 
   First, create a @login.php@ file containing:
 
@@ -1467,7 +1467,7 @@ blang[java].
   Ok, you're ready to see all of this in action. Restart the local server with earlier gradle command and then refresh the page at "http://localhost:3000/":http://localhost:3000/. You should receive an alert to confirm that you're connected as an anonymous user with limited capabilities as follows:
 
 blang[swift].
-  Time to get started. You will distinguish if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
+  Time to get started. You will need to check if the user provided his username, and then based on that issue rights capabilities. Replace the @get '/auth' do ... end@ code in your @server.rb@ with the following:
 
   ```[ruby]
     # Issue token requests to clients sending a request to the /auth endpoint
@@ -1493,9 +1493,9 @@ blang[swift].
       end
   ```
 
-  Now you will customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
+  Now you will need to customize the client. If you have not previously had experience building a basic user interface in Xcode, please refer to the "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
 
-  First you will add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
+  First you will need to add a login button and a textfield so that the user can provide their chosen username. Go to your @ExampleViewController@ and add a @UIButton@ from @Object library@. Name the action "loginAction".
 
   <a href="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" target="_blank">
     <img src="/images/tutorials/tutorials-swift-binding-UI-token-auth.gif" style="width: 100%" alt="Bind action">
@@ -1518,7 +1518,7 @@ blang[swift].
     <img src="/images/tutorials/tutorials-swift-token-auth-logout-screen.png" style="width: 60%" alt="Logout view">
   </a>
 
-  To define the flow between the @ExampleViewController@ and the @LogoutViewController@ you will use segues. If you are not familiar with them, please refer to the "Apple developer guide":https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html on how they work.
+  To define the flow between the @ExampleViewController@ and the @LogoutViewController@ you will need to use segues. If you are not familiar with them, please refer to the "Apple developer guide":https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html on how they work.
 
   First in your @Storyboard@ add a new "Present Modally" action segue. Name it "logoutSegue".
 
@@ -1593,7 +1593,7 @@ blang[swift].
     }
   ```
 
-  You will also update the @getTokenRequest@ method so that it will use the correct URL request:
+  You will also need to update the @getTokenRequest@ method so that it will use the correct URL request:
 
   ```[swift]
     func getTokenRequest(params: NSURL, completion: (NSDictionary?, ErrorType?) -> ())  {
@@ -1638,7 +1638,7 @@ blang[swift].
       }
   ```
 
-  The last thing you'll need to do is perform a logout action. You didn't connect the logout button to an action because you will connect it to a segue right now. In your @Storyboard@ hold ctrl and right-click the button and drag it to @ExampleViewController@ just like the earlier segue. Name it "toLoginSegue". When the user taps the logout button, before the segue is performed you'll need to close the connection to Ably and nullify the instance. All the actions that should be done before performing the segue can be done in the @prepareForSegue@ method in your @LogoutViewController@:
+  The last thing you'll need to do is perform a logout action. You didn't connect the logout button to an action because you will need to connect it to a segue right now. In your @Storyboard@ hold ctrl and right-click the button and drag it to @ExampleViewController@ just like the earlier segue. Name it "toLoginSegue". When the user taps the logout button, before the segue is performed you'll need to close the connection to Ably and nullify the instance. All the actions that should be done before performing the segue can be done in the @prepareForSegue@ method in your @LogoutViewController@:
 
   ```[swift]
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {


### PR DESCRIPTION
A few changes to the token auth tutorial to help with readability and a few fixes. This doesn't in any way look into the actual structure or contents:
- client server => client-server to match auth page.
- General missing and incorrect words (missing 'the', sentence structure, setup to set up when a verb, etc)
- Removed JavaScript as a language option due to it not being an option.
- British => American spelling (Minimising => minimizing, etc)
- Extra spacing removed
- We => You as per our current writing specs.