### PR TITLE
Rest#request: js lib now conforms strictly to the httppaginatedresponse spec. also clarify.

### DIFF
--- a/content/rest/_request.textile
+++ b/content/rest/_request.textile
@@ -21,7 +21,7 @@ h4. Parameters
 blang[jsall,objc,swift].
   h4. Callback result
 
-  On success, @results@ contains an "<span lang="default">@HttpPaginatedResponse@</span><span lang="objc,swift">@ARTHttpPaginatedResponse@</span>":/rest/types#http-paginated-response containing the @statusCode@ and a @success@ boolean, @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.<span lang="jsall"> (Note that for javascript, if the request fails, the callback will have an @err@ rather @results@, so the @success@ boolean is not really used)</span>)
+  On success, @results@ contains an "<span lang="default">@HttpPaginatedResponse@</span><span lang="objc,swift">@ARTHttpPaginatedResponse@</span>":/rest/types#http-paginated-response containing the @statusCode@ and a @success@ boolean, @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.
 
   On failure, @err@ contains an "@ErrorInfo@":/rest/types#error-info object with an error response as defined in the "Ably REST API":/rest-api#common documentation.
 

--- a/content/rest/_request.textile
+++ b/content/rest/_request.textile
@@ -21,25 +21,25 @@ h4. Parameters
 blang[jsall,objc,swift].
   h4. Callback result
 
-  On success, @results@ contains an "<span lang="default">@HttpPaginatedResponse@</span><span lang="objc,swift">@ARTHttpPaginatedResponse@</span>":/rest/types#http-paginated-response containing the @statusCode@ and a @success@ boolean, @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.
+  On successfully receiving a response from Ably, @results@ contains an "<span lang="default">@HttpPaginatedResponse@</span><span lang="objc,swift">@ARTHttpPaginatedResponse@</span>":/rest/types#http-paginated-response containing the @statusCode@ of the response, a @success@ boolean (equivalent to whether the status code is between 200 and 299), @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.
 
-  On failure, @err@ contains an "@ErrorInfo@":/rest/types#error-info object with an error response as defined in the "Ably REST API":/rest-api#common documentation.
+  On failure to obtain a response, @err@ contains an "@ErrorInfo@":/rest/types#error-info object with an error response as defined in the "Ably REST API":/rest-api#common documentation. (Note that if a response is obtained, any response, even with a non-2xx status code, will result in an HTTP Paginated Response, not an @err@).
 
 blang[java,ruby,php,python].
   h4. Returns
 
-  On success, the returned "@HttpPaginatedResponse@":/rest/types#http-paginated-response contains a <span lang="ruby,python">@status_code@</span><span lang="default">@statusCode@</span> and a @success@ boolean, @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.
+  On successfully receiving a response from Ably, the returned "@HttpPaginatedResponse@":/rest/types#http-paginated-response contains a <span lang="ruby,python">@status_code@</span><span lang="default">@statusCode@</span> and a @success@ boolean, @headers@, and an @items@ array containing the current page of results. It supports pagination using "@next@":#paginated-result and "@first@":#paginated-result methods, identically to "@PaginatedResult@":/rest/types#paginated-result.
 
-  Failure to retrieve the message history will raise an "@AblyException@":/realtime/types/#ably-exception
+  Failure to obtain a response will raise an "@AblyException@":/realtime/types/#ably-exception. (Note that if a response is obtained, any response, even with a non-2xx status code, will result in an HTTP Paginated Response, not an exception).
 
 blang[csharp].
   h4. Returns
 
   The method is asynchronous and return a Task that has to be awaited to get the result.
 
-  On success, the returned "@HttpPaginatedResponse@":/rest/types#http-paginated-response containing the @StatusCode@ and a @Success@ boolean, @Headers@, and an @Items@ array containing the current page of results. "@HttpPaginatedResponse@":/rest/types#http-paginated-response supports pagination using "@NextAsync@":#paginated-result and "@FirstAsync@":#paginated-result methods.
+  On successfully receiving a response from Ably, the returned "@HttpPaginatedResponse@":/rest/types#http-paginated-response containing the @StatusCode@ and a @Success@ boolean, @Headers@, and an @Items@ array containing the current page of results. "@HttpPaginatedResponse@":/rest/types#http-paginated-response supports pagination using "@NextAsync@":#paginated-result and "@FirstAsync@":#paginated-result methods.
 
-  Failure to retrieve the message history will raise an "@AblyException@":/realtime/types/#ably-exception
+  Failure to obtain a response will raise an "@AblyException@":/realtime/types/#ably-exception. (Note that if a response is obtained, any response, even with a non-2xx status code, will result in an HTTP Paginated Response, not an exception).
 
 h4. Example
 


### PR DESCRIPTION
(actually was back in march but I forgot to update the docs at the time)