### PR TITLE
Channel Parameters: add first draft of documentation, including rewind

### DIFF
--- a/content/code/realtime/rewind.code
+++ b/content/code/realtime/rewind.code
@@ -1,0 +1,110 @@
+[--- Javascript ---]
+<html>
+<head>
+  <script src="//cdn.ably.io/lib/ably-1.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+</head>
+<body>
+  <h1><a href="https://www.ably.io" target="_blank"><img src="/images/favicon.png">Ably Rewind demo</a></h1>
+
+  <p>In this example, we demonstrate the simplest way to subscribe to a message using rewind in libraries older than v1.2. See <a href="https://www.ably.io/documentation/realtime/channel-params#rewind">our Rewind documentation</a> for more details.
+
+  <div class="row">
+    <input id="publish" type="submit" value="Publish a message">
+  </div>
+
+  <ul class="row white-box" id="channel-status"></ul>
+
+  <div class="row">
+    <input id="subscribe-2" type="submit" value="Subscribe with rewind to last 2 messages">
+    <ul class="row white-box" id="channel-status-sub1"></ul>
+  </div>
+
+    <div class="row">
+    <input id="subscribe-20s" type="submit" value="Subscribe with rewind to last 2 messages">
+    <ul class="row white-box" id="channel-status-sub2"></ul>
+  </div>
+</body>
+</html>
+[--- /Javascript ---]
+
+[--- HTML ---]
+<html>
+<head>
+<script src="//cdn.ably.io/lib/ably-1.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+</head>
+<body>
+  <h1><a href="https://www.ably.io" target="_blank"><img src="/images/favicon.png">Ably Rewind demo</a></h1>
+
+  <p>In this example, we demonstrate the simplest way to subscribe to a message using rewind in libraries older than v1.2. See <a href="https://www.ably.io/documentation/realtime/channel-params#rewind">our Rewind documentation</a> for more details.
+
+  <div class="row">
+    <input id="publish" type="submit" value="Publish a message">
+  </div>
+
+  <ul class="row white-box" id="channel-status"></ul>
+
+  <div class="row">
+    <input id="subscribe-2" type="submit" value="Subscribe with rewind to last 2 messages">
+    <ul class="row white-box" id="channel-status-sub1"></ul>
+  </div>
+
+    <div class="row">
+    <input id="subscribe-20s" type="submit" value="Subscribe with rewind to last 2 messages">
+    <ul class="row white-box" id="channel-status-sub2"></ul>
+  </div>
+</body>
+</html>
+[--- /HTML ---]
+
+[--- CSS ---]
+h1 {
+  font-family: Arial, Sans Serif;
+  font-size: 18px;
+}
+
+pre#curl::before {
+  content: "$";
+  padding-right: 10px;
+  color: #999;
+}
+
+pre {
+  border: 1px solid #CCC;
+  border-radius: 5px;
+  padding: 10px;
+  background-color: #EEE
+}
+
+body {
+  font-family: Arial, Sans Serif;
+  font-size: 13px;
+}
+
+a, a:visited, a:active {
+  color: #ed760a;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+textarea {
+  width: 100%;
+  height: 4em;
+  font-size: 1em;
+  font-family: Fixed, Courier;
+}
+
+#split {
+  height: 40px;
+  float: right;
+}
+
+.white-box {
+  background-color: #FFF;
+  min-height: 50px;
+}
+[--- /CSS ---]

