### PR TITLE
Correction on subscribeClientId usage

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1553,10 +1553,10 @@ class RealtimeChannel:
   unsubscribe(String, (Message) ->) // RTL8a
 
 class PushChannel:
-  subscribeDevice() => io // RSH4a
-  subscribeClientId() => io // RSH4b
-  unsubscribeDevice() => io // RSH4c
-  unsubscribeClientId() => io // RSH4d
+  subscribeDevice() => io // RSH7a
+  subscribeClient() => io // RSH7b
+  unsubscribeDevice() => io // RSH7c
+  unsubscribeClient() => io // RSH7d
   listSubscriptions() => io PaginatedResult<PushChannelSubscription> // RSH7e
 
 enum ChannelState:

--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -6,7 +6,7 @@ api_separator:
 jump_to:
   Help with:
     - Delivering push notifications#deliver
-    - Activating and subscribing a device#activate
+    - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
     - Tutorials#tutorials

--- a/content/general/push/_push_intro.textile
+++ b/content/general/push/_push_intro.textile
@@ -24,7 +24,7 @@ The model for delivering push notifications to devices over channels is intentio
 
 "Find out more about channel-based push notification broadcasting":/general/push/publish#channel-broadcast
 
-h2(#activate). Activating a device and receiving notifications
+h2(#activate-device). Activating a device and receiving notifications
 
 Every device that will receive push notifications must activate itself with the local operating system or framework, and hook into the push notification services that the underlying platform provides. This functionality is platform-specific and can also vary considerably across not just platforms, but also across the push services that operate on those platforms such as GCM and FCM, both of which are available on the Android platform.
 

--- a/content/general/push/activate-subscribe.textile
+++ b/content/general/push/activate-subscribe.textile
@@ -202,7 +202,7 @@ If your client "has the push-subscribe capabilities":#push-capabilities, you can
 }];
 ```
 ```[swift]
