### PR TITLE
Auth callback docs bug fix

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1434,7 +1434,7 @@ class ClientOptions:
   maxFrameSize: Int default 524288 // TO3l8
 
 class AuthOptions: // RSA8e
-  authCallback: (() -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b
+  authCallback: ((TokenParams) -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b
   authHeaders: [String: Stringifiable]? // RSA8c3, TO3j8, AO2e
   authMethod: .GET | .POST default .GET // RSA8c, TO3j7, AO2d
   authParams: [String: Stringifiable]? // RSA8c3, RSA8c1, TO3j9, AO2f


### PR DESCRIPTION
I believe authCallback has the argument `TokenParams` always so this fixes that.  