### PR TITLE
spec: TI5 Clarify when a URL should be appended to log messages

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1199,7 +1199,7 @@ h4. ErrorInfo
 * @(TI2)@ Errors returned from the Ably server are compatible with the @ErrorInfo@ structure and should result in errors that inherit from @ErrorInfo@
 * @(TI3)@ "Ably-common":https://github.com/ably/ably-common should be included as a submodule so that "consistent error codes":https://github.com/ably/ably-common/blob/master/protocol/errors.json can be used
 * @(TI4)@ Ably may additionally include a @href@ attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
-* @(TI5)@ When errors are logged that contain a @code@, the following text should be included in all log entries: "See https://help.ably.io/error/@[CODE]@"
+* @(TI5)@ Log entries generated from errors, where possible, should include a URL to help developers understand the error and resolve the issue. If the URL is not already present within the contents of the @message@ attribute, then it should be included in the log entry as follows: "See @[URL]@". If the @href@ attribute is present, it should be used as the URL. If the @href@ attribute is not present, and the @code@ attribute is present, then the URL should be constructed as follows "https://help.ably.io/error/@[CODE]@". If neither the @href@ or @code@ attributes are present, then an additional URL should not be included in the log entry.
 
 h4. ConnectionStateChange
 


### PR DESCRIPTION
Rather belated, but here's my attempt at clarifying when a URL is included in log entries shown to users.  Specifically addressing https://github.com/ably/ably-ruby/pull/171#issuecomment-426831624 and https://github.com/ably/ably-ruby/pull/171/commits/ea425be4a855d68649a81f161c4483ce6a38ab99.

