### PR TITLE
Misc updates to SSE docs (in particular no longer in beta)

### DIFF
--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -15,8 +15,6 @@ The Ably SSE and raw HTTP streaming API provides a way to get a realtime stream 
 
 HTTP streaming allows for a request from a client to be held by a server, allowing it to push data to the client without further requests. This, much like WebSockets, help avoid the overhead involved in normal HTTP requests. "Server-sent events":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events (SSE) provide a thin layer on top of HTTP streaming. A common use of SSE is through the use of "the EventSource API":https://developer.mozilla.org/en-US/docs/Web/API/EventSource in all modern web browsers.
 
-p(tip). This feature is currently in beta, however is ready for production loads. If you're interested in using this feature, or have suggestions on how we can improve it, we would like you to "get in touch":https://www.ably.io/contact.
-
 It is subscribe-only: you can not interact with the channel, including to publish, enter presence, query the presence set, attach and detach from channels (without closing and re-opening the stream), or anything else.
 
 Customers who do not want to use a client library on platforms that support SSE, and only require simple subscribe-only streams, may choose to use SSE because it's an open standard, simple, and requires no SDKs on the client-side. HTTP Streaming may be considered on platforms without an SSE client. However, where possible, we strongly recommend the use of one of our "Realtime client libraries":https://www.ably.io/download, which provide "more features and higher reliability":https://support.ably.io/solution/articles/3000061848, and the full use of our "normal realtime messaging API":/realtime.
