### PR TITLE
Updated documented jump_to and api_separator usage

### DIFF
--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -32,7 +32,9 @@ title: "Enter a title that will appear in the navigation and HTML page title"
 section: "Specify either rest|realtime|other|none to assign to nav on the left"
 index: 0 # Optional integer position within the nav, 0 is reserved for index & home
 jump_to: # Optional YAML tag that will insert a "jump to" navigation based on YAML
-  "Help with": # surrounding quotes are not normally needed...
+  "External Links": # surrounding quotes are not normally needed...
+    - External Link 1:/external/link #Seperate with a ":" to link to /external/link
+  "Help with":
     - "Item 1#anchor-link-id" # links to #anchor-link-id
   "API methods":
     - "Item 2" # auto-links to #item-2

--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -31,6 +31,10 @@ bc[yaml]. ---
 title: "Enter a title that will appear in the navigation and HTML page title"
 section: "Specify either rest|realtime|other|none to assign to nav on the left"
 index: 0 # Optional integer position within the nav, 0 is reserved for index & home
+api_separator: #This being specified will result in a seperator between docs and API docs
+  Section Title: #Title of a section in API separator
+    - External Link:/external/link #External link
+    - Internal Link#internal-link #auto-links to #internal-link
 jump_to: # Optional YAML tag that will insert a "jump to" navigation based on YAML
   "External Links": # surrounding quotes are not normally needed...
     - External Link 1:/external/link #Seperate with a ":" to link to /external/link


### PR DESCRIPTION
Added examples of both new jump_to usage and api_separator usage to doc formatting guide.