### PR TITLE
Spec should describe emitting ConnectionEvent not ConnectionState

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -320,8 +320,8 @@ h3(#realtime-connection). Connection
 ** @(RTN2g)@ Library and version param @lib@ should include the header value described in "RSC7b":#RSC7b. For example, the 1.0.0 version of the Javascript library would use the param @lib=js-1.0.0@
 * @(RTN3)@ If connection option @autoConnect@ is true, a connection is initiated immediately; otherwise a connection is only initiated following an explicit call to @connect()@
 * @(RTN4)@ The @Connection@ implements @EventEmitter@ and emits @ConnectionEvent@ events
-** @(RTN4a)@ It emits a @ConnectionState@ event (one of @INITIALIZED@, @CONNECTING@, @CONNECTED@, @DISCONNECTED@, @SUSPENDED@, @CLOSING@, @CLOSED@, @FAILED@) for every connection state change
-** @(RTN4h)@ It can emit an @UPDATE@ event (this is the only @ConnectionEvent@ which is not a @ConnectionState@). This is used for changes to connection conditions for which the @ConnectionState@ (e.g. @CONNECTED@) does not change. (The library must never emit a @ConnectionState@ event for a state equal to the previous state).
+** @(RTN4a)@ It emits a @ConnectionEvent@ event (one of @INITIALIZED@, @CONNECTING@, @CONNECTED@, @DISCONNECTED@, @SUSPENDED@, @CLOSING@, @CLOSED@, @FAILED@) for every connection state change
+** @(RTN4h)@ It can emit an @UPDATE@ event (this is the only @ConnectionEvent@ which is not a @ConnectionState@). This is used for changes to connection conditions for which the @ConnectionState@ (e.g. @CONNECTED@) does not change. (The library must never emit a @ConnectionEvent@ event for a state equal to the previous state).
 ** @(RTN4b)@ A new connection will emit the following events in order when connecting: @CONNECTING@, then @CONNECTED@
 ** @(RTN4c)@ A connection will emit the following events when closing the connection: @CLOSING@, then @CLOSED@
 ** @(RTN4d)@ @Connection#state@ attribute is the current state of the connection


### PR DESCRIPTION
RTN4 tells us a ConnectionEvent should be emitted but RTN4a and RTN4h both mentioned emitting ConnectionState, this PR fixes that.