### PR TITLE
Client libs spec: Optional Rest.stats.start/end.

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -69,7 +69,7 @@ h3(#restclient). RestClient
 * @(RSC6)@ @RestClient#stats@ function:
 ** @(RSC6a)@ Returns a @PaginatedResult@ page containing @Stats@ objects in the @PaginatedResult#items@ attribute returned from the stats request
 ** @(RSC6b)@ Supports the following params:
-*** @(RSC6b1)@ @start@ and @end@ are timestamp fields represented as milliseconds since epoch, or where suitable to the language, Date or Time objects. @start@ must be equal to or less than @end@ and is unaffected by the request direction
+*** @(RSC6b1)@ @start@ and @end@ are optional timestamp fields represented as milliseconds since epoch, or where suitable to the language, Date or Time objects. @start@, if provided, must be equal to or less than @end@ if provided or to the current time otherwise, and is unaffected by the request direction
 *** @(RSC6b2)@ @direction@ backwards or forwards; if omitted the direction defaults to the REST API default (backwards)
 *** @(RSC6b3)@ @limit@ supports up to 1,000 items; if omitted the limit defaults to the REST API default (100)
 *** @(RSC6b4)@ @unit@ is the period for which the stats will be aggregated by, values supported are @minute@, @hour@, @day@ or @month@; if omitted the unit defaults to the REST API default (@minute@)
@@ -1434,7 +1434,7 @@ class Rest:
     Dict<String, String> headers
   ) => io HttpPaginatedResponse // RSC19
   stats(
-    start: Time, // RSC6b1
+    start: Time api-default epoch(), // RSC6b1
     end: Time api-default now(), // RSC6b1
     direction: .Backwards | .Forwards api-default .Backwards, // RSC6b2
     limit: int api-default 100, // RSC6b3


### PR DESCRIPTION
They have defaults in the API, so it shouldn't be mandatory to provide them in the libraries.

`end` was already marked as `api-default` which implicitly makes it optional, but only in the IDL.