### PR TITLE
Added jcenter to token auth tutorial for java

### DIFF
--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -185,6 +185,7 @@ blang[java].
   ```[groovy]
     buildscript {
       repositories {
+          jcenter()
           mavenCentral()
       }
       dependencies {


### PR DESCRIPTION
fixes #764 if I've understood correctly.