### PR TITLE
RDDP changed to DSN

### DIFF
--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -13,7 +13,7 @@ In this tutorial, you will learn how to build a Realtime chat application using 
 
 React Native lets you build mobile apps using only JavaScript. It uses the same design as React, letting you compose a rich mobile UI from declarative components. To learn more about React Native, please visit "here":https://facebook.github.io/react-native/.
 
-Ably is a Realtime data delivery platform providing developers everything they need to create, deliver and manage complex projects. Ably solves the hardest parts so they don’t have to. Our 100% data delivery guarantee offers unique peace of mind to stream data between apps, websites, and servers anywhere on earth in milliseconds.
+Ably is a Data Stream Network providing developers everything they need to create, deliver and manage complex projects. Ably solves the hardest parts so they don’t have to. Our 100% data delivery guarantee offers unique peace of mind to stream data between apps, websites, and servers anywhere on earth in milliseconds.
 
 <%= partial 'tutorials/_step-1-setup-free-account' %>
 


### PR DESCRIPTION
For website issue https://github.com/ably/website/issues/1577.
Only found a single case of RDDP. Many references exist of 'Ably platform', would we want those changed to 'Ably network'?