### PR TITLE
update history docs to use PaginatedRequestParams

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -769,14 +769,14 @@ bq(definition).
   default: history(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":#paginated-result<"Message":#message> resultPage))
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash options) -> yields "PaginatedResult":#paginated-result<"Message":#message>
   java:    "PaginatedResult":#paginated-result<"Message":#message> history("Param []":#param options)
-  csharp:  Task<"PaginatedResult<Message>":#paginated-result> HistoryAsync("HistoryRequestParams":#history-request-params dataQuery, bool untilAttach = false)
+  csharp:  Task<"PaginatedResult<Message>":#paginated-result> HistoryAsync("PaginatedRequestParams":#paginated-request-params dataQuery, bool untilAttach = false)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTMessage":#message>?, ARTErrorInfo?) -> Void) throws
 
 Gets a "paginated":#paginated-result set of historical messages for this channel. If the "channel is configured to persist messages to disk":https://support.ably.io/support/solutions/articles/3000030059-how-long-are-messages-stored-for, then message history will "typically be available for 24 - 72 hours":https://support.ably.io/solution/articles/3000030059-how-long-are-messages-stored-for. If not, messages are only retained in memory by the Ably service for two minutes.
 
 h4. Parameters
 
-- <span lang="default">options</span><span lang="objc,swift">query</span><span lang="csharp">dataQuery</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified in the "message history API documentation":/realtime/history#channel-history.<br>__Type: <span lang="default">@Object@</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@</span><span lang="csharp">@HistoryRequestParams@</span><span lang="ruby">@Hash@</span><span lang="java">"@Param []@":#param</span>__
+- <span lang="default">options</span><span lang="objc,swift">query</span><span lang="csharp">dataQuery</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified in the "message history API documentation":/realtime/history#channel-history.<br>__Type: <span lang="default">@Object@</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@</span><span lang="csharp">@PaginatedRequestParams@</span><span lang="ruby">@Hash@</span><span lang="java">"@Param []@":#param</span>__
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="ruby">&block</div> := yields a @PaginatedResult<Message>@ object
@@ -1080,8 +1080,8 @@ h3(#completion-listener).
 blang[java].
   <%= partial partial_version('types/_completion_listener'), indent: 2, skip_first_indent: true %>
 
-h3(#history-request-params).
-  csharp: HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: PaginatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -327,19 +327,19 @@ bq(definition).
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash option) -> yields "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>
   java:    "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] option)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("HistoryRequestParams":#history-request-params query, bool untilAttach = false)
+  csharp:  Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false)
 
 Gets a "paginated":#paginated-result set of historical presence events for this channel.
 
 h4. Parameters
 
-- <span lang="default">option</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"HistoryRequestParams":#history-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified below.
+- <span lang="default">option</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"PaginatedRequestParams":#paginated-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified below.
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="ruby">&block</div> := yields a @PaginatedResult<PresenceMessage>@ object
 - <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message> object or an error
 
-h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@ properties</span><span lang="csharp">"@HistoryRequestParams@":#history-request-params properties</span>
+h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@ properties</span><span lang="csharp">"@PaginatedRequestParams@":#paginated-request-params properties</span>
 
 - <span lang="default">start</span><span lang="ruby">:start</span><span lang="csharp">Start</span> := _beginning of time_ earliest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any presence events retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
 - <span lang="default">end</span><span lang="ruby">:end</span><span lang="csharp">End</span> := _current time_ latest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any presence events retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
@@ -408,8 +408,8 @@ h3(#presence-action).
 
 <%= partial partial_version('types/_presence_action') %>
 
-h3(#history-request-params).
-  csharp: IO.Ably.HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: IO.Ably.PaginatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -260,19 +260,19 @@ bq(definition).
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash option) -> yields "PaginatedResult":#paginated-result<"Message":#message>
   java:    "PaginatedResult":#paginated-result<"Message":#message> history("Param":#param[] option)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTMessage":#message>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<PaginatedResult<Message>> HistoryAsync("HistoryRequestParams":#history-request-params dataQuery, bool untilAttach = false);
+  csharp:  Task<PaginatedResult<Message>> HistoryAsync("PaginatedRequestParams":#paginated-request-params dataQuery, bool untilAttach = false);
 
 Gets a "paginated":#paginated-result set of historical messages for this channel.
 
 h4. Parameters
 
-- <span lang="default">option</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"HistoryRequestParams":#history-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified below.
+- <span lang="default">option</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"PaginatedRequestParams":#paginated-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span>, as specified below.
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="ruby">&block</div> := yields a @PaginatedResult<Message>@ object
 - <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"ARTMessage":#message> object or an error
 
-h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@ properties</span><span lang="csharp">"@HistoryRequestParams@":#history-request-params properties</span>
+h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTRealtimeHistoryQuery@ properties</span><span lang="csharp">"@PaginatedRequestParams@":#paginated-request-params properties</span>
 
 - <span lang="default">start</span><span lang="ruby">:start</span><span lang="csharp">Start</span> := _beginning of time_ earliest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any messages retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
 - <span lang="default">end</span><span lang="ruby">:end</span><span lang="csharp">End</span> := _current time_ latest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any messages retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__

--- a/content/realtime/presence.textile
+++ b/content/realtime/presence.textile
@@ -801,14 +801,14 @@ bq(definition).
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash options) -> yields "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>
   java:    "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] options)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<PaginatedResult<PresenceMessage>> HistoryAsync("HistoryRequestParams":#history-request-params query, bool untilAttach = false)
+  csharp:  Task<PaginatedResult<PresenceMessage>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false)
 
 
 Gets a "paginated":#paginated-result set of historical presence message events for this channel. If the "channel is configured to persist messages to disk":https://support.ably.io/support/solutions/articles/3000030059-how-long-are-messages-stored-for, then the presence message event history will "typically be available for 24 - 72 hours":https://support.ably.io/solution/articles/3000030059-how-long-are-messages-stored-for. If not, presence message events are only retained in memory by the Ably service for two minutes.
 
 h4. Parameters
 
