### PR TITLE
Added general route to code compilation route

### DIFF
--- a/Rules
+++ b/Rules
@@ -43,7 +43,7 @@ compile "/code/**/*" do
   filter :ably_jsbin_publisher
 end
 
-%w(root realtime rest rest-api sse mqtt compare concepts core-features design-patterns api-streamer client-lib-development-guide tutorials).each do |path|
+%w(root realtime rest rest-api sse mqtt compare concepts general core-features design-patterns api-streamer client-lib-development-guide tutorials).each do |path|
   compile "/#{path}/**/*" do
     next if item[:extension] == 'diff'
     filter :erb


### PR DESCRIPTION
Should mean code now appears correctly in all `general` routes, including the push docs.

fixes #749 