### PR TITLE
Push: Fix activate() behavior while syncing device

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1015,7 +1015,7 @@ h3(#activation-state-machine). Activation State Machine
 **** @(RSH3d3c)@ Either way, when the registration is done, a @RegistrationSynced@ or @SyncRegistrationFailed@ event should be fired.
 **** @(RSH3d3d)@ Transitions to @WaitingForRegistrationSync@.
 ** @(RSH3e)@ State @WaitingForRegistrationSync@:
-*** @(RSH3e1)@ On event @CalledActivate@, only if the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event:
+*** @(RSH3e1)@ On event @CalledActivate@, unless the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event:
 **** @(RSH3e1a)@ Makes @Push#activate@ return or call its callback with no error.
 **** @(RSH3e1b)@ Transitions to @WaitingForRegistrationSync@.
 *** @(RSH3e2)@ On event @RegistrationSynced@:

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -965,7 +965,7 @@ h3(#activation-state-machine). Activation State Machine
 **** @(RSH3a1a)@ Makes @Push#deactivate@ return or call its callback with no error.
 **** @(RSH3a1b)@ Transitions to @NotActivated@.
 *** @(RSH3a2)@ On event @CalledActivate@:
-**** @(RSH3a2a)@ If the local device has @deviceIdentityToken@, enqueues a @CalledActivate@ event and performs a validation of the local DeviceDetails via the following steps. "@(RSH3a2b)@":#RSH3a2b onwards then don't apply.
+**** @(RSH3a2a)@ If the local device has @deviceIdentityToken@, performs a validation of the local DeviceDetails via the following steps. "@(RSH3a2b)@":#RSH3a2b onwards then don't apply.
 ***** @(RSH3a2a1)@ Checks the compatibilty of the present client with the existing registration: if the @LocalDevice@ has a non-empty @clientId@, and the present identified client has a different (non-null) @clientId@, then a @SyncRegistrationFailed@ event should be fired containing an error with @code@ 61002, and skips to "@(RSH3a2a4)@":#RSH3a2a4.
 ***** @(RSH3a2a2)@ If a custom @registerCallback@ was provided to @Push#activate@, pass it the local @DeviceDetails@.
 ***** @(RSH3a2a3)@ Otherwise, makes an asynchronous HTTP PUT request to @/push/deviceRegistrations/:deviceId@ using the local @DeviceDetails@ with the push details as body. When the registration validation request is complete, a @RegistrationSynced@ or @SyncRegistrationFailed@ event should be fired.
@@ -1015,7 +1015,7 @@ h3(#activation-state-machine). Activation State Machine
 **** @(RSH3d3c)@ Either way, when the registration is done, a @RegistrationSynced@ or @SyncRegistrationFailed@ event should be fired.
 **** @(RSH3d3d)@ Transitions to @WaitingForRegistrationSync@.
 ** @(RSH3e)@ State @WaitingForRegistrationSync@:
-*** @(RSH3e1)@ On event @CalledActivate@:
+*** @(RSH3e1)@ On event @CalledActivate@, only if the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event:
 **** @(RSH3e1a)@ Makes @Push#activate@ return or call its callback with no error.
 **** @(RSH3e1b)@ Transitions to @WaitingForRegistrationSync@.
 *** @(RSH3e2)@ On event @RegistrationSynced@:


### PR DESCRIPTION
From https://github.com/ably/ably-java/commit/257a6c1e481c572de3d365e3c40c29a7d17632ca:

> This isn't in the spec (yet). The previous behavior causes the
activation callback to be called right away with no error, while a
previous activation is ongoing. The correct behavior is to serialize
the calls, so that the second call is processed after the first has
finished.

> At the same time, remove the CalledActivate enqueue from
NotActivated, which relied on the old behavior but wasn't doing
anything really useful. (This needs to be removed from the spec
too.)

So, this:

```js
rest.push.activate((err) => {
    console.log('First:', err);
});

// Push is now syncing the existing registration.

rest.push.activate((err) => {
    console.log('Second:', err);
});

// Syncing finishes.
```

Before,

```
Second: null  # This gets printed right when the second activate is called
First: <maybe an error>
```

After:

```
First: <maybe an error>
Second: <immediate null if first activate succeeded, otherwise retries and maybe another error>
```