### PR TITLE
Added site_title as metadata option

### DIFF
--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -29,6 +29,7 @@ At the top of each textile page, the following metadata can be included as follo
 
 bc[yaml]. ---
 title: "Enter a title that will appear in the navigation and HTML page title"
+site_title: "Optional title for the main ably website HTML title"
 section: "Specify either rest|realtime|other|none to assign to nav on the left"
 index: 0 # Optional integer position within the nav, 0 is reserved for index & home
 api_separator: #This being specified will result in a seperator between docs and API docs

--- a/content/tutorials/android-push-direct-registration.textile
+++ b/content/tutorials/android-push-direct-registration.textile
@@ -6,7 +6,7 @@ index: 23
 
 Ably can deliver native Push Notifications to Android devices using "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.
 
-In this tutorial, we'll see how to set up and send Push Notifications to your Android app using "Ably's Push Notification service":/general/push. 
+In this tutorial, we'll see how to set up and send Push Notifications to your Android app using "Ably's Push Notification service":/general/push.
 
 Ably supports two types of client permissions for access to the Push Notification service:
 

--- a/content/tutorials/ios-push-direct-registration.textile
+++ b/content/tutorials/ios-push-direct-registration.textile
@@ -1,5 +1,6 @@
 ---
 title: iOS Push Notifications Tutorial - Direct registration
+site_title: iOS Push Notification Registration from Device
 section: tutorials
 index: 69
 ---

--- a/content/tutorials/ios-push-server-registration.textile
+++ b/content/tutorials/ios-push-server-registration.textile
@@ -1,12 +1,13 @@
 ---
 title: iOS Push Notifications Tutorial - Device registration via server
+site_title: iOS Push Notification Registration via Server
 section: tutorials
 index: 69
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.
 
-In this tutorial, we'll see how to set up and send Push Notifications to your iOS app using "Ably's Push Notification service":/general/push. 
+In this tutorial, we'll see how to set up and send Push Notifications to your iOS app using "Ably's Push Notification service":/general/push.
 
 Ably supports two types of client permissions for access to the Push Notification service:
 

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -1,5 +1,6 @@
 ---
 title: Client & Server JWT Authentication Tutorial
+site_title: JWT Authentication
 section: tutorials
 index: 55
 ---
@@ -8,7 +9,7 @@ Ably supports two types of authentication schemes. "Basic authentication":/core-
 
 When using token authentication, we recommend you instantiate Ably with a method to obtain tokens, rather than a token itself. This is due to the fact that tokens eventually expire, resulting in the connection being lost. By providing a method to obtain tokens instead, the Ably client library will automatically get a new token once the current one expires, maintaining a continuous connection.
 
-By definition, "JSON Web Tokens":https://jwt.io/ are an open, industry standard RFC 7519 method for representing claims securely between two parties. JWT auth is especially helpful in scenarios where users want to use a single authentication scheme for all of their users’ devices/browsers as well as other vendors and third party platforms such as Ably. JWT auth is also a convenient way to authenticate your IoT devices or servers which are built using the platforms that Ably doesn't yet support. This is possible because you don't have to instantiate an Ably client when using the JWT auth scheme. 
+By definition, "JSON Web Tokens":https://jwt.io/ are an open, industry standard RFC 7519 method for representing claims securely between two parties. JWT auth is especially helpful in scenarios where users want to use a single authentication scheme for all of their users’ devices/browsers as well as other vendors and third party platforms such as Ably. JWT auth is also a convenient way to authenticate your IoT devices or servers which are built using the platforms that Ably doesn't yet support. This is possible because you don't have to instantiate an Ably client when using the JWT auth scheme.
 
 Ably offers two different ways in which you can use a JSON Web Token to authenticate your users. You can either use the JWT as the token itself by formatting it correctly (called an Ably JWT), or pass to Ably a JWT of any structure which contains an Ably Token. We'll use the former.
 
