### PR TITLE
Rename integration branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When proposing a spec change, changes that you would be happy to have
 incorporated into the current version of client libraries should be made
 against `master`. Changes that should not be incorporated until the next
 minor or major version should be made against the corresponding
-`master-<major>-<minor>` branch, e.g. `master-2-0` (which ideally should
+`integration/<major>.<minor>` branch, e.g. `integration/1.2` (which ideally should
 be regularly rebased on top of `master`).
 
 When a new minor or major version of the spec is released, it is tagged

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ minor or major version should be made against the corresponding
 be regularly rebased on top of `master`).
 
 When a new minor or major version of the spec is released, it is tagged
-with a tag such as `v1.1`. Conformance to the spec at that tag is what
+with a tag such as `v1.2`. Conformance to the spec at that tag is what
 defines whether a library can be released with the a library version
 with that major/minor version.
 


### PR DESCRIPTION
Use `integration/1.2`, not `master-1-2`, for our 1.2 staging branch.