### PR TITLE
Removed 100% uptime from comparison pieces

### DIFF
--- a/content/index.textile
+++ b/content/index.textile
@@ -22,7 +22,7 @@ The Ably documentation is broken down as follows:
 * "REST client library API documentation":/rest/
 * "REST API documentation":/rest-api/.  Note, we recommend you use one of our REST client libraries instead of accessing the Ably REST API directly as the client libraries abstract away underlying complexity and provide a rich convenient feature set to developers.
 * More detail behind some of Ably's key features: "Authentication":/core-features/authentication, "Channel Rules & Namespaces":/general/channel-rules-namespaces/, "Receiving WebHooks":/general/webhooks, and "Application statistics":/general/statistics/
-* Documentation targeted at client library developers including "Protocol documentation":/client-lib-development-guide/protocol/, details on "Encryption":/client-lib-development-guide/encryption/, and "our fallback mechanisms to ensure we can deliver on our 100% uptime guarantee":/client-lib-development-guide/connection-fallback/.  Unless you are developing or extending an existing Ably client library, this documentation is most likely more low level than is needed for you to use the Ably realtime message service.
+* Documentation targeted at client library developers including "Protocol documentation":/client-lib-development-guide/protocol/, details on "Encryption":/client-lib-development-guide/encryption/, and "our fallback mechanisms to ensure we can deliver on our uptime guarantee":/client-lib-development-guide/connection-fallback/.  Unless you are developing or extending an existing Ably client library, this documentation is most likely more low level than is needed for you to use the Ably realtime message service.
 
 ---
 

--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -14,7 +14,7 @@ jump_to:
     - Any internet device
 ---
 
-Ably's global realtime service enables Internet enabled devices, such as a browser, phone, server or IoT sensor, to stream data in realtime between to any other Internet connected device in milliseconds. The Ably platform brings enterprise scale messaging to developers by delivering "100% service availability":http://support.ably.io/solution/articles/3000029531-100-uptime-guarantee, "message delivery guarantees":http://support.ably.io/solution/articles/3000044640-message-durability-and-qos-quality-of-service- and "low-latencies globally":http://support.ably.io/solution/articles/3000044625-round-trip-latency-and-performance (typically less than 60ms).
+Ably's global realtime service enables Internet enabled devices, such as a browser, phone, server or IoT sensor, to stream data in realtime between to any other Internet connected device in milliseconds. The Ably platform brings enterprise scale messaging to developers by delivering "100% service availability":http://support.ably.io/solution/articles/3000029531, "message delivery guarantees":http://support.ably.io/solution/articles/3000044640-message-durability-and-qos-quality-of-service- and "low-latencies globally":http://support.ably.io/solution/articles/3000044625-round-trip-latency-and-performance (typically less than 60ms).
 
 h2. Key concepts
 
@@ -121,7 +121,7 @@ Ably provides the following assurances in regards to connection state recovery:
 
 h3(#redundancy). Redundancy
 
-The Ably global platform is designed to provide an industry first "100% uptime guarantee":https://support.ably.io/support/solutions/articles/3000029531-100-uptime-guarantee. This is possible because redundancy has been addressed in not just every area of our systems, but also within the client libraries used by our customers. Our redundancy is best depicted in the following diagram:
+The Ably global platform is designed to provide rigorous uptime guarantees":https://support.ably.io/support/solutions/articles/3000029531. This is possible because redundancy has been addressed in not just every area of our systems, but also within the client libraries used by our customers. Our redundancy is best depicted in the following diagram:
 
 <a href="/images/diagrams/redundancy.png" target="_blank">
   <img src="/images/diagrams/redundancy.png" style="width: 100%" alt="Ably redundancy diagram">
@@ -137,7 +137,7 @@ h4. Jargon buster:
 - "Load balancers":https://support.ably.io/solution/articles/3000045691-are-you-able-to-scale-indefinitely-to-meet-demand := our load balancers are elastic and scale to meet demand, but are also responsible for intelligently routing traffic to existing and new frontends that are coming online
 - "Stateless":https://en.wikipedia.org/wiki/Stateless_protocol := our frontends do not store any state thus ensuring that frontends can come online quickly and service new requests, but also go offline easily without data loss
 - "Self-healing cluster":https://support.ably.io/solution/articles/3000045692-self-healing-cluster := as problems are detected in the system, they are isolated or remedied by our automated health servers
-- "Data replicas":https://support.ably.io/support/solutions/articles/3000029531-100-uptime-guarantee := all data is stored in at least three datacenters across at least two regions ensuring data availability through any imaginable failure
+- "Data replicas":https://support.ably.io/support/solutions/articles/3000029531 := all data is stored in at least three datacenters across at least two regions ensuring data availability through any imaginable failure
 - "Multiple availability zones":https://www.ably.io/network := in every region our our data is replicated between servers in at least two independent datacenters ensuring outages in one datacenter cannot cause data loss
 - "Multiple regions":https://www.ably.io/network := ensuring that data is always stored in at least two regions protects against complete region outage or network partitioning
 - "Edge acceleration points-of-presence":https://www.ably.io/network := servers running in 175+ locations globally that accept connections close to where users are (reducing latency) and accelerate traffic to an Ably datacenter using dedicated network connections (not over the Internet)

--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -347,13 +347,13 @@ AblyCompare:
           pusher: '*No.*'
         extra: 'Storing connection state means clients can resume from where they left off, providing a better quality of service as nothing is ever lost.<br/><br/>"Find out more about connection state recovery":https://support.ably.io/solution/articles/3000044639'
       uptimeguarantee:
-        description: '100% uptime guarantee<br/><br/>(Unique to Ably)'
+        description: 'Uptime guarantee<br/><br/>'
         compare:
-          ably: '*Yes.*<br/><br/>Ably uniquely offers a 100% uptime guarantee to all "Business and Enterprise customers":https://www.ably.io/pricing. We stand by our 100% uptime promise - if we are unable to meet that goal, "we offer refunds":https://support.ably.io/solution/articles/3000029531.'
-          pubnub: '<b>No.</br>'
+          ably: '*Yes.*<br/><br/>Ably offers varying levels of uptime guarantees depending on your needs. For all of our enterprise customers we provide a 99.999% uptime SLA. If we're unable to meet your SLA goal, "we offer refunds":https://support.ably.io/solution/articles/3000029531.'
+          pubnub: '<b>No. PubNub doesn't offer an SLA unless you a Pro customer.</br>'
           pusher: >
             *No.*<br/><br/>Pusher doesn’t offer an SLA unless you are an Enterprise customer.
-        extra: 'Confidence in a service to offer refunds on any downtime. That is what 100% uptime guarantee means, and it shows a provider values you and your end-users’ experience.<br/><br/>"Learn what we mean with our 100% uptime guarantee":https://support.ably.io/solution/articles/3000029531'
+        extra: 'Confidence in a service to offer refunds on any downtime. That is what an uptime guarantee means, and it shows a provider values you and your end-users’ experience.<br/><br/>"Learn what we mean with our uptime guarantee":https://support.ably.io/solution/articles/3000029531'
   core:
     description: 'Core features'
     sections:


### PR DESCRIPTION
Our SLAs changed so needed to update our SLA info in the comparison pages. Also removed some non-essential 100 mentions in support desk URLs.