### PR TITLE
Push spec clarifications

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -941,7 +941,8 @@ h2(#push-notifications). Push notifications
 * @(RSH2)@ The following should only apply to platforms that support receiving push notifications:
 ** @(RSH2a)@ @Push#activate@ sends a @CalledActivate@ event to "the state machine":#RSH3.
 ** @(RSH2b)@ @Push#deactivate@ sends a @CalledDeactivate@ event to "the state machine":#RSH3.
-** @(RSH2c)@ Whenever, from the platform's APIs, details for sending push notifications to the local device (e. g. GCM's registration token) is received, a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3.
+** @(RSH2c)@ Whenever any change arises of the push transport details for local device (eg an FCM registration token update triggered by the platform), a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3.
+** @(RSH2d)@ Whenever the local device @clientId@ changes after the local device is registered, a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3. A test must exist that verifies the corresponding local device registration update is made if the local @clientId@ is initialised late via the authentication or connection sequence.
 
 h3(#activation-state-machine). Activation state machine
 


### PR DESCRIPTION
This PR adds a requirement that a late-initialised `clientId` is propagated to any existing local device registration.