@@ -38,13 +36,11 @@ eventSource.onmessage = function(event) {
 
 h2(#authentication). Authentication
 
-Typically token authentication should be used, using a "token issued from your server":/core-features/authentication#token-request-process using an Ably SDK and an API key. This can then be passed to Ably using a querystring @token@ parameter or an @Authorization: Bearer <base64-encoded token>@ header.
+It is possible to use either basic auth (with an API key) or token authentication (using a "token issued from your server":/core-features/authentication#token-request-process ) with SSE. We recommend token auth on the client side for "security reasons":https://support.ably.io/support/solutions/articles/3000038607, so you have control over who can connect. Basic auth, while lacking this control, is simpler (it doesn't require you to run an auth server), and you don't have to worry about the client obtaining a new token when the old one expires.
 
-It is possible to use an API key as authentication, however for "security reasons":https://support.ably.io/support/solutions/articles/3000038607 that is rarely advisable. If you do wish to use an API key however, you can use a querystring parameter of @key@ or an @Authorization: Basic <base64-encoded key>@ header. See "REST API authentication":/rest-api#authentication for more information.
+If using basic auth, you can use a querystring parameter of @key@ or an @Authorization: Basic <base64-encoded key>@ header. If token auth, you can use a @accessToken@ querystring parameter or an @Authorization: Bearer <base64-encoded token>@ header. See "REST API authentication":/rest-api#authentication for more information.
 
 Connection state is only retained for two minutes. See "Connection state explained":/realtime/connection#connection-state-explained for full documentation.
-
-Due to this feature being in beta, it is currently subject to other restrictions. For example, at the moment you can not resume from part-way through a backlog of messages that was being sent as part of a previous resume; you can only resume from a message (so you can't resume unless you've received at least one message on the connection); and you can only resume from the id of a message that was sent in the last two minutes (so it will not work if the last message sent on the connection was more than two minutes ago). We expect to fix all of these by the time this feature graduates out of beta. "Get in touch":https://www.ably.io/contact if you'd like more information on when these shortcomings will be fixed in production.
 
 h1(#api). API routes
 
@@ -65,8 +61,8 @@ h5. Request parameters
 - token := **optional** An Ably auth token to use, if using token auth.
 - lastEvent := **optional**. An @id@ to resume from. Only required when starting a new SSE connection which resumes from a previous connection.
 - rewind := **optional**. An integer which, if specified, will send a backlog of the number of messages specified once the connection opens. For example, @rewind=1@ will give you the most recent message sent on the channel. This is best-effort — only messages from within the last two minutes will be available, and only if the channel has been continuously active since the message was sent; it is not a replacement for the "history API":/rest/history. It only has an effect for new connections; when resuming a previous connection using @lastEvent@, it is ignored in favour of sending you the messages you missed since you were last connected.
-- enveloped := **optional**. Default is **true**. If true, the @data@ from each event envelope for a @message@ event will be a "Message":/realtime/types#message object. If false, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
-- heartbeats := **optional**. Default is **false**. if @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
+- enveloped := **optional**. Default is @true@. If @true@, the @data@ from each event envelope for a @message@ event will be a "Message":/realtime/types#message object. If @false@, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
+- heartbeats := **optional**. Default is @false@. if @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
 
 h5(#envelope-format). Envelope format
 
@@ -136,7 +132,7 @@ h3(#event-stream). Plain HTTP event stream
 
 h6. GET realtime.ably.io/event-stream
 
-Start a streaming HTTP request, for ease of consuming with any HTTP library that supports streaming. When possible, we recommend using an SSE library as opposed to a raw HTTP stream as SSE libraries automatically handle reconnecting and resuming from the last received ID.
+Start a streaming HTTP request, for ease of consuming with any HTTP library that supports streaming. Instead of SSE events, uses JSON envelopes. When available, we recommend using an SSE library as opposed to a raw HTTP stream as SSE libraries automatically handle reconnecting and resuming from the last received ID.
 
 h5. Request parameters
 
@@ -147,8 +143,8 @@ h5. Request parameters
 - token := **optional** An Ably auth token to use, if using token auth.
 - lastEvent := **optional**. An @id@ to resume from. Only required when starting a new SSE connection which resumes from a previous connection.
 - rewind := **optional**. An integer which, if specified, will send a backlog of the number of messages specified once the connection opens. For example, @rewind=1@ will give you the most recent message sent on the channel. This is best-effort — only messages from within the last two minutes will be available, and only if the channel has been continuously active since the message was sent; it is not a replacement for the "history API":/rest/history. It only has an effect for new connections; when resuming a previous connection using @lastEvent@, it is ignored in favour of sending you the messages you missed since you were last connected.
-- enveloped := **optional**. Default is **true**. If true, the @data@ from each event envelope for a @message@ event will be a "Message":/realtime/types#message object. If false, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
-- heartbeats := **optional**. Default is **false**. If @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
+- enveloped := **optional**. Default is @true@. If @true@, the @data@ from each event envelope for a @message@ event will be a "Message":/realtime/types#message object. If @false@, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
+- heartbeats := **optional**. Default is @false@. If @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
 
 h5(#envelope-format). Envelope format
 

--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -36,9 +36,9 @@ eventSource.onmessage = function(event) {
 
 h2(#authentication). Authentication
 
-It is possible to use either basic auth (with an API key) or token authentication (using a "token issued from your server":/core-features/authentication#token-request-process ) with SSE. We recommend token auth on the client side for "security reasons":https://support.ably.io/support/solutions/articles/3000038607, so you have control over who can connect. Basic auth, while lacking this control, is simpler (it doesn't require you to run an auth server), and you don't have to worry about the client obtaining a new token when the old one expires.
+It is possible to use either "basic auth":https://www.ably.io/documentation/core-features/authentication#basic-authentication (with an "API key":https://support.ably.io/support/solutions/articles/3000030054) or "token auth":https://www.ably.io/documentation/core-features/authentication#basic-authentication (using a "token issued from your server":/core-features/authentication#token-request-process) with SSE. We recommend token auth on the client side for "security reasons":https://support.ably.io/support/solutions/articles/3000038607, so you have control over who can connect. Basic auth, while lacking this control, is simpler (it doesn't require you to run an auth server), and you don't have to worry about the client obtaining a new token when the old one expires.
 
-If using basic auth, you can use a querystring parameter of @key@ or an @Authorization: Basic <base64-encoded key>@ header. If token auth, you can use a @accessToken@ querystring parameter or an @Authorization: Bearer <base64-encoded token>@ header. See "REST API authentication":/rest-api#authentication for more information.
+If using basic auth, you can use a querystring parameter of @key@ or an @Authorization: Basic <base64-encoded key>@ header. If using token auth, you can use an @accessToken@ querystring parameter or an @Authorization: Bearer <base64-encoded token>@ header. See "REST API authentication":/rest-api#authentication for more information.
 
 Connection state is only retained for two minutes. See "Connection state explained":/realtime/connection#connection-state-explained for full documentation.
 
@@ -132,7 +132,9 @@ h3(#event-stream). Plain HTTP event stream
 
 h6. GET realtime.ably.io/event-stream
 
-Start a streaming HTTP request, for ease of consuming with any HTTP library that supports streaming. Instead of SSE events, uses JSON envelopes. When available, we recommend using an SSE library as opposed to a raw HTTP stream as SSE libraries automatically handle reconnecting and resuming from the last received ID.
+Starts a streaming HTTP request. This allows for messages to be easily consumed with any HTTP library that supports streaming. This is similar to the SSE endpoint, but uses JSON envelopes instead of SSE events.
+
+When available, we recommend using an SSE library as opposed to the raw HTTP stream as SSE libraries automatically handle reconnecting and resuming from the last received ID.
 
 h5. Request parameters
 


### PR DESCRIPTION
[SSE resume phase 2](https://github.com/ably/realtime/pull/2542) (and its [hefty preparatory stuff](https://github.com/ably/realtime/pull/2523)) are now deployed, so we can remove the wording about sse being in beta.

Changed `token` to `accessToken`, since afaict we're [no closer to a decision on `token` than we were a month ago](https://github.com/ably/realtime/pull/2507), and in the meantime the docs have been wrong.

Also toned down the pro-token-auth wording a bit -- it comes across as schizophrenic to have docs that say "Typically token authentication should be used" and that it's "rarely advisable" to use an api key when literally every one of the SSE code examples and tutorials we provide use basic auth. (And presumably they do so because it's a PITA to do token auth properly with SSE without a client library -- but to the extent that people use sse because it's easy, lightweight, and needs no setup, those reasons will apply to them to).