### PR TITLE
Clarify how to make a rule for a metachannel

### DIFF
--- a/content/realtime/channel-metadata.textile
+++ b/content/realtime/channel-metadata.textile
@@ -96,7 +96,9 @@ If you wish to stream this data beyond the limit of a single subscriber connecti
 
 h3(#reactor). Reactor rules
 
-You can associate "Reactor rules":https://www.ably.io/reactor with metachannels in the same way as for regular channels; configure these using the "Message":/realtime/messages source and use a @channelFilter@ that matches the metachannel's name. Please note: the *Channel Lifecycle* events are *not* supported with Reactor Webhooks.
+You can associate "Reactor rules":https://www.ably.io/reactor with metachannels in the same way as for regular channels; configure these using the "Message":/realtime/messages source and use a @channelFilter@ of, for example, @^\[meta\]log@. Normally the @channelFilter@ regex will only match normal, non-meta channels; however, a regex of the form @^\[qualifier\]pattern@ is special-cased to match channels with that qualifier. The @pattern@ is a regex as normal.
+
+If you want webhooks for channel lifecycle events, creating a "channel lifecycle webhook":/general/webhooks#channel-lifecycle is an easy alternative to creating a message rule for the @[meta]channel.lifecycle@ metachannel; such webhooks will have simpler POST bodies as the lifecycle events won't be wrapped in "@Message@":/realtime/types#message objects.
 
 h2(#use-cases). Use cases
 


### PR DESCRIPTION
Previous documentation was a little vague on how exactly you make a rule for a metachannel (the regex has to be quite specific or it won't work).

Also previously contained `Please note: the *Channel Lifecycle* events are *not* supported with Reactor Webhooks` which is wrong, not sure where that came from. Replaced with a quick note that you can just create a Channel Lifecycle webhook as an easy alternative to making a message rule on [meta]channel.lifecycle