### PR TITLE
Add RTL6d7: no bundling if realtime message id set

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -518,6 +518,7 @@ h3(#realtime-channel). Channel
 *** @(RTL6d4)@ Messages can only be bundled together if they are of the same type (that is, @Message@ versus @PresenceMessage@)
 *** @(RTL6d5)@ Only contiguous messages in the queue can be bundled together. For example, if the user publishes three messages, A, B, and C, of which A and C could be bundled together under @RTL6d1-4@ but B could not, then no bundling should occur
 *** @(RTL6d6)@ The order of messages in the resulting @ProtocolMessage@ Messages must match the publish order. For example, if the user publishes @Message@ D, then the @Message@ array [E, F], then @Message@ G, the final @messages@ array should be [D, E, F, G]
+*** @(RTL6d7)@ Messages must not be bundled if any have had had their @Message.id@ property set
 ** @(RTL6e)@ Unidentified clients using "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication (i.e. any @clientId@ is permitted as no @clientId@ specified):
 *** @(RTL6e1)@ When a @Message@ with a @clientId@ value is published, Ably will accept and publish that message with the provided @clientId@. A test should assert that the @clientId@ of the published @Message@ is populated
 ** @(RTL6g)@ Identified clients with a @clientId@ (as a result of either an explicitly configured @clientId@ in @ClientOptions@, or implicitly through Token Auth):

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -43,6 +43,8 @@ This document outlines the complete feature set of both the REST and Realtime cl
 
 We recommend you use the "IDL (Interface Definition Language)":#idl and refer to other existing libraries that adhere to this spec as a reference when reviewing how the API has been implemented.
 
+The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended",  "may", and "optional" (whether lowercased or uppercased) in this document are to be interpreted as described in "RFC 2119":https://tools.ietf.org/html/rfc2119 .
+
 __Please note we maintain a separate Google Sheet that keeps track of which features are implemented and matching test coverage for each client library. If you intend to work on an Ably client library, please "contact us":https://www.ably.io/contact for access to this Google Sheet as it is useful as a reference and also needs to be kept up to date__
 
 h2(#test-guidelines). Test guidelines
@@ -511,7 +513,7 @@ h3(#realtime-channel). Channel
 *** @(RTL6c2)@ If the connection is @INITIALIZED@, @CONNECTING@ or @DISCONNECTED@, and @ClientOptions#queueMessages@ has not been explicitly set to false, then the message will be queued and delivered as soon as the connection is @CONNECTED@ and the channel is in a state in which publishing is permitted per @RTL6c1@
 *** @(RTL6c4)@ If the connection is @SUSPENDED@, @CLOSING@, @CLOSED@, or @FAILED@, or the channel is @SUSPENDED@ or @FAILED@, the operation will result in an error
 *** @(RTL6c5)@ A publish should not trigger an implicit attach (in contrast to earlier version of this spec)
-** @(RTL6d)@ Messages that have been queued may be sent in a single @ProtocolMessage@ by bundling them into the @ProtocolMessage#messages@ or @ProtocolMessage#presence@ array, subject to the following constraints:
+** @(RTL6d)@ The protocol permits @Message@ s that have been queued to be sent in a single @ProtocolMessage@ , by bundling them into the @ProtocolMessage#messages@ or @ProtocolMessage#presence@ array. In general, the client library SHOULD NOT do this. If it does, it MUST conform to all of the following constraints:
 *** @(RTL6d1)@ The resulting @ProtocolMessage@ must not exceed the @maxMessageSize@
 *** @(RTL6d2)@ Messages can only be bundled together if they have the same @clientId@ value (or both have no @clientId@ set). (Note that this constraint only applies to what the client library can autonomously do as part of queuing messages, not to what the user can do by publishing an array of @Messages@. It exists because if any @Message@ in a @ProtocolMessage@ has an invalid @clientId@, the entire @ProtocolMessage@ is rejected. This is fine if the user has deliberately published the @Messages@ together – they requested atomicity – but not if the client library has bundled them without the user's knowledge)
 *** @(RTL6d3)@ Messages can only be bundled together if they are for the same @channel@


### PR DESCRIPTION
Fixes https://github.com/ably/docs/issues/787

ably-js implementation: https://github.com/ably/ably-js/pull/623

TODO: open issues for any realtime client lib that does bundling-while-disconnected (not sure which of them do)