-realtime.channels.get("pushenabled:foo").subscribeDevice { error
+realtime.channels.get("pushenabled:foo").push.subscribeDevice { error
     // Check error.
 }
 ```
@@ -238,7 +238,7 @@ To subscribe your @AblyRealtime@ instance's client ID to a channel:
 }];
 ```
 ```[swift]
-realtime.channels.get("pushenabled:foo").subscribeClient { error
+realtime.channels.get("pushenabled:foo").push.subscribeClient { error
     // Check error.
 }
 ```

--- a/content/general/push/publish.textile
+++ b/content/general/push/publish.textile
@@ -63,7 +63,7 @@ message.extras = @{
 [[rest.channels get:@"pushenabled:foo"] publish:@[message]];
 ```
 ```[swift]
-var message = ARTMesssage(name: "example", data: "rest data")
+var message = ARTMessage(name: "example", data: "rest data")
 message.extras = [
     "push": [
         "notification": [
@@ -128,7 +128,7 @@ channel.publish({ name: 'example', data: 'data', extras: extras });
 ```[python]
 extras = {
   'push': {
-    'notification': { 
+    'notification': {
       'title': 'Hello from Ably!',
       'body': 'Example push notification from Ably.'
     }
@@ -206,7 +206,7 @@ ARTJsonObject *data = @{
         @"baz": @"qux"
     }
 };
-[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error) 
+[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error)
 ```
 ```[java]
 Message message = new Message("example", "rest data");
@@ -241,7 +241,7 @@ rest.push.admin.publish(recipient, data: data)
 recipient = {'deviceId': 'xxxxxxxxxxxx'}
 message = {
   'push': {
-    'notification': { 
+    'notification': {
       'title': 'Hello from Ably!',
       'body': 'Example push notification from Ably.'
     }
@@ -253,11 +253,11 @@ rest.push.admin.publish(recipient, message)
 ```[php]
 $recipient = [ 'deviceId' => 'xxxxxxxxxxxx' ];
 $data = [ 'push' =>
-          [ 'notification' => 
+          [ 'notification' =>
             [ 'title' => 'Hello from Ably!',
               'body' => 'Example push notification from Ably.'
-            ] 
-          ] 
+            ]
+          ]
         ];
 $rest->push->admin->publish( $recipient, $data );
 ```
@@ -304,7 +304,7 @@ ARTJsonObject *data = @{
         @"baz": @"qux"
     }
 };
-[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error) 
+[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error)
 ```
 ```[swift]
 let recipient: [String: Any] = [
@@ -339,7 +339,7 @@ rest.push.admin.publish(arrayOf(Param("clientId", clientId)), message);
 recipient = {'clientId': 'xxxxxxxxxxxx'}
 message = {
   'push': {
-    'notification': { 
+    'notification': {
       'title': 'Hello from Ably!',
       'body': 'Example push notification from Ably.'
     }
@@ -351,11 +351,11 @@ rest.push.admin.publish(recipient, message)
 ```[php]
 $recipient = [ 'clientId' => 'xxxxxxxxxxx' ];
 $data = [ 'push' =>
-          [ 'notification' => 
+          [ 'notification' =>
             [ 'title' => 'Hello from Ably!',
               'body' => 'Example push notification from Ably.'
-            ] 
-          ] 
+            ]
+          ]
         ];
 $rest->push->admin->publish( $recipient, $data );
 ```
@@ -406,7 +406,7 @@ ARTJsonObject *data = @{
         @"baz": @"qux"
     }
 };
-[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error) 
+[rest.push.admin publish:recipient data:data callback:^(ARTErrorInfo *error)
 ```
 ```[swift]
 let recipient: [String: Any] = [
@@ -443,7 +443,7 @@ rest.push.admin.publish(arrayOf(Param("transportType", "apns"), Param("deviceTok
 recipient = {'transportType': 'apns', 'deviceToken': 'XXXXXXX'}
 message = {
   'push': {
-    'notification': { 
+    'notification': {
       'title': 'Hello from Ably!',
       'body': 'Example push notification from Ably.'
     }
@@ -455,11 +455,11 @@ rest.push.admin.publish(recipient, message)
 ```[php]
 $recipient = [  'transportType' => 'apns', 'deviceToken' => 'XXXXXXX' ];
 $data = [ 'push' =>
-          [ 'notification' => 
+          [ 'notification' =>
             [ 'title' => 'Hello from Ably!',
               'body' => 'Example push notification from Ably.'
-            ] 
-          ] 
+            ]
+          ]
         ];
 $rest->push->admin->publish( $recipient, $data );
 ```

--- a/content/general/versions/v1.0/push.textile
+++ b/content/general/versions/v1.0/push.textile
@@ -6,7 +6,7 @@ api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver
-    - Activating and subscribing a device#activate
+    - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
 ---
@@ -43,7 +43,7 @@ Ably provides a REST API that allows native push notifications to be delivered d
 
 "Find out more about direct push notification publishing":/general/push/publish#direct-publish
 
-h2(#activate). Activating a device and receiving notifications
+h2(#activate-device). Activating a device and receiving notifications
 
 <%= partial partial_version('general/push/_activate_subscribe_intro') %>
 

--- a/content/realtime/push.textile
+++ b/content/realtime/push.textile
@@ -6,7 +6,7 @@ api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver
-    - Activating and subscribing a device#activate
+    - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
 ---

--- a/content/rest/push.textile
+++ b/content/rest/push.textile
@@ -6,7 +6,7 @@ api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver
-    - Activating and subscribing a device#activate
+    - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
 ---

--- a/content/types/_push_channel.textile
+++ b/content/types/_push_channel.textile
@@ -13,10 +13,10 @@ bq(definition).
 Subscribe your device to the channel's push notifications.
 
 h6(#subscribe-client-id).
-  default: subscribeClientId
+  default: subscribeClient
 
 bq(definition).
-  default: subscribeClientId()
+  default: subscribeClient()
 
 "Subscribe all devices associated with your device's clientId":/general/push/activate-subscribe#subscribing-client-id to the channel's push notifications.
 
@@ -29,10 +29,10 @@ bq(definition).
 Unsubscribe your device from the channel's push notifications.
 
 h6(#unsubscribe-client-id).
-  default: unsubscribeClientId
+  default: unsubscribeClient
 
 bq(definition).
-  default: unsubscribeClientId()
+  default: unsubscribeClient()
 
 "Unsubscribe all devices associated with your device's clientId":/general/push/activate-subscribe#subscribing-client-id from the channel's push notifications.
 

--- a/content/types/_push_channel.textile
+++ b/content/types/_push_channel.textile
@@ -12,7 +12,7 @@ bq(definition).
 
 Subscribe your device to the channel's push notifications.
 
-h6(#subscribe-client-id).
+h6(#subscribe-client).
   default: subscribeClient
 
 bq(definition).
@@ -28,7 +28,7 @@ bq(definition).
 
 Unsubscribe your device from the channel's push notifications.
 
-h6(#unsubscribe-client-id).
+h6(#unsubscribe-client).
   default: unsubscribeClient
 
 bq(definition).


### PR DESCRIPTION
This PR updates the 1.1 spec to make use of only `subscribeClient` over `subscribeClientId`, and also fixes some documentation which incorrectly makes use of `subscribeClientId`. For #697.

Also fixes `activate` method not appearing in TOC. This was due to a clashing href, which this PR fixes with https://github.com/ably/docs/pull/698/commits/7746a7823f3d07f31d3da7c1fbc6b6e123587310. For #696.

Fixes spelling error per #699.