--- a/content/realtime/channel-params.textile
+++ b/content/realtime/channel-params.textile
@@ -1,0 +1,91 @@
+---
+title: Channel Parameters
+section: realtime
+index: 32
+jump_to:
+  Help with:
+    - Overview#overview
+    - Using params with the Ably library#using-params-with-library
+    - Using params with non-Ably transports#using-params-with-other-transports
+  rewind parameter#rewind
+    - Examples#examples
+---
+
+h2(#overview). Overview
+
+Channel parameters are a general mechanism by which a client can express properties of a channel, or of its attachment to a channel. A set of channel parameters is simply a set of key/value pairs; the keys correspond to specific features that Ably defines. Having a general mechanism for specifying such parameters allows the feature set to be expanded over time without requiring any API change and, in most cases, without requiring any additional library functionality.
+
+The methods provided for specifying channel parameters, and the currently available features, are outlined below.
+
+h2(#using-params-with-library). Using params with the Ably library
+
+The current Ably libraries, at version 1.1, do not expose an API for expressing channel parameters. This means that it is necessary to specify parameters in a way that is opaque to the library. Library version 1.2, to be released shortly, will provide direct API support for expressing channel parameters.
+
+A set of params is expressed by including a query string, using standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
+
+For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, such as @[meta]log@, then the query string follows the existing qualifier, as in @[meta?foor=bar]log@.
+
+Using this syntax with the Ably library means that channel parameters are specified for the lifetime of the @Channel@ instance; in order to reference the same channel, but with different channel parameters, it is necessary to get a new @Channel@ instance, using a qualified name that includes the new channel parameters.
+
+Details of the explicit channel parameters API for use with later library versions, will be made available in due course.
+
+h2(#using-params-with-other-transports). Using params with non-Ably transports
+
+It is possible to interact with Ably channels using transports that do not involve using an Ably library; for example using SSE without any library, or using a supported non-Ably protocol such as MQTT. In these cases, it is also necessary to use a qualified channel name.
+
+A set of params is expressed by including a query string, using standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
+
+For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, such as @[meta]log@, then the query string follows the existing qualifier, as in @[meta?foo=bar]log@.
+
+In an SSE connection, it is also possible to specify channel parameters as a query string in the connection URL, instead of as a qualifier on an individual channel name. In this case, the given channel parameters apply to all channel attachments associated with that connection.
+
+h2(#rewind). rewind parameter
+
+The @rewind@ channel parameter relates to the initial attachment of a connection to a channel, and expresses the intent to attach to the channel at a position, or a point in time, in the past (that is, effectively "rewinding" the channel for the purposes of the present attachment).
+
+A @rewind@ parameter can express a channel position in terms of a number of messages, or a time interval.
+
+A @rewind@ value that is simply a number @n@ (eg @rewind=1@) is a request to attach to the channel at a position @n@ messages before the present position. If that attachment is successful, and one or more messages exist on the channel prior to the present position, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
+
+If fewer than the requested number of messages exists on the channel (including the case that there are no prior messages), then the available messages are sent; this does not constitute an error.
+
+A @rewind@ value can also be a string that is a time interval specifier. Supported specifier values express an integral number of seconds (eg @15s@), minutes (eg @5m@) or hours (eg @4h@). If that attachment is successful, and one or more messages exist on the channel in the given time interval prior to the present time, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
+
+If fewer than the requested number of messages exists on the channel in that interval (including the case that there are no messages), then the available messages are sent; this does not constitute an error.
+
+If the number of messages within the specified interval is greater than the attachment @limit@ (which defaults to 100), then only the most recent messages up to that limit are sent. The attachment succeeds, but truncation of the message backlog is indicated as a non-fatal error in the attachment response.
+
+It is also possible to specify a different limit via a @limit@ channel parameter. So, for example, to request up to 10 messages, in a window 5m before the present time, specify a channel parameter string of @[?rewind=5m&limit=10]@.
+
+By default, a maximum of two minutes of channel history is available when attaching. This means that a rewind time specifier of greater than two minutes will only be able to rewind by two minutes. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel. 
+
+The channel position expressed by a @rewind@ parameter has an effect only on an initial channel attachment. Any subsequent reattachment of the same channel on the same connection, in order to resume the connection, will attempt to resume with continuity from the point at which the connection dropped.
+
+Any @rewind@ parameter value that cannot be parsed either as a number or a time specifier represents an error, and any attachment request will fail with an error.
+
+h2(#examples). Examples
+
+h3(#examples-ably). Using channel parameters with the Ably library
+
+To subscribe to a channel, getting the most recent message if available:
+
+```
+  const subscriber = new Realtime(API_KEY);
+  subscriber.channels.get('[?rewind=1]example-channel').subscribe((msg) => {
+    console.log('Received message: ', msg);
+  });
+```
+
+To subscribe to a channel, getting up to 10 messages in the last 5 minutes:
+
+```
+  const subscriber = new Realtime(API_KEY);
+  subscriber.channels.get('[?rewind=5m&limit=10]example-channel').subscribe((msg) => {
+    console.log('Received message: ', msg);
+  });
+```
+
+h3(#examples-sse). Using channel parameters with SSE
+
+h3(#examples-mqtt). Using channel parameters with MQTT
+

--- a/content/realtime/channel-params.textile
+++ b/content/realtime/channel-params.textile
@@ -5,21 +5,44 @@ index: 32
 jump_to:
   Help with:
     - Overview#overview
-    - Using params with the Ably library#using-params-with-library
+    - Using params with v1.2+ Ably libraries#using-params-with-lib-v12
+    - Using params with v1.1 or earlier Ably libraries#using-params-with-lib-v11
     - Using params with non-Ably transports#using-params-with-other-transports
-  rewind parameter#rewind
     - Examples#examples
+  Parameters:
+    - rewind#rewind
 ---
 
 h2(#overview). Overview
 
-Channel parameters are a general mechanism by which a client can express properties of a channel, or of its attachment to a channel. A set of channel parameters is simply a set of key/value pairs; the keys correspond to specific features that Ably defines. Having a general mechanism for specifying such parameters allows the feature set to be expanded over time without requiring any API change and, in most cases, without requiring any additional library functionality.
+Channel parameters are a general mechanism by which a client can express properties of a channel, or of its attachment to a channel. A set of channel parameters is simply a set of key/value pairs, where both keys and values are strings; the keys correspond to specific features that Ably defines.
 
 The methods provided for specifying channel parameters, and the currently available features, are outlined below.
 
-h2(#using-params-with-library). Using params with the Ably library
+h2(#supported-params). Currently supported channel params
 
-The current Ably libraries, at version 1.1, do not expose an API for expressing channel parameters. This means that it is necessary to specify parameters in a way that is opaque to the library. Library version 1.2, to be released shortly, will provide direct API support for expressing channel parameters.
+- rewind := Used to request that an attachment start from some number of messages or point in time in the past. See "rewind":#rewind for more information
+- delta := **In beta**. Used to request that data payloads should be sent as deltas to the previous payload. "Contact us":https://www.ably.io/contact for more information and supported values
+
+h2(#using-params-with-lib-v12). Using channel params with v1.2+ Ably client libraries
+
+With a client library that is version 1.2 or higher, you can specify channel params as part of the @params@ property of the "channel options":/realtime/channels#channel-options.
+
+h4. Example
+
+For example, to specify the @rewind@ channel param with the value @"1"@:
+
+```[jsall]
+  // only with ably-js v1.2 or higher; currently in beta
+  const realtime = new Ably.Realtime('{{API_KEY}}');
+  const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
+    rewind: '1'
+  });
+```
+
+h2(#using-params-with-lib-v11). Using channel params with v1.1 or earlier Ably client libraries
+
+The current Ably libraries, at version 1.1, do not expose an API for expressing channel parameters. This means that it is necessary to specify parameters in a way that is opaque to the library.
 
 A set of params is expressed by including a query string, using standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
 
@@ -27,7 +50,14 @@ For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, t
 
 Using this syntax with the Ably library means that channel parameters are specified for the lifetime of the @Channel@ instance; in order to reference the same channel, but with different channel parameters, it is necessary to get a new @Channel@ instance, using a qualified name that includes the new channel parameters.
 
-Details of the explicit channel parameters API for use with later library versions, will be made available in due course.
+h4. Example
+
+For example, to specify the @rewind@ channel param with the value @"1"@:
+
+```
+  const realtime = new Ably.Realtime('{{API_KEY}}');
+  const channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+```
 
 h2(#using-params-with-other-transports). Using params with non-Ably transports
 
@@ -39,7 +69,26 @@ For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, t
 
 In an SSE connection, it is also possible to specify channel parameters as a query string in the connection URL, instead of as a qualifier on an individual channel name. In this case, the given channel parameters apply to all channel attachments associated with that connection.
 
-h2(#rewind). rewind parameter
+h4. SSE example
+
+For example, to specify the @rewind@ channel param with the value @"1"@ using a querystring parameter, where it will apply to all channels:
+
+```[javascript]
+var querystring = 'v=1.1&channels={{RANDOM_CHANNEL_NAME}}&rewind=1&key={{API_KEY}}';
+var eventSource = new EventSource('https://realtime.ably.io/event-stream?' + querystring);
+```
+
+Or to specify the same parameter but only applying to one channel of two, using a qualified channel name:
+
+```[javascript]
+  var channelOne = encodeURIComponent('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+  var channelTwo = '{{RANDOM_CHANNEL_NAME}}';
+  var channels = channelOne + ',' + channelTwo;
+  var querystring = 'v=1.1&key={{API_KEY}}&channels=' + channels';
+  var eventSource = new EventSource('https://realtime.ably.io/event-stream?' + querystring);
+```
+
+h2(#rewind). Rewind parameter
 
 The @rewind@ channel parameter relates to the initial attachment of a connection to a channel, and expresses the intent to attach to the channel at a position, or a point in time, in the past (that is, effectively "rewinding" the channel for the purposes of the present attachment).
 
@@ -49,43 +98,61 @@ A @rewind@ value that is simply a number @n@ (eg @rewind=1@) is a request to att
 
 If fewer than the requested number of messages exists on the channel (including the case that there are no prior messages), then the available messages are sent; this does not constitute an error.
 
-A @rewind@ value can also be a string that is a time interval specifier. Supported specifier values express an integral number of seconds (eg @15s@), minutes (eg @5m@) or hours (eg @4h@). If that attachment is successful, and one or more messages exist on the channel in the given time interval prior to the present time, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
+A @rewind@ value can also be a string that is a time interval specifier. Supported specifier values express an integral number of seconds (eg @15s@) or minutes (eg @2m@). If that attachment is successful, and one or more messages exist on the channel in the given time interval prior to the present time, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
 
-If fewer than the requested number of messages exists on the channel in that interval (including the case that there are no messages), then the available messages are sent; this does not constitute an error.
+If you wish to use a time interval rewind but with a custom limit on the number of messages to be returned, you can use the @rewindLimit@ channel param. For example, to request up to 10 messages in a window 5m before the present time, specify a channel parameter string of @rewind=5m&rewindLimit=10@. If fewer than the requested number of messages exists on the channel in that interval (including the case that there are no messages), then the available messages are sent; this does not constitute an error.
 
-If the number of messages within the specified interval is greater than the attachment @limit@ (which defaults to 100), then only the most recent messages up to that limit are sent. The attachment succeeds, but truncation of the message backlog is indicated as a non-fatal error in the attachment response.
+At most 100 messages will be sent in a rewind request. If the number of messages within the specified interval is greater than that limit, then only the most recent messages up to that limit are sent. The attachment succeeds, but truncation of the message backlog is indicated as a non-fatal error in the attachment response.
 
-It is also possible to specify a different limit via a @limit@ channel parameter. So, for example, to request up to 10 messages, in a window 5m before the present time, specify a channel parameter string of @[?rewind=5m&limit=10]@.
+By default, a maximum of two minutes of channel history is available when attaching. This means that a rewind time specifier of greater than two minutes will only be able to rewind by two minutes. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel.
 
-By default, a maximum of two minutes of channel history is available when attaching. This means that a rewind time specifier of greater than two minutes will only be able to rewind by two minutes. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel. 
-
-The channel position expressed by a @rewind@ parameter has an effect only on an initial channel attachment. Any subsequent reattachment of the same channel on the same connection, in order to resume the connection, will attempt to resume with continuity from the point at which the connection dropped.
+The channel position expressed by a @rewind@ parameter has an effect only on an initial channel attachment. Any subsequent reattachment of the same channel on the same connection, in order to resume the connection, will attempt to resume with continuity from the point at which the connection dropped. (There are a few exceptions to this: in particular, client libraries before v1.2 that have been disconnected for over two minutes, and all clients when using "@recover@ mode":/realtime/connection#connection-state-recovery ; in both cases the previous attachment state is not preserved).
 
 Any @rewind@ parameter value that cannot be parsed either as a number or a time specifier represents an error, and any attachment request will fail with an error.
 
-h2(#examples). Examples
-
-h3(#examples-ably). Using channel parameters with the Ably library
+h4(#rewind-example-ably). Rewind example with an Ably client library
 
 To subscribe to a channel, getting the most recent message if available:
 
+```[jsall]
+  // only with ably-js v1.2 or higher; currently in beta
+  const realtime = new Ably.Realtime('{{API_KEY}}');
+  realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
+    rewind: '1'
+  }).subscribe(msg => console.log("Received message: ", msg));
 ```
-  const subscriber = new Realtime(API_KEY);
-  subscriber.channels.get('[?rewind=1]example-channel').subscribe((msg) => {
-    console.log('Received message: ', msg);
+
+```[jsall]
+  // with ably-js v1.1 or below
+  const realtime = new Ably.Realtime('{{API_KEY}}');
+  const channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+  channel.subscribe(msg => console.log("Received message: ", msg));
+```
+
+h4(#rewind-example-sse). Rewind example with SSE
+
+To subscribe to a channel, getting the most recent message if available:
+
+```[javascript]
+  var querystring = 'v=1.1&channels={{RANDOM_CHANNEL_NAME}}&rewind=1&key={{API_KEY}}';
+  var eventSource = new EventSource('https://realtime.ably.io/event-stream?' + querystring);
+```
+
+h3(#rewind-examples-mqtt). Rewind example with MQTT
+
+```[nodejs]
+  var mqtt = require('mqtt');
+  var options = {
+    keepalive: 30,
+    username: 'FIRST_HALF_OF_API_KEY',
+    password: 'SECOND_HALF_OF_API_KEY',
+    port: 8883
+  };
+  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+  client.on('connect', () => {
+    client.subscribe('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+  });
+  client.on('message', (topic, message) => {
+    ...
   });
 ```
-
-To subscribe to a channel, getting up to 10 messages in the last 5 minutes:
-
-```
-  const subscriber = new Realtime(API_KEY);
-  subscriber.channels.get('[?rewind=5m&limit=10]example-channel').subscribe((msg) => {
-    console.log('Received message: ', msg);
-  });
-```
-
-h3(#examples-sse). Using channel parameters with SSE
-
-h3(#examples-mqtt). Using channel parameters with MQTT
-

--- a/content/realtime/channel-params.textile
+++ b/content/realtime/channel-params.textile
@@ -22,18 +22,18 @@ The methods provided for specifying channel parameters, and the currently availa
 h2(#supported-params). Currently supported channel params
 
 - rewind := Used to request that an attachment start from some number of messages or point in time in the past. See "rewind":#rewind for more information
-- delta := **In beta**. Used to request that data payloads should be sent as deltas to the previous payload. "Contact us":https://www.ably.io/contact for more information and supported values
+- delta := **In an experimental state**. Used to request that data payloads should be sent as deltas to the previous payload. "Contact us":https://www.ably.io/contact for more information and supported values
 
 h2(#using-params-with-lib-v12). Using channel params with v1.2+ Ably client libraries
 
-With a client library that is version 1.2 or higher, you can specify channel params as part of the @params@ property of the "channel options":/realtime/channels#channel-options.
+With a client library that is version 1.2 or later, you can specify channel params as part of the @params@ property of the "channel options":/realtime/channels#channel-options.
 
 h4. Example
 
 For example, to specify the @rewind@ channel param with the value @"1"@:
 
 ```[jsall]
-  // only with ably-js v1.2 or higher; currently in beta
+  // only with ably-js v1.2 or later; currently in beta
   const realtime = new Ably.Realtime('{{API_KEY}}');
   const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
     rewind: '1'
@@ -100,7 +100,7 @@ If fewer than the requested number of messages exists on the channel (including 
 
 A @rewind@ value can also be a string that is a time interval specifier. Supported specifier values express an integral number of seconds (eg @15s@) or minutes (eg @2m@). If that attachment is successful, and one or more messages exist on the channel in the given time interval prior to the present time, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
 
-If you wish to use a time interval rewind but with a custom limit on the number of messages to be returned, you can use the @rewindLimit@ channel param. For example, to request up to 10 messages in a window 5m before the present time, specify a channel parameter string of @rewind=5m&rewindLimit=10@. If fewer than the requested number of messages exists on the channel in that interval (including the case that there are no messages), then the available messages are sent; this does not constitute an error.
+If you wish to use a time interval rewind but additionally specify a limit on the number of messages to be returned, you can use the @rewindLimit@ channel param. For example, to request up to 10 messages in a window 5m before the present time, specify a channel parameter string of @rewind=5m&rewindLimit=10@. If fewer than the requested number of messages exists on the channel in that interval (including the case that there are no messages), then the available messages are sent; this does not constitute an error.
 
 At most 100 messages will be sent in a rewind request. If the number of messages within the specified interval is greater than that limit, then only the most recent messages up to that limit are sent. The attachment succeeds, but truncation of the message backlog is indicated as a non-fatal error in the attachment response.
 
@@ -115,7 +115,7 @@ h4(#rewind-example-ably). Rewind example with an Ably client library
 To subscribe to a channel, getting the most recent message if available:
 
 ```[jsall]
-  // only with ably-js v1.2 or higher; currently in beta
+  // only with ably-js v1.2 or later; currently in beta
   const realtime = new Ably.Realtime('{{API_KEY}}');
   realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
     rewind: '1'

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -236,6 +236,147 @@ channel.subscribe { message in
 }
 ```
 
+h4(#rewind). Subscribing to a channel and fetching history with rewind
+
+If you wish to both subscribe to a channel, as well as obtain some messages from said channel's "history":/realtime/history seamlessly, you can make use of the "rewind":/realtime/channel-params feature. This will result in the specified number of messages from "history":/realtime/history being returned as part of the subscription process.
+
+minimize. View details
+  "Rewind":/realtime/channel-params has two methods of obtaining messages from history, either by getting a specified number of messages from history, or messages from a set period of time into the past.
+
+  In Ably libraries older than @v1.2@, you can specify the "rewind":/realtime/channel-params parameter in the "metadata":/realtime/channel-metadata of the channel name, tacking it onto the end of any metadata otherwise specified. For example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
+
+  *Note* that "rewind":/realtime/channel-params is limited to a maximum of @100 messages@, and can only get messages no older than 2 minutes. In addition, rewind will only apply upon *attaching* to a channel, so any subsequent subscriptions post-attach will not fetch old messages.
+
+  *Rewind by number of messages*
+
+  To rewind by a set number of messages, add @?rewind=NUM_MSG@ to your metadata, where @NUM_MSG@ is the number of messages you wish to get at most. For example, to obtain 1 messages from history as you subscribe, you would do the following:
+
+  ```[javascript](code-editor:realtime/rewind)
+    var realtime = new Ably.Realtime('{{API_KEY}}');
+    var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+    channel.subscribe(function(message) {
+      alert('Received: ' + message.data);
+    });
+  ```
+
+  ```[nodejs](code-editor:realtime/rewind)
+    var Ably = require('ably');
+    var realtime = new Ably.Realtime('{{API_KEY}}');
+    var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+    channel.subscribe(function(message) {
+      console.log("Received: "  message.data);
+    });
+  ```
+
+  ```[ruby]
+    realtime = Ably::Realtime.new('{{API_KEY}}')
+    channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}')
+    channel.subscribe do |message|
+      puts "Received: #{message.data}"
+    end
+  ```
+
+  ```[java]
+    AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+    Channel channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+    channel.subscribe(new MessageListener() {
+      @Override
+      public void onMessage(Message message) {
+        System.out.println("New messages arrived. " + message.name);
+      }
+    });
+  ```
+
+  ```[csharp]
+    AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+    IRealtimeChannel channel = realtime.Channels.Get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+    channel.Subscribe(message => {
+      Console.WriteLine($"Message: {message.Name}:{message.Data} received");
+    });
+  ```
+
+  ```[objc]
+  ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+  ARTRealtimeChannel *channel = [realtime.channels get:@"[?rewind=1]{{RANDOM_CHANNEL_NAME}}"];
+  [channel subscribe:^(ARTMessage *message) {
+      NSLog(@"Received: %@", message.data);
+  }];
+  ```
+
+  ```[swift]
+  let realtime = ARTRealtime(key: "{{API_KEY}}")
+  let channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}")
+  channel.subscribe { message in
+      print("Received: \(message.data)")
+  }
+  ```
+
+  *Rewind by period of time*
+
+  To rewind by a set period of time, add @?rewind=TIME@ to your metadata, where @TIME@ is the period of time you wish to get messages for. For example, to obtain 10 seconds of messages from history as you subscribe, you would do the following:
+
+  ```[javascript](code-editor:realtime/rewind)
+    var realtime = new Ably.Realtime('{{API_KEY}}');
+    var channel = realtime.channels.get('[?rewind=10s]{{RANDOM_CHANNEL_NAME}}');
+    channel.subscribe(function(message) {
+      alert('Received: ' + message.data);
+    });
+  ```
+
+  ```[nodejs](code-editor:realtime/rewind)
+    var Ably = require('ably');
+    var realtime = new Ably.Realtime('{{API_KEY}}');
+    var channel = realtime.channels.get('[?rewind=10s]{{RANDOM_CHANNEL_NAME}}');
+    channel.subscribe(function(message) {
+      console.log("Received: "  message.data);
+    });
+  ```
+
+  ```[ruby]
+    realtime = Ably::Realtime.new('{{API_KEY}}')
+    channel = realtime.channels.get('[?rewind=10s]{{RANDOM_CHANNEL_NAME}}')
+    channel.subscribe do |message|
+      puts "Received: #{message.data}"
+    end
+  ```
+
+  ```[java]
+    AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+    Channel channel = realtime.channels.get("[?rewind=10s]{{RANDOM_CHANNEL_NAME}}");
+    channel.subscribe(new MessageListener() {
+      @Override
+      public void onMessage(Message message) {
+        System.out.println("New messages arrived. " + message.name);
+      }
+    });
+  ```
+
+  ```[csharp]
+    AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+    IRealtimeChannel channel = realtime.Channels.Get("[?rewind=10s]{{RANDOM_CHANNEL_NAME}}");
+    channel.Subscribe(message => {
+      Console.WriteLine($"Message: {message.Name}:{message.Data} received");
+    });
+  ```
+
+  ```[objc]
+  ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+  ARTRealtimeChannel *channel = [realtime.channels get:@"[?rewind=1]{{RANDOM_CHANNEL_NAME}}"];
+  [channel subscribe:^(ARTMessage *message) {
+      NSLog(@"Received: %@", message.data);
+  }];
+  ```
+
+  ```[swift]
+  let realtime = ARTRealtime(key: "{{API_KEY}}")
+  let channel = realtime.channels.get("[?rewind=10s]{{RANDOM_CHANNEL_NAME}}")
+  channel.subscribe { message in
+      print("Received: \(message.data)")
+  }
+  ```
+
+  *Note* that currently only seconds (@10s@) and minutes (@2m@) are supported as time periods.
+
 h3(#publishing). Publishing on a channel
 
 In order to publish on a channel, you simply need to make use of the "publish":#publish method:
@@ -285,7 +426,7 @@ channel.publish("example", data: "message data")
 
 h3(#channel-lifecycle). Channel lifecycle
 
-Channels are not pre-configured or provisioned by Ably in advance; they are created on demand when clients attach, and remain active until such time that there are no remaining attached clients. Within the "dashboard for your app":https://support.ably.io/solution/articles/3000030053-how-do-i-access-my-app-dashboard however, you can pre-configure one or more "channel namespaces":#channel-namespaces (i.e. name prefixes), and associate different attributes and access rights with those namespaces. Find out more about "channel namespaces":#channel-namespaces.
+Channels are not pre-configured or provisioned by Ably in advance; they are created on demand when clients attach, and remain active until such time that there are no remaining attached clients. Within the "dashboard for your app":https://support.ably.io/solution/articles/3000030053 however, you can pre-configure one or more "channel namespaces":#channel-namespaces (i.e. name prefixes), and associate different attributes and access rights with those namespaces. Find out more about "channel namespaces":#channel-namespaces.
 
 The following example explicitly attaches to a channel, which results in the channel being provisioned in Ably's global realtime cluster. This channel will remain available globally until there are no more clients attached to the channel:
 

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -243,7 +243,7 @@ It is possible to subscribe to a channel and obtain messages from that channel's
 minimize. View details
   "Rewind":/realtime/channel-params has two methods of obtaining messages from history. You can retreive a specified number of messages from history or messages from a set period of time into the past.
 
-  In Ably libraries older than @v1.2@, you can specify the "rewind":/realtime/channel-params parameter in the "metadata":/realtime/channel-metadata of the channel name, appending it at the end of any metadata otherwise specified. For example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
+  In current Ably libraries, or when using the "service without a library":https://www.ably.io/adapters, this is done by qualifying the channel name. There is a future library release planned in which it will be possible to specify channel params directly via the API. As an example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
 
   *Note* that "rewind":/realtime/channel-params is limited to a maximum of @100 messages@, and can only get messages no older than 2 minutes by default. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel.
 
@@ -315,7 +315,7 @@ minimize. View details
 
   *Rewind by period of time*
 
-  To rewind by a set period of time, add @?rewind=TIME@ to your metadata, where @TIME@ is how far back in time you wish to rewind. For example, to obtain 10 seconds of messages from history as you subscribe, you would do the following:
+  To rewind by a time interval, add @?rewind=TIME@ to your metadata, where @TIME@ is the time specifier. For example, to obtain 10 seconds of messages from history as you subscribe, you would do the following:
 
   ```[javascript](code-editor:realtime/rewind)
     var realtime = new Ably.Realtime('{{API_KEY}}');

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -236,12 +236,12 @@ channel.subscribe { message in
 }
 ```
 
-h4(#rewind). Subscribing to a channel with rewind option enabled
+h4(#rewind). Subscribing to a channel with the rewind option enabled
 
-If you wish to both subscribe to a channel, as well as obtain some messages from said channel's "history":/realtime/history seamlessly, you can make use of the "rewind":/realtime/channel-params feature. This will result in the specified number of messages from "history":/realtime/history being returned as part of the subscription process.
+It is possible to subscribe to a channel and obtain messages from that channel's "history":/realtime/history with a single API request. To do so you would use the "rewind":/realtime/channel-params#rewind feature. This will result in the specified number of messages from "history":/realtime/history being returned as part of the subscription process.
 
 minimize. View details
-  "Rewind":/realtime/channel-params has two methods of obtaining messages from history, either by getting a specified number of messages from history, or messages from a set period of time into the past.
+  "Rewind":/realtime/channel-params has two methods of obtaining messages from history. You can retreive a specified number of messages from history or messages from a set period of time into the past.
 
   In Ably libraries older than @v1.2@, you can specify the "rewind":/realtime/channel-params parameter in the "metadata":/realtime/channel-metadata of the channel name, appending it at the end of any metadata otherwise specified. For example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
 

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -236,20 +236,22 @@ channel.subscribe { message in
 }
 ```
 
-h4(#rewind). Subscribing to a channel and fetching history with rewind
+h4(#rewind). Subscribing to a channel with rewind option enabled
 
 If you wish to both subscribe to a channel, as well as obtain some messages from said channel's "history":/realtime/history seamlessly, you can make use of the "rewind":/realtime/channel-params feature. This will result in the specified number of messages from "history":/realtime/history being returned as part of the subscription process.
 
 minimize. View details
   "Rewind":/realtime/channel-params has two methods of obtaining messages from history, either by getting a specified number of messages from history, or messages from a set period of time into the past.
 
-  In Ably libraries older than @v1.2@, you can specify the "rewind":/realtime/channel-params parameter in the "metadata":/realtime/channel-metadata of the channel name, tacking it onto the end of any metadata otherwise specified. For example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
+  In Ably libraries older than @v1.2@, you can specify the "rewind":/realtime/channel-params parameter in the "metadata":/realtime/channel-metadata of the channel name, appending it at the end of any metadata otherwise specified. For example, if you have no metadata and wish to subscribe to channel @my_channel@ and fetch the most recent message from "history":/realtime/history, you would specify the channel as @[?rewind=1]my_channel@. If the channel had some metadata, @[some_metadata]my_channel@, you would apply "rewind":/realtime/channel-params with @[some_metadata?rewind=1]my_channel@. For more details, look at our "channel paramater":/realtime/channel-params documentation.
 
-  *Note* that "rewind":/realtime/channel-params is limited to a maximum of @100 messages@, and can only get messages no older than 2 minutes. In addition, rewind will only apply upon *attaching* to a channel, so any subsequent subscriptions post-attach will not fetch old messages.
+  *Note* that "rewind":/realtime/channel-params is limited to a maximum of @100 messages@, and can only get messages no older than 2 minutes by default. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel.
+
+  In addition, rewind will only apply upon *attaching* to a channel, so any subsequent subscriptions post-attach will not fetch old messages.
 
   *Rewind by number of messages*
 
-  To rewind by a set number of messages, add @?rewind=NUM_MSG@ to your metadata, where @NUM_MSG@ is the number of messages you wish to get at most. For example, to obtain 1 messages from history as you subscribe, you would do the following:
+  To rewind by a set number of messages, add @?rewind=NUM_MSG@ to your metadata, where @NUM_MSG@ is the number of messages you wish to get at most. For example, to obtain 1 message from history as you subscribe, you would do the following:
 
   ```[javascript](code-editor:realtime/rewind)
     var realtime = new Ably.Realtime('{{API_KEY}}');
@@ -313,7 +315,7 @@ minimize. View details
 
   *Rewind by period of time*
 
-  To rewind by a set period of time, add @?rewind=TIME@ to your metadata, where @TIME@ is the period of time you wish to get messages for. For example, to obtain 10 seconds of messages from history as you subscribe, you would do the following:
+  To rewind by a set period of time, add @?rewind=TIME@ to your metadata, where @TIME@ is how far back in time you wish to rewind. For example, to obtain 10 seconds of messages from history as you subscribe, you would do the following:
 
   ```[javascript](code-editor:realtime/rewind)
     var realtime = new Ably.Realtime('{{API_KEY}}');

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -134,13 +134,83 @@ Both the "@Channel@":/realtime/channels and "@Presence@":/realtime/presence obje
 
 h3(#persisted-history). Enabling persistent history
 
-By default, persisted history on channels is disabled and messages are only stored by the Ably service for two minutes in memory. If persisted history is enabled for the channel, then messages will "typically be stored for 24 - 72 hours on disk":https://support.ably.io/solution/articles/3000030059-how-long-are-messages-stored-for.
+By default, persisted history on channels is disabled and messages are only stored by the Ably service for two minutes in memory. If persisted history is enabled for the channel, then messages will "typically be stored for 24 - 72 hours on disk":https://support.ably.io/solution/articles/3000030059.
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://support.ably.io/solution/articles/3000030053-how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://support.ably.io/solution/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://support.ably.io/solution/articles/3000030053. See the "documentation on channel rules":https://support.ably.io/solution/articles/3000030057 for further information on what they are and how to configure them.
 
 h3(#continuous-history). Continuous history
+
+It is possible to obtain message history that is continuous with the realtime messages received on an attached channel, through the use of either "rewind":/realtime/messages, or the use of @untilAttach@ with History.
+
+h4(#rewind). Rewind
+
+If you wish to obtain history as part of attaching to a channel, you can make use of the "rewind channel parameter":/realtime/channel-params#rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Check out the main "rewind documentation":/realtime/channel-params#rewind for further details.
+
+In versions of Ably prior to v1.2, rewind is specified via the metadata. The parameter is appeneded to any existing metadata, so if the channel were @[some_metadata]my_channel@, you would specify the use of rewind via @[some_metadata?rewind=1]my_channel@. You can specify either a number of messages up to 100 to rewind to (for example @10@), or a period of time in either seconds (@10s@), or minutes (@2m@) up to 2 minutes.
+
+```[javascript](code-editor:realtime/rewind)
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+  channel.subscribe(function(message) {
+    alert('Received: ' + message.data);
+  });
+```
+
+```[nodejs](code-editor:realtime/rewind)
+  var Ably = require('ably');
+  var realtime = new Ably.Realtime('{{API_KEY}}');
+  var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
+  channel.subscribe(function(message) {
+    console.log("Received: "  message.data);
+  });
+```
+
+```[ruby]
+  realtime = Ably::Realtime.new('{{API_KEY}}')
+  channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}')
+  channel.subscribe do |message|
+    puts "Received: #{message.data}"
+  end
+```
+
+```[java]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  Channel channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+  channel.subscribe(new MessageListener() {
+    @Override
+    public void onMessage(Message message) {
+      System.out.println("New messages arrived. " + message.name);
+    }
+  });
+```
+
+```[csharp]
+  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
+  IRealtimeChannel channel = realtime.Channels.Get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+  channel.Subscribe(message => {
+    Console.WriteLine($"Message: {message.Name}:{message.Data} received");
+  });
+```
+
+```[objc]
+ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+ARTRealtimeChannel *channel = [realtime.channels get:@"[?rewind=1]{{RANDOM_CHANNEL_NAME}}"];
+[channel subscribe:^(ARTMessage *message) {
+    NSLog(@"Received: %@", message.data);
+}];
+```
+
+```[swift]
+let realtime = ARTRealtime(key: "{{API_KEY}}")
+let channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}")
+channel.subscribe { message in
+    print("Received: \(message.data)")
+}
+```
+
+h4(#until-attach). History with untilAttach
 
 It is possible to obtain message history that is continuous with the realtime messages received on an attached channel, in the backwards direction from the point of attachment. When a @Channel@ instance is attached, it's automatically populated by the Ably service with the serial number of the last published message on the channel. As such, using this serial number, the client library is able to make a history request to the Ably service for all messages received since the channel was attached. Any new messages therefore are received in realtime via the attached channel, and any historical messages are accessible via the history method.
 

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -148,7 +148,7 @@ h4(#rewind). Rewind
 
 If you wish to obtain history as part of attaching to a channel, you can use the "rewind channel parameter":/realtime/channel-params#rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Check out the main "rewind documentation":/realtime/channel-params#rewind for further details.
 
-In versions of Ably prior to v1.2, rewind is specified via the metadata. The parameter is appeneded to any existing metadata, so if the channel were @[some_metadata]my_channel@, you would specify the use of rewind via @[some_metadata?rewind=1]my_channel@. You can specify either a number of messages up to 100 to rewind to (for example @10@), or a period of time in either seconds (@10s@), or minutes (@2m@) up to 2 minutes.
+In current Ably libraries, or when using the "service without a library":https://www.ably.io/adapters, this is done by qualifying the channel name. There is a future library release planned in which it will be possible to specify channel params directly via the API. As an example, if the channel were @[some_metadata]my_channel@, you would specify the use of rewind via @[some_metadata?rewind=1]my_channel@. You can specify either a number of messages up to 100 to rewind to (for example @10@), or a time specifier of either seconds (@10s@), or minutes (@2m@) up to 2 minutes.
 
 *Note* that this will only work whilst attaching to a channel.
 

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -142,13 +142,15 @@ To enable history on a channel, it is necessary to add a channel rule in the set
 
 h3(#continuous-history). Continuous history
 
-It is possible to obtain message history that is continuous with the realtime messages received on an attached channel, through the use of either "rewind":/realtime/messages, or the use of @untilAttach@ with History.
+By using "rewind":/realtime/channel-params#rewind or History's @untilAttach@, it is possible to obtain message history that is continuous with the realtime messages received on an attached channel.
 
 h4(#rewind). Rewind
 
-If you wish to obtain history as part of attaching to a channel, you can make use of the "rewind channel parameter":/realtime/channel-params#rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Check out the main "rewind documentation":/realtime/channel-params#rewind for further details.
+If you wish to obtain history as part of attaching to a channel, you can use the "rewind channel parameter":/realtime/channel-params#rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Check out the main "rewind documentation":/realtime/channel-params#rewind for further details.
 
 In versions of Ably prior to v1.2, rewind is specified via the metadata. The parameter is appeneded to any existing metadata, so if the channel were @[some_metadata]my_channel@, you would specify the use of rewind via @[some_metadata?rewind=1]my_channel@. You can specify either a number of messages up to 100 to rewind to (for example @10@), or a period of time in either seconds (@10s@), or minutes (@2m@) up to 2 minutes.
+
+*Note* that this will only work whilst attaching to a channel.
 
 ```[javascript](code-editor:realtime/rewind)
   var realtime = new Ably.Realtime('{{API_KEY}}');

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -40,6 +40,7 @@ jsbin_hash:
   6BxZ2LJaEmxbhp7m+biUV2Aufio=: ukuwol
   ecHI+FUOLMPOfG5SjFU4g547Fk4=: uzayib
   XaW+t3v4sFT217bqEc7FLGYFFlA=: oruvuz
+  1EDb7uYe3EwOw0pDJ+Y5jdNUx90=: irazul
 jsbin_id:
   adapters/pusher-pub-sub: jQncq6OcBR6KCAsxnz3q5mit6m4=
   adapters/pubnub-pub-sub: YuO2+EE7oigITwEqrbpZKS6sa38=
@@ -81,3 +82,4 @@ jsbin_id:
   sse/sse: 6BxZ2LJaEmxbhp7m+biUV2Aufio=
   sse/eventstream: kFsT2eCL2NRWubzQ8OC3BMNZFYg=
   rest/batch-presence: XaW+t3v4sFT217bqEc7FLGYFFlA=
+  realtime/rewind: 1EDb7uYe3EwOw0pDJ+Y5jdNUx90=


### PR DESCRIPTION
This is a first draft of some documentation for channel parameters, and `rewind`.

@SimonWoolf @codemerx please review for accuracy, and please add examples for SSE and MQTT.

I don't feel strongly about where this goes in the hierarchy but this seems to make sense, alongside channel-metadata.