@@ -108,7 +109,7 @@ Next, it's time to set up the server. We'll use "express":https://www.npmjs.com/
 var express = require('express'),
     app = express();
 app.use('/', express.static(__dirname))
-``` 
+```
 The Express server uses a middleware to serve the content, and using @express.static(__dirname)@ we are letting the server know that we want any HTML files in the root folder to be served up.
 
 Let's now set up the '/auth' route in this server that will be responsible for creating a JSON Web Token and sending this token back to the client, confirming it's authentication.
@@ -169,7 +170,7 @@ Now let's build the HTML file for our front-end client. We'll embed our JavaScri
 ```
 As you can see, it's a simple HTML skeleton with a form containing two input fields, one for each username and password as well as a button for logging in. We've also linked Ably via CDN and our external stylesheet that we just included above. When the button is clicked, it should invoke the login function that we'll add now within the JavaScript.
 
-The last part is to add the logic into this form, we'll do so by instantiating Ably's Realtime client library and requesting a JSON Web Token. Please note that for simplicity, we are ignoring the username and password credentials which otherwise must be verified by your auth server before signing a JWT and sending it back to the client. 
+The last part is to add the logic into this form, we'll do so by instantiating Ably's Realtime client library and requesting a JSON Web Token. Please note that for simplicity, we are ignoring the username and password credentials which otherwise must be verified by your auth server before signing a JWT and sending it back to the client.
 
 Go ahead and add the following within the head tag of your HTML file, right below the link to your CSS file:
 
@@ -189,7 +190,7 @@ function login(e) {
 ```
 As you can observe, we begin by instantiating Ably's Realtime client library, then we pass the '/auth' path of our auth server within the @authUrl@ parameter. If you remember from above, the '/auth' path of our auth server is responsible for signing a JWT using the private API key and then returning back the tokenId, in other words, the JSON Web Token itself.
 
-With the returned JWT, the client will automatically attempt to connect to Ably using it. If we successfully connect to Ably, we will display an alert to let the client know that the connection was successful. 
+With the returned JWT, the client will automatically attempt to connect to Ably using it. If we successfully connect to Ably, we will display an alert to let the client know that the connection was successful.
 
 That's it, simple as that!
 

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -1,5 +1,6 @@
 ---
 title: "MQTT Tutorial: Snake"
+site_title: MQTT Snake
 section: tutorials
 index: 104
 languages:
@@ -26,10 +27,10 @@ blang[javascript].
   In this tutorial, you'll be using the MQTT protocol with Ably to connect a controller made in "Node.js":https://nodejs.org/en/ with a game of snake to be played in a browser. You'll be using our "Javascript client library SDK":https://github.com/ably/ably-js for the webpage. We're using MQTT with Node.js in this tutorial for demo purposes, but if you were to actually to make something like this we'd suggest using our Javascript client library SDK instead of MQTT.
 
 blang[go].
-  In this tutorial, you'll be using the MQTT protocol with Ably to connect a controller made in "Go":https://golang.org/ with a game of snake to be played in a browser. You'll be using our "Javascript client library SDK":https://github.com/ably/ably-js in this tutorial for the webpage. 
+  In this tutorial, you'll be using the MQTT protocol with Ably to connect a controller made in "Go":https://golang.org/ with a game of snake to be played in a browser. You'll be using our "Javascript client library SDK":https://github.com/ably/ably-js in this tutorial for the webpage.
 
 blang[python].
-  In this tutorial, you'll be using the MQTT protocol with Ably to connect a controller made in "Python":https://www.python.org/ with a game of snake to be played in a browser. You'll be using our "Javascript client library SDK":https://github.com/ably/ably-js in this tutorial for the webpage. 
+  In this tutorial, you'll be using the MQTT protocol with Ably to connect a controller made in "Python":https://www.python.org/ with a game of snake to be played in a browser. You'll be using our "Javascript client library SDK":https://github.com/ably/ably-js in this tutorial for the webpage.
 
 You'll be using a keyboard in this tutorial as input for the controller, but in actuality what device or language you use as the controller doesn't matter so long as it supports MQTT.
 
