### PR TITLE
Update tutorials to tags

### DIFF
--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -45,7 +45,7 @@ Since we'll be using JavaScript in this tutorial, the best way to display result
 <html>
 
 <head>
-    <title>Channel Occupancy Events</title>
+    <title>Channel Lifecycle Events</title>
     <script src="https://cdn.ably.io/lib/ably.min-1.js" crossorigin="anonymous"></script>
 </head>
 
@@ -68,8 +68,9 @@ Since we'll be using JavaScript in this tutorial, the best way to display result
 
 The key thing to note in the HTML above, is the inclusion of two JS files, ones is the Ably Library, referenced via the CDN, while the other is the @main.js@ file which will include our logic. We'll work on this next. We have also added a text area to display our results in.
 
+"See this step in Github":https://github.com/ably/tutorials/tree/lifecycle-javascript-step3
 
-h3(#subscribing-to-channel-lifecycle-events). Adding subscribers for the lifecycle events
+h2(#subscribing-to-channel-lifecycle-events). Step 4 - Adding subscribers for the lifecycle events
 
 For the simplicity of this tutorial, we'll use "Basic authentication":/core-features/authentication#basic-authentication in our realtime client. However, it is highly recommended to use "Token auth":/core-features/authentication#token-authentication on client-side applications for better security and protection of your API key.
 
@@ -118,6 +119,8 @@ metaChannel.subscribe('channel.region.inactive', (msg) => {
 ```
 
 In the above code, we have subscribed to the various channel lifecycle events on the meta-channel and then we display the data returned in the text area. Simple as that!
+
+"See this step in Github":https://github.com/ably/tutorials/tree/lifecycle-javascript-step4
 
 h2(#live-demo). Step - 5 Live Demo
 

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -68,7 +68,7 @@ Since we'll be using JavaScript in this tutorial, the best way to display result
 
 The key thing to note in the HTML above, is the inclusion of two JS files, ones is the Ably Library, referenced via the CDN, while the other is the @main.js@ file which will include our logic. We'll work on this next. We have also added a text area to display our results in.
 
-"See this step in Github":https://github.com/ably/tutorials/tree/lifecycle-javascript-step3
+"See this step in Github":https://github.com/ably/tutorials/commit/lifecycle-javascript-step3
 
 h2(#subscribing-to-channel-lifecycle-events). Step 4 - Adding subscribers for the lifecycle events
 
@@ -120,7 +120,7 @@ metaChannel.subscribe('channel.region.inactive', (msg) => {
 
 In the above code, we have subscribed to the various channel lifecycle events on the meta-channel and then we display the data returned in the text area. Simple as that!
 
-"See this step in Github":https://github.com/ably/tutorials/tree/lifecycle-javascript-step4
+"See this step in Github":https://github.com/ably/tutorials/commit/lifecycle-javascript-step4
 
 h2(#live-demo). Step - 5 Live Demo
 
@@ -157,7 +157,7 @@ h2(#live-demo). Step - 5 Live Demo
         </textarea>
     </div>
 
-"See the full code in GitHub":https://github.com/ably/tutorials/tree/channel-lifecycle-events
+"See the full code in GitHub":https://github.com/ably/tutorials/commit/channel-lifecycle-events
 
 h2(#next-steps). Next Steps
 

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -51,6 +51,14 @@ Since we'll be using JavaScript in this tutorial, the best way to display the re
     Ably Channel Occupancy Events - Demo
     <br/>
     <br/>
+    <div style="text-align: center; padding: 10px;">
+        <button style="padding: 5px; width: 150px" id="add-publisher-instance" onclick="addPublisherInstance()">Add publisher instance</button>
+        <button style="padding: 5px; width: 150px" id="add-subscriber-instance" onclick="addSubscriberInstance()">Add subscriber instance</button>
+    </div>
+    <div style="text-align: center; padding: 10px;">
+        <button style="padding: 5px; width: 150px" id="add-publisher-instance-presence" onclick="addPublisherInstanceWithPresence()">Add publisher instance and enter presence</button>
+        <button style="padding: 5px; width: 150px" id="add-subscriber-instance-presence" onclick="addSubscriberInstanceWithPresence()">Add subscriber instance and enter presence</button>
+    </div>
     <div>
         <br>
         <textarea id="result" rows="30" style="width: 100%; margin-top: 10px; font-family: courier, courier new; background-color: #333; color: orange;  overflow-y: scroll;"
@@ -64,6 +72,8 @@ Since we'll be using JavaScript in this tutorial, the best way to display the re
 ```
 
 The key thing to note in the HTML above is the inclusion of two JS files, one is the Ably Library, referenced via the CDN, while the other is the @main.js@ file which will include our logic, we'll work on this next. We have also added a text area to display our results in.
+
+"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step3
 
 h2(#subscribing-to-occupancy-events). Step 4 - Subscribing to Occupancy events using Ably's Realtime Library
 
@@ -111,7 +121,63 @@ Remember to replace the text '<YOUR-API-KEY>' with an actual Ably API key.
 
 In the above code, we have subscribed to the 'channel.occupancy' events on the metachannel containing the channel lifecycle information. Then, we have displayed the data returned in the text area. Simple as that! 
 
-h2(#live-demo). Step - 5 Live Demo
+"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step4
+
+h2(#add-buttons). Step 5 - Add button functionality
+
+Now that we have the backend code running, it's time to make our buttons work! Add the following code to your @main.js@ file:
+
+```[javascript]
+function addPublisherInstance() {
+    resultArea.value += ('\n[LOCAL LOG - ' + (new Date().toLocaleTimeString()) + ' ]: Adding new publisher instance\n')
+    var myKey = '<YOUR-API-KEY>'
+    var ably = new Ably.Realtime({
+        key: myKey
+    });
+    var regularChannel = ably.channels.get("regular-channel")
+    console.log('adding publisher instance')
+    regularChannel.publish('test-data', {
+        data: "Dummy Data",
+        time: Date.now()
+    })
+}
+
+function addSubscriberInstance() {
+    resultArea.value += ('\n[LOCAL LOG - ' + (new Date().toLocaleTimeString()) + ' ]: Adding new subscriber instance\n')
+    var myKey = '<YOUR-API-KEY>'
+    var ably = new Ably.Realtime({
+        key: myKey
+    });
+    var regularChannel = ably.channels.get("regular-channel")
+    console.log('adding subscriber instance')
+    regularChannel.subscribe('test-data', (data) => {
+        //do whatever
+        console.log('Subscription working')
+    })
+}
+
+function enterPresence() {
+    resultArea.value += ('\n[LOCAL LOG - ' + (new Date().toLocaleTimeString()) + ' ]: Entering presence\n')
+    var ably = new Ably.Realtime({
+        key: apiKey
+    });
+    var regularChannel = ably.channels.get("regular-channel")
+    regularChannel.presence.enter();
+}
+
+function leavePresence() {
+    resultArea.value += ('\n[LOCAL LOG - ' + (new Date().toLocaleTimeString()) + ' ]: Leaving presence\n')
+    var ably = new Ably.Realtime({
+        key: apiKey
+    });
+    var regularChannel = ably.channels.get("regular-channel")
+    regularChannel.presence.leave();
+}
+```
+
+"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step5
+
+h2(#live-demo). Step 6 - Live Demo
 
 For the live demo, we'll manually add new occupants through button clicks, so that we can see the 'channel.occupancy' events live in action.
 

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -73,7 +73,7 @@ Since we'll be using JavaScript in this tutorial, the best way to display the re
 
 The key thing to note in the HTML above is the inclusion of two JS files, one is the Ably Library, referenced via the CDN, while the other is the @main.js@ file which will include our logic, we'll work on this next. We have also added a text area to display our results in.
 
-"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step3
+"See this step in Github":https://github.com/ably/tutorials/commit/occupancy-javascript-step3
 
 h2(#subscribing-to-occupancy-events). Step 4 - Subscribing to Occupancy events using Ably's Realtime Library
 
@@ -120,7 +120,7 @@ Remember to replace the text '<YOUR-API-KEY>' with an actual Ably API key.
 
 In the above code, we have subscribed to the 'channel.occupancy' events on the metachannel containing the channel lifecycle information. Then, we have displayed the data returned in the text area. Simple as that! 
 
-"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step4
+"See this step in Github":https://github.com/ably/tutorials/commit/occupancy-javascript-step4
 
 h2(#add-buttons). Step 5 - Add button functionality
 
@@ -174,7 +174,7 @@ function leavePresence() {
 }
 ```
 
-"See this step in Github":https://github.com/ably/tutorials/tree/occupancy-javascript-step5
+"See this step in Github":https://github.com/ably/tutorials/commit/occupancy-javascript-step5
 
 h2(#live-demo). Step 6 - Live Demo
 
@@ -198,7 +198,7 @@ For the live demo, we'll manually add new occupants through button clicks, so th
         </textarea>
     </div>
 
-"See the full code in GitHub":https://github.com/ably/tutorials/tree/channel-occupancy-events
+"See the full code in GitHub":https://github.com/ably/tutorials/commit/channel-occupancy-events
 
 h2(#next-steps). Next Steps
 

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -116,7 +116,6 @@ metaChannel.subscribe('channel.occupancy', (msg) => {
 })
 ```
 
-
 Remember to replace the text '<YOUR-API-KEY>' with an actual Ably API key.
 
 In the above code, we have subscribed to the 'channel.occupancy' events on the metachannel containing the channel lifecycle information. Then, we have displayed the data returned in the text area. Simple as that! 

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -6,7 +6,7 @@ index: 20
 
 Ably's "history feature":/realtime/history enables you to store messages published on channels that can later be retrieved using the "channel history API":/realtime/history.
 
-By default, channels will only store messages in memory for up to two minutes. However, using "channel rules":https://support.ably.io/solution/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app, you can configure messages published on matching channels to be persisted to disk for "typically 24 - 72 hours":https://support.ably.io/solution/articles/3000030059-how-long-are-messages-stored-for. Those messages will then be immediately available for retrieval via our Realtime and REST API clients for as long as the message is stored on disk.
+By default, channels will only store messages in memory for up to two minutes. However, using "channel rules":https://support.ably.io/solution/articles/3000030057, you can configure messages published on matching channels to be persisted to disk for "typically 24 - 72 hours":https://support.ably.io/solution/articles/3000030059. Those messages will then be immediately available for retrieval via our Realtime and REST API clients for as long as the message is stored on disk.
 
 Using our "history API":/realtime/history is trivial.  Let's get started.
 
@@ -18,7 +18,7 @@ Channels can be named using any unicode string characters with the only restrict
 
 We will be using channel rules in this tutorial to ensure all channels in the @persisted@ namespace are configured to persist messages to disk i.e. we will explicitly enable the history feature. Follow these steps:
 
-# Visit your "account dashboard":https://support.ably.io/solution/articles/3000048664-how-do-i-access-my-account-dashboard, navigate to the same app you chose in Step 1 when obtaining your API key earlier
+# Visit your "account dashboard":https://support.ably.io/solution/articles/3000048664, navigate to the same app you chose in Step 1 when obtaining your API key earlier
 # Click on the Settings tab and scroll down to the "Channel rules" section
 # Click the "Add new rule" button (see below)
 <a href="/images/tutorials/history/channel-rules-add-new-rule.png" target="_blank">
@@ -76,7 +76,7 @@ blang[java].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/56b96fe
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step3
 
 blang[android].
   To build your own Android Project, please visit "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with steps necessary to set up your own application.
@@ -118,7 +118,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/b354fd2
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step3b
 
 blang[javascript].
   To start using Ably in your web app, you first need to include the Ably library. We recommend that you include the latest client library from our CDN using a simple @<script>@ tag. The client library must be instanced with the API key you copied in Step 1. Note in production we recommend you always use the "token authentication scheme":/core-features/authentication#token-authentication for browser clients, however in this example we use an API key for simplicity.
@@ -135,7 +135,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/a55b855
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-javascript-step3
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -159,7 +159,7 @@ blang[ruby].
     ably = Ably::Rest.new(key: api_key)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/05e2e16
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step3
 
 blang[python].
   The REST library for Python is "hosted on Github":https://github.com/ably/ably-python and is "published on PyPI":https://pypi.python.org/pypi/ably and can be installed as follows:
@@ -199,7 +199,7 @@ blang[php].
     $ably = new \Ably\AblyRest("{{ApiKey}}");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/9430f46
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step3
 
 blang[swift].
   We will start by creating an Xcode project for this tutorial. To build your own Xcode Project in Swift visit "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to setup your own application.
@@ -216,7 +216,7 @@ blang[swift].
     <img src="/images/tutorials/shared/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/ed24f3e
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step3a
 
   To start using Ably you first need to install the Ably pod via CocoaPods. You need to add a @Podfile@ to your project directory:
 
@@ -249,7 +249,7 @@ blang[swift].
     let client = ARTRealtime(key: API_KEY)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/e3ecbaf
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step3b
 
 h2. Step 4 - Publishing messages to be stored with channel history
 
@@ -265,7 +265,7 @@ blang[java].
   channel.publish("play", "cluck");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/cb014ca
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step4
 
 blang[android].
   ```[java]
@@ -287,7 +287,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/22c4618
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step4
 
 blang[javascript].
   ```[javascript]
@@ -297,7 +297,7 @@ blang[javascript].
     channel.publish("play", "cluck");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/f460ba7
+  "See this step in Github":https://github.com/ably/tutorials/commit/tree/history-javascript-step4
 
 blang[ruby].
   ```[ruby]
@@ -307,7 +307,7 @@ blang[ruby].
     channel.publish 'play', 'cluck'
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/c99d105
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step4
 
 blang[php].
   ```[php]
@@ -319,7 +319,7 @@ blang[php].
 
   Now you can check how it works by running @php history.php@ in console.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/310f8db
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step4
 
 blang[python].
   ```[python]
@@ -331,7 +331,7 @@ blang[python].
 
   If you would like to try running this now, you can do so with @python history.py@.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/6a350c2
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-python-step4
 
 blang[swift].
   If you have not previously had a chance to build a basic user interface in Xcode, please refer to "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
@@ -348,7 +348,7 @@ blang[swift].
     channel.publish("play", data: "cluck")
   ```
 
-    "See this step in Github":https://github.com/ably/tutorials/commit/6afc0d4
+    "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step4
 
 h2. Step 5 - Retrieving messages from history
 
@@ -364,7 +364,7 @@ blang[java].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/72c9b95
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step5
 
 blang[android].
   ```[java]
@@ -377,7 +377,7 @@ blang[android].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/1eb8b1d
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step5
 
 blang[javascript].
   ```[javascript]
@@ -387,7 +387,7 @@ blang[javascript].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/9716aa2
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-javascript-step5
 
 blang[ruby].
   ```[ruby]
@@ -396,7 +396,7 @@ blang[ruby].
     puts "Last message published: #{result_page.items.first.data}"
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/55ad113
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step5
 
 blang[python].
   ```[python]
@@ -408,7 +408,7 @@ blang[python].
 
   If you would like to try running this now, you can do so with @python history.py@.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/771a63f
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-python-step5
 
 blang[php].
   ```[php]
@@ -424,7 +424,7 @@ blang[php].
 
   Run @php history.php@ to see messages retrieved from channel history.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/868c4c2
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step5
 
 blang[swift].
   We want the retrieved history to show in our @ExampleViewController@. In this tutorial we will load retrieved messages to a table view. Add @UITableView@ from @Object library@ to your view and bind it in code as "tableView" also remember to change:
@@ -512,7 +512,7 @@ blang[swift].
       }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/164b8e2
+  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step5
 
 We're done, it's that simple. We have now shown you how to set up a channel to use persisted history using channel rules, then we published some messages on that channel, and later retrieved them using the history API.
 

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -76,7 +76,7 @@ blang[java].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-java-step3
 
 blang[android].
   To build your own Android Project, please visit "Android Developers":https://developer.android.com/training/basics/firstapp/creating-project.html website and get familiar with steps necessary to set up your own application.
@@ -118,7 +118,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step3b
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-android-step3b
 
 blang[javascript].
   To start using Ably in your web app, you first need to include the Ably library. We recommend that you include the latest client library from our CDN using a simple @<script>@ tag. The client library must be instanced with the API key you copied in Step 1. Note in production we recommend you always use the "token authentication scheme":/core-features/authentication#token-authentication for browser clients, however in this example we use an API key for simplicity.
@@ -135,7 +135,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-javascript-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-javascript-step3
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -159,7 +159,7 @@ blang[ruby].
     ably = Ably::Rest.new(key: api_key)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-ruby-step3
 
 blang[python].
   The REST library for Python is "hosted on Github":https://github.com/ably/ably-python and is "published on PyPI":https://pypi.python.org/pypi/ably and can be installed as follows:
@@ -199,7 +199,7 @@ blang[php].
     $ably = new \Ably\AblyRest("{{ApiKey}}");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-php-step3
 
 blang[swift].
   We will start by creating an Xcode project for this tutorial. To build your own Xcode Project in Swift visit "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to setup your own application.
@@ -216,7 +216,7 @@ blang[swift].
     <img src="/images/tutorials/shared/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step3a
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-swift-step3a
 
   To start using Ably you first need to install the Ably pod via CocoaPods. You need to add a @Podfile@ to your project directory:
 
@@ -249,7 +249,7 @@ blang[swift].
     let client = ARTRealtime(key: API_KEY)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step3b
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-swift-step3b
 
 h2. Step 4 - Publishing messages to be stored with channel history
 
@@ -265,7 +265,7 @@ blang[java].
   channel.publish("play", "cluck");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-java-step4
 
 blang[android].
   ```[java]
@@ -287,7 +287,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-android-step4
 
 blang[javascript].
   ```[javascript]
@@ -297,7 +297,7 @@ blang[javascript].
     channel.publish("play", "cluck");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/tree/history-javascript-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/commit/history-javascript-step4
 
 blang[ruby].
   ```[ruby]
@@ -307,7 +307,7 @@ blang[ruby].
     channel.publish 'play', 'cluck'
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-ruby-step4
 
 blang[php].
   ```[php]
@@ -319,7 +319,7 @@ blang[php].
 
   Now you can check how it works by running @php history.php@ in console.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-php-step4
 
 blang[python].
   ```[python]
@@ -331,7 +331,7 @@ blang[python].
 
   If you would like to try running this now, you can do so with @python history.py@.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-python-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-python-step4
 
 blang[swift].
   If you have not previously had a chance to build a basic user interface in Xcode, please refer to "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
@@ -348,7 +348,7 @@ blang[swift].
     channel.publish("play", data: "cluck")
   ```
 
-    "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step4
+    "See this step in Github":https://github.com/ably/tutorials/commit/history-swift-step4
 
 h2. Step 5 - Retrieving messages from history
 
@@ -364,7 +364,7 @@ blang[java].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-java-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-java-step5
 
 blang[android].
   ```[java]
@@ -377,7 +377,7 @@ blang[android].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-android-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-android-step5
 
 blang[javascript].
   ```[javascript]
@@ -387,7 +387,7 @@ blang[javascript].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-javascript-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-javascript-step5
 
 blang[ruby].
   ```[ruby]
@@ -396,7 +396,7 @@ blang[ruby].
     puts "Last message published: #{result_page.items.first.data}"
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-ruby-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-ruby-step5
 
 blang[python].
   ```[python]
@@ -408,7 +408,7 @@ blang[python].
 
   If you would like to try running this now, you can do so with @python history.py@.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-python-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-python-step5
 
 blang[php].
   ```[php]
@@ -424,7 +424,7 @@ blang[php].
 
   Run @php history.php@ to see messages retrieved from channel history.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-php-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-php-step5
 
 blang[swift].
   We want the retrieved history to show in our @ExampleViewController@. In this tutorial we will load retrieved messages to a table view. Add @UITableView@ from @Object library@ to your view and bind it in code as "tableView" also remember to change:
@@ -512,7 +512,7 @@ blang[swift].
       }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/history-swift-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/history-swift-step5
 
 We're done, it's that simple. We have now shown you how to set up a channel to use persisted history using channel rules, then we published some messages on that channel, and later retrieved them using the history API.
 

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -133,7 +133,7 @@ The above code is invoked when a client application hits the '/auth' route on yo
 
 Note that a cache-control has been added to the response header in order to prevent a chached token from being obtained. This makes sure we never obtain a token which has potentially expired.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/affad7f
+"See this step in Github":https://github.com/ably/tutorials/commit/jwt-node-step2
 
 h2. Step 3 - Setting up the client
 
@@ -193,7 +193,7 @@ With the returned JWT, the client will automatically attempt to connect to Ably 
 
 That's it, simple as that!
 
-"See this step in Github":https://github.com/ably/tutorials/commit/834506b
+"See this step in Github":https://github.com/ably/tutorials/commit/jwt-node-step3
 
 h2. Step 4 - Checking the output
 

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -32,7 +32,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-javascript-step2
 
 blang[nodejs].
   To start using Ably you first need to install the NPM module. The NPM module can be installed as follows:
@@ -50,7 +50,7 @@ blang[nodejs].
     var realtime = new Ably.Realtime({ key: apiKey });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-nodejs-step2
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -78,7 +78,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-ruby-step2
 
 h2. Step 3 - Enter the presence set
 
@@ -98,10 +98,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-javascript-step3
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-nodejs-step3
 
 blang[ruby].
   ```[ruby]
@@ -114,7 +114,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-ruby-step3
 
 We're now in the presence set. The name we'll appear as is the @client ID@ that we included in the Realtime constructor in step 2.
 
@@ -160,10 +160,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-javascript-step4
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-javascript-step4
 
 blang[ruby].
   ```[ruby]
@@ -174,7 +174,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-ruby-step4
 
 As soon as you are attached to the channel, the presence set starts to sync with Ably. When you make this call to get the presence set, it will (by default) wait until it has finished syncing before completing. For small presence sets this will take only a few milliseconds; for larger ones (with hundreds of members) the full sync can take a little longer.
 
@@ -193,10 +193,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-javascript-step5
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-nodejs-step5
 
 blang[ruby].
   ```[ruby]
@@ -208,7 +208,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step5
+  "See this step in Github":https://github.com/ably/tutorials/commit/presence-ruby-step5
 
 
 And that's it. To see this in action, try out the live demo below.

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -32,7 +32,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/71e1fe0
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step2
 
 blang[nodejs].
   To start using Ably you first need to install the NPM module. The NPM module can be installed as follows:
@@ -50,7 +50,7 @@ blang[nodejs].
     var realtime = new Ably.Realtime({ key: apiKey });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/53df419
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step2
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -78,7 +78,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/01c584a
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step2
 
 h2. Step 3 - Enter the presence set
 
@@ -98,10 +98,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/commit/9dcc74b
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step3
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/5a39594
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step3
 
 blang[ruby].
   ```[ruby]
@@ -114,7 +114,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/db18bec
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step3
 
 We're now in the presence set. The name we'll appear as is the @client ID@ that we included in the Realtime constructor in step 2.
 
@@ -160,10 +160,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/commit/087e904
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step4
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/c0376c9
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step4
 
 blang[ruby].
   ```[ruby]
@@ -174,7 +174,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/75f44db
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step4
 
 As soon as you are attached to the channel, the presence set starts to sync with Ably. When you make this call to get the presence set, it will (by default) wait until it has finished syncing before completing. For small presence sets this will take only a few milliseconds; for larger ones (with hundreds of members) the full sync can take a little longer.
 
@@ -193,10 +193,10 @@ blang[javascript,nodejs].
   ```
 
 blang[javascript].
-  "See this step in Github":https://github.com/ably/tutorials/commit/583b582
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-javascript-step5
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/6326cce
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-nodejs-step5
 
 blang[ruby].
   ```[ruby]
@@ -208,7 +208,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/20fca08
+  "See this step in Github":https://github.com/ably/tutorials/tree/presence-ruby-step5
 
 
 And that's it. To see this in action, try out the live demo below.

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -59,7 +59,7 @@ blang[java].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/044c23f
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step2
 
 
 blang[android].
@@ -102,7 +102,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/f390749
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step2
 
 blang[javascript].
   To start using Ably in your web app, you first need to include the Ably library. We recommend that you include the latest client library from our CDN using a simple @<script>@ tag. The client library must be instanced with the API key you copied in Step 1. Note in production we recommend you always use the "token authentication scheme":/core-features/authentication#token-authentication for browser clients, however in this example we use an API key for simplicity.
@@ -119,7 +119,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/publish-subscribe-javascript-install-ably
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step2
 
 blang[nodejs].
   To start using Ably you first need to install the NPM module. The NPM module can be installed as follows:
@@ -137,7 +137,7 @@ blang[nodejs].
     var realtime = new Ably.Realtime({ key: apiKey });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/f8a9f4a
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step2
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -165,7 +165,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/0ec2c7e
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step2
 
 blang[php].
   To start using Ably you first need to install "composer package on packagist":https://packagist.org/packages/ably/ably-php into your composer.
@@ -211,7 +211,7 @@ blang[php].
 
   If you would like to try running the server now, you can do so with @php -S 0.0.0.0:8000@. Once running, open your browser to "http://localhost:8000/":http://localhost:8000/ and you should see "Publish & Subscribe sample".
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/64f73bd
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step2
 
 blang[python].
   To start using Ably you first need to install The REST library for Python, it's "hosted on Github":https://github.com/ably/ably-python and is "published on PyPI":https://pypi.python.org/pypi/ably and can be installed as follows:
@@ -288,7 +288,7 @@ blang[python].
 
   If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Publish & Subscribe sample". If you would like to change port, on which your site will be available, simply add it after command ieg. @python server.py 1234@ for port @1234@.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/277475e
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step2
 
 blang[swift].
   We will start by creating an Xcode project for this tutorial. To build your own Xcode Project in Swift visit "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to setup your own application.
@@ -305,7 +305,7 @@ blang[swift].
     <img src="/images/tutorials/shared/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/a98f1bf
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step2a
 
   To start using Ably you first need to install the Ably pod via CocoaPods. You need to add a @Podfile@ to your project directory:
 
@@ -338,7 +338,7 @@ blang[swift].
     let client = ARTRealtime(key: API_KEY)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/59dcc56
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step2b
 
 h2. Step 3 - Subscribe to messages
 
@@ -355,7 +355,7 @@ blang[java].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/a0c24c5
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step3
 
 blang[android].
   ```[java]
@@ -369,7 +369,7 @@ blang[android].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/48132b8
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step3
 
 blang[javascript].
   ```[javascript]
@@ -379,7 +379,7 @@ blang[javascript].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/publish-subscribe-javascript-subscribe
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step3
 
 blang[nodejs].
   ```[nodejs]
@@ -389,7 +389,7 @@ blang[nodejs].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/334016a
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step3
 
 blang[ruby].
   ```[ruby]
@@ -399,7 +399,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/75becbf
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step3
 
 blang[php].
   Update @index.php@ and add code below before @</script>@ tag:
@@ -411,7 +411,7 @@ blang[php].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/8657a47
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step3
 
 blang[python].
   Update @index.html@ and add code below before @</script>@ tag:
@@ -423,7 +423,7 @@ blang[python].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/0e0b4d5
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step3
 
 blang[swift].
   If you have not previously had experience building a basic user interface in Xcode, please refer to "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
@@ -448,7 +448,7 @@ blang[swift].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/9120f09
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step3
 
 h2. Step 4 - Publishing a message
 
@@ -471,7 +471,7 @@ blang[java].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/71f8444
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step4
 
 blang[android].
   ```[java]
@@ -491,7 +491,7 @@ blang[android].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/aaf5888
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step4
 
 blang[javascript].
   ```[javascript]
@@ -499,7 +499,7 @@ blang[javascript].
     channel.publish("update", { "team": "Man United" });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/publish-subscribe-javascript
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step4
 
 blang[nodejs].
   ```[nodejs]
@@ -507,7 +507,7 @@ blang[nodejs].
     channel.publish("update", { "team": "Man United" });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/f831895
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step4
 
 blang[ruby].
   ```[ruby]
@@ -515,7 +515,7 @@ blang[ruby].
     channel.publish 'update', 'team' => 'Man United'
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/212b65b
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step4
 
 blang[php].
   Create @publish.php@ file which will be responsible for publishing messages:
@@ -547,7 +547,7 @@ blang[php].
 
   If you would like to try running the server now, you can do so with @php -S 0.0.0.0:8000@. Once running, open your browser to "http://localhost:8000/":http://localhost:8000/ and you should see "Publish & Subscribe sample" and box with "input message", try it out.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/534af85
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step4
 
 blang[python].
   Let's create resource for @/publish@, it will serve as message publisher:
@@ -596,7 +596,7 @@ blang[python].
 
   If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Publish & Subscribe sample" and box with "input message", try it out.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/33826f9
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step4
 
 blang[swift].
   In this step add another @UIButton@ and bind it to action named "publishAction". Also, add one more @UILabel@ and an @UITextField@ - bind it in your code as "messageText" . Thanks to that users will be able to write their own messages.
@@ -616,7 +616,7 @@ blang[swift].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/d035f1a
+  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step4
 
 We're done, it's that simple. We have now shown you how to subscribe to messages on a channel, and then publish messages on a channel. To see this in action, try out the live demo below.
 

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -59,7 +59,7 @@ blang[java].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-java-step2
 
 
 blang[android].
@@ -102,7 +102,7 @@ blang[android].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-android-step2
 
 blang[javascript].
   To start using Ably in your web app, you first need to include the Ably library. We recommend that you include the latest client library from our CDN using a simple @<script>@ tag. The client library must be instanced with the API key you copied in Step 1. Note in production we recommend you always use the "token authentication scheme":/core-features/authentication#token-authentication for browser clients, however in this example we use an API key for simplicity.
@@ -119,7 +119,7 @@ blang[javascript].
     </script>
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-javascript-step2
 
 blang[nodejs].
   To start using Ably you first need to install the NPM module. The NPM module can be installed as follows:
@@ -137,7 +137,7 @@ blang[nodejs].
     var realtime = new Ably.Realtime({ key: apiKey });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-nodejs-step2
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -165,7 +165,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-ruby-step2
 
 blang[php].
   To start using Ably you first need to install "composer package on packagist":https://packagist.org/packages/ably/ably-php into your composer.
@@ -211,7 +211,7 @@ blang[php].
 
   If you would like to try running the server now, you can do so with @php -S 0.0.0.0:8000@. Once running, open your browser to "http://localhost:8000/":http://localhost:8000/ and you should see "Publish & Subscribe sample".
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-php-step2
 
 blang[python].
   To start using Ably you first need to install The REST library for Python, it's "hosted on Github":https://github.com/ably/ably-python and is "published on PyPI":https://pypi.python.org/pypi/ably and can be installed as follows:
@@ -288,7 +288,7 @@ blang[python].
 
   If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Publish & Subscribe sample". If you would like to change port, on which your site will be available, simply add it after command ieg. @python server.py 1234@ for port @1234@.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step2
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-python-step2
 
 blang[swift].
   We will start by creating an Xcode project for this tutorial. To build your own Xcode Project in Swift visit "Apple developer website":https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppStoreDistributionTutorial/Setup/Setup.html and get familiar with steps necessary to setup your own application.
@@ -305,7 +305,7 @@ blang[swift].
     <img src="/images/tutorials/shared/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step2a
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step2a
 
   To start using Ably you first need to install the Ably pod via CocoaPods. You need to add a @Podfile@ to your project directory:
 
@@ -338,7 +338,7 @@ blang[swift].
     let client = ARTRealtime(key: API_KEY)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step2b
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step2b
 
 h2. Step 3 - Subscribe to messages
 
@@ -355,7 +355,7 @@ blang[java].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-java-step3
 
 blang[android].
   ```[java]
@@ -369,7 +369,7 @@ blang[android].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-android-step3
 
 blang[javascript].
   ```[javascript]
@@ -379,7 +379,7 @@ blang[javascript].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-javascript-step3
 
 blang[nodejs].
   ```[nodejs]
@@ -389,7 +389,7 @@ blang[nodejs].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-nodejs-step3
 
 blang[ruby].
   ```[ruby]
@@ -399,7 +399,7 @@ blang[ruby].
     end
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-ruby-step3
 
 blang[php].
   Update @index.php@ and add code below before @</script>@ tag:
@@ -411,7 +411,7 @@ blang[php].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-php-step3
 
 blang[python].
   Update @index.html@ and add code below before @</script>@ tag:
@@ -423,7 +423,7 @@ blang[python].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-python-step3
 
 blang[swift].
   If you have not previously had experience building a basic user interface in Xcode, please refer to "Apple developer guide":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/BuildABasicUI.html#//apple_ref/doc/uid/TP40015214-CH5-SW1 on how to build a simple UI and also learn more about "adding @IBOutlets@ and @IBActions@":https://developer.apple.com/library/content/referencelibrary/GettingStarted/DevelopiOSAppsSwift/ConnectTheUIToCode.html#//apple_ref/doc/uid/TP40015214-CH22-SW1.
@@ -448,7 +448,7 @@ blang[swift].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step3
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step3
 
 h2. Step 4 - Publishing a message
 
@@ -471,7 +471,7 @@ blang[java].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-java-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-java-step4
 
 blang[android].
   ```[java]
@@ -491,7 +491,7 @@ blang[android].
     });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-android-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-android-step4
 
 blang[javascript].
   ```[javascript]
@@ -499,7 +499,7 @@ blang[javascript].
     channel.publish("update", { "team": "Man United" });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-javascript-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-javascript-step4
 
 blang[nodejs].
   ```[nodejs]
@@ -507,7 +507,7 @@ blang[nodejs].
     channel.publish("update", { "team": "Man United" });
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-nodejs-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-nodejs-step4
 
 blang[ruby].
   ```[ruby]
@@ -515,7 +515,7 @@ blang[ruby].
     channel.publish 'update', 'team' => 'Man United'
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-ruby-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-ruby-step4
 
 blang[php].
   Create @publish.php@ file which will be responsible for publishing messages:
@@ -547,7 +547,7 @@ blang[php].
 
   If you would like to try running the server now, you can do so with @php -S 0.0.0.0:8000@. Once running, open your browser to "http://localhost:8000/":http://localhost:8000/ and you should see "Publish & Subscribe sample" and box with "input message", try it out.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-php-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-php-step4
 
 blang[python].
   Let's create resource for @/publish@, it will serve as message publisher:
@@ -596,7 +596,7 @@ blang[python].
 
   If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Publish & Subscribe sample" and box with "input message", try it out.
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-python-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-python-step4
 
 blang[swift].
   In this step add another @UIButton@ and bind it to action named "publishAction". Also, add one more @UILabel@ and an @UITextField@ - bind it in your code as "messageText" . Thanks to that users will be able to write their own messages.
@@ -616,7 +616,7 @@ blang[swift].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/tree/pubsub-swift-step4
+  "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step4
 
 We're done, it's that simple. We have now shown you how to subscribe to messages on a channel, and then publish messages on a channel. To see this in action, try out the live demo below.
 

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -46,7 +46,7 @@ Add the following to a file named @server.js@ to instance the Ably library insid
   var rest = new Ably.Rest({ key: ApiKey });
 ```
 
-"See this step in Github":https://github.com/ably/tutorials/commit/e248deb028a09fbee3d0440ebdcfe49c5d925be9
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step2
 
 h2. Step 3 - Set up your web server & base app HTML
 
@@ -98,7 +98,7 @@ At this point, you should also create a @public@ folder for your HTML, CSS and J
 
 If you would like to try running the server now, you can do so with @node server.js@. Once running, open your browser to "http://localhost:3000/":http://localhost:3000/ and you should see the base HTML app.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/db6fa91a1241e39b249b405715f4410c411f537d
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step3
 
 h2. Step 4 - Plug in Ably client-side, add auth endpoint and update UI
 
@@ -196,7 +196,7 @@ And add a subscriber that listens for new safe filtered text:
 
 At this point the web app will instance an Ably Realtime library and connect to Ably, will publish messages to the @neutrino:raw@ channel when requested, and will automatically subscribe to filtered text from the @neutrino:filtered@ channel. However the queues and workers are not in place yet, so at this point publishing text won't do anything.
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/cf84468563234364e2beb7269a0dc1616207ad81
+"See this complete step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step4
 
 h2. Step 5 - Provision Reactor Queue and queue rules
 
@@ -310,7 +310,7 @@ Note that the:
 * The queue name argument @neutrino@ passed to @worker.start@ is in fact appended to the @appId@ in the @start@ function. All fully qualified queue names follow the format @appId:queueName@ as you will see in your queue tab
 * Whilst the code above can handle multiple messages per envelope, we currently only support one message per envelope. The envelope @messages@ attribute is an @Array@ so that in future we could optionally support message bundling
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/48c3f21b821304ebef190b84355161e5736309cc
+"See this complete step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step6
 
 h2. Step 7 - Connect the worker to Neutrino
 
@@ -397,7 +397,7 @@ That's it, you are now issuing HTTP requests to Neutrino whenever a message is c
 
 Try running your server again with @node server.js@ and visit "http://localhost:3000/":http://localhost:3000/. Now type in some text in the text field and click the "Filter my bad language" button. You should see a response from Neutrino appear within the time it takes for Neutrino to filter the profanities from your text.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/eb8418f094ddea3919c527cf8e0f4212053a14c8
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step7
 
 We've covered a lot of ground in this tutorial. You've successfully covered off a lot of Ably functionality including token authentication, realtime pub/sub and message queues. We strongly recommend you review the next steps below for essential further reading to help you understand how to use Reactor Message Queues in more detail.
 

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -46,7 +46,7 @@ Add the following to a file named @server.js@ to instance the Ably library insid
   var rest = new Ably.Rest({ key: ApiKey });
 ```
 
-"See this step in Github":https://github.com/ably/tutorials/commit/16e78e4
+"See this step in Github":https://github.com/ably/tutorials/commit/amqp-wolfram-node-step2
 
 h2. Step 3 - Set up your web server & base app HTML
 
@@ -98,7 +98,7 @@ At this point, you should also create a @public@ folder for your HTML, CSS and J
 
 If you would like to try running the server now, you can do so with @node server.js@. Once running, open your browser to "http://localhost:3000/":http://localhost:3000/ and you should see the base HTML app.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/b21c89a
+"See this step in Github":https://github.com/ably/tutorials/commit/amqp-wolfram-node-step3
 
 h2. Step 4 - Plug in Ably client-side, add auth endpoint and update UI
 
@@ -197,7 +197,7 @@ And add a subscriber that listens for Wolfram answers:
 
 At this point the web app will instance an Ably Realtime library and connect to Ably, will publish messages to the @wolfram:questions@ channel when requested, and will automatically subscribe to answers from the @wolfram:answers@ channel. However the queues and workers are not in place yet, so at this point publishing a question won't do anything.
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/7e067354f85126a927af41ccf948fed214722483
+"See this complete step in Github":https://github.com/ably/tutorials/commit/amqp-wolfram-node-step4
 
 h2. Step 5 - Provision Reactor Queue and queue rules
 
@@ -312,7 +312,7 @@ Note that the:
 * The queue name argument @wolfram@ passed to @worker.start@ is in fact appended to the @appId@ in the @start@ function. All fully qualified queue names follow the format @appId:queueName@ as you will see in your queue tab
 * Whilst the code above can handle multiple messages per envelope, we currently only support one message per envelope. The envelope @messages@ attribute is an @Array@ so that in future we could optionally support message bundling
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/772c7502c4f0f105a1ebfff0cdb897f2b6b217ac
+"See this complete step in Github":https://github.com/ably/tutorials/commit/amqp-wolfram-node-step6
 
 h2. Step 7 - Connect the worker to Wolfram Alpha
 
@@ -395,7 +395,7 @@ That's it, you are now issuing HTTP requests to Wolfram whenever a message is co
 
 Try running your server again with @node server.js@ and visit "http://localhost:3000/":http://localhost:3000/. Now type in a question in the question text field and click the "Ask Wolfram" button. You should see a response from Wolfram appear within the time it takes for Wolfram to answer your question.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/404d37e6d406cb568c9c192edcfccd70a2d0dad1
+"See this step in Github":https://github.com/ably/tutorials/commit/amqp-wolfram-node-step7
 
 We've covered a lot of ground in this tutorial. You've successfully covered off a lot of Ably functionality including token authentication, realtime pub/sub and message queues. We strongly recommend you review the next steps below for essential further reading to help you understand how to use Reactor Message Queues in more detail.
 

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -46,7 +46,7 @@ Add the following to a file named @server.js@ to instance the Ably library insid
   var rest = new Ably.Rest({ key: ApiKey });
 ```
 
-"See this step in Github":https://github.com/ably/tutorials/commit/e248deb028a09fbee3d0440ebdcfe49c5d925be9
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step2
 
 h2. Step 3 - Set up your web server & base app HTML
 
@@ -98,7 +98,7 @@ At this point, you should also create a @public@ folder for your HTML, CSS and J
 
 If you would like to try running the server now, you can do so with @node server.js@. Once running, open your browser to "http://localhost:3000/":http://localhost:3000/ and you should see the base HTML app.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/db6fa91a1241e39b249b405715f4410c411f537d
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step3
 
 h2. Step 4 - Plug in Ably client-side, add auth endpoint and update UI
 
@@ -196,7 +196,7 @@ And add a subscriber that listens for new safe filtered text:
 
 At this point the web app will instance an Ably Realtime library and connect to Ably, will publish messages to the @neutrino:raw@ channel when requested, and will automatically subscribe to filtered text from the @neutrino:filtered@ channel. However the queues and workers are not in place yet, so at this point publishing text won't do anything.
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/96b5a92dfb89887bff4d885bbb90c7925f091448
+"See this complete step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step4
 
 h2. Step 5 - Provision Reactor Queue and queue rules
 
@@ -326,7 +326,7 @@ Note that the:
 * The queue name argument @neutrino@ passed to @worker.start@ is in fact appended to the @appId@ in the @start@ function. All fully qualified queue names follow the format @appId:queueName@ as you will see in your queue tab
 * Whilst the code above can handle multiple messages per envelope, we currently only support one message per envelope. The envelope @messages@ attribute is an @Array@ so that in future we could optionally support message bundling
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/2f44b7153d3bf463e2cd5ac9ed702e303238d51c
+"See this complete step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step6
 
 h2. Step 7 - Connect the worker to Neutrino
 
@@ -413,7 +413,7 @@ That's it, you are now issuing HTTP requests to Neutrino whenever a message is c
 
 Try running your server again with @node server.js@ and visit "http://localhost:3000/":http://localhost:3000/. Now type in some text in the text field and click the "Filter my bad language" button. You should see a response from Neutrino appear within the time it takes for Neutrino to filter the profanities from your text.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/9818ec8bb7eaf97016a8bdae472236cb51335e48
+"See this step in Github":https://github.com/ably/tutorials/commit/neutrino-node-step7
 
 We've covered a lot of ground in this tutorial. You've successfully covered off a lot of Ably functionality including token authentication, realtime pub/sub and message queues. We strongly recommend you review the next steps below for essential further reading to help you understand how to use Reactor Message Queues in more detail.
 

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -61,7 +61,7 @@ blang[java].
     }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/5a72529
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-java-step2
 
 blang[nodejs,android].
   To start using Ably on your Node.js server, you first need to install the NPM module. The NPM module can be installed as follows:
@@ -79,9 +79,9 @@ blang[nodejs,android].
     var rest = new Ably.Rest({ key: apiKey });
   ```
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/d848af7
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-node-step2
 blang[android].
-  "See this step in Github":https://github.com/ably/tutorials/commit/0fbb8ec
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-android-step2
 
 blang[ruby].
   To start using Ably you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -105,7 +105,7 @@ blang[ruby].
     ably = Ably::Rest.new(key: api_key)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/9e06aaf
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-ruby-step2
 
 blang[python].
   To start using Ably you first need to install The REST library for Python, it's "hosted on Github":https://github.com/ably/ably-python and is "published on PyPI":https://pypi.python.org/pypi/ably and can be installed as follows:
@@ -127,7 +127,7 @@ blang[python].
 
   Since Ably supports both string and binary payloads, we recommend that strings passed to the library for publishing to Ably be unicode strings (e.g. event names or payload data). This is to avoid ambiguity regarding the type of payload. In Python 3 this is the normal string type, but in Python 2 it is not, so we suggest you prefix string literals with the @u@ prefix (eg @u'eventname'@ - or alternatively, use @from __future__ import unicode_literals@, which will make this automatic), and to explicitly decode any user input (e.g. @raw_input().decode(sys.stdin.encoding@).
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/aff9d58
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-python-step2
 
 blang[php].
   To start using Ably you first need to install the "composer package on packagist":https://packagist.org/packages/ably/ably-php into your composer.
@@ -145,7 +145,7 @@ blang[php].
     $ably = new \Ably\AblyRest("{{ApiKey}}");
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/cd12634
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-php-step2
 
 blang[swift].
   For this Swift example, you need a web server to generate token requests. You will be using Ruby for the server in this tutorial. To start using Ably with Ruby, you first need to install the Ably RubyGem. The RubyGem can be installed as follows:
@@ -169,7 +169,7 @@ blang[swift].
     ably = Ably::Rest.new(key: api_key)
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/999fe09
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step2
 
 h2. Step 3 - Set up your web server
 
@@ -257,7 +257,7 @@ blang[java].
 
   Once running, open your browser to "http://localhost:3000/":http://localhost:3000/ and you should see the text "Hello, I am a very simple server".
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/6d7ce69
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-java-step3
 
 blang[nodejs,android].
   "Express.js":https://expressjs.com/ is a very popular and simple web framework for Node.js. You'll need to get this setup:
@@ -299,9 +299,9 @@ blang[nodejs,android].
 
   If you would like to try running the server now, you can do so with @node server.js@. Once running, open your browser to "http://localhost:3000/":http://localhost:3000/ and you should see the text "Hello, I am a very simple server".
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/ec3b24c
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-node-step3
 blang[android].
-  "See this step in Github":https://github.com/ably/tutorials/commit/19a0345
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-android-step3
 
 blang[ruby].
   "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in the @routes.rb@ file, add the code to a controller, and then add the HTML to a view.
@@ -323,7 +323,7 @@ blang[ruby].
 
   If you would like to try running the server now, you can do so with @bundle exec ruby server.rb@. Once running, open your browser to "http://localhost:4567/":http://localhost:4567/ and you should see the text "Hello, I am a very simple server".
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/0e9e6db
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-ruby-step3
 
 blang[python].
   "web.py":http://webpy.org/ is a simple web framework for Python. Django is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill.
@@ -358,7 +358,7 @@ blang[python].
 
   If you would like to try running the server now, you can do so with @python server.py@. Once running, open your browser to "http://localhost:8080/":http://localhost:8080/ and you should see the text "Hello, I am a very simple server". If you would like to change the port from which your site is available, simply add the port after the command (e.g. @python server.py 1234@ for port @1234@).
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/91ec78e
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-python-step3
 
 blang[php].
   PHP has a built-in web server functionality which allows it to serve php scripts, making it excellent for the purpose of this tutorial.
@@ -372,7 +372,7 @@ blang[php].
 
   If you would like to try running the server now, you can do so with @php -S 0.0.0.0:8000@. Once running, open your browser to "http://localhost:8000/":http://localhost:8000/ and you should see the text "Hello, I am a very simple server".
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/2314a18
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-php-step3
 
 blang[swift].
   "Sinatra":http://www.sinatrarb.com/ is a very simple and popular web server framework for Ruby. Rails is arguably more popular as a web server framework, however for the purposes of this tutorial it is overkill. Bear in mind that all the code in this tutorial can be used as is within Rails. You will need to configure routes in the file @routes.rb@, add the code to a controller, and then add the HTML to a view.
@@ -394,7 +394,7 @@ blang[swift].
 
   If you would like to try running the server now, you can do so with @bundle exec ruby server.rb@. Once running, open your browser to "http://localhost:4567/":http://localhost:4567/ and you should see the text "Hello, I am a very simple server".
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/6119d95
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step3
 
 h2. Step 4 - Respond to authentication requests
 
@@ -451,7 +451,7 @@ blang[java].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/4828df8
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-java-step4
 
 blang[nodejs,android].
   By adding the following route to your Express.js server, it will be ready to service clients wanting to authenticate with Ably.
@@ -484,9 +484,9 @@ blang[nodejs,android].
   }
   ```
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/6a40d84
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-node-step4
 blang[android].
-  "See this step in Github":https://github.com/ably/tutorials/commit/2614bfe
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-android-step4
 
 blang[ruby].
   By adding the following route to your server, it will be ready to service clients wanting to authenticate with Ably.
@@ -514,7 +514,7 @@ blang[ruby].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/5575d73
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-ruby-step4
 
 blang[python].
   By adding the following class and route to your urls, it will be ready to service clients wanting to authenticate with Ably.
@@ -548,7 +548,7 @@ blang[python].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/7841d7e
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-python-step4
 
 blang[php].
   By adding the following script, it will be ready to service clients wanting to authenticate with Ably.
@@ -575,7 +575,7 @@ blang[php].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/f08a34f
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-php-step4
 
 h2.
   default: Step 5 - Setting up a client to use token authentication
@@ -752,7 +752,7 @@ blang[swift].
   }
   ```
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/e442eb1
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step5
 
 blang[nodejs,ruby,python,java].
   Add the following above the closing @</html>@ tag in your @index.html@ file:
@@ -786,22 +786,22 @@ blang[android].
   Time for us to see what happens now. Restart the local server and rerun your application. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
 blang[android].
-  "See this step in Github":http://github.com/ably/tutorials/commit/ae636ad
+  "See this step in Github":http://github.com/ably/tutorials/commit/token-auth-android-step5b
 
 blang[java].
-  "See this step in Github":https://github.com/ably/tutorials/commit/c2f1ab3
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-java-step5
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/8b96706
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-node-step5
 
 blang[ruby].
-  "See this step in Github":https://github.com/ably/tutorials/commit/9cd2fc2
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-ruby-step5
 
 blang[python].
-  "See this step in Github":https://github.com/ably/tutorials/commit/c26cb53
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-python-step5
 
 blang[php].
-  "See this step in Github":https://github.com/ably/tutorials/commit/f949bcf
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-php-step5
 
 blang[swift].
   Firstly you'll need to set up an Xcode project that will serve as your client.
@@ -825,7 +825,7 @@ blang[swift].
     <img src="/images/tutorials/shared/tutorials-swift-IB-class.png" style="width: 100%" alt="Interface design">
   </a>
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/86d2319
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step5b
 
   To start using Ably you first need to install the Ably pod via CocoaPods. You need to add a @Podfile@ to your project directory:
 
@@ -925,7 +925,7 @@ blang[swift].
 
   Time for us to see what happens now. Execute the code in a simulator. You should receive an alert to confirm that you're connected to Ably which means your server has successfully issued a token request to the client. The client has then obtained a token from Ably with the token request, and then subsequently authenticated and finally connected.
 
-  "See this step in Github":https://github.com/ably/tutorials/commit/6498081
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step5b
 
 We've now covered the basics of client-server token authentication and your client has a means to renew the token whenever it needs one.
 
@@ -1683,28 +1683,25 @@ blang[android].
   </a>
 
 blang[android].
-  "See this step in Github":https://github.com/ably/tutorials/commit/bcce690
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-android-step6
 
 blang[java].
-  "See this step in Github":https://github.com/ably/tutorials/commit/3bd80eb
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-java-step6
 
 blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/4acb241
-
-blang[nodejs].
-  "See this step in Github":https://github.com/ably/tutorials/commit/df18401
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-node-step6
 
 blang[ruby].
-  "See this step in Github":https://github.com/ably/tutorials/commit/9a761bf
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-ruby-step6
 
 blang[python].
-  "See this step in Github":https://github.com/ably/tutorials/commit/6a1ccb4
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-python-step6
 
 blang[php].
-  "See this step in Github":https://github.com/ably/tutorials/commit/ad87bc6
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-php-step6
 
 blang[swift].
-  "See this step in Github":https://github.com/ably/tutorials/commit/439a0a8
+  "See this step in Github":https://github.com/ably/tutorials/commit/token-auth-swift-step6
 
 We've covered a lot of ground in this tutorial. However authentication is one of the more challenging aspects to understand as it requires you to have a good overall understanding of how it all works. We strongly recommend you check out the links below for essential further reading to help you understand authentication in more detail for use in your servers and apps.
 

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -50,7 +50,7 @@ Please note that we included @--skip-active-record@ so as to avoid an unnecessar
 
 Lets make sure Rails has been installed correctly by running @bin/rails server@ and opening a browser window to "http://localhost:3000/":http://localhost:3000/. You should see the Rails default information page.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/2a20a3ec06df109f673ec42c46b859d5e7779326
+"See this step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step2
 
 h2. Step 3 - Set up a root route and add base HTML app
 
@@ -100,7 +100,7 @@ And finally let's add some Javascript as a placeholder for our app at "app/asset
 
 Open a browser window to "http://localhost:3000/":http://localhost:3000/ and confirm that you can see the new Chuck Norris base app page.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/720aa38537d842b54234320304758a077a5d6be1
+"See this step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step3
 
 h2. Step 4 - Install Ably for Rails (server-side) and add auth route
 
@@ -169,7 +169,7 @@ Try visiting "http://localhost:3000/auth":http://localhost:3000/auth and you sho
 
 We now have a web server running with an authentication endpoint. We are ready to setup the Ably Realtime client that uses token auth.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/2197a076f89a0103f85df9393c46192964c5772b
+"See this step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step4
 
 h2. Step 5 - Plug in Ably client-side and update UI
 
@@ -238,7 +238,7 @@ At this point the web app will instance an Ably Realtime library and connect to 
 
 Finally, add "this styling CSS":https://github.com/ably/tutorials/blob/4b3548a3afbd48c46a62ce212a7b844a7c2be159/app/assets/stylesheets/application.css to "@app/assets/stylesheets/application.css":https://github.com/ably/tutorials/blob/4b3548a3afbd48c46a62ce212a7b844a7c2be159/app/assets/stylesheets/application.css so that the app's aesthetic is addressed.
 
-"See this complete step in Github":https://github.com/ably/tutorials/commit/4b3548a3afbd48c46a62ce212a7b844a7c2be159
+"See this complete step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step5
 
 h2. Step 6 - Add WebHook endpoint and configure WebHook
 
@@ -312,7 +312,7 @@ To set up a WebHook for this endpoint, follow these steps:
 
 Once the WebHook is saved, you are now ready to test that WebHook is working. Visit "http://localhost:3000/":http://localhost:3000/ in your browser, enter some text in the text field, and click the "Make me laugh Chuck!" button. You should within a second see your Rails server report an incoming request in the console log along with the message "Received Message with data '...'". If you are having problems with the Webhook setup, please see "our recommendations for debugging WebHooks":https://support.ably.io/solution/articles/3000062287-how-can-i-debug-webhooks.
 
-"See this step in Github":https://github.com/ably/tutorials/commit/fcab8df5749aadeb8de8a98d284eecf941e742da
+"See this step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step6
 
 h2. Step 7 - Integrate with Chuck API and publish jokes over REST
 
@@ -356,7 +356,7 @@ Then replace the message processing in the same controller with:
 
 Once again, visit "http://localhost:3000/":http://localhost:3000/ in your browser. Either type a word or phrase to filter jokes on or go for a random joke and click "Make me laugh Chuck!" button. You should see a response from the Chuck Norris API appear within the time it takes for that API to provide a joke. Given it's a Chuck Norris API, that should be quick right?
 
-"See this step in Github":https://github.com/ably/tutorials/commit/7e00403f27e50be7b312bfa15b9d444c49ba48ee
+"See this step in Github":https://github.com/ably/tutorials/commit/webhook-ruby-step7
 
 We've covered a lot of ground in this tutorial. You've successfully covered off a lot of Ably functionality including token authentication, realtime pub/sub and WebHooks. We strongly recommend you review the next steps below for essential further reading to help you understand how to use Reactor Events and WebHooks in more detail.
 


### PR DESCRIPTION
For https://github.com/ably/tutorials/issues/47. Updates to tags for pubsub and presence tutorials, with said tags having their js lib reference corrected.

Also updates tags for other tutorials, but without a js lib change.