### PR TITLE
Capabilities docs: fix description of channel-metadata capability

### DIFF
--- a/content/partials/core-features/_authentication_capabilities.textile
+++ b/content/partials/core-features/_authentication_capabilities.textile
@@ -7,6 +7,8 @@ The following capability operations are available for API keys and issued tokens
 - stats := can retrieve current and historical usage statistics for an app
 - push-subscribe := can subscribe devices for push notifications
 - push-admin := can manage device registrations and push subscriptions for all devices in an app
-- channel-metadata := can subscribe to metachannels, such as @[meta]channel.lifecycle@
+- channel-metadata := can get metadata for a channel, and enumerate channels
 
 See a working "capabilities example":<%= JsBins.url_for('authentication/capabilities') %>, read "understanding capabilities and token security":/core-features/authentication#capabilities-explained above to get a more thorough overview of how capabilities can be used to secure your application along with working examples.
+
+While most of these capabilities need to be enabled for the resource you're using them with, as described in "resource names and wildcards":/core-features/authentication#wildcards above, there are exceptions. The @stats@ permission only does anything when attached to the wildcard resource @'*'@ (or a resource that contains that as a subset, such as @'[*]*'@), since stats are app-wide. The @channel-metadata@ permission works both ways. When associated with a specific channel or set of channels it allows you to use the "Channel Status API":/rest/channel-status#channel-status to request the status of that channel. When associated with the wilcard resource @'*'@ it takes on an additional meaning: as well as allowing channel status requests for all channels, it also allows you to "enumerate all active channels":/rest/channel-status#enumeration-rest

--- a/content/partials/shared/_channel_enumeration.textile
+++ b/content/partials/shared/_channel_enumeration.textile
@@ -13,7 +13,7 @@ The following parameters are supported:
 - prefix := optionally limits the query to only those channels whose name starts with the given prefix<br>__Type: @string@__
 - by := _value_ optionally specifies whether to return just channel names (@by=id@) or "ChannelDetails":realtime/channel-metadata#channel-details (@by=value@)
 
-The credentials presented with the request must include the @channel-metadata@ permission for the wildcard resource ('@*@') or, if a @prefix@ is specified, for a resource that matches the @prefix@.
+The credentials presented with the request must include the @channel-metadata@ permission for the wildcard resource @'*'@.
 
 Client libraries currently do not provide a dedicated API to enumerate channels, but make this available using the "request":/rest/usage#request method. When using this, you can simply iterate through the "PaginatedResults":rest/types#paginated-result to enumerate through the results.
 


### PR DESCRIPTION
It's nothing to do with subscribing to metachannels (if you want to subscribe to [meta]channel.lifecycle, you need the 'subscribe' capability for [meta]channel.lifecycle, as with any other channel). The channel-metadata capability is just about the channel status and channel enumeration apis. (The actual channel metadata docs get this right).

And add a paragraph of explanation about the different ways some of the capabilities work, as I'm not sure it's obvious to new users.

Also fixed a statement about permissions for channel enumeration wrt prefixes that I think we intended to implement but never got around to it.