@@ -116,7 +117,7 @@ blang[python].
 
 h2. Step 4 - Connect to Ably through MQTT
 
-With the libraries now available, it's time to set up MQTT. When using MQTT with Ably, there are a few requirements with regards to your setup. You'll need to connect to 'mqtt.ably.io' on port 8883, which requires the use of SSL/TLS in your connection. If you have a device which cannot support SSL, you'll need to connect via port 1883 instead, but this will come with a number of "restrictions":https://support.ably.io/solution/articles/3000074906-using-the-mqtt-protocol-adapter. 
+With the libraries now available, it's time to set up MQTT. When using MQTT with Ably, there are a few requirements with regards to your setup. You'll need to connect to 'mqtt.ably.io' on port 8883, which requires the use of SSL/TLS in your connection. If you have a device which cannot support SSL, you'll need to connect via port 1883 instead, but this will come with a number of "restrictions":https://support.ably.io/solution/articles/3000074906-using-the-mqtt-protocol-adapter.
 
 You will need to set the "keep alive" time value to between 15 and 60 seconds, where 60 seconds will maximize the battery life, and 15 seconds will maximize responsiveness to network issues. For this tutorial you'll be setting it to 15.
 
@@ -228,14 +229,14 @@ blang[javascript].
 
   There are three main things occurring in this code. Firstly, @keypress(process.stdin)@, which will simply cause our @process.stdin@ to emit @keypress@ events.
 
-  Secondly, @process.stdin.setRawMode(true)@, which ensures your keyboard input is available character-by-character with no modifiers. For example, when typing ctrl-c, @process.stdin@ will output the following as a @keypress@ event: 
+  Secondly, @process.stdin.setRawMode(true)@, which ensures your keyboard input is available character-by-character with no modifiers. For example, when typing ctrl-c, @process.stdin@ will output the following as a @keypress@ event:
 
   ```
     { name: 'c',
       ctrl: true,
       meta: false,
       shift: false,
-      sequence: '\u0003' 
+      sequence: '\u0003'
     }
   ```
 
@@ -251,7 +252,7 @@ blang[javascript].
 
 blang[go].
   Now it's time for you to detect key presses on the keyboard. For this tutorial, you'll need to know when the arrow keys or space key is pressed, and then communicate which key was pressed through MQTT. You'll be detecting the key presses with the termbox library. Add the following code inside the main function you made, just below the MQTT code:
-  
+
   ```[go]
     err := termbox.Init()
     if err != nil {
@@ -293,7 +294,7 @@ blang[go].
 
 blang[python].
   Now it's time for you to detect key presses on the keyboard. For this tutorial, you'll need to know when the arrow keys, space key or 'c' key is pressed, and then communicate which key was pressed through MQTT. You'll be detecting the key presses with the curses library. Add the following code inside the main function you made, just below the MQTT code:
-  
+
   ```[python]
     def main(win):
       key=''
@@ -345,9 +346,9 @@ blang[javascript].
         if(err) {
           console.log(err);
         }
-      }); 
+      });
     }
-  ``` 
+  ```
 
   This function simply takes the message you wish to publish, and publishes it through MQTT using @client.publish@ into the channel specified. The setting 'qos' (Quality of Service) represents whether messages are guaranteed to be delivered 'at most once' (0), 'at least once' (1), or 'exactly once' (2). Here you'll use 'at most once', as in the case of a disconnect you wouldn't want outdated information to be delivered to the game.
 
@@ -394,7 +395,7 @@ blang[go].
         client.Publish('input', 0, false, 'left')
       case termbox.KeyArrowRight:
         client.Publish('input', 0, false, 'right')
