### PR TITLE
Removes specific pricing from comparisons

### DIFF
--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -629,24 +629,11 @@ AblyCompare:
           ably: >
             *Yes.*<br/><br/>Ably's pricing is simple and transparent. You pay for the messages, peak active channels and peak connections you use for the month. You can either pay for what you've used at the end of the month, or reserve capacity in advance each month and benefit from a discount.
           pubnub: >
-            *Partial.*<br/><br/>PubNub follows a usage-based pricing model. However, pricing is based on six different usage units, making it difficult to predict ongoing costs.
+            *Partial.*<br/><br/>PubNub follows a usage-based pricing model. However, pricing is based on multiple different usage units, making it difficult to predict ongoing costs.
           pusher: >
-            *No.*<br/><br/>Pusher packages are priced in tiers. If you were on a Pro package at $99 with 2k connections and 4m messages, and you later needed 3k connections but the same number of messages, you would have to upgrade to the Business package at $299 (3x the price). With Ably, you'd just pay for an additional 1k connections for less than $10.
+            *No.*<br/><br/>Pusher packages are priced in tiers. If you were on a Pro package at $99 with 2k connections and 4m messages, and you later needed 3k connections but the same number of messages, you would have to upgrade to the Business package at $299 (3x the price). With Ably, you'd just pay for an additional 1k connections.
         extra: >
           Pricing should be clear, flexible, and scalable when it comes to realtime messaging.<br/><br/>"Calculate your usage with Ably's pricing calculator":https://www.ably.io/pricing/calculator
-      pushercost:
-        description: 'Example pricing comparison<br/><br/>3,000 peak connections<br/>5,000,000 messages per day'
-        compare:
-          ably: '*$162 per month*'
-          pusher: '*$299 per month*'
-        extra: 'Flexible, usage-based pricing is ideal for building scalable realtime apps.<br/><br/>"See how much you can save":https://www.ably.io/pricing/calculator'
-      pubnubcost:
-        description: >
-          Example pricing comparison<br/><br/><ul><li>100k users/mo</li><li>200k sessions/mo</li><li>42 messages/ session</li><li>8.4m messages - pub/sub</li><li>8.4m messages - history</li><li>5k peak connections (assumed from 100k customers)</li></ul><br/><br/>Based on example provided on PubNub's pricing page on 31 Aug 2018
-        compare:
-          ably: '*$96.99/mo*'
-          pubnub: '*$452/mo*'
-        extra: 'Flexible, usage-based pricing is ideal for building scalable realtime apps.<br/><br/>"See how much you can save":https://www.ably.io/pricing/calculator'
 
 # Information on the companies themselves
 Companies:


### PR DESCRIPTION
I removed specific pricing comparisons from compare table. We're updating the pricing and this section doesn't add much value anyway.

@tomczoink can you please just give this a once over and then merge into master if all is OK?

I've also updated the comparisons that don't live in this table directly in the website repo.