### PR TITLE
Add addRequestIds client option

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -76,6 +76,7 @@ h3(#restclient). RestClient
 ** @(RSC7a)@ The header @X-Ably-Version: 1.1@ must be included in all REST requests to the Ably endpoint
 ** @(RSC7b)@ The header @X-Ably-Lib: [lib][.optional variant]?-[version]@ should be included in all REST requests to the Ably endpoint where @[lib]@ is the name of the library such as @js@ for @ably-js@, @[.optional variant]@ is an optional library variant, such as @laravel@ for the @php@ library, which is always delimited with a period such as @php.laravel@, and where @[version]@ is the full client library version using "Semver":http://semver.org/ such as @1.0.2@. For example, the 1.0.0 version of the Javascript library would use the header @X-Ably-Lib: js-1.0.0@
 *** @(RSC7b1)@ When it is not possible to send the @X-Ably-Lib@ header, such as for @JSONP@ requests, the library version should be sent as a query param such as @lib=js-1.0.0@
+** @(RSC7c)@ If the @addRequestIds@ client option is enabled, every REST request to Ably should include in a @request_id@ query string parameter a random string obtained by url-safe base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. This request ID must remain the same if a request is retried to a fallback host per @RSC15@. Any log messages associated with the request should include the request ID. If the request fails, the request ID must be included in the @ErrorInfo@ returned to the user.
 * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
 * @(RSC8)@ Supports two protocols:
 ** @(RSC8a)@ "MessagePack":http://msgpack.org/ binary protocol (this is the default for environments having a suitable level or support for binary data)
@@ -1208,7 +1209,7 @@ h4. Stats
 
 h4. ErrorInfo
 
-* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@ and @cause@ attributes
+* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@, optional @cause@, optional @href@, and optional @requestId@ (@RSC7c@) attributes
 * @(TI2)@ Errors returned from the Ably server are compatible with the @ErrorInfo@ structure and should result in errors that inherit from @ErrorInfo@
 * @(TI3)@ "Ably-common":https://github.com/ably/ably-common should be included as a submodule so that "consistent error codes":https://github.com/ably/ably-common/blob/master/protocol/errors.json can be used
 * @(TI4)@ Ably may additionally include a @href@ attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
@@ -1268,6 +1269,7 @@ h4. ClientOptions
 ** @(TO3h)@ @echoMessages@ boolean - defaults to true. If false, suppresses messages originating from this connection being echoed back on the same connection
 ** @(TO3i)@ @recover@ string - A connection recovery string, specified with the intention of inheriting the state of an earlier connection
 ** @(TO3n)@ @idempotentRestPublishing@ boolean - defaults to false for clients with version &lt; 1.2, otherwise true. If true, "RSL1k":#RSL1k1 applies
+** @(TO3o)@ @addRequestIds@ boolean - defaults to false. If true, @RSC7c@ applies
 ** @(TO3j)@ Auth option attributes:
 *** @(TO3j1)@ @key@ string - Full Ably key string as obtained from dashboard
 *** @(TO3j2)@ @token@ string | @TokenDetails@ | @TokenRequest@ - An authentication token issued for this application, either in the form of a token string, a @TokenDetails@ object, or a @TokenRequest@ object
@@ -1462,6 +1464,7 @@ class ClientOptions:
   tlsPort: Int default 443 // TO3k5
   useBinaryProtocol: Bool default true // TO3f
   transportParams: [String: Stringifiable]? // RTC1f
+  addRequestIds: Bool default false // TO3o
   // configurable retry and failure defaults
   disconnectedRetryTimeout: Duration default 15s // TO3l1
   suspendedRetryTimeout: Duration default 30s // RTN14d, TO3l2
@@ -1875,6 +1878,7 @@ class ErrorInfo:
   message: String // TI1
   cause: ErrorInfo? // TI1
   statusCode: Int // TI1
+  requestId: String? // RSC7c
 
 class EventEmitter<Event, Data>:
   on((Data...) ->) // RTE4


### PR DESCRIPTION
Currently this just encodes what ably-ruby does, https://github.com/ably/ably-ruby/pull/133 .

A few obvious questions:
- the ably-ruby behaviour is to use a query string param, which Paddy points out was so it would end up in router logs. Do we want to keep that, or make it a header instead (a bit neater, but needs router changes to log it)? (Or allow both? In ably-js in particular if it's in the query string param we could replace the `rnd` xhr cachebuster with it)
- Do we want to enabled it by default? in ably-ruby it's disabled by default