-    }  
+    }
   ```
 
   What @client.Publish(topic string, qos byte, retained bool, payload interface{})@ does is publish a message through the previously established MQTT connection. In the case of @termbox.KeySpace@, we'll be publishing onto the channel @input@ the message @startstop@ with 'qos' (Quality of Service) 0, and we have also specified that we do not wish to retain the message by stating @false@. QoS represents whether messages are guaranteed to be delivered 'at most once' (0), 'at least once' (1), or 'exactly once' (2). Here you'll use 'at most once', as in the case of a disconnect you wouldn't want outdated information to be delivered to the game.

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -1,5 +1,6 @@
 ---
 title: AMQP and Neutrino Profanity Filter
+site_title: AMQP and Neutrino Profanity Filter
 section: tutorials
 index: 101
 languages:

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -1,5 +1,6 @@
 ---
 title: AMQP and Wolfram Alpha
+site_title: AMQP and Wolfram Alpha
 section: tutorials
 index: 100
 languages:

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -1,5 +1,6 @@
 ---
 title: STOMP and Neutrino Profanity Filter
+site_title: STOMP and Neutrino Profanity Filter
 section: tutorials
 index: 102
 languages:

--- a/content/tutorials/web-rtc-data-channels.textile
+++ b/content/tutorials/web-rtc-data-channels.textile
@@ -1,5 +1,6 @@
 ---
 title: "WebRTC 1. Data channels the right way using Ably"
+site_title: "WebRTC data channels"
 section: tutorials
 index: 105
 jump_to:

--- a/content/tutorials/web-rtc-file-transfer.textile
+++ b/content/tutorials/web-rtc-file-transfer.textile
@@ -1,5 +1,6 @@
 ---
 title: "WebRTC 4. File transfers with Ably"
+site_title: "WebRTC file transfer"
 section: tutorials
 index: 106
 jump_to:

--- a/content/tutorials/web-rtc-introduction.textile
+++ b/content/tutorials/web-rtc-introduction.textile
@@ -1,5 +1,6 @@
 ---
 title: "WebRTC 0. A real world guide to WebRTC concepts with Ably"
+site_title: "WebRTC introduction"
 section: tutorials
 index: 104
 jump_to:

--- a/content/tutorials/web-rtc-screen-sharing.textile
+++ b/content/tutorials/web-rtc-screen-sharing.textile
@@ -1,5 +1,6 @@
 ---
 title: "WebRTC 3. Less code, more efficient screen sharing with Ably"
+site_title: "WebRTC screen sharing"
 section: tutorials
 index: 107
 jump_to:

--- a/content/tutorials/web-rtc-video-calling.textile
+++ b/content/tutorials/web-rtc-video-calling.textile
@@ -1,5 +1,6 @@
 ---
 title: "WebRTC 2. Straightforward Video calls with WebRTC and Ably"
+site_title: "WebRTC video calling"
 section: tutorials
 index: 106
 jump_to:
@@ -441,7 +442,7 @@ Note: This demo uses the @getUserMedia@ API as illustrated throughout the tutori
 </div>
 To try this example yourself, <a href="https://ablyvideocall.herokuapp.com/" id="new-browser" target="_blank">Open this demo in a new browser window</a> to see WebRTC video calls in action.
 
-Please note that if you are using a single Pc to test the demo, please use the same browser to open a new window, as your video and audio source cannot be captured by two different browsers at once. 
+Please note that if you are using a single Pc to test the demo, please use the same browser to open a new window, as your video and audio source cannot be captured by two different browsers at once.
 
 <img src="/images/ably-logo-white-outline.png" id="ably-qr-logo" style="visibility: hidden; width: 1px; height: 1px" crossOrigin="anonymous">
 

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -1,5 +1,6 @@
 ---
 title: WebHooks and Chuck Norris
+site_title: "WebHooks and Chuck Norris"
 section: tutorials
 index: 105
 languages:


### PR DESCRIPTION
This allows for the HTML title on the main website `www.ably.io` to be forced from docs pages. This allows for an intermediate point between using the full title of a page (often too verbose for this purpose) and simply using the url (not complex enough, can't pick up on correct capitalisation such as for WebRTC).