### PR TITLE
Various small doc issue fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -155,6 +155,7 @@ $(function() {
             this.innerHTML = insertKeyUsageWarning(this.innerHTML);
             this.innerHTML = this.innerHTML.
               replace(/{{API_KEY_NAME}}/g, keyName).
+              replace(/{{API_KEY_SECRET}}/g, keySecret).
               replace(/{{API_KEY}}/g, apiKey).
               replace(/{{API_KEY_BASE64}}/g, Base64.encode(apiKey)).
               replace(/{{APP_ID}}/g, keyName.split('.')[0]).
@@ -262,8 +263,8 @@ function insertKeyUsageWarning(code) {
   } else {
     message = `// ${message}`;
   }
-  return code.replace(/(<ol class="linenums">)(.*?)({{API_KEY}})/g, 
-            `$1<li class="L-1"><code class="code-editor open-jsbin" 
+  return code.replace(/(<ol class="linenums">)(.*?)({{API_KEY}})/g,
+            `$1<li class="L-1"><code class="code-editor open-jsbin"
             lang="${currentLang}"><span class="com">${message}</span></code></li>$2$3`);
 }
 

--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -215,6 +215,7 @@ In your code examples you can use handlebar like variables that are replaced wit
 The following variables are supported:
 
 * {{API_KEY_NAME}}
+* {{API_KEY_SECRET}}
 * {{API_KEY}}
 * {{API_KEY_BASE64}}
 * {{APP_ID}}
@@ -228,6 +229,7 @@ The following variables are supported:
 Example of the above variables being used in a code block below:
 
 bc. API_KEY_NAME: "{{API_KEY_NAME}}"
+API_KEY_NAME: "{{API_KEY_SECRET}}"
 API_KEY: "{{API_KEY}}"
 API_KEY_BASE64: "{{API_KEY_BASE64}}"
 TOKEN: "{{TOKEN}}"

--- a/content/code/authentication/jwt-token.code
+++ b/content/code/authentication/jwt-token.code
@@ -1,0 +1,126 @@
+[--- Javascript ---]
+var ably = new Ably.Rest('{{API_KEY}}');
+
+$('input#connect').on('click', function() {
+  var myToken = createAblyJWT();
+  $('#token-container').show();
+  var realtime = new Ably.Realtime({
+    token: myToken
+  });
+  $('#realtime-status').text('Connecting...').css('color', '');
+  realtime.connection.on(function (stateChange){
+    console.log(stateChange);
+  });
+  realtime.connection.on('connected', function() {
+    $('#realtime-status').
+      text('✓ Connected to Ably' + (realtime.auth.clientId ? ' with client ID ' + realtime.auth.clientId : '')).
+      css('color', 'green');
+  });
+});
+
+function createAblyJWT() {
+   var header = {
+    "typ":"JWT",
+    "alg":"HS256",
+    "kid": "{{API_KEY_NAME}}"
+  };
+  var clientId = $('#clientId').val();
+  if(clientId === "") clientId = null;
+  var currentTime = Math.round(Date.now()/1000);
+  var claims = {
+    "iat": currentTime, /* current time in seconds */
+    "exp": currentTime + 3600, /* time of expiration in seconds */
+    "x-ably-capability": $('#capability').val(),
+    "x-ably-clientId": clientId
+  };
+  var base64Header = b64(CryptoJS.enc.Utf8.parse(JSON.stringify(header)));
+  var base64Claims = b64(CryptoJS.enc.Utf8.parse(JSON.stringify(claims)));
+
+  var token = base64Header + "." + base64Claims;
+  /* Apply the hash specified in the header */
+  var signature = b64(CryptoJS.HmacSHA256(token, "{{API_KEY_SECRET}}"));
+  var ablyJWT = token + "." + signature;
+     $('#token').text(JSON.stringify(header, null,'\t') + JSON.stringify(claims, null,'\t'));
+  $('#signed-token').text(ablyJWT);
+  return ablyJWT;
+}
+
+function b64(token) {
+  encode = CryptoJS.enc.Base64.stringify(token);
+  encode = encode.replace( /\=+$/, '');
+  encode = encode.replace(/\+/g, '-');
+  encode = encode.replace(/\//g, '_');
+
+  return encode;
+}
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/hmac-sha256.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/enc-base64-min.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably JWT Example</h1>
+
+<p>In this example, we demonstrate how to create an Ably JWT that can be used by any client authenticate with Ably. The token may optionally set an identify for the client as well as a set of capabilities. See <a href="https://www.ably.io/documentation/core-features/authentication">our authentication documentation</a> for more details.
+
+<div class="row">
+  <label for="clientId">Client ID:</label>
+  <input id="clientId" type="text" placeholder="Optional client identity">
+</div>
+
+<div class="row">
+  <label for="capability">Capability:</label>
+  <select id="capability">
+    <option value='{"*":["*"]}'>All operations: {"*":["*"]}</option>
+    <option value='{"*":["subscribe"]}'>Subscribe all channels: {"*":["subscribe"]}</option>
+    <option value='{"position":["publish"]}'>Publish to 'position' channel: {"position":["publish"]}</option>
+  </select>
+</div>
+
+<div id="token-container">
+  Unencrypted token:
+  <pre id="token"></pre>
+  Encrypted signed token:
+  <pre id="signed-token"></pre>
+</div>
+
+<div class="row">
+  <input id="connect" type="submit" value="Connect to Ably using Ably JWT">
+</div>
+
+<div class="row" id="realtime-status">
+</div>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+label {
+  display: block;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+#token-container {
+  display: none;
+}
+
+#token {
+  border: 1px solid #999;
+  border-radius: 5px;
+  padding: 10px;
+  font-family: "Courier New", Courier, monospace;
+}
+[--- /CSS ---]

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -326,7 +326,7 @@ For example, assuming you were building a chat application and wanted to allow c
 In Ably a client can be identified with a @client ID@ in two ways:
 
 * if the client is authenticated with an Ably-compatible token that is issued for that @client ID@;
-* if the client claims that @client ID@ (as part of "@ClientOptions@":/realtime/usage#client-options in the "constructor":/realtime/usage) and is authenticated with an Ably-compatible token that is issued for a "wildcard @client ID@":https://support.ably.io/solution/articles/3000048586-can-a-client-emulate-any-client-id-i-e-authenticate-using-a-wildcard-client-id (a special token privilege that allows any client identity to be assumed)
+* if the client claims that @client ID@ (as part of "@ClientOptions@":/realtime/usage#client-options in the "constructor":/realtime/usage) and is authenticated with an Ably-compatible token that is issued for a "wildcard @client ID@":https://support.ably.io/solution/articles/3000048586 (a special token privilege that allows any client identity to be assumed)
 
 We encourage customers to always issue Ably-compatible tokens to clients so that they authenticate using the short-lived token and do not have access to a customer's private API keys. Since the customer can then control the @client ID@ that may be used by any of its clients, all other clients can rely on the validity of the @client ID@ in published messages and of members present in presence channels.
 
@@ -338,6 +338,15 @@ The following Javascript example demonstrates how to issue an "Ably Token":#ably
     /* ... issue the TokenRequest to a client ... */
   })
 ```
+
+h1. Authentication API Reference
+
+inline-toc.
+  Token Types:
+    - TokenDetails#ably-tokens
+    - Ably JWT#ably-jwt
+  Objects:
+    - Auth object#auth-object
 
 h2(#tokens). Token Types
 
@@ -362,7 +371,7 @@ An Ably JWT is not strictly an Ably construct, rather it is a "JWT":https://jwt.
 
 Arbitrary additional claims and headers are supported (apart from those prefixed with @x-ably-@ which are reserved for future use).
 
-The Ably JWT must be signed with the secret part of your "Ably API key":https://support.ably.io/support/solutions/articles/3000030054-what-is-an-app-api-key, using one of the following signature algorithms (as defined in "JWA":https://tools.ietf.org/html/rfc7518):
+The Ably JWT must be signed with the secret part of your "Ably API key":https://support.ably.io/support/solutions/articles/3000030054, using one of the following signature algorithms (as defined in "JWA":https://tools.ietf.org/html/rfc7518):
 
 * *HS256* - HMAC using the SHA-256 hash algorithm
 * *HS384* - HMAC using the SHA-384 hash algorithm
@@ -371,7 +380,7 @@ We recommend you use one of the many "JWT libraries available for simplicity":ht
 
 h2(#auth-object). Auth object
 
-The principal use-case for the @Auth@ object is to create Ably "@TokenRequest@":/realtime/authentication#token-request objects with "createTokenRequest":/realtime/authentication#create-token-request or obtain "Ably Tokens":#ably-tokens from Ably with "requestToken":#request-token, and then issue them to other "less trusted" clients. Typically, your servers should be the only devices to have a "private API key":https://support.ably.io/solution/articles/3000030054-what-is-an-app-api-key, and this private API key is used to securely sign Ably "@TokenRequest@":/realtime/authentication#token-request objects or request "Ably Tokens":#ably-tokens from Ably. Clients are then issued with these short-lived "Ably Tokens":#ably-tokens or Ably "@TokenRequest@":/realtime/authentication#token-request objects, and the libraries can then use these to authenticate with Ably. If you adopt this model, your private API key is never shared with clients directly.
+The principal use-case for the @Auth@ object is to create Ably "@TokenRequest@":/realtime/authentication#token-request objects with "createTokenRequest":/realtime/authentication#create-token-request or obtain "Ably Tokens":#ably-tokens from Ably with "requestToken":#request-token, and then issue them to other "less trusted" clients. Typically, your servers should be the only devices to have a "private API key":https://support.ably.io/solution/articles/3000030054, and this private API key is used to securely sign Ably "@TokenRequest@":/realtime/authentication#token-request objects or request "Ably Tokens":#ably-tokens from Ably. Clients are then issued with these short-lived "Ably Tokens":#ably-tokens or Ably "@TokenRequest@":/realtime/authentication#token-request objects, and the libraries can then use these to authenticate with Ably. If you adopt this model, your private API key is never shared with clients directly.
 
 A subsidiary use-case for the @Auth@ object is to preemptively trigger renewal of a token or to acquire a new token with a revised set of capabilities by explicitly calling "<span lang="default">@authorize@</span><span lang="csharp">@Authorize@</span>":/realtime/authentication#authorize.
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -122,7 +122,8 @@ Similarly to with the "TokenRequest flow":#timetip , you should ensure that your
 An example of creating an "Ably JWT":/core-features/authentication#ably-jwt manually can be seen below, with *SECRET* being the "secret part of your API key":https://support.ably.io/support/solutions/articles/3000030054-what-is-an-app-api-key. In most scenarios however, we would recommend you use one of the many "JWT libraries available for simplicity":https://jwt.io/:
 
 minimize. View example of creating an Ably JWT
-  bc[javascript]. var header = {
+  ```[javascript]
+    var header = {
       "typ":"JWT",
       "alg":"HS256",
       "kid": "{{API_KEY_NAME}}"
@@ -138,6 +139,7 @@ minimize. View example of creating an Ably JWT
     /* Apply the hash specified in the header */
     var signature = hash((base64Header + "." + base64Claims), SECRET);
     var ablyJwt = base64Header + "." + base64Claims + "." + signature;
+  ```
 
   *Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party. If this is something you'd be interested in, please "get in touch":https://www.ably.io/contact.
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -113,16 +113,16 @@ h3(#ably-jwt-process). Ably JWT is created by your servers and passed to clients
 
 p(tip). In most scenarios, we would recommend you use one of the many "JWT libraries available":https://jwt.io/ when constructing your JWT.
 
-It is possible to use a "JWT":https://jwt.io as a form of token for authentication with Ably, so long as it is structured appropriately, in what will be referred to as an "*Ably JWT*":#ably-jwt. It is possible for an "Ably JWT":/core-features/authentication#ably-jwt to contain claims indicating its clientId, capabilities and expiry - in an analogous way to an "Ably Token":#tokens - and it is signed with the applicable "Ably API key's secret part":https://support.ably.io/support/solutions/articles/3000030054-what-is-an-app-api-key.
+It is possible to use a "JWT":https://jwt.io as a form of token for authentication with Ably, so long as it is structured appropriately, in what will be referred to as an "*Ably JWT*":#ably-jwt. It is possible for an "Ably JWT":/core-features/authentication#ably-jwt to contain claims indicating its clientId, capabilities and expiry - in an analogous way to an "Ably Token":#tokens - and it is signed with the applicable "Ably API key's secret part":https://support.ably.io/support/solutions/articles/3000030054.
 
 This is similar to signing an Ably "@TokenRequest@":/realtime/authentication#request-token, but the client does not need then to request an "Ably Token":#ably-tokens, instead being able to use the "Ably JWT":/core-features/authentication#ably-jwt as a token in itself. "Any compliant third-party JWT library":https://jwt.io/ may be used to create the JWT without requiring the token to be issued by Ably. This can be useful for situations where an Ably client library is not available, such as an embedded device connecting to Ably via "MQTT":/mqtt.
 
 Similarly to with the "TokenRequest flow":#timetip , you should ensure that your auth server has an accurate clock, as the JWT includes absolute "issued at" and "expires at" timestamps.
 
-An example of creating an "Ably JWT":/core-features/authentication#ably-jwt manually can be seen below, with *SECRET* being the "secret part of your API key":https://support.ably.io/support/solutions/articles/3000030054-what-is-an-app-api-key. In most scenarios however, we would recommend you use one of the many "JWT libraries available for simplicity":https://jwt.io/:
+An example of creating an "Ably JWT":/core-features/authentication#ably-jwt manually can be seen below, with *SECRET* being the "secret part of your API key":https://support.ably.io/support/solutions/articles/3000030054. In most scenarios however, we would recommend you use one of the many "JWT libraries available for simplicity":https://jwt.io/:
 
 minimize. View example of creating an Ably JWT
-  ```[javascript]
+  ```[javascript](code-editor:authentication/jwt-token)
     var header = {
       "typ":"JWT",
       "alg":"HS256",
@@ -137,7 +137,7 @@ minimize. View example of creating an Ably JWT
     var base64Header = btoa(header);
     var base64Claims = btoa(claims);
     /* Apply the hash specified in the header */
-    var signature = hash((base64Header + "." + base64Claims), SECRET);
+    var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
     var ablyJwt = base64Header + "." + base64Claims + "." + signature;
   ```
 
@@ -379,6 +379,28 @@ The Ably JWT must be signed with the secret part of your "Ably API key":https://
 * *HS384* - HMAC using the SHA-384 hash algorithm
 
 We recommend you use one of the many "JWT libraries available for simplicity":https://jwt.io/ when creating your JWTs.
+
+minimize. View example of creating an Ably JWT
+  ```[javascript](code-editor:authentication/jwt-token)
+    var header = {
+      "typ":"JWT",
+      "alg":"HS256",
+      "kid": "{{API_KEY_NAME}}"
+    };
+    var currentTime = Math.round(Date.now()/1000);
+    var claims = {
+      "iat": currentTime, /* current time in seconds */
+      "exp": currentTime + 3600, /* time of expiration in seconds */
+      "x-ably-capability": "{\"*\":[\"*\"]}"
+    };
+    var base64Header = btoa(header);
+    var base64Claims = btoa(claims);
+    /* Apply the hash specified in the header */
+    var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
+    var ablyJwt = base64Header + "." + base64Claims + "." + signature;
+  ```
+
+  *Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party. If this is something you'd be interested in, please "get in touch":https://www.ably.io/contact.
 
 h2(#auth-object). Auth object
 

--- a/content/realtime/usage.textile
+++ b/content/realtime/usage.textile
@@ -173,7 +173,6 @@ inline-toc.
     - push#push
     - device#device
     - channels#channels
-    - clientId#client-id
     - connection#connection
   Methods:
     - connect()#connect
@@ -264,13 +263,6 @@ h6(#channels).
   csharp: Channels
 
 A reference to the "@Channel@":/realtime/channels collection instance for this library indexed by the channel name. See "channels":/realtime/channels and "messages":/realtime/messages/ for more information.
-
-h6(#client-id).
-  default: clientId
-  ruby:    client_id
-  csharp:  ClientId
-
-The client ID string, if any, configured for this client connection. See "authentication":/realtime/authentication for more information on authentication and using a client ID.
 
 h6(#connection).
   default: connection

--- a/content/rest/channel-status.textile
+++ b/content/rest/channel-status.textile
@@ -109,6 +109,6 @@ inline-toc.
 
 h2(#types). Types
 
-The payload of metadata events for channels is the "@ChannelDetails@":#channel-details type which contains the @channelId@ and other static information about the channel, plus a @status@ containing a "@ChannelStatus@":#channel-status instance which contains information about the current state of the channel.
+The payload of metadata events for channels is the "@ChannelDetails@":#channel-details type which contains the @channelId@ (AKA the "channel's name":/realtime/channels#name) and other static information about the channel, plus a @status@ containing a "@ChannelStatus@":#channel-status instance which contains information about the current state of the channel.
 
 <%= partial partial_version('types/_channel_details') %>

--- a/content/rest/usage.textile
+++ b/content/rest/usage.textile
@@ -202,7 +202,6 @@ inline-toc.
     - push#push
     - device#device
     - channels#channels
-    - clientId#client-id
   Methods:
     - stats(options)#stats
     - time()#time
@@ -298,13 +297,6 @@ h6(#channels).
   csharp,go: Channels
 
 A reference to the "@Channel@":/realtime/channels collection instance for this library indexed by the channel name. See "channels":/rest/channels and "messages":/rest/messages for more information.
-
-h6(#client-id).
-  default:     clientId
-  ruby,python: client_id
-  csharp,go:   ClientId
-
-The client ID string, if any, configured for this client connection. See "authentication":/rest/authentication for more information on authentication and using a client ID.
 
 h2(#methods).
   default: AblyRest Methods

--- a/content/shared/_channel_metadata.textile
+++ b/content/shared/_channel_metadata.textile
@@ -7,4 +7,66 @@ bc[sh]. curl https://rest.ably.io/channels/<channelId> \
 
 The credentials presented with the request must include the @channel-metadata@ permission for the channel in question.
 
-Client libraries currently do not support this API, but it is usable via the generic "request API":/rest/usage#request.
+Client libraries currently do not support this API, but it is usable via the generic "request API":/rest/usage#request:
+
+```[jsall]
+var rest = new Ably.Rest({ key: '{{API_KEY}}' });
+
+rest.request(
+  'get',
+  '/channels/<my_channel>',
+  null,
+  null,
+  null,
+  function(err, response) {
+    if(err) {
+      console.log('An error occurred; err = ' + err.toString());
+    } else {
+      console.log('Success! status code was ' + response.statusCode);
+      console.log(response.items);
+    }
+  }
+);
+```
+```[php]
+$client = new Ably\AblyRest('{{API_KEY}}');
+
+$response = $rest->request('GET', '/channels/<my_channel>');
+echo("Response code: " . $response->statusCode);
+echo("<br>isActive: " . $response->items[0]->status->isActive . "<br>");
+print_r($response->items[0]->status->occupancy);
+```
+```[python]
+rest = AblyRest('{{API_KEY}}')
+response = rest.request('GET', '/channels/<my_channel>').items[0]
+print('Response is is: ' + str(recent_message))
+```
+```[java]
+AblyRest ablyRest = new AblyRest("{{API_KEY}}");
+HttpPaginatedResponse resultPage = ablyRest.request("GET", "/channels/<my_channel>", null, null, null);
+System.out.println(resultPage.items()[0].toString());
+```
+```[ruby]
+client = Ably::Rest.new(key: '{{API_KEY}}')
+
+response = client.request(:get, '/channels/<my_channel>')
+puts "Status: #{response.items[0]['status']}"
+```
+```[objc]
+ARTRest *client = [[ARTRest alloc] initWithKey:@"{{API_KEY}}"];
+[client.request method:"GET" path:"/channels/<my_channel>" callback:^(ARTHTTPPaginatedResponse *response, ARTErrorInfo *error) {
+    NSLog(@"%@", response);
+}];
+```
+```[go]
+rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+if err != nil {
+  panic(err)
+}
+response, err := rest.Request("GET", "/channels/<my_channel>", nil, nil, nil)
+if err != nil {
+  panic(err)
+}
+
+fmt.Println(response.PaginatedResult)
+```

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -41,6 +41,7 @@ jsbin_hash:
   KLOsf4s5KuRyHZaVRl+L6X9hsnA=: omihuk
   abZx53u8UDccCug5pAKKuGT5euI=: asasev
   0mral5B3E8UfMEPBq8MsCmeOGzc=: ipojey
+  Q0XIw74KKfK3Zv34fqKSck4ip5U=: ivihud
 jsbin_id:
   adapters/pusher-pub-sub: eBxLJU1YqdX+JW9JQY70S4iQfmU=
   adapters/pubnub-pub-sub: pzHKfCW4/o2wDnCfbg1m0Pkl7v8=
@@ -83,3 +84,4 @@ jsbin_id:
   sse/eventstream: kFsT2eCL2NRWubzQ8OC3BMNZFYg=
   rest/batch-presence: cHvxfaSCnHR6qzdutJZ/TZWK0FE=
   realtime/rewind: fDq9P84O672WgwAsIhYmPxnPLRA=
+  authentication/jwt-token: Q0XIw74KKfK3Zv34fqKSck4ip5U=


### PR DESCRIPTION
Going to add small fixes to this PR rather than making a load of PRs for many 1 line changes. I'll tag each commit with the issue to make it clearer what does what.

fixes #761 , currently not able to run the actual website repo locally so can only check locally `docs`, if it behaves like everything else this should work to remove number formatting + divide up the page a bit better until our full rework.

fixes #751 adding ChannelStatus code examples for all languages.

fixes #759 , note on what `channelId` is.

fixes #760 's indentation issue.

fixes #580 , removes incorrect claim that `rest.clientId` and `realtime.clientId` exist (is actually `rest.auth.clientId`)

fixes #578, adds JSBin example for JWT token generation + usage