### PR TITLE
Update showing the rewind functionality.

### DIFF
--- a/content/core-features/history.textile
+++ b/content/core-features/history.textile
@@ -17,3 +17,11 @@ h2(#persisted-history). Enabling persistent history
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quota. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
 To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://support.ably.io/solution/articles/3000030053-how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://support.ably.io/solution/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+
+h2(#rewind). Rewinding previous messages upon connection
+
+Persistant history allows clients that are reconnecting from a lost connection to recover messages they may have lost; the "channel parameter":/realtime/channels/#channel-parameters @rewind@ allows new connections to retrieve earlier messages on initial connection. For example, using the parameter, a new connection could request the last 2 minutes of messages to be returned. 
+
+The default maximum for messages retrieved using rewind is 2 minutes; however, if persisted history is enabled, messages can be retrieved up to your persisted limit.
+
+For more information on setting up rewind, see "channel parameters":/realtime/channels/#channel-parameters and "rewind":/realtime/history#rewind.

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -172,6 +172,38 @@ bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = realtime.channels.get("channelName", options: options)
 
+h4(#channel-parameters). Setting channel parameters
+
+Channel parameters allow the client to provide additional properties of a channel, or of its attachment to a channel, at the point of connection. A set of channel parameters is simply a set of key/value pairs; the keys correspond to specific features that Ably defines.
+
+Using this syntax with the Ably library means that channel parameters are specified for the lifetime of the @Channel@ instance; in order to reference the same channel, but with different channel parameters, it is necessary to get a new @Channel@ instance, using a qualified name that includes the new channel parameters.
+
+Channel parameters are prepended to the channel name when subscribing to a channel. For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, such as @[meta]log@, then the query string follows the existing qualifier, as in @[meta?foor=bar]log@.
+
+Below is an example using the @rewind@ property, passed into @example-channel@.
+
+bc[jsall]. const subscriber = new Realtime(API_KEY);
+subscriber.channels.get('[?rewind=1]example-channel').subscribe((msg) => {
+  console.log('Received message: ', msg);
+});
+
+h5(#available-parameters). Available Parameters
+
+Currently, the only available channel parameters are listed below:
+
+- <span lang="default">"rewind":/realtime/history#rewind</span> := The @rewind@ channel parameter allows the initial connection to a channel to begin at a position, or a point in time, in the past.
+- <span lang="default">"limit":/realtime/history#rewind-limit</span> := The @limit@ channel parameter allows you to set the default limit (1000) of returned messages when connecting to a channel when using the @rewind@ channel parameter.
+
+h5(#using-params-with-other-transports). Using channel paramaters with non-Ably transports
+
+It is possible to interact with Ably channels using transports that do not involve using an Ably library, for example using SSE without any library or using a supported non-Ably protocol such as MQTT. In these cases, it is also necessary to use a qualified channel name.
+
+A set of params is expressed by including a query string, using standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
+
+For example, to specify the parameter @foo@ with value @bar@ on channel @baz@, the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, such as @[meta]log@, then the query string follows the existing qualifier, as in @[meta?foo=bar]log@.
+
+In an SSE connection, it is also possible to specify channel parameters as a query string in the connection URL, instead of as a qualifier on an individual channel name. In this case, the given channel parameters apply to all channel attachments associated with that connection.
+
 h3(#subscribing). Subscribing to a channel
 
 To subscribe to a channel, use the "subscribe":#subscribe method of a channel:

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -20,6 +20,7 @@ jump_to:
     - Channel and Presence history#channel-and-presence
     - Persisted history
     - Continuous history
+    - rewind
   API reference:
     - Message history#channel-history
     - Presence history#presence-history
@@ -229,6 +230,42 @@ channel.on(.attached) { error in
         print("Last message before attach: \(lastMessage.id) - \(lastMessage.data)")
     }
 }
+```
+
+h3(#rewind). @rewind@
+
+Closely connected to channel history is @rewind@, a "channel parameter":/realtime/channels/#channel-parameters which allows the initial connection to a channel to begin at a position, or a point in time, in the past. All messages from that point to the present will be returned, assuming the "limit":#rewind-limit is not reached. The receiving of new messages will then begin as normal.
+
+A @rewind@ value can be a number or a string:
+
+- <span lang="default">number (e.g. @50@)</span> := A number value being passed results in a request to attach the channel at a position @n@ messages into the past. Any messages existing on the channel up to and including that value will be delivered to the subscriber immediately attachement is completed, in order.
+- <span lang="default">string (e.g. @"15s"@ or @"2m"@)</span> := A string value being passed results in a request to attach the channel at a position specified by the time signifier. Any messages existing on the channel in that timeframe will be delivered to the subscriber immediately attachement is completed, in order. The letters 's' for second and 'm' for minute are supported.
+
+In either case, if fewer than the requested number of messages exists on the channel (including the case that there are no prior messages), then the available messages are sent; this does not constitute an error.
+
+An example is shown below using a number passed into @rewind@, retrieving 10 messages previous to the time of connection.
+
+```[javascript]
+  const subscriber = new Realtime(API_KEY);
+  subscriber.channels.get('[?rewind=10]example-channel').subscribe((msg) => {
+    console.log('Received message: ', msg);
+  });
+```
+By default, a maximum of two minutes of channel history is available when attaching. Any request that would return greater than 2 minutes of messages will be truncated to 2 minutes. However, a channel with "persistant history":#persisted-history enabled will return messages up to the persisted hisotry limit on the channel. 
+
+Any @rewind@ parameter value that cannot be parsed either as a number or a time specifier will fail with an error.
+
+h4(#rewind-limit). @limit@
+
+If the number of messages within the specified interval (time or number of messages) is greater than the attachment @limit@ (default: 1000), then the most recent messages up to that limit are sent. The attachment succeeds, but truncation of the message backlog is indicated as a non-fatal error in the attachment response.
+
+This limit can be set via the @limit@ "channel parameter":/realtime/channels/#channel-parameters. So, for example, to request up to 10 messages, in a window 2m before the present time, specify a channel parameter string of @[?rewind=2m&limit=10]@ as shown below.
+
+```[javascript]
+const subscriber = new Realtime(API_KEY);
+subscriber.channels.get(‘[?rewind=2m&limit=10]example-channel’).subscribe((msg) => {
+console.log(’Received message: ’, msg);
+});
 ```
 
 h1. API reference


### PR DESCRIPTION
As per my email to Jodie: I've updated the docs in three places: core-features/history, realtime/channels and realtime/history. I think this makes sense for now, although as more channel parameters are added and the API updated they may need to be moved to a more prominent position. 