### PR TITLE
Extend batch docs

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -14,12 +14,17 @@ api_separator:
 jump_to:
   Help with:
     - Getting started#getting-started
-    - Channels & lifecycle#channels
+    - Channels#channels
+    - Subscribing to a channel#subscribing
+    - Publishing to a channel#publishing
+    - Channel lifecycle#channel-lifecycle
     - Channel metadata#channel-metadata
-    - Channel states
-    - Handling failures
-    - Channel namespaces
-    - Presence#presence
+    - Implicit attach#implicit-attach
+    - Transient Publishing#transient-publish
+    - Channel states#channel-states
+    - Handling failures#handling-failures
+    - Channel namespaces#channel-namespaces
+    - Presence#presence-api
   Channel API properties:
     - state
     - errorReason#error-reason
@@ -166,6 +171,117 @@ bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = realtime.channels.get("channelName", options: options)
 
+h3(#subscribing). Subscribing to a channel
+
+To subscribe to a channel, use the "subscribe":#subscribe method of a channel:
+
+```[javascript](code-editor:realtime/channel-publish)
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.subscribe(function(message) {
+    alert('Received: ' + message.data);
+  });
+```
+
+```[nodejs](code-editor:realtime/channel-publish)
+  var Ably = require('ably');
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.subscribe(function(message) {
+    console.log("Received: "  message.data);
+  });
+```
+
+```[ruby]
+  realtime = Ably::Realtime.new('{{API_KEY}}')
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  channel.subscribe do |message|
+    puts "Received: #{message.data}"
+  end
+```
+
+```[java]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}");
+  channel.subscribe(new MessageListener() {
+    @Override
+    public void onMessage(Message message) {
+      System.out.println("New messages arrived. " + message.name);
+    }
+  });
+```
+
+```[csharp]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  IRealtimeChannel channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
+  channel.Subscribe(message => {
+    Console.WriteLine($"Message: {message.Name}:{message.Data} received");
+  });
+```
+
+```[objc]
+ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
+[channel subscribe:^(ARTMessage *message) {
+    NSLog(@"Received: %@", message.data);
+}];
+```
+
+```[swift]
+let realtime = ARTRealtime(key: "{{API_KEY}}")
+let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}")
+channel.subscribe { message in
+    print("Received: \(message.data)")
+}
+```
+
+h3(#publishing). Publishing on a channel
+
+In order to publish on a channel, you simply need to make use of the "publish":#publish method:
+
+```[javascript](code-editor:realtime/channel-publish)
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.publish('example', 'message data');
+```
+
+```[nodejs](code-editor:realtime/channel-publish)
+  var Ably = require('ably');
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.publish("example", "message data");
+```
+
+```[ruby]
+  realtime = Ably::Realtime.new('{{API_KEY}}')
+  channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  channel.publish 'example', 'message data'
+```
+
+```[java]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}");
+  channel.publish("example", "message data");
+```
+
+```[csharp]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  IRealtimeChannel channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
+  channel.Publish("example", "message data");
+```
+
+```[objc]
+ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
+[channel publish:@"example" data:@"message data"];
+```
+
+```[swift]
+let realtime = ARTRealtime(key: "{{API_KEY}}")
+let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}")
+channel.publish("example", data: "message data")
+```
+
 h3(#channel-lifecycle). Channel lifecycle
 
 Channels are not pre-configured or provisioned by Ably in advance; they are created on demand when clients attach, and remain active until such time that there are no remaining attached clients. Within the "dashboard for your app":https://support.ably.io/solution/articles/3000030053-how-do-i-access-my-app-dashboard however, you can pre-configure one or more "channel namespaces":#channel-namespaces (i.e. name prefixes), and associate different attributes and access rights with those namespaces. Find out more about "channel namespaces":#channel-namespaces.
@@ -207,7 +323,7 @@ bc[swift]. realtime.channels.get("chatroom").attach { error in
 
 Clients attach to a channel in order to participate on that channel in any way (either to publish, subscribe, or be present on the channel). It is worth noting that some libraries allow for "publishing to a channel without attaching to it":#transient-publish. "See if your chosen SDK supports this":https://www.ably.io/download.
 
-h2(#channel-metadata). Channel metadata
+h3(#channel-metadata). Channel metadata
 
 Ably provides a "REST API":/realtime/channel-metadata to query your app for metadata about channels, as well as a "realtime API":/realtime/channel-metadata to subscribe to channel lifecycle events. Using the "REST API":/rest-api, you can enumerate all active channels, or obtain the status of an individual channel. Using our Realtime API, you can subscribe to "channel lifecycle events":/realtime/channel-metadata#lifecycle-events (such as being created or closed etc), or subscribe to periodic "occupancy":/realtime/channel-metadata#occupancy-rest updates for all active channels (such as how many people are subscribed to a channel).
 

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -20,6 +20,7 @@ jump_to:
     - Channel lifecycle#channel-lifecycle
     - Channel metadata#channel-metadata
     - Implicit attach#implicit-attach
+    - Batch publishing#batch-publish
     - Transient Publishing#transient-publish
     - Channel states#channel-states
     - Handling failures#handling-failures
@@ -329,7 +330,7 @@ Ably provides a "REST API":/realtime/channel-metadata to query your app for meta
 
 h3(#implicit-attach). Implicit attach
 
-Although the attach operation can be initiated explicitly by a client, it is more common for the client to subscribe, which will initiate the attach if the channel is not already attached. This client library allows clients to begin publishing "messages":/realtime/messages without attaching to the channel with "transient publishing":#transient-publish. *Note*: Transient publishing is only available for "certain libraries":https://www.ably.io/download, otherwise publishing will also attach you to the channel.
+Although the attach operation can be initiated explicitly by a client, it is more common for the client to subscribe, which will initiate the attach if the channel is not already attached. This client library allows clients to begin publishing "messages":/realtime/messages without attaching to the channel with "transient publishing":#transient-publish.
 
 bc[jsall](code-editor:realtime/channel-implicit). var channel = realtime.channels.get('chatroom');
 channel.subscribe('action', function(message) { // implicit attach
@@ -371,11 +372,15 @@ channel.publish("action", data: "boom!")
 
 Normally, errors in attaching to a channel are communicated through the attach callback. For implicit attaches (and other cases where a channel is attached or reattached automatically, e.g. following the library reconnecting after a period in the @suspended@ state), there is no callback, so if you want to know what happens, you'll need to listen for channel state changes.
 
+h3(#batch-publish). Batch publishing
+
+It is common for a single message to be intended for multiple channels. With a realtime connection, you can effectively send a message to multiple channels at once by allowing multiple concurrent publish operations. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch.
+
 h3(#transient-publish). Transient publishing
 
 When attempting to only publish to a client, it is possible to publish without attaching to the channel. This can be beneficial if you intend to publish into many channels, removing the need to attach to a channel each time you wish to publish. Additionally, it avoids the client subscribing to messages, avoiding messages being sent to it redundantly.
 
-*Note* that transient publishing is only available for "certain libraries":https://www.ably.io/download, otherwise publishing will also attach you to the channel.
+*Note* that transient publishing is only available for "certain libraries":https://www.ably.io/download/sdk-feature-support-matrix, otherwise publishing will also attach you to the channel.
 
 bc[jsall]. var channel = realtime.channels.get('chatroom');
 // The publish below will not attach you to the channel

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -20,7 +20,7 @@ jump_to:
     - Channel lifecycle#channel-lifecycle
     - Channel metadata#channel-metadata
     - Implicit attach#implicit-attach
-    - Batch publishing#batch-publish
+    - Publishing to multiple channels#multi-publish
     - Transient Publishing#transient-publish
     - Channel states#channel-states
     - Handling failures#handling-failures
@@ -372,9 +372,11 @@ channel.publish("action", data: "boom!")
 
 Normally, errors in attaching to a channel are communicated through the attach callback. For implicit attaches (and other cases where a channel is attached or reattached automatically, e.g. following the library reconnecting after a period in the @suspended@ state), there is no callback, so if you want to know what happens, you'll need to listen for channel state changes.
 
-h3(#batch-publish). Batch publishing
+h3(#multi-publish). Publishing to multiple channels
 
-It is common for a single message to be intended for multiple channels. With a realtime connection, you can effectively send a message to multiple channels at once by allowing multiple concurrent publish operations. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch.
+Often it is necessary to publish a single message in multiple channels at the same time. In the realtime API, this is achieved simply by making multiple separate "publish":#publish requests. If a seperate publish is made in each of the channels in question, the realtime protocol will allow for those concurrent requests to be in-flight simultaneously. This ensures that a publish on a channel is not delayed waiting for completion of operations in other channels.
+
+It is also possible to publish one or more messages into multiple channels in a single operation using the "REST batch API":/rest-api/beta#batch.
 
 h3(#transient-publish). Transient publishing
 

--- a/content/realtime/messages.textile
+++ b/content/realtime/messages.textile
@@ -247,7 +247,7 @@ channel.unsubscribe(listener)
 
 h3(#message-publish). Publishing messages
 
-Channels expose a <span lang="default">@publish@</span><span lang="csharp">@Publish@</span> method whereby a client can publish either a single message or an array of messages to a channel. A listener optionally passed in to the <span lang="default">@publish@</span><span lang="csharp">@Publish@</span> method enables the client to know whether or not the operation succeeded.
+Channels expose a "<span lang="default">@publish@</span><span lang="csharp">@Publish@</span>":/realtime/channels#publish method whereby a client can "publish":/realtime/channels#publish  either a single message or an array of messages to a channel. A listener optionally passed in to the <span lang="default">@publish@</span><span lang="csharp">@Publish@</span> method enables the client to know whether or not the operation succeeded.
 
 bc[jsall](code-editor:realtime/channel-publish). channel.publish('event', 'This is my payload', function(err) {
   if(err) {
@@ -311,6 +311,10 @@ blang[csharp].
       Console.WriteLine("Message published successfully");
     }
   ```
+
+h4(#batch-publish). Batch publishing
+
+It is common for a single message to be intended for multiple channels. With a realtime connection, you can effectively send a message to multiple channels at once by allowing multiple concurrent publish operations. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch.
 
 h3(#message-history). Retrieving message history
 

--- a/content/rest-api/beta.textile
+++ b/content/rest-api/beta.textile
@@ -26,7 +26,7 @@ A batch mode request translates a single set of request details (ie the request 
 Once each request has completed, the batch-mode response is formulated to be returned to the caller. There are three possible outcomes:
 
 * all requests succeeded. This is of course the expected case. The response is then an array containing the responses to the constituent queries in request order.
-* the batch request failed prior to attempting the constituent API calls. This could typically be an authorisation failure, an invalid request, or some required element of the service being unavailable. The response is then an error response, with the applicable status code and error response body (with `message@, @code@ and any other relevant error information.
+* the batch request failed prior to attempting the constituent API calls. This could typically be an authorisation failure, an invalid request, or some required element of the service being unavailable. The response is then an error response, with the applicable status code and error response body (with @message@, @code@ and any other relevant error information.
 * one or more constituent API calls failed. In this case the response contains a generic @400@ status code and the response body contains an error object with a specific error code @40020@ signifying an error in a batch operation. The error body also then contains a @batchResponse@ property which in an array, in request order, containing the outcome of each of the constituent API calls.
 This means that caller can usually make the call and have access to the success result or an error in the case of failure. In the case of a partial failure, many callers may just wish to know whether or not the call succeeded fully, in which case they do not need to look at the @batchResponse@ detail. However, callers that wish to know the detail of the outcome of each call can discover this from the @batchResponse@.
 
@@ -78,12 +78,16 @@ The bulk publish endpoint accepts a request body containing either a single @Bat
 
 Therefore the following are all valid request bodies for a bulk publish request:
 
+h5. Using a single BatchSpec object
+
 ```[json]
 {
   channels: ['a channel name, containing a comma', 'another channel name'],
   messages: {data: 'My message contents'}
 }
 ```
+
+h5. Using multiple BatchSpec objects in an array
 
 ```[json]
 [
@@ -107,7 +111,7 @@ h4(#batch-response). Batch reponses
 
 The request
 
-```
+```[sh]
 POST /messages
 {
   channels: ['channel0', 'channel1', 'channel2'],
@@ -119,7 +123,7 @@ would have the following possible outcomes:
 
 Success:
 
-```
+```[sh]
 status code: 201
 response body:
 [
@@ -140,7 +144,7 @@ response body:
 
 Common-cause failure:
 
-```
+```[sh]
 status code: 401
 response body:
 {
@@ -154,7 +158,8 @@ response body:
 ```
 
 Partial success:
-```
+
+```[sh]
 status code: 400
 response body
 {

--- a/content/rest-api/index.textile
+++ b/content/rest-api/index.textile
@@ -354,13 +354,19 @@ bc[sh]. curl -X POST https://rest.ably.io/channels/rest-example/messages \
  -H "Content-Type: application/json" \
  --data '{ "name": "publish", "data": "example" }'
 
+If you wish to publish a message to multiple channels at once, you should consider using our "batch publish functionality":/rest-api/beta#batch.
+
+h5(#idempotent-publish). Idempotent publishing
+
+It is possible for a client publishing through REST to not receive an acknowledgement of receipt from Ably for numerous reasons such as network failures outside of our control. In this scenario, you will likely wish to re-publish the message, but not risk duplicating it within the network. This is possible through the addition of an @id@ in the body of your POST, where the @id@ should uniquely identify the message.
+
 h5(#message-extras). Message extras
 
 Messages can include an optional @extras@ field, used by extensions to Ably's core realtime service.
 
-h6(#message-extras-push). Send push notification
+h5(#message-extras-push). Send push notification
 
-You can send a push notification to devices "subscribed to the channel":#post-channel-subscription the message is sent to by setting the @push@ field in the @extras@ object, like this:
+You can send a push notification to devices "subscribed to a channel":#post-channel-subscription by setting the @push@ field in the @extras@ object, like this:
 
 bc[json]. {
   <... message fields ...>

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -18,6 +18,7 @@ jump_to:
   Help with:
     - Getting started#getting-started
     - Channels#channels
+    - Batch publishing#batch-publish
     - Channel Metadata#channel-metadata
     - Channel namespaces
     - Presence#presence
@@ -197,7 +198,11 @@ bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = rest.channels.get("channelName", options: options)
 
-h2(#channel-metadata). Channel metadata
+h3(#batch-publish). Batch publishing
+
+It is common for a single message to be intended for multiple channels. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch. With a "realtime":/realtime connection, you can also effectively send a message to multiple channels at once by allowing multiple concurrent publish operations.
+
+h3(#channel-metadata). Channel metadata
 
 Ably provides a "REST API":/realtime/channel-metadata to query your app for metadata about channels, as well as a "realtime API":/realtime/channel-metadata to subscribe to channel lifecycle events. Using the "REST API":/rest-api, you can enumerate all active channels, or obtain the status of an individual channel. Using our Realtime API, you can subscribe to "channel lifecycle":/realtime/channel-metadata events (such as being created or closed etc), or subscribe to periodic "occupancy":/realtime/channel-metadata#occupancy-rest updates for all active channels (such as how many people are subscribed to a channel).
 

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -18,6 +18,8 @@ jump_to:
   Help with:
     - Getting started#getting-started
     - Channels#channels
+    - Subscribing to a channel#subscribing
+    - Obtaining history of a channel#channel-history
     - Batch publishing#batch-publish
     - Channel Metadata#channel-metadata
     - Channel namespaces
@@ -197,6 +199,148 @@ ARTRestChannel *channel = [rest.channels get:@"channelName" options:options];
 bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = rest.channels.get("channelName", options: options)
+
+h3(#publishing). Publishing to a channel
+
+To publish to a channel, make use of the "publish":#publish method of the channel:
+
+```[javascript](code-editor:rest/channel-history)
+  var rest = new Ably.Rest('{{API_KEY}}');
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.publish('example', 'message data');
+```
+
+```[nodejs](code-editor:rest/channel-history)
+  var rest = new Ably.Rest('{{API_KEY}}');
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.publish('example', 'message data');
+```
+
+```[ruby]
+  rest = Ably::Rest.new('{{API_KEY}}')
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  channel.publish 'example', 'message data'
+```
+
+```[python]
+  rest = AblyRest('{{API_KEY}}')
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  channel.publish(u'example', u'message data')
+```
+
+```[php]
+  $rest = new Ably\AblyRest('{{API_KEY}}');
+  $channel = $rest->channels->get('{{RANDOM_CHANNEL_NAME}}');
+  $channel->publish('example', 'message data');
+```
+
+```[java]
+  AblyRest rest = new AblyRest("{{API_KEY}}");
+  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}");
+  channel.publish("example", "message data");
+```
+
+```[csharp]
+  AblyRest rest = new AblyRest("{{API_KEY}}");
+  var channel = rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
+  await channel.PublishAsync("example", "message data");
+```
+
+```[objc]
+  ARTRest *rest = [[ARTRest alloc] initWithKey:@"{{API_KEY}}"];
+  ARTRestChannel *channel = [rest.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
+  [channel publish:@"example" data:@"message data"];
+```
+
+```[swift]
+  let rest = ARTRest(key: "{{API_KEY}}")
+  let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}")
+  channel.publish("example", data: "message data")
+```
+
+```[go]
+  rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  err = channel.Publish("example", "message data")
+```
+
+h3(#channel-history). Getting history of a channel
+
+To get the history of a channel, make use of the "history":#history method of the channel:
+
+```[javascript](code-editor:rest/channel-history)
+  var rest = new Ably.Rest('{{API_KEY}}');
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.history(function(err, resultPage) {
+    console.log('Last published message:' + resultPage.items[0]);
+  });
+```
+
+```[nodejs](code-editor:rest/channel-history)
+  var rest = new Ably.Rest('{{API_KEY}}');
+  var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
+  channel.history(function(err, resultPage) {
+    console.log('Last published message:' + resultPage.items[0]);
+  });
+```
+
+```[ruby]
+  rest = Ably::Rest.new('{{API_KEY}}')
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  result_page = channel.history()
+  puts "Last published message: #{result_page.items.first}"
+```
+
+```[python]
+  rest = AblyRest('{{API_KEY}}')
+  channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
+  result_page = channel.history()
+  print("Last published message data: " + result_page.items[0].data)
+```
+
+```[php]
+  $rest = new Ably\AblyRest('{{API_KEY}}');
+  $channel = $rest->channels->get('{{RANDOM_CHANNEL_NAME}}');
+  $resultPage = $channel->history();
+  echo("Last published data: " . $resultPage->items[0]->data);
+```
+
+```[java]
+  AblyRest rest = new AblyRest("{{API_KEY}}");
+  Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}");
+  PaginatedResult<Message> resultPage = channel.history(null);
+  System.out.println("Last published message ID: " + resultPage.items[0].id);
+```
+
+```[csharp]
+  AblyRest rest = new AblyRest("{{API_KEY}}");
+  var channel = rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
+  PaginatedResult<Message> resultPage = await channel.HistoryAsync();
+  Console.WriteLine("Last published message ID: " + resultPage.Items[0].id);
+```
+
+```[objc]
+  ARTRest *rest = [[ARTRest alloc] initWithKey:@"{{API_KEY}}"];
+  ARTRestChannel *channel = [rest.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
+  [channel history:^(ARTPaginatedResult<ARTMessage *> *resultPage, ARTErrorInfo *error) {
+      NSLog(@"Last published message ID: %@", resultPage.items[0].id);
+  }];
+```
+
+```[swift]
+  let rest = ARTRest(key: "{{API_KEY}}")
+  let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}")
+  channel.history { resultPage, error in
+      print("Last published message ID: \(resultPage!.items[0].id)")
+  }
+```
+
+```[go]
+  rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  page, err := channel.History(nil)
+  fmt.Println("Last published message: %s\n", page.Messages[0].Data)
+```
 
 h3(#batch-publish). Batch publishing
 

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -343,7 +343,7 @@ To get the history of a channel, make use of the "history":#history method of th
 
 h3(#batch-publish). Batch publishing
 
-It is common for a single message to be intended for multiple channels. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch. With a "realtime":/realtime connection, you can also effectively send a message to multiple channels at once by allowing multiple concurrent publish operations.
+It is common for a single message to be intended for multiple channels. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch.
 
 h3(#channel-metadata). Channel metadata
 

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -18,7 +18,6 @@ jump_to:
   Help with:
     - Getting started#getting-started
     - Channels#channels
-    - Subscribing to a channel#subscribing
     - Obtaining history of a channel#channel-history
     - Batch publishing#batch-publish
     - Channel Metadata#channel-metadata

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -272,6 +272,8 @@ bq(definition#publish-data).
 
 Publish a single message on this channel based on a given event name and payload. <span lang="jsall,java,objc,swift">A <span lang="default">callback</span><span lang="java">listener</span> may optionally be passed in to this call to be notified of success <span lang="default">or failure</span><span lang="ruby"></span> of the operation.</span>
 
+It is also possible to publish a message to multiple channels at once using our "batch publish feature":/rest-api/beta#batch.
+
 bq(definition#publish-msg-array).
   default:  publish(Object[] messages, callback("ErrorInfo":/realtime/types#error-info err))
   ruby,php: publish("Message":#message[] messages)

--- a/content/rest/messages.textile
+++ b/content/rest/messages.textile
@@ -157,6 +157,10 @@ bc[swift]. channel.publish("event", data: "This is my payload")
 
 bc[go]. channel.Publish("event", "This is my payload")
 
+h4(#batch-publish). Batch publishing
+
+It is common for a single message to be intended for multiple channels. If you wish to send a message to multiple channels within a single operation, you can make use of the "REST batch API":/rest-api/beta#batch. With a "realtime":/realtime connection, you can also effectively send a message to multiple channels at once by allowing multiple concurrent publish operations.
+
 h4(#idempotent). Enabling idempotent publishing
 
 Idempotency ensures that multiple publishes of the same message cannot result in duplicate messages. "Find out more about what idempotency is, and how we provide idempotency in our REST operations.":https://www.ably.io/concepts/idempotency
@@ -311,7 +315,7 @@ h6(#id).
   default: id
   csharp,go: Id
 
-A Unique ID assigned by Ably to this message. Can optionally be assigned by the client as part of "idempotent publishing":#idempotent<br>__Type: @String@__
+A Unique ID assigned by Ably to this message. Can optionally be assigned by the client as part of "idempotent publishing":#idempotent.<br>__Type: @String@__
 
 h6(#client-id).
   default: clientId


### PR DESCRIPTION
For #684, largely involves mentioning batch publishing more extensively throughout the docs, as well as cleaning up some of the batch publish docs themselves.

Includes the addition of subscribe/publish sections in realtime/channels and history/publish in rest/channels to make the functionality even more obvious per feedback in the initial issue.