-- <span lang="default">options</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] options</span><span lang="csharp">"HistoryRequestParams":#history-request-params query</span> := <span lang="default">an optional object containing query parameters</span><span lang="ruby">an optional set of key value pairs containing query parameters</span>, as specified in the "presence history API documentation":/realtime/history#presence-history.
+- <span lang="default">options</span><span lang="objc,swift">query</span><span lang="java">"Param":#param[] options</span><span lang="csharp">"PaginatedRequestParams":#paginated-request-params query</span> := <span lang="default">an optional object containing query parameters</span><span lang="ruby">an optional set of key value pairs containing query parameters</span>, as specified in the "presence history API documentation":/realtime/history#presence-history.
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="ruby">&block</div> := yields a @PaginatedResult<Message>@ object
@@ -1164,8 +1164,8 @@ h3(#presence-action).
 
 <%= partial partial_version('types/_presence_action') %>
 
-h3(#history-request-params).
-  csharp: HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: PaginatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/realtime/types.textile
+++ b/content/realtime/types.textile
@@ -289,8 +289,8 @@ h3(#connection-state-change).
 
 <%= partial partial_version('types/_connection_state_change') %>
 
-h3(#history-request-params).
-  csharp: IO.Ably.HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: IO.Ably.PaginatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -332,7 +332,7 @@ bq(definition).
   python:  "PaginatedResult":#paginated-result<"Message":#message> history(kwargs_options)
   php:     "PaginatedResult":#paginated-result<"Message":#message> history(Array options)
   java:    "PaginatedResult":#paginated-result<"Message":#message> history("Param":#param[] options)
-  csharp:  Task<"PaginatedResult":#paginated-result<"Message":#message>> HistoryAsync("HistoryRequestParams":#history-request-params dataQuery)
+  csharp:  Task<"PaginatedResult":#paginated-result<"Message":#message>> HistoryAsync("PaginiatedRequestParams":#paginated-request-params dataQuery)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTMessage":#message>?, ARTErrorInfo?) -> Void) throws
   go:      (c &ast;RestChannel) History(options &ast;PaginateParams) (&ast;"PaginatedResult":#paginated-result, "error":#error-info)
 
@@ -398,8 +398,8 @@ h3(#channel-options).
 
 <%= partial partial_version('types/_channel_options') %>
 
-h3(#history-request-params).
-  csharp: HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: PaginiatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/rest/history.textile
+++ b/content/rest/history.textile
@@ -170,7 +170,7 @@ bq(definition).
   python:     "PaginatedResult":#paginated-result<"Message":#message> history(kwargs_options)
   php:        "PaginatedResult":#paginated-result<"Message":#message> history(Array option)
   java:       "PaginatedResult":#paginated-result<"Message":#message> history("Param":#param[] option)
-  csharp:     Task<"PaginatedResult":#paginated-result<"Message":#message>> HistoryAsync("HistoryRequestParams":#data-request query);
+  csharp:     Task<"PaginatedResult":#paginated-result<"Message":#message>> HistoryAsync("PaginiatedRequestParams":#data-request query);
   objc,swift: history(query: ARTDataQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTMessage":#message>?, ARTErrorInfo?) -> Void) throws
   go:         (c &ast;RestChannel) History(option &ast;PaginateParams) (&ast;"PaginatedResult":#paginated-result, error)
 
@@ -183,7 +183,7 @@ h4. Parameters
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"ARTMessage":#message> object or an error
 
-h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTDataQuery@ properties</span><span lang="csharp">"@HistoryRequestParams@":#history-request-params properties</span>
+h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTDataQuery@ properties</span><span lang="csharp">"@PaginiatedRequestParams@":#paginated-request-params properties</span>
 
 - <span lang="default">start</span><span lang="ruby">:start</span><span lang="csharp,go">Start</span> := _beginning of time_ earliest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any messages retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
 - <span lang="default">end</span><span lang="ruby">:end</span><span lang="csharp,go">End</span> := _current time_ latest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any messages retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
@@ -236,7 +236,7 @@ bq(definition).
   python:     "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history(kwargs_options)
   php:        "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history(Array option)
   java:       "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] option)
-  csharp:     Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("HistoryRequestParams":#data-request query);
+  csharp:     Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("PaginiatedRequestParams":#data-request query);
   objc,swift: history(query: ARTDataQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
   go:         (p &ast;RestPresence) History(option &ast;PaginateParams) (&ast;PaginatedResult, error)
 
@@ -244,12 +244,12 @@ Gets a "paginated":#paginated-result set of historical presence events for this 
 
 h4. Parameters
 
-- <span lang="default">option</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"HistoryRequestParams":#history-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="python">optional keyword arguments containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span><span lang="php">an Associate Array containing the query parameters</span>, as specified below.
+- <span lang="default">option</span><span lang="java">"Param":#param[] option</span><span lang="csharp">"PaginiatedRequestParams":#paginated-request-params query</span> := <span lang="default">an optional object containing the query parameters</span><span lang="python">optional keyword arguments containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing the query parameters</span><span lang="php">an Associate Array containing the query parameters</span>, as specified below.
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message> object or an error
 
-h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTDataQuery@ properties</span><span lang="csharp">"@HistoryRequestParams@":#history-request-params properties</span>
+h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ARTDataQuery@ properties</span><span lang="csharp">"@PaginiatedRequestParams@":#paginated-request-params properties</span>
 
 - <span lang="default">start</span><span lang="ruby">:start</span><span lang="csharp,go">Start</span> := _beginning of time_ earliest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any presence events retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
 - <span lang="default">end</span><span lang="ruby">:end</span><span lang="csharp,go">End</span> := _current time_ latest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any presence events retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
@@ -316,8 +316,8 @@ h3(#presence-action).
 
 <%= partial partial_version('types/_presence_action') %>
 
-h3(#history-request-params).
-  csharp: IO.Ably.HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: IO.Ably.PaginiatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/rest/presence.textile
+++ b/content/rest/presence.textile
@@ -309,7 +309,7 @@ bq(definition).
   python:     "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history(kwargs_options)
   php:        "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history(Array options)
   java:       "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] options)
-  csharp:     Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("HistoryRequestParams":#history-request-params query);
+  csharp:     Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("PaginiatedRequestParams":#paginated-request-params query);
   objc,swift: history(query: ARTDataQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
   go:         (p &ast;RestPresence) History(params &ast;PaginateParams) (&ast;PaginatedResult, error)
 
@@ -317,7 +317,7 @@ Gets a "paginated":#paginated-result set of historical presence message events f
 
 h4. Parameters
 
-- <span lang="default">options</span><span lang="java">"Param":#param[] options</span><span lang="objc,swift">query</span><span lang="csharp">"HistoryRequestParams":#history-request-params query</span> := <span lang="default">an optional object containing query parameters</span><span lang="python">optional keyword arguments containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing query parameters</span><span lang="php">an optional Associate Array containing the query parameters</span>, as specified in the "presence history API documentation":/rest/history#presence-history.
+- <span lang="default">options</span><span lang="java">"Param":#param[] options</span><span lang="objc,swift">query</span><span lang="csharp">"PaginiatedRequestParams":#paginated-request-params query</span> := <span lang="default">an optional object containing query parameters</span><span lang="python">optional keyword arguments containing the query parameters</span><span lang="ruby">an optional set of key value pairs containing query parameters</span><span lang="php">an optional Associate Array containing the query parameters</span>, as specified in the "presence history API documentation":/rest/history#presence-history.
 
 - <div lang="jsall">callback</div> := is a function of the form: @function(err, resultPage)@
 - <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message> object or an error
@@ -366,8 +366,8 @@ h3(#presence-action).
 
 <%= partial partial_version('types/_presence_action') %>
 
-h3(#history-request-params).
-  csharp: HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: PaginiatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>

--- a/content/rest/types.textile
+++ b/content/rest/types.textile
@@ -163,8 +163,8 @@ h3(#stats-granularity).
 
 <%= partial partial_version('types/_stats_granularity') %>
 
-h3(#history-request-params).
-  csharp: IO.Ably.HistoryRequestParams
+h3(#paginated-request-params).
+  csharp: IO.Ably.PaginiatedRequestParams
 
 blang[csharp].
   <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>


### PR DESCRIPTION
update history docs to use PaginatedRequestParams for History calls (breaking change made in v1.1

See https://github.com/ably/ably-dotnet/pull/323 for more details