### PR TITLE
Tutorials metadata update for new website tutorials design

### DIFF
--- a/app/assets/stylesheets/documentation.scss
+++ b/app/assets/stylesheets/documentation.scss
@@ -830,3 +830,23 @@ nav.jump-to-nav {
     }
   }
 }
+
+
+.docs-helpbox {
+  background-color: #F1F1F1;
+  padding: 20px;
+  border-radius: 4px;
+
+  // title
+  strong {
+    display: block;
+    font-size: 18px;
+    margin-bottom: 8px;
+    color: #161616;
+  }
+
+  // body
+  span {
+    color: #555555;
+  }
+}

--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -77,6 +77,33 @@ competitors:
   - "competitor2 ID, which should match the ID used on the website"
 ---
 
+h4(#tutorials-metadata). Tutorial pages metadata
+
+Pages in the @/tutorials@ folder require certain metadata to make them indexable at Ably's website. 
+_* denotes required meta fields, but isn't valid yaml. If copy/pasting, don't forget to remove them_
+
+bc[yaml]. ---
+alt_title: an alternative title to display on the website
+excerpt: A small blurb introduction for your tutorial
+category*: introduction | external-services | liberaries-integration
+platform*: mobile | browser | mixed
+authors*:
+- author_name: Supports multiple authors
+  author_bio: but must be an array even if single author
+  author_profile_url: https://authors_website.com
+  author_image: hosted gravatar or an image present in websites images/tutorials/ folder
+- author_name: Second Author
+  author_bio: ""
+  author_profile_url: ""
+  author_image: ""
+level: String (suggestions: medium | easy | hard)
+reading_time: Number in minutes
+tags:
+  - ably-realtime
+  - ably-features
+  - example-apps
+---
+
 h2(#markup-fundamentals). Markup fundamentals
 
 h3. Headings
@@ -587,3 +614,25 @@ It's possible to automatically generate a comparison table for any two companies
 compare_table(CATEGORY, OPTIONAL_COLUMN_TITLE).
 
 This will check if there are any comparible points between the the companies specified in the metadata of the pages, within the specified @CATEGORY@. If there are, a table will be generated to compare said points. The @OPTIONAL_COLUMN_TITLE@, if specified, will check if the category has an @extras@ field, and if so will use that when creating the table as an additional column, using the title specified.
+
+h3(#tutorials). Tutorials pages
+
+In order to build a stepped view mode of the tutorials, certain markup guidelines must be respected
+
+* Each step is marked by an @h2@ heading
+* Heading text will be used to create the TOC menu for navigation
+* You should assign identifiable ids to each tutorial step: otherwise a generated id will be created, but it's name won't be humanized
+* You can add additional piece of help at the end of a step busing the following custom block
+
+```[text]
+
+h2(#step-3). Step 3 title
+
+content... 
+
+div(docs-helpbox). 
+  *HelpboxTitle*
+  %If you need any extra help just ask "link text":/example% 
+
+h2(#step-4). Step 4 title
+```

--- a/content/tutorials/android-push-direct-registration.textile
+++ b/content/tutorials/android-push-direct-registration.textile
@@ -4,7 +4,7 @@ alt_tile: Direct device registration
 excerpt: Learn how to setup, send and receive Push Notifications on Android devices. This tutorial shows direct device registration with FCM
 section: tutorials
 category: external-services
-platform: push-notifications
+platform: mobile
 index: 23
 authors:
 - author_name: Amit Surana
@@ -16,6 +16,9 @@ reading_time: 20
 languages:
   - android
   - nodejs
+ably_product: push-notifications
+tags:
+  - ably-features
 ---
 
 Ably can deliver native Push Notifications to Android devices using "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/android-push-direct-registration.textile
+++ b/content/tutorials/android-push-direct-registration.textile
@@ -1,7 +1,21 @@
 ---
 title: Android Push Notifications tutorial - Direct device registration
+alt_tile: Direct device registration
+excerpt: Learn how to setup, send and receive Push Notifications on Android devices. This tutorial shows direct device registration with FCM
 section: tutorials
+category: external-services
+platform: push-notifications
 index: 23
+authors:
+- author_name: Amit Surana
+  author_bio: ""
+  author_profile_url: https://github.com/amsurana
+  author_image: "https://avatars1.githubusercontent.com/u/817920?s=460&v=4"
+level: easy
+reading_time: 20
+languages:
+  - android
+  - nodejs
 ---
 
 Ably can deliver native Push Notifications to Android devices using "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/android-push-server-registration.textile
+++ b/content/tutorials/android-push-server-registration.textile
@@ -17,6 +17,8 @@ languages:
   - android
   - nodejs
 ably_product: push-notifications
+tags:
+  - ably-features
 ---
 
 Ably can deliver native push notifications to devices using "Google’s Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ service. Native push notifications, unlike Ably’s "channel based pub/sub messaging":/realtime/channels, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery-efficient transport to receive push notifications. Therefore, native push notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery-efficient manner.

--- a/content/tutorials/android-push-server-registration.textile
+++ b/content/tutorials/android-push-server-registration.textile
@@ -5,7 +5,7 @@ excerpt: Learn how to setup, send and receive Push Notifications on Android devi
 section: tutorials
 category: external-services
 index: 17
-platform: push-notifications
+platform: mobile
 authors:
 - author_name: Amit Surana
   author_bio: ""
@@ -16,6 +16,7 @@ reading_time: 20
 languages:
   - android
   - nodejs
+ably_product: push-notifications
 ---
 
 Ably can deliver native push notifications to devices using "Google’s Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ service. Native push notifications, unlike Ably’s "channel based pub/sub messaging":/realtime/channels, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery-efficient transport to receive push notifications. Therefore, native push notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery-efficient manner.

--- a/content/tutorials/android-push-server-registration.textile
+++ b/content/tutorials/android-push-server-registration.textile
@@ -1,7 +1,21 @@
 ---
 title: Android Push Notifications tutorial - Device registration via server
+alt_title: Device registration via server
+excerpt: Learn how to setup, send and receive Push Notifications on Android devices. This tutorial shows device registration with FCM via your server
 section: tutorials
+category: external-services
 index: 17
+platform: push-notifications
+authors:
+- author_name: Amit Surana
+  author_bio: ""
+  author_profile_url: https://github.com/amsurana
+  author_image: "https://avatars1.githubusercontent.com/u/817920?s=460&v=4"
+level: easy
+reading_time: 20
+languages:
+  - android
+  - nodejs
 ---
 
 Ably can deliver native push notifications to devices using "Google’s Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ service. Native push notifications, unlike Ably’s "channel based pub/sub messaging":/realtime/channels, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery-efficient transport to receive push notifications. Therefore, native push notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery-efficient manner.

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -126,20 +126,19 @@ Remember to replace <YOUR-API-KEY> with an actual Ably API key.
 
 In the code above, we have set the REST endpoint to be @/channels@. The @enumerateChannels()@ function is invoked on a button click from the front end. Inside this function, we have made a simple request to Ably's REST API, using Ably's JavaScript REST client library. We can optionally specify a limit to the results returned; you can have a look at the "API reference":/general/channel-lifecycle.textile in the docs to learn more. As mentioned before, the results are returned in the form of an @HTTPPaginatedResponse@; hence we are required to process them page by page. Each page contains one @Channel@ per active channel that exists within an app. Here, all we are interested in is the name of the channel, so we used @by: 'id'@ parameter to request only a list of names. If you want more detailed information about each channel (such as occupancy data), you can remove this parameter. See "our REST API docs":/rest-api#enumeration-rest for documentation on all supported parameters.
 
-h2(#live-demo). Step - 5 Live Demo
+h2(#live-demo). Step - 5 Live Demo 
 
-    Ably Channel Enumeration using REST API - Demo
-    <br/><br/>
-    Make sure that you've enabled the channel metadata permission on your API key.
-    <br/>
-    <div>
-        <input type="text" style="width: 30%" id="user-api-key" placeholder="Paste your Ably API key"></input>
-        <br/>
-        <button id='enumerate' onclick="enumerateChannels()">Enumerate channels</button>
-        <br>
-        <textarea id="result" rows="30" style="width: 100%; margin-top: 14px; font-family: courier, courier new; background-color: #333; color: orange;  overflow-y: scroll;" autocomplete="off" disabled>
-        </textarea>
-    </div>
+Ably Channel Enumeration using REST API - Demo
+Make sure that you've enabled the channel metadata permission on your API key. 
+
+<div>
+  <input type="text" style="width: 30%" id="user-api-key" placeholder="Paste your Ably API key">
+  <br/>
+  <button id='enumerate' onclick="enumerateChannels()">Enumerate channels</button>
+  <br/>
+  <textarea id="result" rows="30" style="width: 100%; margin-top: 14px; font-family: courier, courier new; background-color: #333; color: orange;  overflow-y: scroll;" autocomplete="off" disabled>
+  </textarea>
+</div>
 
 "See the full code in GitHub":https://github.com/ably/tutorials/tree/channel-enumeration-rest
 

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 languages:
   - javascript
 level: easy

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -1,7 +1,19 @@
 ---
 title: Channel Enumeration using the REST API
+excerpt: Learn how to enumerate through live channels and see their metadata.
 section: tutorials
+category: introduction
 index: 14
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+languages:
+  - javascript
+level: easy
+reading_time: 5
 ---
 
 Ably Realtime's Data Stream Network organizes all of the message traffic within its applications into named "channels":https://www.ably.io/channels. Channels are the “unit” of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcasted to all subscribers.

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 languages:
   - javascript
 level: easy

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -1,7 +1,19 @@
 ---
 title: Channel Lifecycle Events
+excerpt: Learn how to access channel metadata and make use of it.
 section: tutorials
+category: introduction
 index: 17
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+languages:
+  - javascript
+level: easy
+reading_time: 5
 ---
 
 Ably Realtime's Data Stream Network organizes all of the message traffic within its applications into named "channels":https://www.ably.io/channels. Channels are the “unit” of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcasted to all subscribers. 

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -1,7 +1,19 @@
 ---
 title: Channel Occupancy Events
+excerpt: Learn how to access channel occupancy and make use of it.
 section: tutorials
+category: introduction
 index: 17
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+languages:
+  - javascript
+level: easy
+reading_time: 5
 ---
 
 Ably Realtime's Data Stream Network organizes all of the message traffic within its applications into named "channels":https://www.ably.io/channels. Channels are the “unit” of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcasted to all subscribers.

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 languages:
   - javascript
 level: easy

--- a/content/tutorials/channel-rewind.textile
+++ b/content/tutorials/channel-rewind.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 languages:
   - javascript
 level: easy

--- a/content/tutorials/channel-rewind.textile
+++ b/content/tutorials/channel-rewind.textile
@@ -1,7 +1,19 @@
 ---
 title: Historical data with Channel Rewind
+excerpt: Learn how to get historical data on channel subscribe with the the Channel Rewind parameter
 section: tutorials
+category: introduction
 index: 32
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+languages:
+  - javascript
+level: easy
+reading_time: 5
 ---
 
 The Ably Realtime service organizes the message traffic within applications into named channels. Channels are the “unit” of message distribution; clients attach to any number of channels to subscribe to messages, and every message published to a channel is broadcasted to all its subscribers.

--- a/content/tutorials/encryption.textile
+++ b/content/tutorials/encryption.textile
@@ -1,9 +1,27 @@
 ---
 title: Encryption Tutorial
+alt_title: Message Encryption
 section: tutorials
 index: 21
+excerpt: Learn how to encrypt messages being shared on the Ably platform
+section: tutorials
+category: introduction
+tags:
+  - ably-realtime
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "tutorials/ably.png"
+languages:
+  - javascript
+  - java
+  - nodejs
+level: easy
+reading_time: 10
 jump_to:
- Section:
+  Section:
     - Introduction#intro
     - Step 1 - Install Ably#install-ably
     - Step 2 - Publish encrypted messages to a channel#publish-messages

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -20,8 +20,12 @@ authors:
   author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
   - javascript
+  - java
   - android
-  - ios
+  - python
+  - php
+  - ruby
+  - swift
 level: easy
 reading_time: 10
 ---

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -1,7 +1,29 @@
 ---
-title: History Tutorial
+title: Message History
+excerpt: Learn how to publish messages and later retrieve them using our history API in your browser, or natively in Android and iOS.
 section: tutorials
-index: 20
+category: introduction
+index: 11
+platform: mixed
+authors:
+- author_name: Piotr Kazmierczak
+  author_bio: ""
+  author_profile_url: https://github.com/piotrekkazmierczak
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+- author_name: Bartłomiej Wereszczyński
+  author_bio: ""
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+- author_name: Shelin Hime
+  author_bio: ""
+  author_profile_url: https://github.com/ShelinHime
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
+languages:
+  - javascript
+  - android
+  - ios
+level: easy
+reading_time: 10
 ---
 
 Ably's "history feature":/realtime/history enables you to store messages published on channels that can later be retrieved using the "channel history API":/realtime/history.

--- a/content/tutorials/ios-push-direct-registration.textile
+++ b/content/tutorials/ios-push-direct-registration.textile
@@ -17,6 +17,9 @@ languages:
   - swift
   - nodejs
 ably_product: push-notifications
+tags:
+  - ably-features
+  - ably-realtime
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-direct-registration.textile
+++ b/content/tutorials/ios-push-direct-registration.textile
@@ -1,7 +1,21 @@
 ---
 title: iOS Push Notifications Tutorial - Direct registration
+alt_title: Direct device registration
+excerpt: Learn how to setup, send and receive Push Notifications on iOS devices. This tutorial shows direct device registration with APNs
 section: tutorials
+category: external-services
 index: 69
+platform: push-notifications
+authors:
+- author_name: Christopher Batin
+  author_bio: ""
+  author_profile_url: https://github.com/cjbatin
+  author_image: "https://avatars3.githubusercontent.com/u/6270943?s=460&v=4"
+level: easy
+reading_time: 20
+languages:
+  - swift
+  - noodejs
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-direct-registration.textile
+++ b/content/tutorials/ios-push-direct-registration.textile
@@ -15,7 +15,7 @@ level: easy
 reading_time: 20
 languages:
   - swift
-  - noodejs
+  - nodejs
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-direct-registration.textile
+++ b/content/tutorials/ios-push-direct-registration.textile
@@ -5,7 +5,7 @@ excerpt: Learn how to setup, send and receive Push Notifications on iOS devices.
 section: tutorials
 category: external-services
 index: 69
-platform: push-notifications
+platform: mobile
 authors:
 - author_name: Christopher Batin
   author_bio: ""
@@ -16,6 +16,7 @@ reading_time: 20
 languages:
   - swift
   - nodejs
+ably_product: push-notifications
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-server-registration.textile
+++ b/content/tutorials/ios-push-server-registration.textile
@@ -15,7 +15,7 @@ level: easy
 reading_time: 20
 languages:
   - swift
-  - noodejs
+  - nodejs
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-server-registration.textile
+++ b/content/tutorials/ios-push-server-registration.textile
@@ -5,7 +5,7 @@ excerpt: Learn how to setup, send and receive Push Notifications on iOS devices.
 section: tutorials
 category: external-services
 index: 69
-platform: push-notifications
+platform: mobile
 authors:
 - author_name: Christopher Batin
   author_bio: ""
@@ -16,6 +16,7 @@ reading_time: 20
 languages:
   - swift
   - nodejs
+ably_product: push-notifications
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-server-registration.textile
+++ b/content/tutorials/ios-push-server-registration.textile
@@ -1,7 +1,21 @@
 ---
 title: iOS Push Notifications Tutorial - Device registration via server
+alt_title: Device registration via server
+excerpt: Learn how to setup, send and receive Push Notifications on iOS devices. This tutorial shows device registration with APNs via your server
 section: tutorials
+category: external-services
 index: 69
+platform: push-notifications
+authors:
+- author_name: Christopher Batin
+  author_bio: ""
+  author_profile_url: https://github.com/cjbatin
+  author_image: "https://avatars3.githubusercontent.com/u/6270943?s=460&v=4"
+level: easy
+reading_time: 20
+languages:
+  - swift
+  - noodejs
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/ios-push-server-registration.textile
+++ b/content/tutorials/ios-push-server-registration.textile
@@ -17,6 +17,8 @@ languages:
   - swift
   - nodejs
 ably_product: push-notifications
+tags:
+  - ably-features
 ---
 
 Ably can deliver native Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Native Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, native Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -1,7 +1,20 @@
 ---
 title: Client & Server JWT Authentication Tutorial
+excerpt: Learn how to issue Ably JWTs for your users, configure their capabilities (permissions) and authenticate clients using these tokens.
 section: tutorials
+category: introduction
 index: 55
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: medium
+reading_time: 20
+languages:
+  - javascript
+  - nodejs
 ---
 
 Ably supports two types of authentication schemes. "Basic authentication":/core-features/authentication#basic-authentication uses one of your private API keys and is the simplest scheme designed for use by your servers. "Token authentication":/core-features/authentication#token-authentication is mostly used by your device and browser clients whereby a short-lived secure token is issued to them by your auth servers. "JSON Web Token authentication":/core-features/authentication#token-authentication is an extension of the token based authentication scheme in Ably.
@@ -169,7 +182,7 @@ Now let's build the HTML file for our front-end client. We'll embed our JavaScri
 ```
 As you can see, it's a simple HTML skeleton with a form containing two input fields, one for each username and password as well as a button for logging in. We've also linked Ably via CDN and our external stylesheet that we just included above. When the button is clicked, it should invoke the login function that we'll add now within the JavaScript.
 
-The last part is to add the logic into this form, we'll do so by instantiating Ably's Realtime client library and requesting a JSON Web Token. Please note that for simplicity, we are ignoring the username and password credentials which otherwise must be verified by your auth server before signing a JWT and sending it back to the client. 
+The last part is to add the logic into this form, we'll do so by instantiating Ably's Realtime client library and requesting a JSON Web Token. Please note that for simplicity, we are ignoring the username and password credentials which otherwise must be verified by your auth server before signing a JWT and sending it back to the client.
 
 Go ahead and add the following within the head tag of your HTML file, right below the link to your CSS file:
 

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: medium
 reading_time: 20
 languages:

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -27,11 +27,10 @@ Ably offers two different ways in which you can use a JSON Web Token to authenti
 
 In this tutorial, we will build a simple login form which would authenticate a client with Ably, using JWT. We'll make use of the "jsonwebtoken":https://www.npmjs.com/package/jsonwebtoken npm library which is an implementation of JWT. This library allows our auth server to conveniently create a JSON Web Token by specifying only certain service specific data in the payload and headers while allowing us to skip the default data. So, let's get started and see a typical client-server architecture using JWT authentication.
 
-h2(#live-demo). Skip to demo
+h2(#live-demo). Ably JWT auth example
 
 <section class="container">
     <div class="login">
-        <h1>Ably JWT auth example</h1>
         <form>
             <input type="text" placeholder="Enter Username" name="username">
             <br/>

--- a/content/tutorials/live-bitcoin-pricing.textile
+++ b/content/tutorials/live-bitcoin-pricing.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 - author_name: KendoUI
   author_bio: ""
   author_profile_url: https://www.telerik.com/kendo-ui

--- a/content/tutorials/live-bitcoin-pricing.textile
+++ b/content/tutorials/live-bitcoin-pricing.textile
@@ -14,7 +14,7 @@ authors:
 - author_name: KendoUI
   author_bio: ""
   author_profile_url: https://www.telerik.com/kendo-ui
-  author_image: "/assets/tutorials/kendo-ui"
+  author_image: "tutorials/kendo-ui.jpg"
 level: easy
 reading_time: 15
 languages:

--- a/content/tutorials/live-bitcoin-pricing.textile
+++ b/content/tutorials/live-bitcoin-pricing.textile
@@ -1,7 +1,22 @@
 ---
 title: Building a live bitcoin pricing chart in Angular using Ably and Kendo UI
+alt_title: "Ably <> Kendo UI"
+excerpt: Building a live bitcoin pricing chart in Angular using Ably and KendoUI
 section: tutorials
-index: 111
+category: libraries-integration
+index: 95
+platform: browser
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+- author_name: KendoUI
+  author_bio: ""
+  author_profile_url: https://www.telerik.com/kendo-ui
+  author_image: "/assets/tutorials/kendo-ui"
+level: easy
+reading_time: 15
 languages:
   - typescript
 ---

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -17,6 +17,8 @@ languages:
   - go
   - python
 ably_product: adapters
+tags:
+  - ably-features
 ---
 
 blang[javascript].

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -1,12 +1,22 @@
 ---
 title: "MQTT Tutorial: Snake"
+excerpt: Learn how to make a game of snake in your browser using Ably's MQTT adapter.
 section: tutorials
+category: external-services
 index: 104
+platform: adapters
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: easy
+reading_time: 10
 languages:
   - javascript
-  - nodejs
   - go
   - python
+  - nodejs
 ---
 
 blang[javascript].

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -16,7 +16,6 @@ languages:
   - javascript
   - go
   - python
-  - nodejs
 ---
 
 blang[javascript].

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -4,7 +4,7 @@ excerpt: Learn how to make a game of snake in your browser using Ably's MQTT ada
 section: tutorials
 category: external-services
 index: 104
-platform: adapters
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -16,6 +16,7 @@ languages:
   - javascript
   - go
   - python
+ably_product: adapters
 ---
 
 blang[javascript].

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: easy
 reading_time: 10
 languages:

--- a/content/tutorials/newsfeed-react.textile
+++ b/content/tutorials/newsfeed-react.textile
@@ -1,9 +1,23 @@
 ---
 title: Building a live news feed app in ReactJS using Ably
+alt_title: Live news feed app in ReactJS using Ably
+excerpt: Learn how to build a live newsfeed app as popularly seen on social media based applications
 section: tutorials
-index: 90
+category: libraries-integration
+index: 100
+platform: browser
+authors:
+- author_name: Apoorv Vardhan
+  author_bio: ""
+  author_profile_url: https://github.com/vardhanapoorv
+  author_image: https://avatars3.githubusercontent.com/u/13391028?s=460&v=4
+level: beginner
+reading_time: 40
+languages:
+  - reactjs
+
 jump_to:
- Section:
+  Section:
    - 1. Setup an Ably account#setup-ably-account
    - 2. Create a React app#create-react-app
    - 3. Update CSS#update-css

--- a/content/tutorials/newsfeed-react.textile
+++ b/content/tutorials/newsfeed-react.textile
@@ -14,6 +14,8 @@ authors:
 level: beginner
 reading_time: 40
 languages:
+  - javascript
+libraries: 
   - reactjs
 
 jump_to:

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -16,6 +16,8 @@ languages:
   - ruby
 level: medium
 reading_time: 15
+tags:
+  - ably-realtime
 ---
 
 Presence enables clients to be aware of other clients that are currently “present” on a channel. Each member present on a channel has a self-assigned name — a "@client ID@" — along with an optional payload that can be used to describe the member’s status or attributes. Presence allows you to quickly build apps such as chat rooms and multiplayer games by automatically keeping track of who is present in real time across any device.

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -1,7 +1,21 @@
 ---
 title: Presence Tutorial
+excerpt: Learn how to track who and which devices are online or offline, and what the status of each user is.
 section: tutorials
+category: introduction
 index: 15
+platform: mixed
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+languages:
+  - javascript
+  - nodejs
+  - ruby
+level: medium
+reading_time: 15
 ---
 
 Presence enables clients to be aware of other clients that are currently “present” on a channel. Each member present on a channel has a self-assigned name — a "@client ID@" — along with an optional payload that can be used to describe the member’s status or attributes. Presence allows you to quickly build apps such as chat rooms and multiplayer games by automatically keeping track of who is present in real time across any device.

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 languages:
   - javascript
   - nodejs

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -2,29 +2,28 @@
 title: Publish & Subscribe Tutorial
 excerpt: Learn how to publish and subscribe to messages on channels in your browser in 5 minutes.
 section: tutorials
+category: introduction
 index: 10
-platforms:
-  - browser
-
+platform: mixed
 authors:
 - author_name: Piotr Kazmierczak
   author_bio: ""
   author_profile_url: https://github.com/piotrekkazmierczak
   author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
-- author_name: Piotr Kazmierczak
+- author_name: Bartłomiej Wereszczyński
   author_bio: ""
-  author_profile_url: https://github.com/piotrekkazmierczak
-  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
-
-jump_to:
-  Required thing:
-    - Setup#setup-ably-account
-    - Install#step-2
-    - Subscribe to messages#step-3
-    - Step 4 #step-4
-    - Live Demo #live-demo
-    - Download Tutorial Source code#next-steps
-    - Next Steps#next-steps
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+- author_name: Shelin Hime
+  author_bio: ""
+  author_profile_url: https://github.com/ShelinHime
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
+languages:
+  - javascript
+  - android
+  - iOS
+level: easy
+reading_time: 5 — 10
 ---
 
 The Ably Realtime service organizes the message traffic within applications into named channels. Channels are the “unit” of message distribution; clients attach to any number of channels to subscribe to messages, and every message published to a channel is broadcasted to all subscribers. This scalable and resilient messaging pattern is commonly called pub/sub.

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -1,7 +1,30 @@
 ---
 title: Publish & Subscribe Tutorial
+excerpt: Learn how to publish and subscribe to messages on channels in your browser in 5 minutes.
 section: tutorials
 index: 10
+platforms:
+  - browser
+
+authors:
+- author_name: Piotr Kazmierczak
+  author_bio: ""
+  author_profile_url: https://github.com/piotrekkazmierczak
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+- author_name: Piotr Kazmierczak
+  author_bio: ""
+  author_profile_url: https://github.com/piotrekkazmierczak
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+
+jump_to:
+  Required thing:
+    - Setup#setup-ably-account
+    - Install#step-2
+    - Subscribe to messages#step-3
+    - Step 4 #step-4
+    - Live Demo #live-demo
+    - Download Tutorial Source code#next-steps
+    - Next Steps#next-steps
 ---
 
 The Ably Realtime service organizes the message traffic within applications into named channels. Channels are the “unit” of message distribution; clients attach to any number of channels to subscribe to messages, and every message published to a channel is broadcasted to all subscribers. This scalable and resilient messaging pattern is commonly called pub/sub.
@@ -14,7 +37,7 @@ Messages published can contain string, JSON object, JSON array or binary data pa
 
 <%= partial 'tutorials/_step-1-setup-free-account' %>
 
-h2.
+h2(#step-2).
   default: Step 2 - Install Ably
   swift: Step 2 - Setup an Xcode project and install Ably
   android: Step 2 – Set up environment and install Ably
@@ -450,7 +473,7 @@ blang[swift].
 
   "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step3
 
-h2. Step 4 - Publishing a message
+h2(#step-4). Step 4 - Publishing a message
 
 Publishing a message on a channel ensures that any number of subscribers on that channel receive the message in real time. To publish a message on the "sports" channel we simply call the publish method on the channel, specify an optional message event name, and provide the payload as the second argument.
 
@@ -637,7 +660,7 @@ h2(#live-demo). Live demo
 
 <img src="/images/ably-logo-white-outline.png" id="ably-qr-logo" style="visibility: hidden; width: 1px; height: 1px" crossOrigin="anonymous">
 
-h2. Download tutorial source code
+h2(#download). Download tutorial source code
 
 blang[java].
   The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-java.
@@ -760,7 +783,7 @@ blang[python].
 
   and run the web server @python server.py@.
 
-h2. Next steps
+h2(#next-steps). Next steps
 
 1. If you would like to find out more about how channels, publishing and subscribing works, see the Realtime "channels":/realtime/channels & "messages":/realtime/messages documentation
 2. Learn more about "Ably features":https://www.ably.io/features by stepping through our other "Ably tutorials":https://www.ably.io/tutorials

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -20,8 +20,13 @@ authors:
   author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
   - javascript
+  - java
   - android
-  - iOS
+  - python
+  - php
+  - ruby
+  - nodejs
+  - swift
 level: easy
 reading_time: 5 — 10
 ---

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -363,7 +363,11 @@ blang[swift].
 
   "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-swift-step2b
 
-h2. Step 3 - Subscribe to messages
+
+div(docs-helpbox). *HelpboxTitle* %If you need any help with your implementation or if you have encountered any problems, do get in touch. You can also quickly find answers from our knowledge base, and blog. If you can’t find an "link text":/example answer to your problem you can contact us.%
+
+
+h2(#step-3). Step 3 - Subscribe to messages
 
 Now that the library is installed, you can subscribe to messages published on channels. Every app can have an arbitrary number of channels that should be used to filter the messages received by subscribing clients. For example, if building a news feed, you may want one channel for politics named "politics", and another for sport named "sport". A user interested in "sport" can subscribe to the "sport" channel to receive updates. If that user is not subscribed to the "politics" channel, then "politics" updates will not be delivered to that user.
 

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: easy
 reading_time: 5
 languages:

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -18,6 +18,8 @@ languages:
   - nodejs
   - ruby
 ably_product: adapters
+tags:
+  - ably-features
 ---
 
 The Pubnub protocol adapter allows you to interact with Ably using the Pubnub protocol. You can use this to gradually migrate across from Pubnub to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pubnub client libraries":https://www.ably.io/compare/ably-vs-pubnub, such as "the ability to use websockets":https://support.ably.io/solution/articles/3000044831-which-transports-are-supported%2D (Pubnub client libraries support "long-polling":/concepts/long-polling only). Alternatively, you can use a Pubnub client library on some platform for which no native Ably client library is available yet, such as Arduino.

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -5,7 +5,7 @@ excerpt: Learn how to use our protocol adapters to migrate a simple app from Pub
 section: tutorials
 category: external-services
 index: 15
-platform: adapters
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -17,6 +17,7 @@ languages:
   - javascript
   - nodejs
   - ruby
+ably_product: adapters
 ---
 
 The Pubnub protocol adapter allows you to interact with Ably using the Pubnub protocol. You can use this to gradually migrate across from Pubnub to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pubnub client libraries":https://www.ably.io/compare/ably-vs-pubnub, such as "the ability to use websockets":https://support.ably.io/solution/articles/3000044831-which-transports-are-supported%2D (Pubnub client libraries support "long-polling":/concepts/long-polling only). Alternatively, you can use a Pubnub client library on some platform for which no native Ably client library is available yet, such as Arduino.

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -1,7 +1,22 @@
 ---
 title: Pubnub Protocol Adapter Tutorial
+alt_title: Migrating from PubNub
+excerpt: Learn how to use our protocol adapters to migrate a simple app from PubNub to Ably by changing only the settings of your PubNub client.
 section: tutorials
+category: external-services
 index: 15
+platform: adapters
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: easy
+reading_time: 5
+languages:
+  - javascript
+  - nodejs
+  - ruby
 ---
 
 The Pubnub protocol adapter allows you to interact with Ably using the Pubnub protocol. You can use this to gradually migrate across from Pubnub to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pubnub client libraries":https://www.ably.io/compare/ably-vs-pubnub, such as "the ability to use websockets":https://support.ably.io/solution/articles/3000044831-which-transports-are-supported%2D (Pubnub client libraries support "long-polling":/concepts/long-polling only). Alternatively, you can use a Pubnub client library on some platform for which no native Ably client library is available yet, such as Arduino.

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -4,7 +4,7 @@ alt_title: Migrating from Pusher
 excerpt: Learn how to use our protocol adapters to migrate a simple app from Pusher to Ably by changing only the settings of your Pusher client.
 section: tutorials
 index: 15
-platform: adapters
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -16,6 +16,7 @@ languages:
   - javascript
   - nodejs
   - ruby
+ably_product: adapters
 ---
 
 The Pusher protocol adapter allows you to interact with Ably using the Pusher protocol. You can use this to gradually migrate across from Pusher to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pusher client libraries":https://www.ably.io/compare/ably-vs-pubnub such as "connection state recovery":https://support.ably.io/support/solutions/articles/3000044639-connection-state-recovery. Alternatively, you can use a Pusher client library on some platform for which no native Ably client library is available yet.

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -17,6 +17,8 @@ languages:
   - nodejs
   - ruby
 ably_product: adapters
+tags:
+  - ably-features
 ---
 
 The Pusher protocol adapter allows you to interact with Ably using the Pusher protocol. You can use this to gradually migrate across from Pusher to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pusher client libraries":https://www.ably.io/compare/ably-vs-pubnub such as "connection state recovery":https://support.ably.io/support/solutions/articles/3000044639-connection-state-recovery. Alternatively, you can use a Pusher client library on some platform for which no native Ably client library is available yet.

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: easy
 reading_time: 5
 languages:

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -1,7 +1,21 @@
 ---
 title: Pusher Protocol Adapter Tutorial
+alt_title: Migrating from Pusher
+excerpt: Learn how to use our protocol adapters to migrate a simple app from Pusher to Ably by changing only the settings of your Pusher client.
 section: tutorials
 index: 15
+platform: adapters
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: easy
+reading_time: 5
+languages:
+  - javascript
+  - nodejs
+  - ruby
 ---
 
 The Pusher protocol adapter allows you to interact with Ably using the Pusher protocol. You can use this to gradually migrate across from Pusher to Ably. Rather than having to rewrite all your apps to use Ably client libraries at once, you can use the protocol adapter, then migrate across to Ably client libraries one by one at your leisure, to take advantage of "Ably features not supported by the Pusher client libraries":https://www.ably.io/compare/ably-vs-pubnub such as "connection state recovery":https://support.ably.io/support/solutions/articles/3000044639-connection-state-recovery. Alternatively, you can use a Pusher client library on some platform for which no native Ably client library is available yet.

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -15,6 +15,8 @@ reading_time: 25
 languages:
   - nodejs
 ably_product: reactor
+tags: 
+  - ably-features
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -1,7 +1,17 @@
 ---
 title: AMQP and Neutrino Profanity Filter
+excerpt: Learn how to use our messages queues to consume realtime data over AMQP and use Neutrino's Profanity Filter API to strip out bad words before republishing the message.
 section: tutorials
+category: external-services
 index: 101
+platform: reactor
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: medium
+reading_time: 25
 languages:
   - nodejs
 ---

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -4,7 +4,7 @@ excerpt: Learn how to use our messages queues to consume realtime data over AMQP
 section: tutorials
 category: external-services
 index: 101
-platform: reactor
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -14,6 +14,7 @@ level: medium
 reading_time: 25
 languages:
   - nodejs
+ably_product: reactor
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -9,14 +9,14 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: medium
 reading_time: 25
 languages:
   - nodejs
 ably_product: reactor
 tags: 
-  - ably-features
+  -ably-features
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -1,7 +1,17 @@
 ---
 title: AMQP and Wolfram Alpha
+excerpt: Learn how to use our messages queues to consume realtime data over AMQP and communicate with Wolfram Alpha to get answers to questions in real time.
 section: tutorials
+category: external-services
 index: 100
+platform: reactor
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: medium
+reading_time: 25
 languages:
   - nodejs
 ---

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -4,7 +4,7 @@ excerpt: Learn how to use our messages queues to consume realtime data over AMQP
 section: tutorials
 category: external-services
 index: 100
-platform: reactor
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -14,6 +14,7 @@ level: medium
 reading_time: 25
 languages:
   - nodejs
+ably_product: reactor
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -15,6 +15,8 @@ reading_time: 25
 languages:
   - nodejs
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: medium
 reading_time: 25
 languages:

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -15,6 +15,8 @@ reading_time: 25
 languages:
   - nodejs
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: medium
 reading_time: 25
 languages:

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -4,7 +4,7 @@ excerpt: Learn how to use our messages queues to consume realtime data over STOM
 section: tutorials
 category: external-services
 index: 102
-platform: reactor
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -14,6 +14,7 @@ level: medium
 reading_time: 25
 languages:
   - nodejs
+ably_product: reactor
 ---
 
 "Ably Reactor Queues":https://www.ably.io/reactor are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -1,7 +1,17 @@
 ---
 title: STOMP and Neutrino Profanity Filter
+excerpt: Learn how to use our messages queues to consume realtime data over STOMP and use Neutrino's Profanity Filter API to strip out bad words before republishing the message.
 section: tutorials
+category: external-services
 index: 102
+platform: reactor
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: medium
+reading_time: 25
 languages:
   - nodejs
 ---

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: medium
 reading_time: 30
 languages:

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -12,6 +12,8 @@ authors:
   author_image: "/assets/tutorials/samuelayo"
 level: medium
 reading_time: 30
+languages:
+  - javascript
 libraries:
   - React Native
 ---

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -12,7 +12,7 @@ authors:
   author_image: "/assets/tutorials/samuelayo"
 level: medium
 reading_time: 30
-languages:
+libraries:
   - React Native
 ---
 

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -1,7 +1,19 @@
 ---
 title: Build a Realtime chat app with React Native and Ably
+excerpt: Learn how to create your very own Messaging App which runs on both iOS and Android.
 section: tutorials
+category: libraries-integration
 index: 103
+platform: mobile
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: medium
+reading_time: 30
+languages:
+  - React Native
 ---
 
 h2. Introduction

--- a/content/tutorials/reactjs-realtime-commenting.textile
+++ b/content/tutorials/reactjs-realtime-commenting.textile
@@ -11,7 +11,7 @@ authors:
   author_image: https://avatars2.githubusercontent.com/u/6279134?s=460&v=4
 level: medium
 reading_time: 30
-languages:
+libraries:
   - React JS
 ---
 

--- a/content/tutorials/reactjs-realtime-commenting.textile
+++ b/content/tutorials/reactjs-realtime-commenting.textile
@@ -1,7 +1,18 @@
 ---
 title: React Realtime Commenting Tutorial
+excerpt: Learn how to set up live commenting on your site using the React.js framework.
 section: tutorials
 index: 60
+platform: mobile
+authors:
+- author_name: Chimezie Enyinnaya
+  author_bio: ""
+  author_profile_url: hhttps://github.com/ammezie
+  author_image: https://avatars2.githubusercontent.com/u/6279134?s=460&v=4
+level: medium
+reading_time: 30
+languages:
+  - React JS
 ---
 
 In this tutorial, we will see how to use Ably "Realtime client library":/realtime to build a realtime commenting system with React. We'll be making use Ably's public channel. Once a comment is made, we'll publish it to the public channel. We will also be subscribed to the channel so we can see comments as they are added in realtime.

--- a/content/tutorials/reactor-event-aws.textile
+++ b/content/tutorials/reactor-event-aws.textile
@@ -1,9 +1,20 @@
 ---
 title: "Reactor Events Tutorial: AWS Lambda Function"
+alt_title: "Pizza ordering with AWS Lambda Function"
+excerpt: "Learn how to use our Reactor Functions to consume realtime data with AWS Lambda, and have your serverless function automatically respond to requests for pizza."
 section: tutorials
+category: external-services
 index: 100
+platform: reactor
+authors:
+- author_name: Nathan Ridley
+  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
+  author_profile_url: https://github.com/axefrog
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+level: medium
+reading_time: 40
 languages:
-  - javascript
+  - Javascript
   - nodejs
 ---
 

--- a/content/tutorials/reactor-event-aws.textile
+++ b/content/tutorials/reactor-event-aws.textile
@@ -14,7 +14,6 @@ authors:
 level: medium
 reading_time: 40
 languages:
-  - Javascript
   - nodejs
 ---
 

--- a/content/tutorials/reactor-event-aws.textile
+++ b/content/tutorials/reactor-event-aws.textile
@@ -16,6 +16,8 @@ reading_time: 40
 languages:
   - nodejs
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-aws.textile
+++ b/content/tutorials/reactor-event-aws.textile
@@ -5,7 +5,7 @@ excerpt: "Learn how to use our Reactor Functions to consume realtime data with A
 section: tutorials
 category: external-services
 index: 100
-platform: reactor
+platform: browser
 authors:
 - author_name: Nathan Ridley
   author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
@@ -15,6 +15,7 @@ level: medium
 reading_time: 40
 languages:
   - nodejs
+ably_product: reactor
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-azure.textile
+++ b/content/tutorials/reactor-event-azure.textile
@@ -1,7 +1,18 @@
 ---
 title: "Reactor Events Tutorial: Azure Function"
+alt_title: "Pizza ordering with Azure Function"
+excerpt: Learn how to use our Reactor Functions to consume realtime data with Microsoft Azure, and have your serverless function automatically respond to requests for pizza.
 section: tutorials
+category: external-services
 index: 100
+platform: reactor
+authors:
+- author_name: Nathan Ridley
+  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
+  author_profile_url: https://github.com/axefrog
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+level: medium
+reading_time: 40
 languages:
   - javascript
   - nodejs

--- a/content/tutorials/reactor-event-azure.textile
+++ b/content/tutorials/reactor-event-azure.textile
@@ -5,7 +5,7 @@ excerpt: Learn how to use our Reactor Functions to consume realtime data with Mi
 section: tutorials
 category: external-services
 index: 100
-platform: reactor
+platform: browser
 authors:
 - author_name: Nathan Ridley
   author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
@@ -16,6 +16,7 @@ reading_time: 40
 languages:
   - javascript
   - nodejs
+ably_product: reactor
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-azure.textile
+++ b/content/tutorials/reactor-event-azure.textile
@@ -17,6 +17,8 @@ languages:
   - javascript
   - nodejs
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-google.textile
+++ b/content/tutorials/reactor-event-google.textile
@@ -5,7 +5,7 @@ excerpt: "Learn how to use our Reactor Functions to consume realtime data with G
 section: tutorials
 category: external-services
 index: 100
-platform: reactor
+platform: browser
 authors:
 - author_name: Nathan Ridley
   author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
@@ -16,6 +16,7 @@ reading_time: 40
 languages:
   - javascript
   - nodejs
+ably_product: reactor
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-google.textile
+++ b/content/tutorials/reactor-event-google.textile
@@ -17,6 +17,8 @@ languages:
   - javascript
   - nodejs
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-google.textile
+++ b/content/tutorials/reactor-event-google.textile
@@ -1,7 +1,18 @@
 ---
 title: "Reactor Events Tutorial: Google Cloud Function"
+alt_title: "Pizza ordering with Google Cloud Function"
+excerpt: "Learn how to use our Reactor Functions to consume realtime data with Google Cloud, and have your serverless function automatically respond to requests for pizza."
 section: tutorials
+category: external-services
 index: 100
+platform: reactor
+authors:
+- author_name: Nathan Ridley
+  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
+  author_profile_url: https://github.com/axefrog
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+level: medium
+reading_time: 40
 languages:
   - javascript
   - nodejs

--- a/content/tutorials/sse-and-http-streaming.textile
+++ b/content/tutorials/sse-and-http-streaming.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 languages:
   - javascript
   - python

--- a/content/tutorials/sse-and-http-streaming.textile
+++ b/content/tutorials/sse-and-http-streaming.textile
@@ -1,10 +1,20 @@
 ---
 title: Super-lightweight realtime subscriptions with SSE and Ably
+excerpt: Learn how to implement subscribe-only capabilities on your clients with SSE
 section: tutorials
+category: introduction
 index: 109
+platform: mixed
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
 languages:
   - javascript
   - python
+level: easy
+reading_time: 5
 ---
 
 h2(#what-is-sse). What is SSE?

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -1,7 +1,23 @@
 ---
 title: Client & Server Token Authentication Tutorial
+excerpt: Learn how to issue signed tokens for your users, configure their capabilities (permissions) and authenticate mobile clients using these tokens.
 section: tutorials
+category: introduction
 index: 50
+platform: mixed
+authors:
+- author_name: Piotr Kazmierczak
+  author_bio: ""
+  author_profile_url: https://github.com/piotrekkazmierczak
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+- author_name: Bartłomiej Wereszczyński
+  author_bio: ""
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+- author_name: Shelin Hime
+  author_bio: ""
+  author_profile_url: https://github.com/ShelinHime
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
   - java
   - android
@@ -10,6 +26,8 @@ languages:
   - ruby
   - nodejs
   - swift
+level: medium
+reading_time: 15 — 20
 ---
 
 Ably supports two types of authentication schemes. Basic authentication uses one of your private API keys and is the simplest scheme designed for use by your servers. Token authentication is mostly used by your device and browser clients whereby a short-lived secure token is issued to them by your servers.

--- a/content/tutorials/vue-tictactoe.textile
+++ b/content/tutorials/vue-tictactoe.textile
@@ -1,9 +1,19 @@
 ---
 title: Implementing Multiplayer Tic Tac Toe with Ably and Vue.js
+excerpt: Creating a Multiplayer Tic Tac Toe game with Ably and Vue.js.
 section: tutorials
+category: libraries-integration
 index: 105
+platform: browser
+authors:
+- author_name: Nathan Ridley
+  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
+  author_profile_url: https://github.com/axefrog
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+level: medium
 languages:
   - javascript
+library_or_framework: Vue JS
 ---
 
 This tutorial is for those of you who have a little familiarity with Vue.js and are looking for some examples of how you might use Ably Realtime in your own application.

--- a/content/tutorials/vue-tictactoe.textile
+++ b/content/tutorials/vue-tictactoe.textile
@@ -13,7 +13,8 @@ authors:
 level: medium
 languages:
   - javascript
-library_or_framework: Vue JS
+libraries: 
+  - Vue JS
 ---
 
 This tutorial is for those of you who have a little familiarity with Vue.js and are looking for some examples of how you might use Ably Realtime in your own application.

--- a/content/tutorials/web-rtc-data-channels.textile
+++ b/content/tutorials/web-rtc-data-channels.textile
@@ -1,7 +1,20 @@
 ---
 title: "WebRTC 1. Data channels the right way using Ably"
+alt_title: "1. WebRTC - Data Channels"
+excerpt: Learn how to implement Data Channels with WebRTC and Ably
 section: tutorials
-index: 105
+category: libraries-integration
+index: 161
+platform: browser
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: medium
+reading_time: 30
+languages:
+  - javascript
 jump_to:
  Section:
    - 1. Introduction#intro

--- a/content/tutorials/web-rtc-data-channels.textile
+++ b/content/tutorials/web-rtc-data-channels.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: medium
 reading_time: 30
 languages:

--- a/content/tutorials/web-rtc-file-transfer.textile
+++ b/content/tutorials/web-rtc-file-transfer.textile
@@ -1,7 +1,20 @@
 ---
 title: "WebRTC 4. File transfers with Ably"
+alt_title: "4. WebRTC - File Sharing"
+excerpt: Learn how to implement File Sharing using WebRTC and Ably
 section: tutorials
-index: 106
+category: libraries-integration
+index: 164
+platform: browser
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: easy
+reading_time: 5
+languages:
+  - javascript
 jump_to:
  Section:
    - 1. Introduction#intro

--- a/content/tutorials/web-rtc-file-transfer.textile
+++ b/content/tutorials/web-rtc-file-transfer.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: easy
 reading_time: 5
 languages:

--- a/content/tutorials/web-rtc-introduction.textile
+++ b/content/tutorials/web-rtc-introduction.textile
@@ -1,9 +1,22 @@
 ---
 title: "WebRTC 0. A real world guide to WebRTC concepts with Ably"
+alt_title: 0. WebRTC - Introduction
+excerpt: An introduction to WebRTC and how to use it with Ably
 section: tutorials
-index: 104
+category: libraries-integration
+index: 160
+platform: browser
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: easy
+reading_time: 5
+languages:
+  - javascript
 jump_to:
- Section:
+  Section:
    - Introduction#intro
    - WebRTC support in current browsers#webrtc-supporting-browsers
    - Frequent Terminologies#frequent-terminologies

--- a/content/tutorials/web-rtc-introduction.textile
+++ b/content/tutorials/web-rtc-introduction.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: easy
 reading_time: 5
 languages:

--- a/content/tutorials/web-rtc-screen-sharing.textile
+++ b/content/tutorials/web-rtc-screen-sharing.textile
@@ -1,7 +1,20 @@
 ---
 title: "WebRTC 3. Less code, more efficient screen sharing with Ably"
+alt_title: "3. WebRTC - Screen Sharing"
+excerpt: Learn how to implement Screen Sharing using WebRTC and Ably
 section: tutorials
-index: 107
+category: libraries-integration
+index: 163
+platform: browser
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: medium
+reading_time: 30
+languages:
+  - javascript
 jump_to:
  Section:
    - 1. Introduction#intro

--- a/content/tutorials/web-rtc-screen-sharing.textile
+++ b/content/tutorials/web-rtc-screen-sharing.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: medium
 reading_time: 30
 languages:

--- a/content/tutorials/web-rtc-video-calling.textile
+++ b/content/tutorials/web-rtc-video-calling.textile
@@ -1,7 +1,20 @@
 ---
 title: "WebRTC 2. Straightforward Video calls with WebRTC and Ably"
+alt_title: "2. WebRTC - Video Calling"
+excerpt: "Learn how to implement Video Calling using WebRTC and Ably"
 section: tutorials
-index: 106
+category: libraries-integration
+index: 162
+platform: browser
+authors:
+- author_name: Samuel Ogundipe
+  author_bio: ""
+  author_profile_url: https://github.com/samuelayo
+  author_image: "/assets/tutorials/samuelayo"
+level: medium
+reading_time: 30
+languages:
+  - javascript
 jump_to:
  Section:
    - 1. Introduction#intro

--- a/content/tutorials/web-rtc-video-calling.textile
+++ b/content/tutorials/web-rtc-video-calling.textile
@@ -10,7 +10,7 @@ authors:
 - author_name: Samuel Ogundipe
   author_bio: ""
   author_profile_url: https://github.com/samuelayo
-  author_image: "/assets/tutorials/samuelayo"
+  author_image: "tutorials/samuelayo.png"
 level: medium
 reading_time: 30
 languages:

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -15,6 +15,8 @@ reading_time: 25
 languages:
   - ruby
 ably_product: reactor
+tags:
+  - ably-features
 ---
 
 "Ably Reactor Events":https://www.ably.io/reactor allow your servers to be notified or your server-less functions to be invoked via an HTTP request following "channel lifecycle events":/realtime/channel-metadata#lifecycle-events (such as channel creation), presence events (such as members entering or leaving) or messages being published.

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -4,7 +4,7 @@ excerpt: Learn how to use our WebHooks to trigger HTTP requests when realtime da
 section: tutorials
 category: external-services
 index: 105
-platform: reactor
+platform: browser
 authors:
 - author_name: Ably Team
   author_bio: ""
@@ -14,6 +14,7 @@ level: medium
 reading_time: 25
 languages:
   - ruby
+ably_product: reactor
 ---
 
 "Ably Reactor Events":https://www.ably.io/reactor allow your servers to be notified or your server-less functions to be invoked via an HTTP request following "channel lifecycle events":/realtime/channel-metadata#lifecycle-events (such as channel creation), presence events (such as members entering or leaving) or messages being published.

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -1,7 +1,17 @@
 ---
 title: WebHooks and Chuck Norris
+excerpt: Learn how to use our WebHooks to trigger HTTP requests when realtime data is published and then use the Chuck Norris API to publish jokes in real time.
 section: tutorials
+category: external-services
 index: 105
+platform: reactor
+authors:
+- author_name: Ably Team
+  author_bio: ""
+  author_profile_url: https:ably.io/about/team
+  author_image: "/assets/tutorials/ably"
+level: medium
+reading_time: 25
 languages:
   - ruby
 ---

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -9,7 +9,7 @@ authors:
 - author_name: Ably Team
   author_bio: ""
   author_profile_url: https:ably.io/about/team
-  author_image: "/assets/tutorials/ably"
+  author_image: "tutorials/ably.png"
 level: medium
 reading_time: 25
 languages:


### PR DESCRIPTION
TL;DR: 
- This PR adapts tutorials metadata with information required for wesbite indexing and new design view.
- Writes guidelines for future tutorials

### Notes
Before https://github.com/ably/website/pull/2866, tutorials indexing was hardcoded into the website, since the display required extra metadata that wasn't available here at the time. This required a manual update everytime a new tutorial was added. An automatic indexing mechanism was implemented at https://github.com/ably/website/pull/2866 but that requires new metadata fields to properly categorize tutorials.

#### New metadata fields are required for proper indexing and filtering at ably.io/tutorials

- `category*` — field is now required to put the tutorial in the correct section at 
- `platform*` — field that allow us to filter tutorials for each tab of new design: `(browser| mobile | mixed)`
- `alt_title` — field, because titles at the website can be slightly different from docs
- `authors*`— an array of multiple author hashes
  - expects an hash `{author_name: "name", author_bio: "optional", author_profile_url: "link", author_image: "gravatar url or relative path to assets/images/ folder on the website"}`
- `reading_time:` a number in minutes of the expected reading time
- `level`: a string (easy|medium|hard)
- `tags`: an Array of strings with (ably-realtime, ably-features, ex)
- `libraries`: (if code is uses any framework or library `(react js | vue js | angular... )`

<sup>* denotes required fields</sup>

#### Advised structure

With the new stepped view mode, each `h2` will be used as marker for a step/chapter of the tutorial. This requires extra careful when building tutorials content: specially when live examples includes markup as the following


```html

h2(#test). Live demo

<div id="app">
  <!-- please avoid using this, prefer and lower heading -->
  <h1>Demove title</h1>
</div>

```

A new helpbox component, this will created collapsible sections at single-page view mode, and will expand automatically at multi-page view mode

```markdown
div(docs-helpbox). 
 *HelpboxTitle wrapped in strong tag* 
 %Content wrapped in span tag, but can contain other inline markdown elements%
```


