### PR TITLE
Updated client lib spec to v1.2

### DIFF
--- a/content/client-lib-development-guide/versions/features-1-1__1-2.diff
+++ b/content/client-lib-development-guide/versions/features-1-1__1-2.diff
@@ -1,0 +1,651 @@
+diff --git a/content/client-lib-development-guide/features.textile b/content/client-lib-development-guide/features.textile
+index b5bc397..35c05ec 100644
+--- a/content/client-lib-development-guide/features.textile
++++ b/content/client-lib-development-guide/features.textile
+@@ -13,6 +13,7 @@ jump_to:
+     - Auth#rest-auth
+     - Channels#rest-channels
+     - Channel#rest-channel
++    - Plugins#plugins
+     - Presence#rest-presence
+     - Encryption#rest-encryption
+     - Forwards compatibility#rest-compatibility
+@@ -43,6 +44,8 @@ This document outlines the complete feature set of both the REST and Realtime cl
+
+ We recommend you use the "IDL (Interface Definition Language)":#idl and refer to other existing libraries that adhere to this spec as a reference when reviewing how the API has been implemented.
+
++The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended",  "may", and "optional" (whether lowercased or uppercased) in this document are to be interpreted as described in "RFC 2119":https://tools.ietf.org/html/rfc2119 .
++
+ __Please note we maintain a separate Google Sheet that keeps track of which features are implemented and matching test coverage for each client library. If you intend to work on an Ably client library, please "contact us":https://www.ably.io/contact for access to this Google Sheet as it is useful as a reference and also needs to be kept up to date__
+
+ h2(#test-guidelines). Test guidelines
+@@ -50,7 +53,7 @@ h2(#test-guidelines). Test guidelines
+ * @(G1)@ Every test should be executed using all supported protocols (i.e. JSON and "MessagePack":http://msgpack.org/ if supported).  This includes both sending & receiving data
+ * @(G2)@ All tests by default are run against a special Ably sandbox environment.  This environment allows apps to be provisioned without any authentication that can then be used for client library testing. Bear in mind that all apps created in the sandbox environment are automatically deleted after 60 minutes and have low limits to prevent abuse. Apps are configured by sending a @POST@ request to @https://sandbox-rest.ably.io/apps@ with a JSON body that specifies the keys and their associated capabilities, channel namespace rules and any presence fixture data that is required; see "ably-common test-app-setup.json":https://github.com/ably/ably-common/blob/master/test-resources/test-app-setup.json. Presence fixture data is necessary for the REST library presence tests as there is no way to register presence on a channel in the REST library
+ * @(G3)@ Testing statistics can be tricky due to timing issues and slow test suites as a result of sending requests to generate statistics.  As such, we provide a special stats endpoint in our sandbox environment that allows stats to be injected into our metrics system so that stats tests can make predictable assertions.  To create stats you must send an authenticated @POST@ request to the stats JSON to @https://sandbox-rest.ably.io/stats@ with the stats data you wish to create. See the "Javascript stats fixture":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/rest/stats.test.js#L8-L51 and "setup helper":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/common/modules/testapp_manager.js#L158-L182 as an example
+-* @(G4)@ This spec defines API version 1.1. A client library must identify to Ably the version of the spec it uses in all requests and connections, per the API version per @G4@. The spec it uses is defined as the latest API version for which the library implements all spec items relating to the wire protocol
++* @(G4)@ This spec defines API version 1.2. A client library must identify to Ably the version of the spec it uses in all requests and connections, per "RSC7a":#RSC7a and "RTN2f":#RTN2f. The spec it uses is defined as the latest API version for which the library implements all spec items relating to the wire protocol
+
+ h2(#rest). REST client library
+
+@@ -73,9 +76,10 @@ h3(#restclient). RestClient
+ *** @(RSC6b4)@ @unit@ is the period for which the stats will be aggregated by, values supported are @minute@, @hour@, @day@ or @month@; if omitted the unit defaults to the REST API default (@minute@)
+ * @(RSC16)@ @RestClient#time@ function sends a get request to @rest.ably.io/time@ and returns the server time in milliseconds since epoch or as a Date/Time object where suitable
+ * @(RSC7)@ Sends REST requests over HTTP and HTTPS to the REST endpoint @rest.ably.io@
+-** @(RSC7a)@ The header @X-Ably-Version: 1.0@ must be included in all REST requests to the Ably endpoint
++** @(RSC7a)@ The header @X-Ably-Version: 1.2@ must be included in all REST requests to the Ably endpoint
+ ** @(RSC7b)@ The header @X-Ably-Lib: [lib][.optional variant]?-[version]@ should be included in all REST requests to the Ably endpoint where @[lib]@ is the name of the library such as @js@ for @ably-js@, @[.optional variant]@ is an optional library variant, such as @laravel@ for the @php@ library, which is always delimited with a period such as @php.laravel@, and where @[version]@ is the full client library version using "Semver":http://semver.org/ such as @1.0.2@. For example, the 1.0.0 version of the Javascript library would use the header @X-Ably-Lib: js-1.0.0@
+ *** @(RSC7b1)@ When it is not possible to send the @X-Ably-Lib@ header, such as for @JSONP@ requests, the library version should be sent as a query param such as @lib=js-1.0.0@
++** @(RSC7c)@ If the @addRequestIds@ client option is enabled, every REST request to Ably should include in a @request_id@ query string parameter a random string obtained by url-safe base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. This request ID must remain the same if a request is retried to a fallback host per @RSC15@. Any log messages associated with the request should include the request ID. If the request fails, the request ID must be included in the @ErrorInfo@ returned to the user.
+ * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
+ * @(RSC8)@ Supports two protocols:
+ ** @(RSC8a)@ "MessagePack":http://msgpack.org/ binary protocol (this is the default for environments having a suitable level or support for binary data)
+@@ -87,10 +91,10 @@ h3(#restclient). RestClient
+ * @(RSC13)@ The client library must use the connection and request timeouts specified in the @ClientOptions@, falling back to the defaults described in @ClientOptions@ below
+ * @(RSC15)@ Host Fallback
+ ** @(RSC15b)@ The fallback behavior described below only applies when the default @rest.ably.io@ endpoint is being used and has not been overriden (see "RSC11":#RSC11), @ClientOptions#fallbackHostsUseDefault@ is @true@, or an array of @ClientOptions#fallbackHosts@ is provided. If host fallback is not supported, failing HTTP requests that would have "qualified for a retry against a fallback host (see RSC15d)":#RSC15d, will instead result in an error immediately
+-** @(RSC15e)@ The primary host is by default @rest.ably.io@ (unless overriden in @ClientOptions#environment@ or @ClientOptions#restHost@), which, through DNS, is automatically routed to the client's closest data center. New HTTP requests (except where @RSC15f@ applies and a cached fallback host is in effect) are first attempted against the primary host.
+-** @(RSC15a)@ In the case of an error necessitating use of an alternative host (see "RSC15d":#RSC15d), try fallback hosts (with a matching Host header as this is necessary when fallbacks are proxied through a CDN) in random order, continuing to try further hosts if "qualifying errors":#RSC15d occur, failing when all have been tried or the configured @httpMaxRetryCount@ has been reached (see "TO3l@":#TO3l5). This ensures that a client library is able to work around routing or other problems for the user's closest data center. For example, if a @POST@ request to @rest.ably.io@ fails because the default endpoint is unreachable or unserviceable, then the @POST@ request should be retried again against the fallback hosts in attempt to find an alternate healthy data center to service the request. The five default fallback hosts are @[a-e].ably-realtime.com@. If an array of custom fallback hosts are provided in @ClientOptions#fallbackHosts@, then they will be used instead. If an empty array of fallback hosts is provided, then fallback host functionality is disabled
+-** @(RSC15d)@ Errors that necessitate use of an alternative host include: host unresolvable or unreachable, request timeout, or a response but with an applicable HTTP status code in the range @500 <= code <= 504@. Resending requests that have failed for other failure conditions will not fix the problem and will simply increase the load on other data-centers unnecessarily
+-** @(RSC15f)@ Once/if a given fallback host succeeds, the client should store that successful fallback host for @ClientOptions.fallbackRetryTimeout@. Future HTTP requests during that period should use that host. If during this period a "qualifying errors":#RSC15d occurs on that host, or after @fallbackRetryTimeout@ has expired, it should be un-stored, and the fallback sequence begun again from scratch, starting with the default primary host (@rest.ably.io@ or @ClientOptions#restHost@)
++** @(RSC15e)@ The primary host is by default @rest.ably.io@ (unless overriden in @ClientOptions#environment@ or @ClientOptions#restHost@), which, through DNS, is automatically routed to the client's closest datacenter. New HTTP requests (except where @RSC15f@ applies and a cached fallback host is in effect) are first attempted against the primary host.
++** @(RSC15a)@ In the case of an error necessitating use of an alternative host (see "RSC15d":#RSC15d), try fallback hosts (with a matching Host header as this is necessary when fallbacks are proxied through a CDN) in random order, continuing to try further hosts if "qualifying errors":#RSC15d occur, failing when all have been tried or the configured @httpMaxRetryCount@ has been reached (see "TO3l@":#TO3l5). This ensures that a client library is able to work around routing or other problems for the user's closest datacenter. For example, if a @POST@ request to @rest.ably.io@ fails because the default endpoint is unreachable or unserviceable, then the @POST@ request should be retried again against the fallback hosts in attempt to find an alternate healthy datacenter to service the request. The five default fallback hosts are @[a-e].ably-realtime.com@. If an array of custom fallback hosts are provided in @ClientOptions#fallbackHosts@, then they will be used instead. If an empty array of fallback hosts is provided, then fallback host functionality is disabled
++** @(RSC15d)@ Errors that necessitate use of an alternative host include: host unresolvable or unreachable, request timeout, or a response but with an applicable HTTP status code in the range @500 <= code <= 504@. Resending requests that have failed for other failure conditions will not fix the problem and will simply increase the load on other datacenters unnecessarily
++** @(RSC15f)@ Once/if a given fallback host succeeds, the client should store that successful fallback host for @ClientOptions.fallbackRetryTimeout@. Future HTTP requests during that period should use that host. If during this period a "qualifying errors":#RSC15d occurs on that host, or after @fallbackRetryTimeout@ has expired, it should be un-stored, and the fallback sequence begun again from scratch, starting with the default primary host (@rest.ably.io@ or @ClientOptions#restHost@) or, in the case of an existing fallback realtime connection as per (RTN17e), with the current fallback realtime host.
+ * @(RSC17)@ When instancing the library, if a @clientId@ attribute is set in @ClientOptions@, then the @Auth#clientId@ attribute will contain the provided @clientId@
+ * @(RSC19)@ @RestClient#request@ function is provided as a convenience for customers who wish to use bleeding edge REST API functionality that is either not documented or is not included in the API for our client libraries. The REST client library provides a function to issue HTTP requests to the Ably endpoints with all the built in functionality of the library such as authentication, paging, fallback hosts, MsgPack and JSON support etc. The function:
+ ** @(RSC19a)@ Method signature is @request(string method, string path, Dict<String, String> params?, JsonObject | JsonArray body?, Dict<String, String> headers?) -> HttpPaginatedResponse@ with arguments: @method@ is a valid "HTTP verb":https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html (must support @"GET"@, @"POST"@, and @"PUT"@, should support @"PATCH"@ and @"DELETE", may support others); @path@ is the path component of the URL such as @"/channels"@; @params@ and @headers@ are optional arguments containing pairs of key value strings (multi-valued headers are not supported) that will result in query params and HTTP headers being added respectively in the request (the argument types can be idiomatic for the language such as @Object@ in the case of Javascript); @body@ is an optional @JsonObject@ or @JsonArray@ like object argument that can be easily serialized to MsgPack or JSON
+@@ -122,8 +126,9 @@ h3(#rest-auth). Auth
+ ** @(RSA4a)@ When a @token@ or @tokenDetails@ is used to instance the library, and no means to renew the token is provided (either an API key, @authCallback@ or @authUrl@):
+ *** @(RSA4a1)@ At instantiation time, a message at @info@ log level with error code @40171@ should be logged indicating that no means has been provided to renew the supplied token, including an associated url per @TI5@
+ *** @(RSA4a2)@ if the server responds with a token error (401 HTTP status code and an Ably error value @40140 <= code < 40150@), then the client library should indicate an error with error code @40171@, not retry the request and, in the case of the realtime library, transition the connection to the @FAILED@ state
+-** @(RSA4b)@ When the client does have a means to renew the token automatically, and the token has expired or the server has responded with a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@), then the client should automatically make a single attempt to reissue the token and resend the request using the new token. If the token creation failed or the subsequent request with the new token failed due to a token error, then the request should result in an error (in the case of a realtime library, follow @RSA4c@)
+-** @(RSA4c)@ If an attempt by the realtime client library to authenticate is made using the @authUrl@ or @authCallback@, and the request to @authUrl@ fails (unless @RSA4d@ applies), the callback @authCallback@ results in an error (unless "RSA4d":#RSA4 applies), an attempt to exchange a @TokenRequest@ for a @TokenDetails@ results in an error (unless "RSA4d":#RSA4 applies), the provided token is in an invalid format (as defined in "RSA4e":#RSA4e), or the attempt times out after "@realtimeRequestTimeout@":#DF1b, then:
++** @(RSA4b)@ When the client does have a means to renew the token automatically, and the server has responded with a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) or the client library has optionally detected the current token has expired (see "RSA4b1":#RSA4b1), then the client should automatically make a single attempt to reissue the token and resend the request using the new token. If the token creation failed or the subsequent request with the new token failed due to a token error, then the request should result in an error (in the case of a realtime library, follow @RSA4c@)
++*** @(RSA4b1)@ Client libraries can optionally save a round-trip request to the Ably service for expired tokens by detecting when a token has expired when all of the following applies: the current token is a @TokenDetails@ object with an @expires@ attribute; the library has previously queried the time from the Ably service and persisted the local clock offset according to "RSA10k":#RSA10k; the @expires@ time has passed based on the Ably service time and not the local clock (which is not guaranteed to be accurate)
++** @(RSA4c)@ If an attempt by the realtime client library to authenticate is made using the @authUrl@ or @authCallback@, and the request to @authUrl@ fails (unless @RSA4d@ applies), the callback @authCallback@ results in an error (unless "RSA4d":#RSA4d applies), an attempt to exchange a @TokenRequest@ for a @TokenDetails@ results in an error (unless "RSA4d":#RSA4d applies), the provided token is in an invalid format (as defined in "RSA4e":#RSA4e), or the attempt times out after "@realtimeRequestTimeout@":#DF1b, then:
+ *** @(RSA4c1)@An @ErrorInfo@ with @code@ @80019@, @statusCode@ 401, and @cause@ set to the underlying cause should be emitted with the state change if there is one (per @RSA4c2/3@) and set as the connection @errorReason@
+ *** @(RSA4c2)@If the connection is @CONNECTING@, then the connection attempt should be treated as unsuccessful, and as such the connection should transition to the @DISCONNECTED@ or @SUSPENDED@ state as defined in "RTN14":#RTN14 and "RTN15":#RTN15
+ *** @(RSA4c3)@If the connection is @CONNECTED@, then the connection should remain @CONNECTED@
+@@ -193,23 +198,28 @@ h3(#rest-auth). Auth
+ ** @(RSA10h)@ Will use the value from @Auth#clientId@ by default, if not @null@
+ ** @(RSA10i)@ Adheres to all requirements in @RSA8@ relating to @TokenParams@, @authCallback@ and @authUrl@
+ ** @(RSA10l)@ Has an alias method @RestClient#authorise@ and @RealtimeClient#authorise@ that will log a deprecation warning stating that this alias method will be removed in @v1.0@ and the user should instead use @authorize@
++* @(RSA16)@ @Auth#tokenDetails@:
++** @(RSA16a)@ Holds a @TokenDetails@ representing the token currently in use by the library, if any;
++** @(RSA16b)@ If the library is provided with a token without the corresponding @TokenDetails@, then this holds a @TokenDetails@ instance in which only the @token@ attribute is populated with that token string
++** @(RSA16c)@ Is set with the current token (if applicable) on instantiation and each time it is replaced, whether the result of an explicit @Auth#authorize@ operation, or a library-initiated renewal resulting from expiry or a token error response
++** @(RSA16d)@ Is empty if there is no current token, including after a previous token has been determined to be invalid or expired, or if the library is using basic auth
+
+ h3(#rest-channels). Channels
+
+ * @(RSN1)@ @Channels@ is a collection of @Channel@ objects accessible through @Rest#channels@
+ * @(RSN2)@ Methods should exist to check if a channel exists or iterate through the existing channels
+ * @(RSN3)@ @Channels#get@ function:
+-** @(RSN3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be specified when instancing a new @Channel@
++** @(RSN3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
+ ** @(RSN3b)@ If options are provided, the options are set on the @Channel@
+-** @(RSN3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object
++** @(RSN3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object. (Note that this is soft-deprecated and may be removed in a future release, so should not be implemented in new client libraries. The supported way to update a set of @ChannelOptions@ is @Channel#setOptions@)
+ * @(RSN4)@ @Channels#release@ function:
+ ** @(RSN4a)@ Releases the channel resource i.e. it's deleted and can then be garbage collected
+
+ h3(#rest-channel). Channel
+
+ * @(RSL1)@ @Channel#publish@ function:
+-** @(RSL1a)@ Expects either an array of @Message@ objects or a @name@ string and @data@ payload
+-** @(RSL1b)@ When @name@ and @data@ is provided, a single message is published to Ably
++** @(RSL1a)@ Expects either a @Message@ object, an array of @Message@ objects, or a @name@ string and @data@ payload
++** @(RSL1b)@ When @name@ and @data@ (or a @Message@) is provided, a single message is published to Ably
+ ** @(RSL1c)@ When an array of @Message@ objects is provided, a single request is made to Ably
+ ** @(RSL1d)@ Indicates an error if the message was not successfully published to Ably
+ ** @(RSL1e)@ Allows @name@ and/or @data@ to be @null@.  If any of the values are @null@, that property is not sent to Ably, e.g. a payload with a @null@ value for @data@ would be sent as @{"name":"click"}@
+@@ -222,15 +232,17 @@ h3(#rest-channel). Channel
+ *** @(RSL1g2)@ When publishing a @Message@ with the @clientId@ attribute value set to the identified client's @clientId@, Ably will accept the message and publish it. A test should assert that the @clientId@ value is populated for the @Message@ when received
+ *** @(RSL1g3)@ When publishing a @Message@ with a different @clientId@ attribute value to the identified client's @clientId@, the client library should reject the message, and indicate an error. The connection and channel remain available for further operations
+ *** @(RSL1g4)@ When publishing a message with an explicit @clientId@ that is incompatible with the identified client's @clientId@ (either inferred or explicitly configured in the token or @ClientOptions@), the library will reject the message immediately and indicate an error
+-** @(RSL1h)@ Where the library language permits, the @Channel#publish(name, data)@ method should provide an optional argument that allows the @clientId@ value to be specified such as @Channel#publish('event', 'data', { clientId: 'John' })@, and/or the @extras@ field to be specified such as @Channel#publish('event', 'data', { extras: { push: { 'key': 'value' } })@
++** @(RSL1h)@ The @publish(name, data)@ form should not take any additional arguments. If a client library has supported additional arguments to the @(name, data)@ form (e.g. separate arguments for @clientId@ and @extras@, or a single @attributes@ argument) in any 1.x version, it should continue to do so until version 2.0.
+ ** @(RSL1i)@ If the total size of the message or (if publishing an array) messages, calculated per "TO3l8":#TO3l8, exceeds the @maxMessageSize@, then the client library should reject the publish and indicate an error with code 40009
+ ** @(RSL1j)@ When @Message@ objects are provided, any valid @Message@ attribute (that is, an attribute specified in "TM2":#TM2) that is supplied by the caller must be included in the encoded message. (This does not mean it must be included _unaltered_; for example the @data@ and @encoding@ will be subject to processing per "RSL4":#RSL4)
+ ** @(RSL1k)@ Idempotent publishing via REST is supported by populating the @id@ attribute of @Message@ instances passed to @publish()@:
+-*** @(RSL1k1)@ Idempotent publishing via library-generated @Message@ @id@s is supported if @idempotentRestPublishing@ (see "TO3n":#TO3n) is enabled and one or more @Message@ instances are passed to @publish()@ and all @Message@s have an empty @id@ attribute. The library generates a base @id@ string by base64-encoding  a sequence of at least 9 bytes obtained from a source of randomness. Each individual @Message@ in the set of messages to be published is assigned a unique @id@ of the form &lt;base id&gt;:&lt;serial&gt; (where @serial@ is the zero-based index into the set).
+-*** @(RSL1k2)@ Idempotent publishing via client-supplied @Message@ @id@s is supported where a single @Message@ is passed to @publish()@ and it contains a non-empty @id@. The @id@ is preserved on sending the message.
++*** @(RSL1k1)@ Idempotent publishing via library-generated @Message@ @id@ s is supported if @idempotentRestPublishing@ (see "TO3n":#TO3n) is enabled and one or more @Message@ instances are passed to @publish()@ and all @Message@ s have an empty @id@ attribute. The library generates a base @id@ string by base64-encoding  a sequence of at least 9 bytes obtained from a source of randomness. Each individual @Message@ in the set of messages to be published is assigned a unique @id@ of the form &lt;base id&gt;:&lt;serial&gt; (where @serial@ is the zero-based index into the set).
++*** @(RSL1k2)@ Idempotent publishing via client-supplied @Message@ @id@ s is supported where a single @Message@ is passed to @publish()@ and it contains a non-empty @id@. The @id@ is preserved on sending the message.
+ *** @(RSL1k3)@ If more than one @Message@ is passed to @publish()@ and one or more of those messages contains a non-empty @id@ attribute, then all message ids (present or absent) are preserved on sending the batch of messages.
+ *** @(RSL1k4)@ An explicit test for idempotency of publishes with library-generated ids shall exist that simulates an error response to a successful publish of a batch of messages, expects an automatic retry by the library, and verifies that the net outcome is that the batch is published only once.
+ *** @(RSL1k5)@ An explicit test for idempotency of publishes with client-supplied ids shall exist that involves multiple explicit publish requests for a given message and verifies that the net outcome is that the message is published only once.
++** @(RSL1l)@ The @publish(Message)@ and @publish(Message[])@ forms of the method should take an extra @Dict<String, Stringifiable>@ argument. These parameters should be encoded using normal querystring-encoding and sent as part of the query string of the REST publish. (@Stringifiable@ is defined in @RTC1f@)
++*** @(RSL1l1)@ Publish params can be tested by publishing with a @_forceNack=true@ parameter, which will result in the publish being rejected with a @40099@ error code
+ * @(RSL2)@ @Channel#history@ function:
+ ** @(RSL2a)@ Returns a @PaginatedResult@ page containing the first page of messages in the @PaginatedResult#items@ attribute returned from the history request
+ ** @(RSL2b)@ Supports the following params:
+@@ -259,7 +271,14 @@ h3(#rest-channel). Channel
+ ** @(RSL6a)@ All messages received will be decoded automatically based on the @encoding@ field and the payloads will be converted into the format they were originally sent using i.e. binary, string, or JSON
+ *** @(RSL6a1)@ A set of tests must exist to ensure that the client library provides data encoding & decoding interoperability with other client libraries. The tests must use the "set of predefined interoperability message fixtures":https://github.com/ably/ably-common/blob/master/test-resources/messages-encoding.json to 1) publish a raw message to the REST API using the JSON transport and subscribe to the message using Realtime to ensure the @data@ attribute matches the fixture; 2) publish a message using the REST client library and retrieve the raw message using the history REST API using the JSON transport ensuring the @data@ matches the fixture; 3) perform the client library operation using both @JSON@ and @MsgPack@ transports. For reference, see the "Ruby":https://github.com/ably/ably-ruby/pull/94 and "iOS":https://github.com/ably/ably-cocoa/pull/459 implementations
+ *** @(RSL6a2)@ A set of tests must exist to ensure that the client library provides interoperability for the @extras@ field which is a JSON-encodable object (ie a value that represents a JSON @object@ value and supports serialization to and from JSON text). The test, at a minimum, should publish a message with an @extras@ object such as @{"push":[{"title":"Testing"}]}@ and ensure it is received with an equivalent JSON-encodable object
+-** @(RSL6b)@ If, for example, incompatible encryption details are provided or invalid Base64 is detected in the message payload, an error message will be sent to the logger, but the message will still be delivered with last successful decoding and the @encoding@ field. For example, if a message had a decoding of "utf-8/cipher+aes-128-cbc/base64", and the payload was successfully Base64 decoded but the payload could not be encrypted because the @CipherParam@ details were not configured, the message would be delivered with a binary payload and an @encoding@ with the value "utf-8/cipher+aes-128-cbc"
++** @(RSL6b)@ If, for example, incompatible encryption details are provided or invalid Base64 is detected in the message payload, an error message will be sent to the logger, but the message will still be delivered with last successful decoding and the @encoding@ field. For example, if a message had a decoding of "utf-8/cipher+aes-128-cbc/base64", and the payload was successfully Base64 decoded but the payload could not be decrypted because the @CipherParam@ details were not configured, the message would be delivered with a binary payload and an @encoding@ with the value "utf-8/cipher+aes-128-cbc". Additional steps need to be taken if decoding failed on "vcdiff" encoding; see "RTL18":#RTL18
++* @(RSL7)@ @Channel#setOptions@ takes a @ChannelOptions@ object and sets or updates the stored channel options, then indicates success
++
++h3(#plugins). Plugins
++* @(PC1)@ Specific client library features that are not commonly used may be supplied as independent libraries, as plugins, in order to avoid excessively bloating the client library. Although such plugins are packaged as independent libraries, they are still considered logically to be part of the client library code and, as such, may be tightly coupled with the client library implementation. The client library can be assumed to be aware of the plugin specific type and capabilities, and such plugins may by design be coupled to a specific version of the client library.
++* @(PC2)@ No generic plugin interface is specified, and therefore there is no common API exposed by all plugins. However, for type-safety, the opaque interface @Plugin@ should be used in strongly-typed languages as the type of the @ClientOptions.plugins@ collection as per "TO3o":#TO3o.
++* @(PC3)@ A plugin provided with the @PluginType@ enum key value of @vcdiff@ should be capable of decoding "vcdiff"-encoded messages. It must implement the the @VCDiffDecoder@ interface and the client library must be able to use it by casting it to this interface.
++** @(PC3a)@ The base argument of the @VCDiffDecoder.decode@ method should receive the stored base payload of the last message on a channel as specified by "RTL19":#RTL19. If the base payload is a string it should be encoded to binary using UTF-8 before being passed as base argument of the @VCDiffDecoder.decode@ method.
+
+ h3(#rest-presence). Presence
+ * @(RSP1)@ Presence object is associated with a single channel and is accessible through @Channel#presence@
+@@ -340,7 +359,7 @@ h3(#realtime-connection). Connection
+ ** @(RTN2b)@ @echo@ should be @true@ by default; @false@ will prevent messages published by the client being echoed back
+ ** @(RTN2d)@ @clientId@ contains the provided @clientId@ option of @ClientOptions@, unless @clientId@ is @null@
+ ** @(RTN2e)@ Depending on the authentication scheme, either @accessToken@ contains the token string, or @key@ contains the API key
+-** @(RTN2f)@ API version param @v@ should be @1.0@
++** @(RTN2f)@ API version param @v@ should be the API version per "G4":#G4
+ ** @(RTN2g)@ Library and version param @lib@ should include the header value described in "RSC7b":#RSC7b. For example, the 1.0.0 version of the Javascript library would use the param @lib=js-1.0.0@
+ * @(RTN3)@ If connection option @autoConnect@ is true, a connection is initiated immediately; otherwise a connection is only initiated following an explicit call to @connect()@
+ * @(RTN4)@ The @Connection@ implements @EventEmitter@ and emits @ConnectionEvent@ events, where a @ConnectionEvent@ is either a @ConnectionState@ or @UPDATE@, and a @ConnectionState@ is either @INITIALIZED@, @CONNECTING@, @CONNECTED@, @DISCONNECTED@, @SUSPENDED@, @CLOSING@, @CLOSED@, or @FAILED@
+@@ -374,7 +393,7 @@ h3(#realtime-connection). Connection
+ ** @(RTN11a)@ Explicitly connects to the Ably service if not already connected
+ ** @(RTN11b)@ If the state is @CLOSING@, the client should make a new connection with a new transport instance and remove all references to the old one. In particular, it should make sure that, when the @CLOSED@ @ProtocolMessage@ arrives for the old connection, it doesn't affect the new one.
+ ** @(RTN11c)@ If the state is @DISCONNECTED@ or @SUSPENDED@, aborts the retry process described in "RTN14d":#RTN14d and "RTN14e":#RTN14e and immediately tries to reconnect.
+-** @(RTN11d)@ If the state is @FAILED@, transitions all the channels to @INITIALIZED@, sets their @errorReason@ to @null@, and sets the connection's @errorReason@ to @null@.
++** @(RTN11d)@ If the state is @CLOSED@ or @FAILED@, transitions all the channels to @INITIALIZED@ and unsets their @Channel.errorReason@, unsets the @Connection.errorReason@, clears all connection state (including in particular @Connection.recoveryKey@), and resets the @msgSerial@ to @0@
+ * @(RTN12)@ @Connection#close@ function:
+ ** @(RTN12f)@ If the connection state is @CONNECTING@, moves immediately to @CLOSING@. If the connection attempt succeeds, ie. a @CONNECTED@ @ProtocolMessage@ arrives from Ably, then do as specified in "RTN12a":#RTN12a. If it doesn't succeed, move to @CLOSED@.
+ ** @(RTN12a)@ If the connection state is @CONNECTED@, sends a @CLOSE@ @ProtocolMessage@ to the server, transitions the state to @CLOSING@ and waits for a @CLOSED@ @ProtocolMessage@ to be received
+@@ -392,7 +411,7 @@ h3(#realtime-connection). Connection
+ ** @(RTN14b)@ If a connection request fails due to an @ERROR@ @ProtocolMessage@ being received by the client containing a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) and an empty @channel@ attribute, then if the token is renewable, a single attempt to create a new token should be made and a new connection attempt initiated using the newly created token. If the attempt to create a new token fails, or the subsequent connection attempt fails due to another token error, then the connection will transition to the @DISCONNECTED@ state, and the @Connection#errorReason@ should be set. (If no means to renew the token is provided, @RSA4a@ applies)
+ ** @(RTN14g)@ If an @ERROR@ @ProtocolMessage@ with an empty @channel@ attribute is received for any reason other than "RTN14b":#RTN14b, then the connection will transition to the @FAILED@ state and the server will terminate the connection. Additionally the @Connection#errorReason@ must be set with the error from the @ERROR@ @ProtocolMessage@
+ ** @(RTN14c)@ A new connection attempt will fail if not connected within the "default realtime request timeout":#defaults
+-** @(RTN14d)@ If a connection attempt fails for any recoverable reason (i.e. a network failure or timeout such as "RTN14c":#RTN14c other than a token failure "RTN14b":#RTN14b), the @Connection#state@ will transition to @DISCONNECTED@, the @Connection#errorReason@ will be updated, a @ConnectionStateChange@ with the @reason@ will be emitted, and new connection attempts will periodically be made until the maximum time in that state threshold is reached.  The @retryIn@ attribute of the @ConnectionStateChange@ object will contain the time in milliseconds until the next connection attempt. See the @disconnectedRetryTimeout@ of @ClientOptions@ below. Each time a new connection attempt is made the state will transition to @CONNECTING@ and then to @CONNECTED@ if successful, or @DISCONNECTED@ if unsuccessful and the "default @connectionStateTtl@":#defaults has not been exceeded
++** @(RTN14d)@ If a connection attempt fails for any recoverable reason (i.e. a network failure, a timeout such as "RTN14c":#RTN14c, or a disconnected response, other than a token failure "RTN14b":#RTN14b), the @Connection#state@ will transition to @DISCONNECTED@, the @Connection#errorReason@ will be updated, a @ConnectionStateChange@ with the @reason@ will be emitted, and new connection attempts will periodically be made until the maximum time in that state threshold is reached.  The @retryIn@ attribute of the @ConnectionStateChange@ object will contain the time in milliseconds until the next connection attempt. See the @disconnectedRetryTimeout@ of @ClientOptions@ below. Each time a new connection attempt is made the state will transition to @CONNECTING@ and then to @CONNECTED@ if successful, or @DISCONNECTED@ if unsuccessful and the "default @connectionStateTtl@":#defaults has not been exceeded. Fallback hosts are used for new connection attempts in accordance with "RTN17":#RTN17.
+ ** @(RTN14e)@ Once the connection state has been in the @DISCONNECTED@ state for more than the "default @connectionStateTtl@":#defaults, the state will change to @SUSPENDED@ and be emitted with the @reason@, and the @Connection#errorReason@ will be updated. In this state, a new connection attempt will be made periodically as specified within @suspendedRetryTimeout@ of @ClientOptions@
+ ** @(RTN14f)@ The connection will remain in the @SUSPENDED@ state indefinitely, whilst periodically attempting to reestablish a connection
+ * @(RTN15)@ @Connection@ failures once @CONNECTED@:
+@@ -400,7 +419,7 @@ h3(#realtime-connection). Connection
+ *** @(RTN15h1)@ If the @DISCONNECTED@ message contains a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) and the library does not have a means to renew the token, the connection will transition to the @FAILED@ state and the @Connection#errorReason@ will be set
+ *** @(RTN15h2)@ If the @DISCONNECTED@ message contains a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) and the library has the means to renew the token, a single attempt to create a new token should be made and a new connection attempt initiated using the new token. If the token creation fails or the next connection attempt fails due to a token error, the connection will transition to the @DISCONNECTED@ state and the @Connection#errorReason@ will be set.
+ ** @(RTN15i)@ If an @ERROR@ @ProtocolMessage@ is received, this indicates a fatal error in the connection. The server will close the transport immediately after. The client should transition to the @FAILED@ state triggering all attached channels to transition to the @FAILED@ state as well. Additionally the @Connection#errorReason@ should be set with the error received from Ably
+-** @(RTN15a)@ If a @Connection@ transport is disconnected unexpectedly or if a token expires, then the @Connection@ manager will immediately attempt to reconnect and restore the connection state. Connection state recovery is provided by the Ably service and ensures that whilst the client is disconnected, all events are queued and channel state is retained on the Ably servers. When a new connection is made with the correct connection recovery key, the client is able to catch up by receiving the queued @ProtocolMessages@ from Ably.
++** @(RTN15a)@ If a @Connection@ transport is disconnected unexpectedly or because a token has expired, then the @Connection@ manager will immediately attempt to reconnect and restore the connection state. Connection state recovery is provided by the Ably service and ensures that whilst the client is disconnected, all events are queued and channel state is retained on the Ably servers. When a new connection is made with the correct connection recovery key, the client is able to catch up by receiving the queued @ProtocolMessages@ from Ably.
+ ** @(RTN15g)@ Connection state is only maintained server-side for a brief period, given by the @connectionStateTtl@ in the @connectionDetails@, see "CD2f":#CD2f. If a client has been disconnected for longer than the @connectionStateTtl@, it should not attempt to resume. Instead, it should clear the local connection state, and any connection attempts should be made as for a fresh connection
+ *** @(RTN15g1)@ This check should be made before each connection attempt. It is generally not sufficient to merely clear the connection state when moving to @SUSPENDED@ state (though that may be done too), since the device may have been sleeping / suspended, in which case it may have been many hours since it was last actually connected, even though, having been in the @CONNECTED@ state when it was put to sleep, it has only moved out of that state very recently (after waking up and noticing it's no longer connected)
+ *** @(RTN15g2)@ Another consequence of that is that the measure of whether the client been disconnected for too long (for the purpose of this check) cannot just be whether the client left the @CONNECTED@ state more than @connectionStateTtl@ ago. Instead, it should be whether the difference between the current time and the last activity time is greater than the sum of the @connectionStateTtl@ and the @maxIdleInterval@, where the last activity time is the time of the last known actual sign of activity from Ably per "RTN23a":#RTN23a
+@@ -429,14 +448,13 @@ h3(#realtime-connection). Connection
+ ** @(RTN16f)@ The @msgSerial@ component of the @recoveryKey@, unlike the other two components, is not sent to Ably, but rather is used to set the library internal @msgSerial@. (If the recover fails, the counter should be reset to 0 per "RTN15c3":#RTN15c3 )
+ * @(RTN17)@ Host Fallback
+ ** @(RTN17b)@ The fallback behavior described below only applies when the default @realtime.ably.io@ endpoint is being used and has not been overriden (see "RTC1d":#RTC1d and "RTC1e":#RTC1e), @ClientOptions#fallbackHostsUseDefault@ is @true@, or an array of @ClientOptions#fallbackHosts@ is provided.
+-** @(RTN17a)@ By default, every connection attempt is first attempted to the default primary host @realtime.ably.io@ (unless overriden in @ClientOptions#realtimeHost@), which, through DNS, is automatically routed to the client's closest data center. The client library must always prefer the default endpoint (closest data center), even if a previous connection attempt to that endpoint has failed. (That is, @RSC15f@ does not apply)
+-** @(RTN17c)@ In the case of an error necessitating use of an alternative host (see "RTN17d":#RTN17d), the @Connection@ manager should first check if an internet connection is available by issuing a @GET@ request to @https://internet-up.ably-realtime.com/is-the-internet-up.txt@. If the request succeeds and the text "yes" is included in the body, then the client library can assume it has a viable internet connection and should then immediately retry the connection against all fallback hosts to find an alternative healthy data center. The five default fallback hosts are @[a-e].ably-realtime.com@ and should be attempted in random order. The connection requests must include a matching Host header as this is necessary when fallbacks are proxied through a CDN. See "RSC15a":#RSC15a for details on how custom fallback hosts are specified and used
+-** @(RTN17d)@ Errors that necessitate use of an alternative host include: host unresolvable or unreachable, connection timeout, or a response but with an "error body @statusCode@":/rest-api#error-response or HTTP response status code in the range @500 <= code <= 504@. Attempting to reconnect to a fallback host for other failure conditions will not fix the problem and will simply increase the load on other data-centers unnecessarily
+-** @(RTN17e)@ If the realtime client is connected to a fallback host endpoint, then for the duration that the transport is connected to that host, all HTTP requests, such as history or token requests, should be first attempted to the same data center the realtime connection is established with i.e. the same fallback host must be used as the default HTTP request host. If however the HTTP request against that fallback host fails, then the normal fallback host behavior should be followed attempting the request against another fallback host as described in "RSC15":#RSC15
++** @(RTN17a)@ By default, every connection attempt is first attempted to the default primary host @realtime.ably.io@ (unless overriden in @ClientOptions#realtimeHost@), which, through DNS, is automatically routed to the client's closest datacenter. The client library must always prefer the default endpoint (closest datacenter), even if a previous connection attempt to that endpoint has failed. (That is, @RSC15f@ does not apply)
++** @(RTN17c)@ In the case of an error necessitating use of an alternative host (see "RTN17d":#RTN17d), the @Connection@ manager should first check if an internet connection is available by issuing a @GET@ request to @https://internet-up.ably-realtime.com/is-the-internet-up.txt@. If the request succeeds and the text "yes" is included in the body, then the client library can assume it has a viable internet connection and should then immediately retry the connection against all fallback hosts to find an alternative healthy datacenter. The five default fallback hosts are @[a-e].ably-realtime.com@ and should be attempted in random order. The connection requests must include a matching Host header as this is necessary when fallbacks are proxied through a CDN. See "RSC15a":#RSC15a for details on how custom fallback hosts are specified and used
++** @(RTN17d)@ Errors that necessitate use of an alternative host include: host unresolvable or unreachable, connection timeout, or a @DISCONNECTED@ response with an @error.statusCode@ in the range @500 <= code <= 504@ or HTTP response status code in the range @500 <= code <= 504@. Attempting to reconnect to a fallback host for other failure conditions will not fix the problem and will simply increase the load on other data-centers unnecessarily
++** @(RTN17e)@ If the realtime client is connected to a fallback host endpoint, then for the duration that the transport is connected to that host, all HTTP requests, such as history or token requests, should be first attempted to the same datacenter the realtime connection is established with i.e. the same fallback host must be used as the default HTTP request host. If however the HTTP request against that fallback host fails, then the normal fallback host behavior should be followed attempting the request against another fallback host as described in "RSC15":#RSC15
+ * @(RTN19)@ Transport state side effects - when a transport is upgraded or disconnected for any reason:
+ ** @(RTN19a)@ Any @ProtocolMessage@ that is awaiting an @ACK@/@NACK@ on the old transport will not receive the @ACK@/@NACK@ on the new transport. The client library must therefore resend any @ProtocolMessage@ that is awaiting a @ACK@/@NACK@ to Ably in order to receive the expected @ACK@/@NACK@ for that message. The Ably service is responsible for keeping track of messages, ignoring duplicates and responding with suitable @ACK@/@NACK@ messages
+ ** @(RTN19b)@ If there are any pending channels i.e. in the @ATTACHING@ or @DETACHING@ state, the respective @ATTACH@ or @DETACH@ message should be resent to Ably
+-** @(RTN19c)@ If a @SYNC@ is underway, ensure the client library adheres to @RTP3@
+ * @(RTN23)@ Heartbeats
+ ** @(RTN23a)@ If a transport does not receive any indication of activity on a transport for a period greater than the sum of the @maxIdleInterval@ (which will be sent in the @connectionDetails@ of the most recent @CONNECTED@ message received on that transport) and the @realtimeRequestTimeout@, that transport should be disconnected. This requirement is not mandatory; in deciding whether to implement, client library developers should take into account whether the transport in question is susceptible to undetected dropped connections. Any message (or non-message indicator, see @RTN23b@) received counts as an indication of activity and should reset the timer, not merely heartbeat messages. However, it must be received (that is, sent from the server to the client); client-sent data does not count.
+ ** @(RTN23b)@ When initiating a connection, the client may send a @heartbeats@ param in the querystring, with value @true@ or @false@. If the value is true, the server will use Ably protocol messages (for example, a message with a @HEARTBEAT@ action) to satisfy the @maxIdleInterval@ requirement. If it is false or unspecified, the server is permitted to use any transport-level mechanism (for example, "websocket":/concepts/websockets ping frames) to satisfy this. So for example, for "websocket transports":/concepts/websockets, if the client is able to observe websocket pings, then it should send @heartbeats=false@. If not, it should send @heartbeats=true@.
+@@ -447,15 +465,16 @@ h3(#realtime-channels). Channels
+ * @(RTS1)@ @Channels@ is a collection of @Channel@ objects accessible through @Realtime#channels@
+ * @(RTS2)@ Methods should exist to check if a channel exists or iterate through the existing channels
+ * @(RTS3)@ @Channels#get@ function:
+-** @(RTS3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be specified when instancing a new @Channel@
++** @(RTS3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
+ ** @(RTS3b)@ If options are provided, the options are set on the @Channel@ when creating a new @Channel@
+-** @(RTS3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object
++** @(RTS3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object. (Note that this is soft-deprecated and may be removed in a future release, so should not be implemented in new client libraries. The supported way to update a set of @ChannelOptions@ is @Channel#setOptions@)
++*** @(RTS3c1)@ If a new set of @ChannelOptions@ is supplied to @Channels#get@ that would trigger a reattachment of the channel if supplied to @Channel#setOptions@ per "@RTL16a@":#RTL16a, it must raise an error, informing the user that they must use @Channel#setOptions@ instead
+ * @(RTS4)@ @Channels#release@ function:
+ ** @(RTS4a)@ Detaches the channel and then releases the channel resource i.e. it's deleted and can then be garbage collected
+
+ h3(#realtime-channel). Channel
+
+-* @(RTL1)@ As soon as a @Channel@ becomes attached, all incoming messages and presence messages are processed and emitted where applicable. @PRESENCE@ and @SYNC@ messages are passed to the @Presence@ object ensuring it maintains a map of current members on a channel in realtime
++* @(RTL1)@ As soon as a @Channel@ becomes attached, all incoming messages and presence messages (where 'incoming' is defined as 'received from Ably over the realtime transport') are processed and emitted where applicable. @PRESENCE@ and @SYNC@ messages are passed to the @Presence@ object ensuring it maintains a map of current members on a channel in realtime
+ * @(RTL2)@ The @Channel@ implements @EventEmitter@ and emits @ChannelEvent@ events, where a @ChannelEvent@ is either a @ChannelState@ or @UPDATE@, and a @ChannelState@ is either @INITIALIZED@, @ATTACHING@, @ATTACHED@, @DETACHING@, @DETACHED@, @SUSPENDED@ and @FAILED@
+ ** @(RTL2a)@ It emits a @ChannelState@ @ChannelEvent@ for every channel state change
+ ** @(RTL2g)@ It emits an @UPDATE@ @ChannelEvent@ for changes to channel conditions for which the @ChannelState@ (e.g. @ATTACHED@) does not change. (The library must never emit a @ChannelState@ @ChannelEvent@ for a state equal to the previous state)
+@@ -481,6 +500,13 @@ h3(#realtime-channel). Channel
+ ** @(RTL4f)@ Once an @ATTACH@ @ProtocolMessage@ is sent, if an @ATTACHED@ @ProtocolMessage@ is not received within the "default realtime request timeout":#defaults, the attach request should be treated as though it has failed and the channel should transition to the @SUSPENDED@ state. The channel will then be subsequently automatically re-attached as described in "RTL13":#RTL13
+ ** @(RTL4d)@ If the language permits, a callback can be provided that is called when the channel is attached successfully or the attach fails and the @ErrorInfo@ error is passed as an argument to the callback
+ ** @(RTL4e)@ If the user does not have sufficient permissions to attach to the channel, the channel will transition to @FAILED@ and set the @Channel#errorReason@
++** @(RTL4j)@ If the attach is not a clean attach (defined in @RTL4j1@), for example an automatic reattach triggered by "@RTN15c3@":#RTN15c3 or "@RTL13a@":#RTL13a (non-exhaustive), the library should set the "@ATTACH_RESUME@":#TR3f flag in the @ATTACH@ message
++*** @(RTL4j1)@ A 'clean attach' is an attach attempt where the channel has either not previously been attached or has been explicitly detached since the last time it was attached. Note that this is not purely a function of the immediate previous channel state. An example implementation would be to set the flag from an @attachResume@ private boolean variable on the channel, that starts out set to @false@, is set to @true@ when the channel moves to the @ATTACHED@ state, and set to @false@ when the channel moves to the @DETACHING@ or @FAILED@ states.
++*** @(RTL4j2)@ The client library can test that the flag is being correctly encoded (and that @RTL4k@ channel params are correctly included) by publishing a message on a channel, then having another two clients attach to that channel both specifying a @rewind@ channel param of @"1"@, one of which has the @ATTACH_RESUME@ flag forcibly set, other doesn't. The client without the flag set should receive the previously-published message once the attach succeeds; the one with that flag set should not
++** @(RTL4k)@ If the user has specified a non-empty @params@ object in the @ChannelOptions@ ("@TB2c@":#TB2c), it must be included in a @params@ field of the @ATTACH@ @ProtocolMessage@
++*** @(RTL4k1)@ If any channel parameters are requested (which may be through the @params@ field of the @ATTACH@ message or some other way opaque to the client library), the @ATTACHED@ (and any subsequent @ATTACHED@ s) will include a @params@ property (also a @Dict<String, String>@) containing the subset of those params that the server has recognised and validated. This should be exposed as a read-only @params@ field of the @Channel@ (or a @getParams()@ method where that is more idiomatic). An @ATTACHED@ message with no @params@ property must be treated as equivalent to a @params@ of @{}@ (that is, @Channel.params@ should be set to the empty dict)
++** @(RTL4l)@ If the user has specified a @modes@ array in the @ChannelOptions@ ("@TB2d@":#TB2d), it must be encoded as a bitfield per "@TR3@":#TR3 and set as the @flags@ field of the @ATTACH@ @ProtocolMessage@. (For the avoidance of doubt, when multiple different spec items require flags to be set in the @ATTACH@, the final @flags@ field should be the bitwise OR of them all)
++** @(RTL4m)@ On receipt of an @ATTACHED@, the client library should decode the @flags@ into an array of @ChannelMode@ s (that is, the same format as @ChannelOptions.modes@) and expose it as a read-only @modes@ field of the @Channel@ (or a @getModes()@ method where that is more idiomatic). This should only contain @ChannelMode@ s: it should not contain flags which are not modes (see "@TB2d@":#TB2d)
+ * @(RTL5)@ @Channel#detach@ function:
+ ** @(RTL5a)@ If the channel state is @INITIALIZED@ or @DETACHED@ nothing is done
+ ** @(RTL5i)@ If the channel is in a pending state @DETACHING@ or @ATTACHING@, do the detach operation after the completion of the pending request
+@@ -493,10 +519,10 @@ h3(#realtime-channel). Channel
+ ** @(RTL5e)@ If the language permits, a callback can be provided that is called when the channel is detached successfully or the detach fails and the @ErrorInfo@ error is passed as an argument to the callback
+ * @(RTL6)@ @Channel#publish@ function:
+ ** @(RTL6a)@ Messages are encoded in the same way as the REST @Channel#publish@ method, and "RSL1g":#RSL1g (size limit) applies similarly
+-*** @(RTL6a1)@ "RSL1k":#RSL1k (@idempotentRestPublishing@ option) and "RSL1j1":#RSL1j1 (idempotent publishing test) do not apply to realtime publishes
++*** @(RTL6a1)@ "RSL1k":#RSL1k (@idempotentRestPublishing@ option), "RSL1j1":#RSL1j1 (idempotent publishing test), and "RSL1l":#RSL1l (@publish(Message, params)@ form) do not apply to realtime publishes
+ ** @(RTL6b)@ An optional callback can be provided to the @#publish@ method that is called when the message is successfully delivered or upon failure with the appropriate @ErrorInfo@ error. A test should exist to publish lots of messages on a few connections to ensure all message success callbacks are called for all messages published
+-** @(RTL6i)@ Expects either an array of @Message@ objects or a @name@ string and @data@ payload:
+-*** @(RTL6i1)@ When @name@ and @data@ is provided, a single @ProtocolMessage@ containing one @Message@ is published to Ably
++** @(RTL6i)@ Expects either a @Message@ object, an array of @Message@ objects, or a @name@ string and @data@ payload:
++*** @(RTL6i1)@ When @name@ and @data@ (or a @Message@) is provided, a single @ProtocolMessage@ containing one @Message@ is published to Ably
+ *** @(RTL6i2)@ When an array of @Message@ objects is provided, a single @ProtocolMessage@ is used to publish all @Message@ objects in the array.
+ *** @(RTL6i3)@ Allows @name@ and or @data@ to be @null@.  If any of the values are @null@, then key is not sent to Ably i.e. a payload with a @null@ value for @data@ would be sent as follows @{ "name": "click" }@
+ ** @(RTL6c)@ Connection and channel state conditions:
+@@ -504,13 +530,14 @@ h3(#realtime-channel). Channel
+ *** @(RTL6c2)@ If the connection is @INITIALIZED@, @CONNECTING@ or @DISCONNECTED@, and @ClientOptions#queueMessages@ has not been explicitly set to false, then the message will be queued and delivered as soon as the connection is @CONNECTED@ and the channel is in a state in which publishing is permitted per @RTL6c1@
+ *** @(RTL6c4)@ If the connection is @SUSPENDED@, @CLOSING@, @CLOSED@, or @FAILED@, or the channel is @SUSPENDED@ or @FAILED@, the operation will result in an error
+ *** @(RTL6c5)@ A publish should not trigger an implicit attach (in contrast to earlier version of this spec)
+-** @(RTL6d)@ Messages that have been queued may be sent in a single @ProtocolMessage@ by bundling them into the @ProtocolMessage#messages@ or @ProtocolMessage#presence@ array, subject to the following constraints:
++** @(RTL6d)@ The protocol permits @Message@ s that have been queued to be sent in a single @ProtocolMessage@ , by bundling them into the @ProtocolMessage#messages@ or @ProtocolMessage#presence@ array. In general, the client library SHOULD NOT do this. If it does, it MUST conform to all of the following constraints:
+ *** @(RTL6d1)@ The resulting @ProtocolMessage@ must not exceed the @maxMessageSize@
+ *** @(RTL6d2)@ Messages can only be bundled together if they have the same @clientId@ value (or both have no @clientId@ set). (Note that this constraint only applies to what the client library can autonomously do as part of queuing messages, not to what the user can do by publishing an array of @Messages@. It exists because if any @Message@ in a @ProtocolMessage@ has an invalid @clientId@, the entire @ProtocolMessage@ is rejected. This is fine if the user has deliberately published the @Messages@ together – they requested atomicity – but not if the client library has bundled them without the user's knowledge)
+ *** @(RTL6d3)@ Messages can only be bundled together if they are for the same @channel@
+ *** @(RTL6d4)@ Messages can only be bundled together if they are of the same type (that is, @Message@ versus @PresenceMessage@)
+ *** @(RTL6d5)@ Only contiguous messages in the queue can be bundled together. For example, if the user publishes three messages, A, B, and C, of which A and C could be bundled together under @RTL6d1-4@ but B could not, then no bundling should occur
+ *** @(RTL6d6)@ The order of messages in the resulting @ProtocolMessage@ Messages must match the publish order. For example, if the user publishes @Message@ D, then the @Message@ array [E, F], then @Message@ G, the final @messages@ array should be [D, E, F, G]
++*** @(RTL6d7)@ Messages must not be bundled if any have had had their @Message.id@ property set
+ ** @(RTL6e)@ Unidentified clients using "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication (i.e. any @clientId@ is permitted as no @clientId@ specified):
+ *** @(RTL6e1)@ When a @Message@ with a @clientId@ value is published, Ably will accept and publish that message with the provided @clientId@. A test should assert that the @clientId@ of the published @Message@ is populated
+ ** @(RTL6g)@ Identified clients with a @clientId@ (as a result of either an explicitly configured @clientId@ in @ClientOptions@, or implicitly through Token Auth):
+@@ -520,7 +547,7 @@ h3(#realtime-channel). Channel
+ *** @(RTL6g2)@ When publishing a @Message@ with the @clientId@ attribute value set to the identified client's @clientId@, Ably will accept the message and publish it. A test should assert that the @clientId@ value is populated for the @Message@ when received
+ *** @(RTL6g3)@ When publishing a @Message@ with a different @clientId@ attribute value from the identified client's @clientId@, the client library should reject that publish operation immediately. The message should not be sent to Ably and it should result in an error, typically in the form of an error callback. The connection and channel must remain available for further operations
+ *** @(RTL6g4)@ When using Token Auth, unless a @clientId@ has been provided in @ClientOptions@ or inferred following authentication, the client library is unidentified and will not be constrained when publishing messages with any explicit @clientId@. If a @Message@ with a @clientId@ value is published before the @clientId@ is configured or inferred following authentication, the client library should not reject any explicit @clientId@ specified in a message. A test should instance a library without an explicit @clientId@ and an @authCallback@ that returns a @tokenDetails@ object with a @clientId@, then publish a message with the same @clientId@ before authentication, and ensure that the message is published following authentication and received back with the @clientId@ intact. A further test should follow the same sequence of events, but should instead use an incompatible @clientId@ in the message, expecting that the message is rejected by the Ably service and the message error should contain the server error message, and the connection and channel should remain available for further operations
+-** @(RTL6h)@ Where the library language permits, the @Channel#publish(name, data)@ method should provide an optional argument that allows the @clientId@ value to be specified such as @Channel#publish('event', 'data', { clientId: 'John' })@, and/or the @extras@ field to be specified such as @Channel#publish('event', 'data', { extras: { push: { 'key': 'value' } })@
++** @(RTL6h)@ The @publish(name, data)@ form should not take any arguments other than those two. If a client library has supported additional arguments to the @(name, data)@ form (e.g. separate arguments for @clientId@ and @extras@, or a single @attributes@ argument) in any 1.x version, it should continue to do so until version 2.0.
+ ** @(RTL6f)@ @Message#connectionId@ should match the current @Connection#id@ for all published messages, a test should exist to ensure the @connectionId@ for received messages matches that of the publisher
+ * @(RTL7)@ @Channel#subscribe@ function:
+ ** @(RTL7a)@ Subscribe with no arguments subscribes a listener to all messages
+@@ -547,6 +574,19 @@ h3(#realtime-channel). Channel
+ ** @(RTL13b)@ If the attempt to re-attach fails, or if the channel was already in the @ATTACHING@ state, the channel will transition to the @SUSPENDED@ state and the error will be emitted in the @ChannelStateChange@ event. An attempt to re-attach the channel automatically will then be made after the period defined in @ClientOptions#channelRetryTimeout@. When re-attaching the channel, the channel will transition to the @ATTACHING@ state. If that request to attach fails i.e. it times out or a @DETACHED@ message is received, then the process described here in @RTL13b@ will be repeated, indefinitely
+ ** @(RTL13c)@ If the connection is no longer @CONNECTED@, then the automatic attempts to re-attach the channel described in "RTL13b":#RTL13b must be cancelled as any implicit channel state changes subsequently will be covered by "RTL3":#RTL3
+ * @(RTL14)@ If an @ERROR ProtocolMessage@ is received for this channel (the channel attribute matches this channel's name), then the channel should immediately transition to the FAILED state, and the @Channel.errorReason@ should be set
++* @(RTL16)@ @Channel#setOptions@ takes a @ChannelOptions@ object and sets or updates the stored channel options.
++** @(RTL16a)@ If the user has provided either @ChannelOptions.params@ or @ChannelOptions.modes@ and the channel is in either the @attached@ or @attaching@ state, @Channel#setOptions@ sends an @ATTACH@ message to the server with the params & modes encoded per "@RTL4@":#RTL4, and indicates success once the server has replied with an @ATTACHED@ (or indicates failure if the channel becomes detached or failed before that happens, as with @Channel#attach@); else it indicates success immediately
++* @(RTL17)@ No messages should be passed to subscribers if the channel is in any state other than @ATTACHED@.
++* @(RTL18)@ Given "vcdiff"-encoded deltas are applied to the previous message published on a channel, when a "vcdiff" encoding fails to be decoded, it makes it impossible for a client to apply subsequent deltas received from that point of failure forward. As such, the client must automatically execute the following recovery procedure in lieu of "RTL7e":#"RTL7e":
++** @(RTL18a)@ Log error with code 40018
++** @(RTL18b)@ Discard the message
++** @(RTL18c)@ Send an @ATTACH@ @ProtocolMessage@ with the @channelSerial@ set to the previous message to the message for which "vcdiff" decoding failed to the server, transitioning the channel state to @ATTACHING@, and waiting for a confirmation @ATTACHED@, as per @RTL4c@ and @RTL4f@. @ChannelStateChange.reason@ should be set to @ErrorInfo@ object with with code 40018.
++* @(RTL19)@ The data payload of the last message on each channel must be stored at all times since it will be needed to decode any subsequent message that has a "vcdiff" encoding step. The stored value is the "base payload" of the most recent message; this is the @data@ member of the message, in string or binary form, once all application-level encoding steps have been applied. The base payload is derived initially by processing a non-delta message; the processing and bookkeeping rules are as follows:
++** @(RTL19a)@ When processing any message (whether a delta or a full message), if the message @encoding@ string ends in @base64@, the message @data@ should be base64-decoded (and the @encoding@ string modified accordingly per "RSL6":#RSL6).
++** @(RTL19b)@ In the case of a non-delta message, the resulting @data@ value is stored as the base payload.
++** @(RTL19c)@ In the case of a delta message with a @vcdiff@ @encoding@ step, the @vcdiff@ decoder must be used to decode the base payload of the of delta message, applying that delta to the stored base payload. The direct result of that vcdiff delta application, before performing any further decoding steps, is stored as the updated base payload.
++* @(RTL20)@ The @id@ of the last received message on each channel must be stored along with the base payload. When processing a delta message (i.e. one whose @encoding@ contains @vcdiff@ step) the stored last message @id@ must be compared against the delta reference @id@, indicated in the @Message.extras.delta.from@ field of the delta message. If the delta reference @id@ of the received delta message does not equal the stored @id@ corresponding to the base payload, the message decoding must fail. The recovery procedure from "RTL18":#RTL18 must be executed.
++* @(RTL21)@ The messages in the @messages@ array of a @ProtocolMessage@ should each be decoded in ascending order of their index in the array.
+
+ h3(#realtime-presence). Presence
+
+@@ -561,25 +601,25 @@ h3(#realtime-presence). Presence
+ ** @(RTP2e)@ If a @SYNC@ is not in progress, then when a presence message with an action of @LEAVE@ arrives,  that @memberKey@ should be deleted from the presence map, if present
+ ** @(RTP2f)@ If a @SYNC@ is in progress, then when a presence message with an action of @LEAVE@ arrives, it should be stored in the presence map with the action set to @ABSENT@. When the @SYNC@ completes, any @ABSENT@ members should be deleted from the presence map. (This is because in a @SYNC@, we might receive a @LEAVE@ before the corresponding @ENTER@).
+ ** @(RTP2g)@ Any incoming presence message that passes the newness check should be emitted on the @Presence@ object, with an event name set to its original action. Note: this action may not be the same one that it will have when stored in the presence map. For example: an incoming presence message with an @ENTER@ action will be emitted as an @enter@ event, and the emitted presence message will have its action set to @ENTER@. However, it will be stored in the presence map with a @PRESENT@ action.
+-* @(RTP3)@ If a @SYNC@ operation is underway but not yet complete, and the transport is disconnected unexpectedly, then if the connection is resumed successfully, it is the responsibility of the client library to complete the @SYNC@ operation. The client library requests a @SYNC@ resume by sending a @SYNC@ @ProtocolMessage@ with the @channelSerial@ set to the same as the @channelSerial@ of the most recently received @SYNC@.
+ * @(RTP18)@ The realtime system reserves the right to initiate a sync of the presence members at any point once a channel is attached. A server initiated sync provides Ably with a means to send a complete list of members present on the channel at any point
+ ** @(RTP18a)@ The client library determines that a new sync has started whenever a @SYNC@ @ProtocolMessage@ is received with a @channel@ attribute and a new sync sequence identifier in the @channelSerial@ attribute. The @channelSerial@ is used as the sync cursor and is a two-part identifier @<sync sequence id>:<cursor value>@. If a new sequence identifier is sent from Ably, then the client library must consider that to be the start of a new sync sequence and any previous in-flight sync should be discarded
+ ** @(RTP18b)@ The sync operation for that sequence identifier has completed once the cursor is empty; that is, when the @channelSerial@ looks like @<sync sequence id>:@
+ ** @(RTP18c)@ a @SYNC@ may also be sent with no @channelSerial@ attribute. In this case, the sync data is entirely contained within that @ProtocolMessage@
+ * @(RTP19)@ If the @PresenceMap@ has existing members when a @SYNC@ is started, the client library must ensure that members no longer present on the channel are removed from the local @PresenceMap@ once the sync is complete. In order to do this, the client library must keep track of any members that have not been added or updated in the @PresenceMap@ during the sync process. Note that a member can be added or updated when received in a @SYNC@ message or when received in a @PRESENCE@ message during the sync process. Once the sync is complete, the members in the @PresenceMap@ that have not been added or updated should be removed from the @PresenceMap@ and a @LEAVE@ event should be published for each. The @PresenceMessage@ published should contain the original attributes of the presence member with the @action@ set to @LEAVE@, @PresenceMessage#id@ set to @null@, and the @timestamp@ set to the current time. This behavior should be tested as follows: @ENTER@ presence on a channel, wait for @SYNC@ to complete, inject a member directly into the local @PresenceMap@ so that it only exists locally and not on the server, send a @SYNC@ message with the @channel@ attribute populated with the current channel which will trigger a server initiated @SYNC@. A @LEAVE@ event should then be published for the injected member, and checking the @PresenceMap@ should reveal that the member was removed and the valid member entered for this connection is still present
+ ** @(RTP19a)@ If the @PresenceMap@ has existing members when an @ATTACHED@ message is received without a @HAS_PRESENCE@ flag, the client library should emit a @LEAVE@ event for each existing member, and the @PresenceMessage@ published should contain the original attributes of the presence member with the @action@ set to @LEAVE@, @PresenceMessage#id@ set to @null@, and the @timestamp@ set to the current time. Once complete, all members in the @PresenceMap@ should be removed as there are no members present on the channel
+-* @(RTP17)@ The Presence object is also responsible for keeping a separate copy of an object logically equivalent to the @PresenceMap@ containing only members that match the current @connectionId@. Any incoming presence message that satisfies @RTP17b@ should be applied to this object in the same way as for the normal @PresenceMap@. This object should be private and is used to maintain a list of members that need to be automatically re-entered by the @Presence@ object when a @Channel@ becomes @ATTACHED@ with some or all continuity lost.
++* @(RTP17)@ The Presence object should also keep a second @PresenceMap@ containing only members that match the current @connectionId@. Any incoming presence message that satisfies @RTP17b@ should be applied to this object in the same way as for the normal @PresenceMap@. This object should be private and is used to maintain a list of members that need to be automatically re-entered by the @Presence@ object when required to by @RTP17c@.
+ ** @(RTP17a)@ All members belonging to the current connection are published as a @PresenceMessage@ on the @Channel@ by the server irrespective of whether the client has permission to subscribe or the @Channel@ is configured to publish presence events. A test should exist that attaches to a @Channel@ with a @presence@ capability and without a @subscribe@ capability. It should then enter the @Channel@ and ensure that the member entered from the current connection is present in the internal and public presence set available via "@Presence#get@":#RTP11
+ ** @(RTP17b)@ The events that should be applied to the @RTP17@ presence map are: any @ENTER@, @PRESENT@ or @UPDATE@ event with a @connectionId@ that matches the current client's @connectionId@; any @LEAVE@ event with a @connectionId@ that matches the current client's @connectionId@ and is not a 'synthesized leave' (an event that has a connectionId which is not an initial substring of its id, per "@RTP2b1@":#RTP2b1 )
++** @(RTP17c)@ The Presence object should perform automatic re-entry in the following situations:
++*** @(RTP17c1)@ After a @SYNC@ operation has completed, per "@RTP18b@":#RTP18b
++*** @(RTP17c2)@ When an @ATTACHED@ message is received with no "@HAS_PRESENCE@":#TR3a flag (so no @SYNC@ is expected as the server does not believe anyone is currently present)
++** @(RTP17d)@ Automatic re-entry consists of, for each member of the @RTP17@ internal @PresenceMap@ whose @memberKey@ is not also a member of the normal @PresenceMap@, publishing a @PresenceMessage@ with an @ENTER@ action using the @clientId@ and @data@ attributes from that member, and removing that member from the internal @PresenceMap@
++** @(RTP17e)@ If the publish attempt fails for an automatic presence @ENTER@ (for example, by Ably rejecting it with a @NACK@), an @UPDATE@ event should be emitted on the channel with @resumed@ set to true and @reason@ set to an @ErrorInfo@ object with @code@ @91004@, a @message@ indicating that an automatic re-enter has failed and indicating the @clientId@, and @cause@ set to the the reason for the enter failure. The error should also be logged at @warn@ level or higher.
+ * @(RTP4)@ Ensure a test exists that enters 250 members using @Presence#enterClient@ on a single connection, and checks for @PRESENT@ events to be emitted on another connection for each member, and once sync is complete, all 250 members should be present in a @Presence#get@ request
+ * @(RTP5)@ Channel state change side effects:
+ ** @(RTP5a)@ If the channel enters the @DETACHED@ or @FAILED@ state then all queued presence messages will fail immediately, and the @PresenceMap@ and "internal PresenceMap (see RTP17)":#RTP17 is cleared. The latter ensures members are not automatically re-entered if the @Channel@ later becomes attached. Since channels in the @DETACHED@ and @FAILED@ states will not receive any presence updates from Ably, presence events (specifically @LEAVE@) should not be emitted when the @PresenceMap@ is cleared as each presence member's state is unknown
+ ** @(RTP5f)@ If the channel enters the @SUSPENDED@ state then all queued presence messages will fail immediately, and the @PresenceMap@ is maintained. This ensures that if the channel later becomes @ATTACHED@, it will only publish presence events for the changes in the @PresenceMap@ that have occurred whilst the client was disconnected. A test should exist for a channel that is in the @SUSPENDED@ state containing presence members to transition to the @ATTACHED@ state, and following the @SYNC@ process after attaching, any members present before and after the sync should not emit presence events, all other changes should be reflected in the @PresenceMap@ and should emit presence events on the channel
+-** @(RTP5b)@ If a channel enters the @ATTACHED@ state then all queued presence messages will be sent immediately and a presence @SYNC@ may be initiated by the Ably service or the Ably service may indicate there is no @SYNC@ necessary
+-** @(RTP5c)@ In addition, when a channel becomes @ATTACHED@, the following must happen in regards to @Presence@:
+-*** @(RTP5c1)@ If the "@resumed@ flag":#TH4 is true and no @SYNC@ is initiated as part of the attach, do nothing as there is no loss of continuity on the channel and no change to presence. The @PresenceMap@ is not affected and no members need to be re-entered
+-*** @(RTP5c2)@ If either a @SYNC@ is initiated as part of the attach and the @SYNC@ is complete, or if the @resumed@ flag is false and a @SYNC@ is not expected, all members not present in the @PresenceMap@ but present in the "internal @PresenceMap@":#RTP17 must be re-entered automatically by the client using the @clientId@ and @data@ attributes from each. The members re-entered automatically must be removed from the "internal @PresenceMap@":#RTP17 ensuring that members present on the channel are constructed from presence events sent from Ably since the channel became @ATTACHED@
+-*** @(RTP5c3)@ If any of the automatic @ENTER@ presence messages published in "RTP5c2":#RTP5c2 fail, then an @UPDATE@ event should be emitted on the channel with @resumed@ set to true and @reason@ set to an @ErrorInfo@ object with error @code@ value @91004@ and the error @message@ string containing the message received from Ably (if applicable), the @code@ received from Ably (if applicable) and the explicit or implicit @client_id@ of the @PresenceMessage@
++** @(RTP5b)@ If a channel enters the @ATTACHED@ state then all queued presence messages will be sent immediately. A presence @SYNC@ may be initiated per "@RTP1@":#RTP1
+ * @(RTP16)@ Connection state conditions:
+ ** @(RTP16a)@ If the connection is @CONNECTED@ and the channel is @ATTACHED@ then all presence messages are published immediately
+ ** @(RTP16b)@ If the connection is @INITIALIZED@, @CONNECTING@ or @DISCONNECTED@ or the channel is @ATTACHING@ or @INITIALIZED@, and @ClientOptions#queueMessages@ has not been explicitly set to false, then all presence messages will be queued and delivered as soon as the connection state returns to @CONNECTED@ and the channel is @ATTACHED@
+@@ -943,9 +983,11 @@ h2(#push-notifications). Push notifications
+ * @(RSH2)@ The following should only apply to platforms that support receiving push notifications:
+ ** @(RSH2a)@ @Push#activate@ sends a @CalledActivate@ event to "the state machine":#RSH3.
+ ** @(RSH2b)@ @Push#deactivate@ sends a @CalledDeactivate@ event to "the state machine":#RSH3.
+-** @(RSH2c)@ Whenever, from the platform's APIs, details for sending push notifications to the local device (e. g. GCM's registration token) is received, a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3.
++** @(RSH2c)@ (Moved to "@(RSH8g)@":#RSH8g ).
++** @(RSH2d)@ (Moved to "@(RSH8h)@":#RSH8h ).
++** @(RSH2e)@ (Moved to "@(RSH8i)@":#RSH8i ).
+
+-h3(#activation-state-machine). Activation state machine
++h3(#activation-state-machine). Activation State Machine
+
+ * @(RSH3)@ In platforms that support receiving push notifications, in order to connect the device's push features with Ably's, the library must perform the process described in the following abstract state machine. While this process should be implemented in whatever way better fits the concrete platform, it should be taken into account that its lifetime is that of the _app_ that runs it, which outlives that of the @Rest@ instance or (typically) the process running the app. This typically forces some kind of on-disk storage to which the state machine's state must be persisted, so that it can be recovered later by new instances and processes running the app triggered by external events.
+ ** @(RSH3a)@ State @NotActivated@ (the initial one).
+@@ -953,12 +995,17 @@ h3(#activation-state-machine). Activation state machine
+ **** @(RSH3a1a)@ Makes @Push#deactivate@ return or call its callback with no error.
+ **** @(RSH3a1b)@ Transitions to @NotActivated@.
+ *** @(RSH3a2)@ On event @CalledActivate@:
+-**** @(RSH3a2a)@ If the local device has @deviceIdentityToken@, enqueues a @CalledActivate@ event and transitions to @WaitingForNewPushDeviceDetails@ and #RSH3a2b onwards don't apply.
++**** @(RSH3a2a)@ If the local device has @deviceIdentityToken@, performs a validation of the local DeviceDetails via the following steps. "@(RSH3a2b)@":#RSH3a2b onwards then don't apply.
++***** @(RSH3a2a1)@ Checks the compatibilty of the present client with the existing registration: if the @LocalDevice@ has a non-empty @clientId@, and the present identified client has a different (non-null) @clientId@, then a @SyncRegistrationFailed@ event should be fired containing an error with @code@ 61002, and skips to "@(RSH3a2a4)@":#RSH3a2a4.
++***** @(RSH3a2a2)@ If a custom @registerCallback@ was provided to @Push#activate@, pass it the local @DeviceDetails@.
++***** @(RSH3a2a3)@ Otherwise, makes an asynchronous HTTP PUT request to @/push/deviceRegistrations/:deviceId@ using the local @DeviceDetails@ with the push details as body. When the registration validation request is complete, a @RegistrationSynced@ or @SyncRegistrationFailed@ event should be fired.
++***** @(RSH3a2a4)@ Transitions to @WaitingForRegistrationSync@.
+ **** @(RSH3a2b)@ If the local device does not have @id@ and @deviceSecret@, both are generated locally. The @id@ must be a "ulid":https://github.com/ulid/spec or similar globally-unique identifier. The @deviceSecret@ must be created using secure random data with sufficient entropy to generate a digest of at least 32 bytes (eg using sha256) and encoding that digest with base64. The local @DeviceDetails@ is updated with the resulting @deviceId@ and @deviceSecret@.
+ **** @(RSH3a2c)@ If the local device has the necessary push details (registration token, etc.), sends a @GotPushDeviceDetails@ event.
+-**** @(RSH3a2d)@ Transitions to @WaitingForPushDeviceDetails@.
++**** @(RSH3a2d)@ If the local device does not have the necessary push details, it initiates a request to the underlying platform (or otherwise generates them)
++**** @(RSH3a2e)@ Transitions to @WaitingForPushDeviceDetails@.
+ *** @(RSH3a3)@ On event @GotPushDeviceDetails@:
+-**** @(RSH3a3a)@ Transitions to @NotActivated@. (This consumes the event; #RSH3a2 produces it again once @Push#activate@ is called.)
++**** @(RSH3a3a)@ Transitions to @NotActivated@. (This consumes the event; "@(RSH3a2)@":#RSH3a2 produces it again once @Push#activate@ is called.)
+ ** @(RSH3b)@ State @WaitingForPushDeviceDetails@:
+ *** @(RSH3b1)@ On event @CalledActivate@:
+ **** @(RSH3b1a)@ Transitions to @WaitingForPushDeviceDetails@.
+@@ -970,6 +1017,9 @@ h3(#activation-state-machine). Activation state machine
+ **** @(RSH3b3b)@ Otherwise, make an asynchronous HTTP @POST@ request to "/push/deviceRegistrations":/rest-api/#post-device-registration using the local @DeviceDetails@ updated with the push details as body.
+ **** @(RSH3b3c)@ Either way, when the registration is done, a @GotDeviceRegistration@ or @GettingDeviceRegistrationFailed@ event should be fired.
+ **** @(RSH3b3d)@ Transitions to @WaitingForDeviceRegistration@.
++*** @(RSH3b4)@ On event @GettingPushDeviceDetailsFailed@:
++**** @(RSH3b4a)@ Makes @Push#activate@ return or call its callback with the error.
++**** @(RSH3b4b)@ Transitions to @NotActivated@.
+ ** @(RSH3c)@ State @WaitingForDeviceRegistration@:
+ *** @(RSH3c1)@ On event @CalledActivate@:
+ **** @(RSH3c1a)@ Transitions to @WaitingForDeviceRegistration@.
+@@ -989,35 +1039,37 @@ h3(#activation-state-machine). Activation state machine
+ **** @(RSH3d2b)@ Otherwise, make an asynchronous DELETE HTTP request to "/push/deviceRegistrations":/rest-api/#delete-device-registration using the local @DeviceDetails@ 's ID. This operation requires "push device authentication":#push-device-authentication.
+ **** @(RSH3d2c)@ Either way, when the registration is done, a @Deregistered@ or @DeregistrationFailed@ event should be fired.
+ **** @(RSH3d2d)@ Transitions to @WaitingForDeregistration@.
+-*** @(RSH3d3)@ On event @GotPushDeviceDetails@ (note that this will only happen on platforms whose push device details, after first set, can change, e. g. GCM's registration token refresh):
++*** @(RSH3d3)@ On event @GotPushDeviceDetails@ (note that this will only happen on platforms whose push device details, after first set, can change, e. g. FCM's registration token refresh):
+ **** @(RSH3d3a)@ If a custom @registerCallback@ was provided to @Push#activate@, pass it the local @DeviceDetails@ updated with the push details.
+ **** @(RSH3d3b)@ Otherwise, make an asynchronous PATCH HTTP request to "/push/deviceRegistrations/:deviceId":/rest-api/#update-device-registration using the local @DeviceDetails@ 's push details as body (but only the changed fields, as described in "the REST endpoint documentation":/rest-api/#update-device-registration). This operation requires "push device authentication":#push-device-authentication.
+-**** @(RSH3d3c)@ Either way, when the registration is done, a @RegistrationUpdated@ or @UpdatingRegistrationFailed@ event should be fired.
+-**** @(RSH3d3d)@ Transitions to @WaitingForRegistrationUpdate@.
+-** @(RSH3e)@ State @WaitingForRegistrationUpdate@:
+-*** @(RSH3e1)@ On event @CalledActivate@:
++**** @(RSH3d3c)@ Either way, when the registration is done, a @RegistrationSynced@ or @SyncRegistrationFailed@ event should be fired.
++**** @(RSH3d3d)@ Transitions to @WaitingForRegistrationSync@.
++** @(RSH3e)@ State @WaitingForRegistrationSync@:
++*** @(RSH3e1)@ On event @CalledActivate@, unless the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event:
+ **** @(RSH3e1a)@ Makes @Push#activate@ return or call its callback with no error.
+-**** @(RSH3e1b)@ Transitions to @WaitingForRegistrationUpdate@.
+-*** @(RSH3e2)@ On event @RegistrationUpdated@:
++**** @(RSH3e1b)@ Transitions to @WaitingForRegistrationSync@.
++*** @(RSH3e2)@ On event @RegistrationSynced@:
++**** @(RSH3e2b)@ If the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event, make @Push#activate@ return or call its callback with no error.
+ **** @(RSH3e2a)@ Transitions to @WaitingForNewPushDeviceDetails@.
+-*** @(RSH3e3)@ On event @UpdatingRegistrationFailed@:
+-**** @(RSH3e3a)@ Calls the @updateFailedCallback@ provided to @Push#activate@ with the error.
+-**** @(RSH3e3b)@ Transitions to @AfterRegistrationUpdateFailed@.
+-** @(RSH3f)@ State @AfterRegistrationUpdateFailed@:
++*** @(RSH3e3)@ On event @SyncRegistrationFailed@:
++**** @(RSH3e3c)@ If the machine is in state @WaitingForRegistrationSync@ as a result of a @CalledActivate@ event, make @Push#activate@ return or call its callback with the error.
++**** @(RSH3e3a)@ Otherwise, calls the @updateFailedCallback@ provided to @Push#activate@ with the error.
++**** @(RSH3e3b)@ Transitions to @AfterRegistrationSyncFailed@.
++** @(RSH3f)@ State @AfterRegistrationSyncFailed@:
+ *** @(RSH3f1)@ On events @CalledActivate@ or @GotPushDeviceDetails@:
+-**** @(RSH3f1a)@ Does the same as "RSH3d3":#RSH3d3.
++**** @(RSH3f1a)@ Does the same as "RSH3a2a":#RSH3a2a.
+ *** @(RSH3f2)@ On events @CalledDeactivate@:
+ **** @(RSH3f2a)@ Does the same as "RSH3d2":#RSH3d2.
+ ** @(RSH3g)@ State @WaitingForDeregistration@:
+ *** @(RSH3g1)@ On event @CalledDeactivate@:
+ **** @(RSH3g1a)@ Transitions to @WaitingForDeregistration@.
+ *** @(RSH3g2)@ On event @Deregistered@:
+-**** @(RSH3g2a)@ Removes the @deviceIdentityToken@ from the local @DeviceDetails@.
++**** @(RSH3g2a)@ Clears all local @DeviceDetails@.
+ **** @(RSH3g2b)@ Makes @Push#deactivate@ return or call its callback with no error.
+ **** @(RSH3g2c)@ Transitions to @NotActivated@.
+ *** @(RSH3g3)@ On event @DeregistrationFailed@:
+ **** @(RSH3g3a)@ Makes @Push#deactivate@ return or call its callback with the error.
+-**** @(RSH3g3b)@ Transitions to the previous state, which is either @WaitingForNewPushDeviceDetails@ or @AfterRegistrationUpdateFailed@ (so, in purity, @WaitingForDeregistration@ are two separate states, one for each previous state).
++**** @(RSH3g3b)@ Transitions to the previous state, which is either @WaitingForNewPushDeviceDetails@ or @AfterRegistrationSyncFailed@ (so, in purity, @WaitingForDeregistration@ are two separate states, one for each previous state).
+ * @(RSH4)@ When an event is fired and a transition from the current state is not defined for such event, the event is put into a queue. Then, whenever a transition happens, an event is dequeued from the queue. If a transition from the new current state is defined for the dequeued event, such transition happens. If not, the event is put back in its place in the queue. E. g. we're @WaitingForDeregistration@, and an event @CalledActivate@ happens. This event will be put in the queue, since there's no transition defined for it. Then, an event @Deregistered@ arrives, causing a transition to @NotActivated@. Now we peek the next item on the queue: @CalledActivate@. Because @NotActivated@ transitions on @CalledActivate@, the event is consumed and the machine transitions.
+ * @(RSH5)@ Event handling is atomic and sequential: while an event is being handled, the next one should be handled only after the current one has caused a state transition or has been put into the pending events queue.
+
+@@ -1046,6 +1098,19 @@ h3(#push-channels). Push channels
+ *** @(RSH7d2)@ Performs a DELETE request to "/push/channelSubscriptions":/rest-api#delete-channel-subscription with the device's @clientId@ and the channel name.
+ ** @(RSH7e)@ @#listSubscriptions(params)@ performs a GET request to "/push/channelSubscriptions":/rest-api#list-channel-subscriptions and returns a paginated result with @PushChannelSubscription@ objects filtered by the provided params, the channel name, the device ID, and the client ID if it exists, as supported by the REST API. A @concatFilters@ param needs to be set to @true@ as well.
+
++h3(#local-device). LocalDevice
++
++* @(RSH8)@ In platforms that support receiving push notifications, the @device@ method on the @Rest@ or @Realtime@ interfaces returns an instance of @LocalDevice@ that represents the current state of the device in respect of it being a target for push notifications.
++** @(RSH8a)@ The @LocalDevice@ is initialised when first required, either as a result of a call to @Rest#device@ or @Realtime#device@, or as a result of an operation involving the Activation State Machine. The @LocalDevice@ @id@, @clientId@, @deviceSecret@ and @deviceIdentityToken@ attributes are populated, together with any @recipient@-related attributes, to the extent that they exist, from the persisted state.
++** @(RSH8b)@ The @LocalDevice@ @id@ and @deviceSecret@ attributes are generated, and persisted as part of the @LocalDevice@ state, when required by step "@(RSH3a2b)@":#RSH3a2b in the Activation State Machine. At that time, the @clientId@ attribute is also initialised, if the client is identified according to "@(RSA7)@":#RSA7.
++** @(RSH8c)@ Following successful registration of a @LocalDevice@, following the procedure in "@(RSH3c2a)@":#RSH3c2a, the now known @deviceIdentityToken@ is set and persisted.
++** @(RSH8d)@ If the @LocalDevice* is created by an unidentified client (see "@(RSA7)@":#RSA7 ) and therefore has no @clientId@ set, but the client subsequently becomes identified (as a result of "@(RSA7b2)@":#RSA7b2 or "@(RSA7b3)@":#RSA7b3 ), then the @LocalDevice@ @clientId@ is set and persisted.
++** @(RSH8e)@ If the @LocalDevice@ @clientId@ becomes set as a result of "@(RSH8d)@":#RSH8d, and the @LocalDevice@ is already registered (ie the @deviceIdentityToken@ is set), and the ActivationStateMachine is in any state other than @NotActivated@, then a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3 once the effects of "@(RSH8d)@":#RSH8d are visible, ie. once @LocalDevice@ @clientId@ is set.
++** @(RSH8f)@ If the @LocalDevice@ is created by an unidentified client (see "@(RSA7)@":#RSA7 ) and therefore has no @clientId@ set, but on receipt of a registration response (see "@(RSH3c2)@":#RSH3c2 ) the registered device has a non-empty @clientId@, then the @LocalDevice@ @clientId@ is set with that @clientId@.
++** @(RSH8g)@ Whenever any change arises of the push transport details for local device (eg an FCM registration token update triggered by the platform), a @GotPushDeviceDetails@ event is sent to "the state machine":#RSH3.
++** @(RSH8h)@ If an attempt to obtain the push transport details for local device (eg an FCM registration token) fails, a @GettingPushDeviceDetailsFailed@ event containing the indicated error is sent to "the state machine":#RSH3.
++** @(RSH8i)@ Each time the library is instanced, if the LocalDevice has push device details (eg an APNS deviceToken), and if the platform supports it, it must verify the validity of those details (eg by requesting a token from the platform and comparing that with the already-known token). If as a result there are updated details, then an update to the Ably server is triggered by sending a @GotPushDeviceDetails@ event to "the state machine":#RSH3.
++
+ h2. Types
+
+ h3(#types). Data types
+@@ -1061,7 +1126,7 @@ h4. Message
+ ** @(TM2g)@ @name@ string
+ ** @(TM2d)@ @data@ string, buffer or JSON-encodable object or array
+ ** @(TM2e)@ @encoding@ string
+-** @(TM2i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The extras field is provided to contain message metadata and/or ancillary payloads in support of specific functionality, e.g. push. Each of these supported extensions is documented separately; for 1.1 the only supported extension is @push@, via the @extras.push@ member. The processing of any other members is undefined
++** @(TM2i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The @extras@ field is provided to contain message metadata and/or ancillary payloads in support of specific functionality, e.g. push. Each of these supported extensions is documented separately; for 1.1 the only supported extension is @push@, via the @extras.push@ member; 1.2 adds the @delta@ extension which is of type @DeltaExtras@. The processing of any other members is undefined
+ ** @(TM2f)@ @timestamp@ time in milliseconds since epoch. If a message received from Ably does not contain a @timestamp@, it should be set to the @timestamp@ of the encapsulating @ProtocolMessage@
+ * @(TM3)@ @fromEncoded@ and @fromEncodedArray@ are alternative constructors that take an (already deserialized) @Message@-like object (or array of such objects), and optionally a @channelOptions@, and return a @Message@ (or array of such @Messages@) that's decoded and decrypted as specified in @RSL6@, using the cipher in the @channelOptions@ if the message is encrypted, with any residual transforms (ones that the library cannot decode or decrypt) left in the @encoding@ property per @RSL6b@. This is intended for users receiving messages other than from a REST or Realtime channel (for example, from a queue), to avoid them having to parse the @encoding@ string themselves.
+
+@@ -1091,6 +1156,7 @@ h4. ProtocolMessage
+ ** @(TR3c)@ 2: @RESUMED@
+ ** @(TR3d)@ 3: @HAS_LOCAL_PRESENCE@
+ ** @(TR3e)@ 4: @TRANSIENT@
++** @(TR3f)@ 5: @ATTACH_RESUME@
+ ** @(TR3q)@ 16: @PRESENCE@
+ ** @(TR3r)@ 17: @PUBLISH@
+ ** @(TR3s)@ 18: @SUBSCRIBE@
+@@ -1106,11 +1172,12 @@ h4. ProtocolMessage
+ ** @(TR4o)@ @connectionDetails@ @ConnectionDetails@ object - provides details on the constraints or defaults for the connection such as max message size, client ID or connection state TTL
+ ** @(TR4g)@ @count@ integer
+ ** @(TR4h)@ @error@ @ErrorInfo@ object
+-** @(TR4i)@ @flags@ integer. Contains one or more of the following bit flags: @HAS_PRESENCE: 1@, @HAS_BACKLOG: 2@, @RESUMED: 4@
++** @(TR4i)@ @flags@ integer. Contains one or more of the bit flags specified in @TR3@
+ ** @(TR4j)@ @msgSerial@ long
+ ** @(TR4k)@ @messages@ Array of @Message@ objects
+ ** @(TR4l)@ @presence@ Array of @PresenceMessage@ objects
+ ** @(TR4m)@ @timestamp@ time in milliseconds since epoch
++** @(TR4q)@ @params@ @Dict<String, String>@ key-value pairs
+
+ h4. PaginatedResult
+
+@@ -1195,7 +1262,7 @@ h4. Stats
+
+ h4. ErrorInfo
+
+-* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@ and @cause@ attributes
++* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@, optional @cause@, optional @href@, and optional @requestId@ (@RSC7c@) attributes
+ * @(TI2)@ Errors returned from the Ably server are compatible with the @ErrorInfo@ structure and should result in errors that inherit from @ErrorInfo@
+ * @(TI3)@ "Ably-common":https://github.com/ably/ably-common should be included as a submodule so that "consistent error codes":https://github.com/ably/ably-common/blob/master/protocol/errors.json can be used
+ * @(TI4)@ Ably may additionally include a @href@ attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
+@@ -1265,7 +1332,7 @@ h4. ClientOptions
+ *** @(TO3j7)@ @authMethod@ - The HTTP verb to be used when a request is made by the library to the @authUrl@. Defaults to @GET@, supports @GET@ and @POST@
+ *** @(TO3j8)@ @authHeaders@ - Headers to be included in any request made by the library to the @authUrl@
+ *** @(TO3j9)@ @authParams@ - Additional params to be included in any request made by the library to the @authUrl@, either as query params added to the URL in the case of @GET@, or form-encoded in the body in the case of @POST@
+-*** @(TO3j10)@ @queryTime@ - If true, the library will query the Ably system for the current time instead of relying on a locally-available time of day
++*** @(TO3j10)@ @queryTime@ - If true, the library will when issuing a token request query the Ably system for the current time instead of relying on a locally-available time of day
+ *** @(TO3j11)@ @defaultTokenParams@ - When a "TokenParams":#token-params object is provided, it will override the client library defaults described in "TokenParams":#token-params
+ ** @(TO3k)@ Development environment attributes:
+ *** @(TO3k1)@ @environment@ string - for development environments only; allows a non-default Ably environment to be used such as @sandbox@
+@@ -1291,6 +1358,8 @@ h4. ClientOptions
+ **** @(TO3l8e)@ The size of a @null@ or omitted property is zero
+ *** @(TO3l9)@ @maxFrameSize@ integer - default 524288 (512KiB). The maximum size of a single POST body or "WebSocket":/concepts/websockets frame. This is mostly only relevant for `Rest#request` (e.g. for batch publishes), since publishes will hit the @maxMessageSize@ limit before this
+ *** @(TO3l10)@ @fallbackRetryTimeout@ integer - default 600000 (10 minutes). (After a failed request to the default endpoint, followed by a successful request to a fallback endpoint), the period in milliseconds before HTTP requests are retried  against the default endpoint
++** @(TO3o)@ @plugins@ @Dict<PluginType:Plugin>@ A map between a @PluginType@ and a @Plugin@ object. The client library might downcast a @Plugin@ to particular plugin type.
++** @(TO3p)@ @addRequestIds@ boolean - defaults to false. If true, @RSC7c@ applies
+
+ h4(#token-params). TokenParams
+ * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorize@, @Auth#requestToken@ and @Auth#createTokenRequest@
+@@ -1311,7 +1380,7 @@ h4. AuthOptions
+ ** @(AO2d)@ @authMethod@ - The HTTP verb to be used when a request is made by the library to the @authUrl@. Defaults to @GET@, supports @GET@ and @POST@
+ ** @(AO2e)@ @authHeaders@ - Headers to be included in any request made by the library to the @authUrl@
+ ** @(AO2f)@ @authParams@ - Additional params to be included in any request made by the library to the @authUrl@, either as query params in the case of @GET@, or form-encoded in the body in the case of @POST@
+-** @(AO2g)@ @queryTime@ - If true, the library will query the Ably system for the current time instead of relying on a locally-available time of day
++** @(AO2g)@ @queryTime@ - If true, the library will when issuing a token request query the Ably system for the current time instead of relying on a locally-available time of day
+
+ h4. ChannelOptions
+ * @(TB1)@ options provided when instancing a channel
+@@ -1319,6 +1388,8 @@ h4. ChannelOptions
+ ** @(TB2b)@ @cipher@, which is either:
+ *** @(TB2b1)@ A @CipherParams@ instance, or
+ *** @(TB2b2)@ an options hash (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@. In this case, the client library should call @getDefaultParams@, passing it the options hash, to obtain a @CipherParams@ instance
++** @(TB2c)@ @params@ (for realtime client libraries only) a @Dict<string,string>@ of key/value pairs
++** @(TB2d)@ @modes@ (for realtime client libraries only) an array of @ChannelMode@ s, where a @ChannelMode@ is a member of an enum containing the names of those children of "@TR3@":#TR3 whose value is ≥16 (or see the IDL below)
+ * @(TB3)@ The client lib may optionally provide an alternative constructor @withCipherKey@ for ChannelOptions that takes a @key@ only. (This must be differentiated from the normal constructor such that it is clear that the value being passed in is a key). (This is intended for languages where requiring a hash map is unidiomatic)
+
+ h4. CipherParams
+@@ -1449,6 +1520,7 @@ class ClientOptions:
+   tlsPort: Int default 443 // TO3k5
+   useBinaryProtocol: Bool default true // TO3f
+   transportParams: [String: Stringifiable]? // RTC1f
++  addRequestIds: Bool default false // TO3p
+   // configurable retry and failure defaults
+   disconnectedRetryTimeout: Duration default 15s // TO3l1
+   suspendedRetryTimeout: Duration default 30s // RTN14d, TO3l2
+@@ -1459,6 +1531,7 @@ class ClientOptions:
+   httpMaxRetryDuration: Duration default 15s // TO3l6
+   maxMessageSize: Int default 65536 // TO3l8
+   maxFrameSize: Int default 524288 // TO3l8
++  plugins: Dict<PluginType, Plugin> // TO3o
+
+ class AuthOptions: // RSA8e
+   authCallback: ((TokenParams) -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b
+@@ -1519,8 +1592,11 @@ class RestChannel:
+     direction: .Backwards | .Forwards api-default .Backwards, // RSL2b2
+     limit: int api-default 100 // RSL2b3
+   ) => io PaginatedResult<Message> // RSL2a
+-  publish([Message]) => io // RSL1
+-  publish(name: String?, data: Data?, clientId?: String, extras?: JsonObject) => io // RSL1, RSL1h
++  publish(Message, params?: Dict<String, Stringifiable>) => io // RSL1
++  publish([Message], params?: Dict<String, Stringifiable>) => io // RSL1
++  publish(name: String?, data: Data?) => io // RSL1
++  setOptions(options: ChannelOptions) => io // RSL7 - note asynchronous return value for
++    // compatibility with RealtimeChannel#setOptions; not required for REST-only libraries
+
+   // Only on platforms that support receiving notifications:
+   push: PushChannel // RSH4
+@@ -1532,6 +1608,8 @@ class RealtimeChannel:
+   presence: RealtimePresence // RTL9
+   properties: ChannelProperties // CP1, RTL15
+   push: PushChannel
++  modes: readonly [ChannelMode] // RTL4m
++  params: readonly Dict<String, String> // RTL4k1
+   attach() => io // RTL4d
+   detach() => io // RTL5e
+   history(
+@@ -1541,19 +1619,21 @@ class RealtimeChannel:
+     limit: int api-default 100, // RTL10a
+     untilAttach: Bool default false // RTL10b
+   ) => io PaginatedResult<Message> // RSL2a
++  publish(Message) => io // RTL6i
+   publish([Message]) => io // RTL6i
+-  publish(name: String?, data: Data?, clientId?: String, extras?: JsonObject) => io // RTL6i, RTL6h
++  publish(name: String?, data: Data?) => io // RTL6i
+   subscribe((Message) ->) => io // RTL7a
+   subscribe(String, (Message) ->) => io // RTL7b
+   unsubscribe() // RTL8a, RTE5
+   unsubscribe((Message) ->) // RTL8a
+   unsubscribe(String, (Message) ->) // RTL8a
++  setOptions(options: ChannelOptions) => io // RTL16
+
+ class PushChannel:
+-  subscribeDevice() => io // RSH4a
+-  subscribeClientId() => io // RSH4b
+-  unsubscribeDevice() => io // RSH4c
+-  unsubscribeClientId() => io // RSH4d
++  subscribeDevice() => io // RSH7a
++  subscribeClient() => io // RSH7b
++  unsubscribeDevice() => io // RSH7c
++  unsubscribeClient() => io // RSH7d
+   listSubscriptions() => io PaginatedResult<PushChannelSubscription> // RSH7e
+
+ enum ChannelState:
+@@ -1569,6 +1649,12 @@ enum ChannelEvent:
+   embeds ChannelState
+   UPDATE // RTL2g
+
++enum ChannelMode: // TB2d
++  PRESENCE
++  PUBLISH
++  SUBSCRIBE
++  PRESENCE_SUBSCRIBE
++
+ class ChannelStateChange:
+   current: ChannelState // RTL2a, RTL2b
+   event: ChannelEvent // TH5
+@@ -1579,6 +1665,8 @@ class ChannelStateChange:
+ class ChannelOptions:
+   +withCipherKey(key: Binary | String)? -> ChannelOptions // TB3
+   cipher: (CipherParams | Params)? // RSL5a, TB2b
++  params?: Dict<String, String> // TB2c
++  modes?: [ChannelMode] // TB2d
+
+ class CipherParams:
+   algorithm: String default "AES" // TZ2a
+@@ -1684,12 +1772,13 @@ class ProtocolMessage:
+   connectionSerial: Int? // RTN10c, TR4f
+   count: Int? // TR4g
+   error: ErrorInfo? // RTN15c2, TR4h
+-  flags: .HAS_PRESENCE & .HAS_BACKLOG & .RESUMED ? // RTP1, TR3, TR4i, RTL2f
++  flags: Int? // TR4i; bitfield containing zero or more boolean flags specified in TR3
+   id: String? // TR4b
+   messages: [Message]? // TR4k
+   msgSerial: Int? // RTN7b, TR4j
+   presence: [PresenceMessage]? // TR4l
+   timestamp: Time? // TR4m
++  params: Dict<String, String>? // TR4q, RTL4k
+
+ enum ProtocolMessageAction:
+   HEARTBEAT // TR2
+@@ -1860,6 +1949,7 @@ class ErrorInfo:
+   message: String // TI1
+   cause: ErrorInfo? // TI1
+   statusCode: Int // TI1
++  requestId: String? // RSC7c
+
+ class EventEmitter<Event, Data>:
+   on((Data...) ->) // RTE4
+@@ -1886,11 +1976,26 @@ class HttpPaginatedResponse // RSC19b
+   errorCode: Int // HP6
+   errorMessage: String // HP7
+   headers: Dict<String, String> // HP8
++
++class Plugin // PC2
++  // Empty class/interface. Plugins are not expected to share any common interface.
++  // An opaque base interface type for plugins is defined for type-safety in statically-typed languages.
++
++enum PluginType
++  "vcdiff"
++
++class VCDiffDecoder
++  decode([byte] delta, [byte] base) -> [byte]
++
++class DeltaExtras
++  from: String // the id of the message the delta was generated from
++  format: String //the delta format. Only vcdiff is supported as at API version 1.2
+ ```
+
+ h2(#old-specs). Old specs
+
+ Use the version navigation to view older versions.  References to diffs for each version are maintained below:
+
++* v1.1 deprecated in Mar 2020. "View 1.1 → 1.2 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-1-1__1-2.diff
+ * v1.0 deprecated in Jan 2019. "View 1.0 → 1.1 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-1-0__1-1.diff
+ * v0.8 deprecated in Jan 2017. "View 0.8 → 1.0 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-0-8__1-0.diff

--- a/content/client-lib-development-guide/versions/v1.1/features.textile
+++ b/content/client-lib-development-guide/versions/v1.1/features.textile
@@ -13,7 +13,6 @@ jump_to:
     - Auth#rest-auth
     - Channels#rest-channels
     - Channel#rest-channel
-    - Plugins#plugins
     - Presence#rest-presence
     - Encryption#rest-encryption
     - Forwards compatibility#rest-compatibility
@@ -53,7 +52,7 @@ h2(#test-guidelines). Test guidelines
 * @(G1)@ Every test should be executed using all supported protocols (i.e. JSON and "MessagePack":http://msgpack.org/ if supported).  This includes both sending & receiving data
 * @(G2)@ All tests by default are run against a special Ably sandbox environment.  This environment allows apps to be provisioned without any authentication that can then be used for client library testing. Bear in mind that all apps created in the sandbox environment are automatically deleted after 60 minutes and have low limits to prevent abuse. Apps are configured by sending a @POST@ request to @https://sandbox-rest.ably.io/apps@ with a JSON body that specifies the keys and their associated capabilities, channel namespace rules and any presence fixture data that is required; see "ably-common test-app-setup.json":https://github.com/ably/ably-common/blob/master/test-resources/test-app-setup.json. Presence fixture data is necessary for the REST library presence tests as there is no way to register presence on a channel in the REST library
 * @(G3)@ Testing statistics can be tricky due to timing issues and slow test suites as a result of sending requests to generate statistics.  As such, we provide a special stats endpoint in our sandbox environment that allows stats to be injected into our metrics system so that stats tests can make predictable assertions.  To create stats you must send an authenticated @POST@ request to the stats JSON to @https://sandbox-rest.ably.io/stats@ with the stats data you wish to create. See the "Javascript stats fixture":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/rest/stats.test.js#L8-L51 and "setup helper":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/common/modules/testapp_manager.js#L158-L182 as an example
-* @(G4)@ This spec defines API version 1.2. A client library must identify to Ably the version of the spec it uses in all requests and connections, per "RSC7a":#RSC7a and "RTN2f":#RTN2f. The spec it uses is defined as the latest API version for which the library implements all spec items relating to the wire protocol
+* @(G4)@ This spec defines API version 1.1. A client library must identify to Ably the version of the spec it uses in all requests and connections, per "RSC7a":#RSC7a and "RTN2f":#RTN2f. The spec it uses is defined as the latest API version for which the library implements all spec items relating to the wire protocol
 
 h2(#rest). REST client library
 
@@ -76,10 +75,9 @@ h3(#restclient). RestClient
 *** @(RSC6b4)@ @unit@ is the period for which the stats will be aggregated by, values supported are @minute@, @hour@, @day@ or @month@; if omitted the unit defaults to the REST API default (@minute@)
 * @(RSC16)@ @RestClient#time@ function sends a get request to @rest.ably.io/time@ and returns the server time in milliseconds since epoch or as a Date/Time object where suitable
 * @(RSC7)@ Sends REST requests over HTTP and HTTPS to the REST endpoint @rest.ably.io@
-** @(RSC7a)@ The header @X-Ably-Version: 1.2@ must be included in all REST requests to the Ably endpoint
+** @(RSC7a)@ The header @X-Ably-Version: 1.1@ must be included in all REST requests to the Ably endpoint
 ** @(RSC7b)@ The header @X-Ably-Lib: [lib][.optional variant]?-[version]@ should be included in all REST requests to the Ably endpoint where @[lib]@ is the name of the library such as @js@ for @ably-js@, @[.optional variant]@ is an optional library variant, such as @laravel@ for the @php@ library, which is always delimited with a period such as @php.laravel@, and where @[version]@ is the full client library version using "Semver":http://semver.org/ such as @1.0.2@. For example, the 1.0.0 version of the Javascript library would use the header @X-Ably-Lib: js-1.0.0@
 *** @(RSC7b1)@ When it is not possible to send the @X-Ably-Lib@ header, such as for @JSONP@ requests, the library version should be sent as a query param such as @lib=js-1.0.0@
-** @(RSC7c)@ If the @addRequestIds@ client option is enabled, every REST request to Ably should include in a @request_id@ query string parameter a random string obtained by url-safe base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. This request ID must remain the same if a request is retried to a fallback host per @RSC15@. Any log messages associated with the request should include the request ID. If the request fails, the request ID must be included in the @ErrorInfo@ returned to the user.
 * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
 * @(RSC8)@ Supports two protocols:
 ** @(RSC8a)@ "MessagePack":http://msgpack.org/ binary protocol (this is the default for environments having a suitable level or support for binary data)
@@ -209,9 +207,9 @@ h3(#rest-channels). Channels
 * @(RSN1)@ @Channels@ is a collection of @Channel@ objects accessible through @Rest#channels@
 * @(RSN2)@ Methods should exist to check if a channel exists or iterate through the existing channels
 * @(RSN3)@ @Channels#get@ function:
-** @(RSN3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
+** @(RSN3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be specified when instancing a new @Channel@
 ** @(RSN3b)@ If options are provided, the options are set on the @Channel@
-** @(RSN3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object. (Note that this is soft-deprecated and may be removed in a future release, so should not be implemented in new client libraries. The supported way to update a set of @ChannelOptions@ is @Channel#setOptions@)
+** @(RSN3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object
 * @(RSN4)@ @Channels#release@ function:
 ** @(RSN4a)@ Releases the channel resource i.e. it's deleted and can then be garbage collected
 
@@ -236,8 +234,8 @@ h3(#rest-channel). Channel
 ** @(RSL1i)@ If the total size of the message or (if publishing an array) messages, calculated per "TO3l8":#TO3l8, exceeds the @maxMessageSize@, then the client library should reject the publish and indicate an error with code 40009
 ** @(RSL1j)@ When @Message@ objects are provided, any valid @Message@ attribute (that is, an attribute specified in "TM2":#TM2) that is supplied by the caller must be included in the encoded message. (This does not mean it must be included _unaltered_; for example the @data@ and @encoding@ will be subject to processing per "RSL4":#RSL4)
 ** @(RSL1k)@ Idempotent publishing via REST is supported by populating the @id@ attribute of @Message@ instances passed to @publish()@:
-*** @(RSL1k1)@ Idempotent publishing via library-generated @Message@ @id@ s is supported if @idempotentRestPublishing@ (see "TO3n":#TO3n) is enabled and one or more @Message@ instances are passed to @publish()@ and all @Message@ s have an empty @id@ attribute. The library generates a base @id@ string by base64-encoding  a sequence of at least 9 bytes obtained from a source of randomness. Each individual @Message@ in the set of messages to be published is assigned a unique @id@ of the form &lt;base id&gt;:&lt;serial&gt; (where @serial@ is the zero-based index into the set).
-*** @(RSL1k2)@ Idempotent publishing via client-supplied @Message@ @id@ s is supported where a single @Message@ is passed to @publish()@ and it contains a non-empty @id@. The @id@ is preserved on sending the message.
+*** @(RSL1k1)@ Idempotent publishing via library-generated @Message@ @id@s is supported if @idempotentRestPublishing@ (see "TO3n":#TO3n) is enabled and one or more @Message@ instances are passed to @publish()@ and all @Message@s have an empty @id@ attribute. The library generates a base @id@ string by base64-encoding  a sequence of at least 9 bytes obtained from a source of randomness. Each individual @Message@ in the set of messages to be published is assigned a unique @id@ of the form &lt;base id&gt;:&lt;serial&gt; (where @serial@ is the zero-based index into the set).
+*** @(RSL1k2)@ Idempotent publishing via client-supplied @Message@ @id@s is supported where a single @Message@ is passed to @publish()@ and it contains a non-empty @id@. The @id@ is preserved on sending the message.
 *** @(RSL1k3)@ If more than one @Message@ is passed to @publish()@ and one or more of those messages contains a non-empty @id@ attribute, then all message ids (present or absent) are preserved on sending the batch of messages.
 *** @(RSL1k4)@ An explicit test for idempotency of publishes with library-generated ids shall exist that simulates an error response to a successful publish of a batch of messages, expects an automatic retry by the library, and verifies that the net outcome is that the batch is published only once.
 *** @(RSL1k5)@ An explicit test for idempotency of publishes with client-supplied ids shall exist that involves multiple explicit publish requests for a given message and verifies that the net outcome is that the message is published only once.
@@ -271,14 +269,7 @@ h3(#rest-channel). Channel
 ** @(RSL6a)@ All messages received will be decoded automatically based on the @encoding@ field and the payloads will be converted into the format they were originally sent using i.e. binary, string, or JSON
 *** @(RSL6a1)@ A set of tests must exist to ensure that the client library provides data encoding & decoding interoperability with other client libraries. The tests must use the "set of predefined interoperability message fixtures":https://github.com/ably/ably-common/blob/master/test-resources/messages-encoding.json to 1) publish a raw message to the REST API using the JSON transport and subscribe to the message using Realtime to ensure the @data@ attribute matches the fixture; 2) publish a message using the REST client library and retrieve the raw message using the history REST API using the JSON transport ensuring the @data@ matches the fixture; 3) perform the client library operation using both @JSON@ and @MsgPack@ transports. For reference, see the "Ruby":https://github.com/ably/ably-ruby/pull/94 and "iOS":https://github.com/ably/ably-cocoa/pull/459 implementations
 *** @(RSL6a2)@ A set of tests must exist to ensure that the client library provides interoperability for the @extras@ field which is a JSON-encodable object (ie a value that represents a JSON @object@ value and supports serialization to and from JSON text). The test, at a minimum, should publish a message with an @extras@ object such as @{"push":[{"title":"Testing"}]}@ and ensure it is received with an equivalent JSON-encodable object
-** @(RSL6b)@ If, for example, incompatible encryption details are provided or invalid Base64 is detected in the message payload, an error message will be sent to the logger, but the message will still be delivered with last successful decoding and the @encoding@ field. For example, if a message had a decoding of "utf-8/cipher+aes-128-cbc/base64", and the payload was successfully Base64 decoded but the payload could not be decrypted because the @CipherParam@ details were not configured, the message would be delivered with a binary payload and an @encoding@ with the value "utf-8/cipher+aes-128-cbc". Additional steps need to be taken if decoding failed on "vcdiff" encoding; see "RTL18":#RTL18
-* @(RSL7)@ @Channel#setOptions@ takes a @ChannelOptions@ object and sets or updates the stored channel options, then indicates success
-
-h3(#plugins). Plugins
-* @(PC1)@ Specific client library features that are not commonly used may be supplied as independent libraries, as plugins, in order to avoid excessively bloating the client library. Although such plugins are packaged as independent libraries, they are still considered logically to be part of the client library code and, as such, may be tightly coupled with the client library implementation. The client library can be assumed to be aware of the plugin specific type and capabilities, and such plugins may by design be coupled to a specific version of the client library.
-* @(PC2)@ No generic plugin interface is specified, and therefore there is no common API exposed by all plugins. However, for type-safety, the opaque interface @Plugin@ should be used in strongly-typed languages as the type of the @ClientOptions.plugins@ collection as per "TO3o":#TO3o.
-* @(PC3)@ A plugin provided with the @PluginType@ enum key value of @vcdiff@ should be capable of decoding "vcdiff"-encoded messages. It must implement the the @VCDiffDecoder@ interface and the client library must be able to use it by casting it to this interface.
-** @(PC3a)@ The base argument of the @VCDiffDecoder.decode@ method should receive the stored base payload of the last message on a channel as specified by "RTL19":#RTL19. If the base payload is a string it should be encoded to binary using UTF-8 before being passed as base argument of the @VCDiffDecoder.decode@ method.
+** @(RSL6b)@ If, for example, incompatible encryption details are provided or invalid Base64 is detected in the message payload, an error message will be sent to the logger, but the message will still be delivered with last successful decoding and the @encoding@ field. For example, if a message had a decoding of "utf-8/cipher+aes-128-cbc/base64", and the payload was successfully Base64 decoded but the payload could not be encrypted because the @CipherParam@ details were not configured, the message would be delivered with a binary payload and an @encoding@ with the value "utf-8/cipher+aes-128-cbc"
 
 h3(#rest-presence). Presence
 * @(RSP1)@ Presence object is associated with a single channel and is accessible through @Channel#presence@
@@ -465,10 +456,9 @@ h3(#realtime-channels). Channels
 * @(RTS1)@ @Channels@ is a collection of @Channel@ objects accessible through @Realtime#channels@
 * @(RTS2)@ Methods should exist to check if a channel exists or iterate through the existing channels
 * @(RTS3)@ @Channels#get@ function:
-** @(RTS3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
+** @(RTS3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be specified when instancing a new @Channel@
 ** @(RTS3b)@ If options are provided, the options are set on the @Channel@ when creating a new @Channel@
-** @(RTS3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object. (Note that this is soft-deprecated and may be removed in a future release, so should not be implemented in new client libraries. The supported way to update a set of @ChannelOptions@ is @Channel#setOptions@)
-*** @(RTS3c1)@ If a new set of @ChannelOptions@ is supplied to @Channels#get@ that would trigger a reattachment of the channel if supplied to @Channel#setOptions@ per "@RTL16a@":#RTL16a, it must raise an error, informing the user that they must use @Channel#setOptions@ instead
+** @(RTS3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object
 * @(RTS4)@ @Channels#release@ function:
 ** @(RTS4a)@ Detaches the channel and then releases the channel resource i.e. it's deleted and can then be garbage collected
 
@@ -500,13 +490,6 @@ h3(#realtime-channel). Channel
 ** @(RTL4f)@ Once an @ATTACH@ @ProtocolMessage@ is sent, if an @ATTACHED@ @ProtocolMessage@ is not received within the "default realtime request timeout":#defaults, the attach request should be treated as though it has failed and the channel should transition to the @SUSPENDED@ state. The channel will then be subsequently automatically re-attached as described in "RTL13":#RTL13
 ** @(RTL4d)@ If the language permits, a callback can be provided that is called when the channel is attached successfully or the attach fails and the @ErrorInfo@ error is passed as an argument to the callback
 ** @(RTL4e)@ If the user does not have sufficient permissions to attach to the channel, the channel will transition to @FAILED@ and set the @Channel#errorReason@
-** @(RTL4j)@ If the attach is not a clean attach (defined in @RTL4j1@), for example an automatic reattach triggered by "@RTN15c3@":#RTN15c3 or "@RTL13a@":#RTL13a (non-exhaustive), the library should set the "@ATTACH_RESUME@":#TR3f flag in the @ATTACH@ message
-*** @(RTL4j1)@ A 'clean attach' is an attach attempt where the channel has either not previously been attached or has been explicitly detached since the last time it was attached. Note that this is not purely a function of the immediate previous channel state. An example implementation would be to set the flag from an @attachResume@ private boolean variable on the channel, that starts out set to @false@, is set to @true@ when the channel moves to the @ATTACHED@ state, and set to @false@ when the channel moves to the @DETACHING@ or @FAILED@ states.
-*** @(RTL4j2)@ The client library can test that the flag is being correctly encoded (and that @RTL4k@ channel params are correctly included) by publishing a message on a channel, then having another two clients attach to that channel both specifying a @rewind@ channel param of @"1"@, one of which has the @ATTACH_RESUME@ flag forcibly set, other doesn't. The client without the flag set should receive the previously-published message once the attach succeeds; the one with that flag set should not
-** @(RTL4k)@ If the user has specified a non-empty @params@ object in the @ChannelOptions@ ("@TB2c@":#TB2c), it must be included in a @params@ field of the @ATTACH@ @ProtocolMessage@
-*** @(RTL4k1)@ If any channel parameters are requested (which may be through the @params@ field of the @ATTACH@ message or some other way opaque to the client library), the @ATTACHED@ (and any subsequent @ATTACHED@ s) will include a @params@ property (also a @Dict<String, String>@) containing the subset of those params that the server has recognised and validated. This should be exposed as a read-only @params@ field of the @Channel@ (or a @getParams()@ method where that is more idiomatic). An @ATTACHED@ message with no @params@ property must be treated as equivalent to a @params@ of @{}@ (that is, @Channel.params@ should be set to the empty dict)
-** @(RTL4l)@ If the user has specified a @modes@ array in the @ChannelOptions@ ("@TB2d@":#TB2d), it must be encoded as a bitfield per "@TR3@":#TR3 and set as the @flags@ field of the @ATTACH@ @ProtocolMessage@. (For the avoidance of doubt, when multiple different spec items require flags to be set in the @ATTACH@, the final @flags@ field should be the bitwise OR of them all)
-** @(RTL4m)@ On receipt of an @ATTACHED@, the client library should decode the @flags@ into an array of @ChannelMode@ s (that is, the same format as @ChannelOptions.modes@) and expose it as a read-only @modes@ field of the @Channel@ (or a @getModes()@ method where that is more idiomatic). This should only contain @ChannelMode@ s: it should not contain flags which are not modes (see "@TB2d@":#TB2d)
 * @(RTL5)@ @Channel#detach@ function:
 ** @(RTL5a)@ If the channel state is @INITIALIZED@ or @DETACHED@ nothing is done
 ** @(RTL5i)@ If the channel is in a pending state @DETACHING@ or @ATTACHING@, do the detach operation after the completion of the pending request
@@ -574,19 +557,6 @@ h3(#realtime-channel). Channel
 ** @(RTL13b)@ If the attempt to re-attach fails, or if the channel was already in the @ATTACHING@ state, the channel will transition to the @SUSPENDED@ state and the error will be emitted in the @ChannelStateChange@ event. An attempt to re-attach the channel automatically will then be made after the period defined in @ClientOptions#channelRetryTimeout@. When re-attaching the channel, the channel will transition to the @ATTACHING@ state. If that request to attach fails i.e. it times out or a @DETACHED@ message is received, then the process described here in @RTL13b@ will be repeated, indefinitely
 ** @(RTL13c)@ If the connection is no longer @CONNECTED@, then the automatic attempts to re-attach the channel described in "RTL13b":#RTL13b must be cancelled as any implicit channel state changes subsequently will be covered by "RTL3":#RTL3
 * @(RTL14)@ If an @ERROR ProtocolMessage@ is received for this channel (the channel attribute matches this channel's name), then the channel should immediately transition to the FAILED state, and the @Channel.errorReason@ should be set
-* @(RTL16)@ @Channel#setOptions@ takes a @ChannelOptions@ object and sets or updates the stored channel options.
-** @(RTL16a)@ If the user has provided either @ChannelOptions.params@ or @ChannelOptions.modes@ and the channel is in either the @attached@ or @attaching@ state, @Channel#setOptions@ sends an @ATTACH@ message to the server with the params & modes encoded per "@RTL4@":#RTL4, and indicates success once the server has replied with an @ATTACHED@ (or indicates failure if the channel becomes detached or failed before that happens, as with @Channel#attach@); else it indicates success immediately
-* @(RTL17)@ No messages should be passed to subscribers if the channel is in any state other than @ATTACHED@.
-* @(RTL18)@ Given "vcdiff"-encoded deltas are applied to the previous message published on a channel, when a "vcdiff" encoding fails to be decoded, it makes it impossible for a client to apply subsequent deltas received from that point of failure forward. As such, the client must automatically execute the following recovery procedure in lieu of "RTL7e":#"RTL7e":
-** @(RTL18a)@ Log error with code 40018
-** @(RTL18b)@ Discard the message
-** @(RTL18c)@ Send an @ATTACH@ @ProtocolMessage@ with the @channelSerial@ set to the previous message to the message for which "vcdiff" decoding failed to the server, transitioning the channel state to @ATTACHING@, and waiting for a confirmation @ATTACHED@, as per @RTL4c@ and @RTL4f@. @ChannelStateChange.reason@ should be set to @ErrorInfo@ object with with code 40018.
-* @(RTL19)@ The data payload of the last message on each channel must be stored at all times since it will be needed to decode any subsequent message that has a "vcdiff" encoding step. The stored value is the "base payload" of the most recent message; this is the @data@ member of the message, in string or binary form, once all application-level encoding steps have been applied. The base payload is derived initially by processing a non-delta message; the processing and bookkeeping rules are as follows:
-** @(RTL19a)@ When processing any message (whether a delta or a full message), if the message @encoding@ string ends in @base64@, the message @data@ should be base64-decoded (and the @encoding@ string modified accordingly per "RSL6":#RSL6).
-** @(RTL19b)@ In the case of a non-delta message, the resulting @data@ value is stored as the base payload.
-** @(RTL19c)@ In the case of a delta message with a @vcdiff@ @encoding@ step, the @vcdiff@ decoder must be used to decode the base payload of the of delta message, applying that delta to the stored base payload. The direct result of that vcdiff delta application, before performing any further decoding steps, is stored as the updated base payload.
-* @(RTL20)@ The @id@ of the last received message on each channel must be stored along with the base payload. When processing a delta message (i.e. one whose @encoding@ contains @vcdiff@ step) the stored last message @id@ must be compared against the delta reference @id@, indicated in the @Message.extras.delta.from@ field of the delta message. If the delta reference @id@ of the received delta message does not equal the stored @id@ corresponding to the base payload, the message decoding must fail. The recovery procedure from "RTL18":#RTL18 must be executed.
-* @(RTL21)@ The messages in the @messages@ array of a @ProtocolMessage@ should each be decoded in ascending order of their index in the array.
 
 h3(#realtime-presence). Presence
 
@@ -1126,7 +1096,7 @@ h4. Message
 ** @(TM2g)@ @name@ string
 ** @(TM2d)@ @data@ string, buffer or JSON-encodable object or array
 ** @(TM2e)@ @encoding@ string
-** @(TM2i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The @extras@ field is provided to contain message metadata and/or ancillary payloads in support of specific functionality, e.g. push. Each of these supported extensions is documented separately; for 1.1 the only supported extension is @push@, via the @extras.push@ member; 1.2 adds the @delta@ extension which is of type @DeltaExtras@. The processing of any other members is undefined
+** @(TM2i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The extras field is provided to contain message metadata and/or ancillary payloads in support of specific functionality, e.g. push. Each of these supported extensions is documented separately; for 1.1 the only supported extension is @push@, via the @extras.push@ member. The processing of any other members is undefined
 ** @(TM2f)@ @timestamp@ time in milliseconds since epoch. If a message received from Ably does not contain a @timestamp@, it should be set to the @timestamp@ of the encapsulating @ProtocolMessage@
 * @(TM3)@ @fromEncoded@ and @fromEncodedArray@ are alternative constructors that take an (already deserialized) @Message@-like object (or array of such objects), and optionally a @channelOptions@, and return a @Message@ (or array of such @Messages@) that's decoded and decrypted as specified in @RSL6@, using the cipher in the @channelOptions@ if the message is encrypted, with any residual transforms (ones that the library cannot decode or decrypt) left in the @encoding@ property per @RSL6b@. This is intended for users receiving messages other than from a REST or Realtime channel (for example, from a queue), to avoid them having to parse the @encoding@ string themselves.
 
@@ -1156,7 +1126,6 @@ h4. ProtocolMessage
 ** @(TR3c)@ 2: @RESUMED@
 ** @(TR3d)@ 3: @HAS_LOCAL_PRESENCE@
 ** @(TR3e)@ 4: @TRANSIENT@
-** @(TR3f)@ 5: @ATTACH_RESUME@
 ** @(TR3q)@ 16: @PRESENCE@
 ** @(TR3r)@ 17: @PUBLISH@
 ** @(TR3s)@ 18: @SUBSCRIBE@
@@ -1172,12 +1141,11 @@ h4. ProtocolMessage
 ** @(TR4o)@ @connectionDetails@ @ConnectionDetails@ object - provides details on the constraints or defaults for the connection such as max message size, client ID or connection state TTL
 ** @(TR4g)@ @count@ integer
 ** @(TR4h)@ @error@ @ErrorInfo@ object
-** @(TR4i)@ @flags@ integer. Contains one or more of the bit flags specified in @TR3@
+** @(TR4i)@ @flags@ integer. Contains one or more of the following bit flags: @HAS_PRESENCE: 1@, @HAS_BACKLOG: 2@, @RESUMED: 4@
 ** @(TR4j)@ @msgSerial@ long
 ** @(TR4k)@ @messages@ Array of @Message@ objects
 ** @(TR4l)@ @presence@ Array of @PresenceMessage@ objects
 ** @(TR4m)@ @timestamp@ time in milliseconds since epoch
-** @(TR4q)@ @params@ @Dict<String, String>@ key-value pairs
 
 h4. PaginatedResult
 
@@ -1262,7 +1230,7 @@ h4. Stats
 
 h4. ErrorInfo
 
-* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@, optional @cause@, optional @href@, and optional @requestId@ (@RSC7c@) attributes
+* @(TI1)@ Provides a generic Ably @ErrorInfo@ object that contains Ably @code@, @statusCode@ (analogous to HTTP status code), @message@ and @cause@ attributes
 * @(TI2)@ Errors returned from the Ably server are compatible with the @ErrorInfo@ structure and should result in errors that inherit from @ErrorInfo@
 * @(TI3)@ "Ably-common":https://github.com/ably/ably-common should be included as a submodule so that "consistent error codes":https://github.com/ably/ably-common/blob/master/protocol/errors.json can be used
 * @(TI4)@ Ably may additionally include a @href@ attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
@@ -1358,8 +1326,6 @@ h4. ClientOptions
 **** @(TO3l8e)@ The size of a @null@ or omitted property is zero
 *** @(TO3l9)@ @maxFrameSize@ integer - default 524288 (512KiB). The maximum size of a single POST body or "WebSocket":/concepts/websockets frame. This is mostly only relevant for `Rest#request` (e.g. for batch publishes), since publishes will hit the @maxMessageSize@ limit before this
 *** @(TO3l10)@ @fallbackRetryTimeout@ integer - default 600000 (10 minutes). (After a failed request to the default endpoint, followed by a successful request to a fallback endpoint), the period in milliseconds before HTTP requests are retried  against the default endpoint
-** @(TO3o)@ @plugins@ @Dict<PluginType:Plugin>@ A map between a @PluginType@ and a @Plugin@ object. The client library might downcast a @Plugin@ to particular plugin type.
-** @(TO3p)@ @addRequestIds@ boolean - defaults to false. If true, @RSC7c@ applies
 
 h4(#token-params). TokenParams
 * @(TK1)@ A class providing parameters of a token request. These params are used when invoking @Auth#authorize@, @Auth#requestToken@ and @Auth#createTokenRequest@
@@ -1388,8 +1354,6 @@ h4. ChannelOptions
 ** @(TB2b)@ @cipher@, which is either:
 *** @(TB2b1)@ A @CipherParams@ instance, or
 *** @(TB2b2)@ an options hash (or language equivalent) consisting of any subset of @CipherParams@ fields that includes a @key@. In this case, the client library should call @getDefaultParams@, passing it the options hash, to obtain a @CipherParams@ instance
-** @(TB2c)@ @params@ (for realtime client libraries only) a @Dict<string,string>@ of key/value pairs
-** @(TB2d)@ @modes@ (for realtime client libraries only) an array of @ChannelMode@ s, where a @ChannelMode@ is a member of an enum containing the names of those children of "@TR3@":#TR3 whose value is ≥16 (or see the IDL below)
 * @(TB3)@ The client lib may optionally provide an alternative constructor @withCipherKey@ for ChannelOptions that takes a @key@ only. (This must be differentiated from the normal constructor such that it is clear that the value being passed in is a key). (This is intended for languages where requiring a hash map is unidiomatic)
 
 h4. CipherParams
@@ -1520,7 +1484,6 @@ class ClientOptions:
   tlsPort: Int default 443 // TO3k5
   useBinaryProtocol: Bool default true // TO3f
   transportParams: [String: Stringifiable]? // RTC1f
-  addRequestIds: Bool default false // TO3p
   // configurable retry and failure defaults
   disconnectedRetryTimeout: Duration default 15s // TO3l1
   suspendedRetryTimeout: Duration default 30s // RTN14d, TO3l2
@@ -1531,7 +1494,6 @@ class ClientOptions:
   httpMaxRetryDuration: Duration default 15s // TO3l6
   maxMessageSize: Int default 65536 // TO3l8
   maxFrameSize: Int default 524288 // TO3l8
-  plugins: Dict<PluginType, Plugin> // TO3o
 
 class AuthOptions: // RSA8e
   authCallback: ((TokenParams) -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b
@@ -1595,8 +1557,6 @@ class RestChannel:
   publish(Message, params?: Dict<String, Stringifiable>) => io // RSL1
   publish([Message], params?: Dict<String, Stringifiable>) => io // RSL1
   publish(name: String?, data: Data?) => io // RSL1
-  setOptions(options: ChannelOptions) => io // RSL7 - note asynchronous return value for
-    // compatibility with RealtimeChannel#setOptions; not required for REST-only libraries
 
   // Only on platforms that support receiving notifications:
   push: PushChannel // RSH4
@@ -1608,8 +1568,6 @@ class RealtimeChannel:
   presence: RealtimePresence // RTL9
   properties: ChannelProperties // CP1, RTL15
   push: PushChannel
-  modes: readonly [ChannelMode] // RTL4m
-  params: readonly Dict<String, String> // RTL4k1
   attach() => io // RTL4d
   detach() => io // RTL5e
   history(
@@ -1627,7 +1585,6 @@ class RealtimeChannel:
   unsubscribe() // RTL8a, RTE5
   unsubscribe((Message) ->) // RTL8a
   unsubscribe(String, (Message) ->) // RTL8a
-  setOptions(options: ChannelOptions) => io // RTL16
 
 class PushChannel:
   subscribeDevice() => io // RSH7a
@@ -1649,12 +1606,6 @@ enum ChannelEvent:
   embeds ChannelState
   UPDATE // RTL2g
 
-enum ChannelMode: // TB2d
-  PRESENCE
-  PUBLISH
-  SUBSCRIBE
-  PRESENCE_SUBSCRIBE
-
 class ChannelStateChange:
   current: ChannelState // RTL2a, RTL2b
   event: ChannelEvent // TH5
@@ -1665,8 +1616,6 @@ class ChannelStateChange:
 class ChannelOptions:
   +withCipherKey(key: Binary | String)? -> ChannelOptions // TB3
   cipher: (CipherParams | Params)? // RSL5a, TB2b
-  params?: Dict<String, String> // TB2c
-  modes?: [ChannelMode] // TB2d
 
 class CipherParams:
   algorithm: String default "AES" // TZ2a
@@ -1772,13 +1721,12 @@ class ProtocolMessage:
   connectionSerial: Int? // RTN10c, TR4f
   count: Int? // TR4g
   error: ErrorInfo? // RTN15c2, TR4h
-  flags: Int? // TR4i; bitfield containing zero or more boolean flags specified in TR3
+  flags: .HAS_PRESENCE & .HAS_BACKLOG & .RESUMED ? // RTP1, TR3, TR4i, RTL2f
   id: String? // TR4b
   messages: [Message]? // TR4k
   msgSerial: Int? // RTN7b, TR4j
   presence: [PresenceMessage]? // TR4l
   timestamp: Time? // TR4m
-  params: Dict<String, String>? // TR4q, RTL4k
 
 enum ProtocolMessageAction:
   HEARTBEAT // TR2
@@ -1949,7 +1897,6 @@ class ErrorInfo:
   message: String // TI1
   cause: ErrorInfo? // TI1
   statusCode: Int // TI1
-  requestId: String? // RSC7c
 
 class EventEmitter<Event, Data>:
   on((Data...) ->) // RTE4
@@ -1976,26 +1923,11 @@ class HttpPaginatedResponse // RSC19b
   errorCode: Int // HP6
   errorMessage: String // HP7
   headers: Dict<String, String> // HP8
-
-class Plugin // PC2
-  // Empty class/interface. Plugins are not expected to share any common interface.
-  // An opaque base interface type for plugins is defined for type-safety in statically-typed languages.
-
-enum PluginType
-  "vcdiff"
-
-class VCDiffDecoder
-  decode([byte] delta, [byte] base) -> [byte]
-
-class DeltaExtras
-  from: String // the id of the message the delta was generated from
-  format: String //the delta format. Only vcdiff is supported as at API version 1.2
 ```
 
 h2(#old-specs). Old specs
 
 Use the version navigation to view older versions.  References to diffs for each version are maintained below:
 
-* v1.1 deprecated in Mar 2020. "View 1.1 → 1.2 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-1-1__1-2.diff
 * v1.0 deprecated in Jan 2019. "View 1.0 → 1.1 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-1-0__1-1.diff
 * v0.8 deprecated in Jan 2017. "View 0.8 → 1.0 changes":https://github.com/ably/docs/blob/master/content/client-lib-development-guide/versions/features-0-8__1-0.diff

--- a/content/client-lib-development-guide/versions/v1.1/protocol.textile
+++ b/content/client-lib-development-guide/versions/v1.1/protocol.textile
@@ -1,0 +1,240 @@
+---
+title: Realtime Protocol Definition
+section: client-lib-development-guide
+index: 10
+jump_to:
+  Help with:
+    - Overview
+    - Formats
+    - Actions
+    - Protocol Message fields
+    - Other message structs
+    - Message acknowledgement protocol
+---
+
+h2(#overview). Overview
+
+The Ably Realtime protocol operates over a connection-oriented, framed, transport. It supports a single connection (and thus a single application) at a time, and enables traffic belonging to multiple channels to be sent over that single connection.
+
+In the current Ably service the backend supports the Realtime protocol over a WebSocket transport and over a Comet transport. Other transports are possible and this document aims to define the protocol in a transport-independent manner.
+
+The protocol supports both a text-based format using "JSON":http://json.org/ and a binary format using "MessagePack":http://msgpack.org/. All structures passed on the wire are defined in a JSON-like format. Other encodings may be considered in the future.
+
+h2(#formats). Formats
+
+The unit of any protocol transmission is a @ProtocolMessage@ key value Hash object, referred to in this description as a Protocol Message.
+
+The WebSocket transport transmits Protocol Messages in a single WebSocket data frame. In the binary transport, these are sent as binary data frames, with the Protocol Message being encoded with MessagePack. In the text transport these are sent as text data frames, the text itself being the white-space-free JSON encoding of the Protocol Message. Empty fields may be encoded as null, or may be handled as undefined (and thus absent from the JSON encoding) and clients should handle both possibilities. Handling empty fields as undefined is clearly preferable, however, since the encoded text is shorter and the encode and decode overhead is minimized. Binary data payloads are handled in the same was as JSON encoded payloads are handled.
+
+In the Comet protocol, all request and response bodies contain an array of one or more protocol messages. In the binary protocol this is standard MessagePack binary encoding of a MessageSet Hash object. In the text (JSON) protocol request and response bodies are simply JSON-encoded arrays containing the Protocol Message content, again either in binary or text encoding.
+
+Separate sections provide more detailed information on the WebSocket and Comet transports.
+
+h2(#actions). Actions
+
+Each Protocol Message has an @action@ that indicates the nature of the message.
+
+- HEARTBEAT (0) := A heartbeat message is sent periodically by the service over a connection in order to keep the connection alive (anticipating that proxies or other gateways may close the connection if it is idle indefinitely) and, in the Comet case, to prevent HTTP request timeout errors. The heartbeat interval is a configurable property of the realtime service and is not selectable by the client.<br><br>
+Heartbeat messages are not exposed to the client app, and are silently consumed in the transport layer of the client library. However, client library unit tests will typically wish to check for the presence of a heartbeat to confirm that a connection is intact, and therefore client libraries should expose some means for tests to observe the occurrence of heartbeats.<br><br>
+No other message fields are populated in a heartbeat message.
+
+- ACK (1) := An acknowledgement message, sent from the service to a client, to confirm receipt of one or more messages published by the client. Further details of the acknowledgement protocol is given below.
+
+- NACK (2) := An negative acknowledgement message, sent from the service to a client, that indicates failure of one or more messages published by the client. Further details of the acknowledgement protocol is given below.
+
+- CONNECT (3) := Unused. This is a placeholder for transports that might need to pass connection request parameters in a Protocol Message instead of in URI params as happens presently for the WebSocket and Comet transports.
+
+- CONNECTED (4) := Passed by the service back to a client to signify that a connection request has succeeded, and passing various connection parameters (such as the connection ID and connection Key). See connection information for each of the transports for more information.
+
+- DISCONNECT (5) := Unused. This is a placeholder for transports that might need to explicitly disconnect a transport but keep the connection open and connection state available.
+
+- DISCONNECTED (6) := Passed by the service to a client in response to a @DISCONNECT@ message or if a connection has been disconnected because of an error state with the error reason included in the @DISCONNECT@ Protocol Message.
+
+- CLOSE (7) := Passed by a client to the service to request that a connection is closed. Once this message is received by the service, a @CLOSED@ message will be sent by the service and the transport will be closed, if it has not already been closed by the client, and all connection state for that connection will be disposed. No connection state recovery is possible.<br><br>
+Note that to disconnect a transport without destroying connection state, the client simply closes the transport without sending any protocol message.
+
+- CLOSED (8) := Passed by the service back to the client to signify that a connection has been in response to a @CLOSE@ request from the client.  The transport will be closed by the service immediately after, and all connection state for that connection will be disposed. No connection state recovery is possible.
+
+- ERROR (9) := Passed by the service to a client to signify an unrecoverable error condition. The scope of the error might be the connection, or a single channel. @ERROR@ messages that apply to a channel have the channel field populated with the channel name; @ERROR@ messages that apply to the connection have no channel field value.<br><br>
+@ERROR@ messages will have a value in the error field that provides information about the failure condition. Client libraries must make a transition (either of the connection or the relevant channel) to the failed state, and pass the contained error information to the client.<br><br>
+Note that non-fatal errors may occur in various contexts (notably connection state recovery) and @CONNECTED@ and @ATTACHED@ response messages may also have the error field populated with information about those non-fatal conditions. These are handled differently from the unrecoverable conditions indicated with an @ERROR@ message.
+
+- ATTACH (10) := Sent by a client to the service to request attachment to a channel. The request must include the channel name in the channel field. Attachment is synchronous, and the client library must place the channel object into the pending state until it sees either an @ATTACHED@ (success) response or an @ERROR@ (failed) response.
+
+- ATTACHED (11) := Sent by the service to a client to indicate successful attachment to a channel. The message contains the channel name in the channel field, and may also contain non-fatal error information in the error field. Clients must move the channel to the attached state and, where present, pass the error information to the caller.<br><br>
+@ATTACHED@ messages may also include a presence flag (right most bit value 1), which if present, indicates that members are currently present on the channel and a presence @SYNC@ is about to commence. Equally, the service might send an @ATTACHED@ message with no presence flag thus indicating that at the time of attach no members are present on the channel and as such the client can assume the presence set is empty.<br>
+@ATTACHED@ messages are not required to be send in any order relative to their corresponding @ATTACH@ requests, and any other Protocol Message may intervene between the @ATTACH@ and @ATTACHED@ messages.<br><br>
+Clients must silently ignore an @ATTACHED@ response if the channel is not in the pending state.
+
+- DETACH (12) := Sent by a client to the service to request detachment to a channel. The request must include the channel name in the channel field. Detachment is acknowledged by the service, but the client library must place the channel object into the detached state immediately on sending the @DETACH@ request.
+
+- DETACHED (13) := Sent by the service to a client to indicate successful detachment from a channel. The message contains the channel name in the channel field, and may also contain non-fatal error information in the error field. Clients must move the channel to the detached state if not already detached and, where present, pass the error information to the caller.
+
+- PRESENCE (14) := Indicates that the Protocol Message has a payload of one or more PresenceMessages associated with a single channel. @PRESENCE@ messages may be sent in either direction. The channel associated with these presence updates is indicated in the channel field.<br><br>
+The serial number of the message must be included in the @msgSerial@ field (in the client &rarr; service direction) or in the @connectionSerial@ field (in the service &rarr; client direction). Further information on message serial numbering is given below.
+
+- MESSAGE (15) := Indicates that the Protocol Message has a payload of one or more Messages associated with a single channel. @MESSAGE@ messages may be sent in either direction. The channel associated with these messages is indicated in the channel field.<br><br>
+The serial number of the message must be included in the @msgSerial@ field (in the client &rarr; service direction) or in the @connectionSerial@ field (in the service &rarr; client direction). Further information on message serial numbering is given below.
+
+- SYNC (16) := Currently reserved for us with presence member synchronization following a channel @ATTACHED@ Protocol Message being received by the client. Once a channel becomes attached, the server will automatically send a list of all members present on the channel to the client. Every @SYNC@ Protocol Message received will contain a channelSerial value and one or more PresenceMessages for each member currently present on the channel i.e. they are in the @PRESENT@ state.  The channelSerial serves two purposes, it provides a way for the client library to resume a @SYNC@ should the transport be disconnected, and it also provides a means for the client library to know when the sync is complete.  A channelSerial that is being synced will contian an ID with followed by a cursor after a colon such as "cf30e75054887:psl_7g:client:189", however the final page of @SYNC@ messages will have a serial with an empty cursor such as "cf30e75054887:".  A client can explicitly request a SYNC with an optional channelSerial; if no channelSerial is provided the server will send a complete set of members on the channel; if a channelSerial is provided, the server will resume the @SYNC@ operation.
+
+- AUTH (17) := Sent by the client with a new token to reauthenticate the connection, with the connection either being closed due to incompatible token details being provided, or a @CONNECTED@ message being sent back to the client confirming the authentication succeeded. The server can request that the client authenticates by sending an @AUTH@ protocol message to the client, and the client must respond with a new token in an @AUTH@ protocol message.
+
+h2(#protocol-message-fields). Protocol Message fields
+
+ProtocolMessages are populated with one or more of the following fields.
+
+- i32 @action@ := Indicates the purpose of the message. See "Actions":#actions above.
+
+- string @id@ := Unique identifier for each protocol message
+
+- AuthDetails @auth@ := Object used for providing authentication details
+
+- string @channel@ := Present when protocol message applies to a single channel
+
+- string @channelSerial@ := Contains a serial number for a message on the channel
+
+- i32 @count@ := The count field is used for @ACK@ and @NACK@ actions. See "message acknowledgement protocol":#message-acknowledgement.
+
+- string @connectionId@ := Contains a public string connection ID. This field is populated in the first @CONNECTED@ Protocol Messages from the service to the client.  The connection ID is a public identifier used to uniquely identify each connected client.
+
+- string @connectionKey@ := Contains a private string connection Key. Note that this field is soon to be deprecated; when @ConnectionDetails#connectionKey@ is present, it should be considered the definitive @connectionKey@ for the current connection
+
+- ConnectionDetails @connectionDetails@ := provides details on the constraints or defaults for the connection such as max message size, client ID or connection state TTL
+
+- i64 @connectionSerial@ := Contains a serial number for a message on the current connection, in @MESSAGE@ and @PRESENCE@ protocol messages sent from the service to the client. The @connectionSerial@ is a zero-based, serially increasing number which, in combination with the @connectionId@, uniquely identifies an attempted delivery of a Protocol Message to the client. The client uses the connection serial to track the receipt of messages, and may specify the @connectionSerial@ when performing connection state recovery.
+
+- Error @error@ := Contains error information. See @Error@ type description for details of the contained information. The error field is populated in an @ERROR@ message and may also be populated to provide supplementary information (eg for non-fatal errors) in various other message types (@CONNECTED@, @ATTACHED@, @DETACHED@, @ACK@, @NACK@).
+
+- i32 @flags@ := Currently used to flag properties in messages such as the presence sync state of an @ATTACHED@ ProtocolMessage.  See "client library spec TR4i":/client-lib-development-guide/features#TR4i
+
+- i64 @msgSerial@ := Contains a serial number for a message sent from the client to the service. The @msgSerial@ is a zero-based, serially increasing number which, in combination with the @connectionId@, uniquely identifies the message across the system. The @msgSerial@ is also used in the message acknowledgement protocol.
+
+- list<Message> @messages@ := A ProtocolMessage with a @MESSAGE@ action contains one or more messages belonging to a channel. The messages field of the ProtocolMessage contains a collection of messages.
+
+- list<Presence> @presence@ := A ProtocolMessage with a @PRESENCE@ action contains one or more presence updates belonging to a channel. The presence field of the ProtocolMessage contains a collection of presence messages.
+
+- i64 @timestamp@ := An optional timestamp, applied by the service in messages sent to the client, to indicate the system time at which the message was sent. Note that this differs from the timestamp field of a @Message@ or @PresenceMessage@ which is an indication of the timestamp of receipt of that message by the system.<br><br>
+Currently there are no requirements for the client library to process or populate the timestamp.
+
+h2(#other-message-structs). Other message object
+
+The protocol relies on a number of structs embedded in Protocol Messages.
+
+h3. Error
+
+An object containing error information. This is used for unrecoverable error conditions (relating to connections, channels or individual messages) and also "informatively" for non-fatal errors in @ATTACHED@ or @CONNECTED@ responses.
+
+Error contains the following fields.
+
+- i16 statusCode := An optional HTTP response code that most closely matches the nature of the error. This is typically also the actual HTTP response code if this error is reported as an HTTP response to a Comet request.
+- i16 code := An Ably-specific error code that indicates the specific error condition. The various codes are defined in errors.json. Implementations may use errors.json to provide descriptive error messages to clients.
+- string reason := An optional string message that indicates the error condition, and may contain specific identifying information (e.g. channel name or message serial, for example).
+
+h3. Data
+
+In transports that support JSON encoding, Strings and the JSON Object and Array types are represented as their natural JSON value in the enclosing type. For example, a Message with a string payload would be encoded in JSON (with white-space added here for clarity) as:
+
+bc[json]. {
+  "name": "my_event",
+  "data": "my_string_payload"
+}
+
+For string and binary payload types, an @encoded@ member is optionally added to the enclosing type. The only supported encodings are "utf8" for strings, "json" for JSON and "base64" for binary. If the encoding member is omitted it defaults to "utf8".
+
+Therefore, the following encoded messages each have string type:
+
+bc[json]. {
+  "name": "my_event",
+  "data": "my string payload"
+}
+{
+  "name": "my_event",
+  "data": "my string payload",
+  "encoding": "utf8"
+}
+
+The following encoded message has binary type:
+
+bc[json]. {
+  "name": "my_event",
+  "data": "bXkgYmluYXJ5IHBheWxvYWQ=",
+  "encoding": "base64"
+}
+
+The base64 encoding used is RFC4648 and clients must accept and process values with or without linefeeds.
+
+The following encoded message has JSON type:
+
+bc[json]. {
+  "name": "my_event",
+  "data": "{\"id\":\"value\"}",
+  "encoding": "json"
+}
+
+h3. Message
+
+This is an individual channel message.
+
+The members are as follows.
+
+- string id := A globally unique identifier for this message
+
+- string name := The optional event name.
+
+- string clientId := The optional clientId of the client that sent the message.<br><br>
+Client libraries do not need to populate this field if the clientId is implicit (ie a clientId was specified when the library was initialized, and is therefore connection-wide. Also, this field will be empty if no clientId has been specified either on library initialization or when publishing the message.<br><br>
+Messages sent from the service to the client will contain a clientId if one is available.
+
+- i64 timestamp := This is the timestamp indicating the time at which the message was received by the system from the publishing client. The timestamp is included in messages sent by the service to the client. The field is expected to be empty in messages sent from a client to the service.
+
+- string or binary data := The payload of the message, binary is supported when using MessagePack.
+
+- string encoding := A string identifier indicating the encodings applied to the data payload in left to right order.  For example, an encoding with the value "utf-8/cipher+aes-128-cbc/base64" indicates that a UTF-8 payload was encrypted with AES 128 CBC encryption and then the binary cipher was encoded with Base64.
+
+- string connectionId := optional public connection ID of the message publisher.  The field is expected to be empty in messages sent from a client to the service.
+
+h3. Presence Message
+
+This is an individual channel presence update, as defined in the Thrift @TPresence@ struct.
+
+The members are as follows.
+
+- string id := A globally unique identifier for this presence message
+
+- Action state := The presence action (@ABSENT@, @PRESENT@, @ENTER@, @LEAVE@, or @UPDATE@) encoded as the ordinal in the "PresenceMessage Action":/realtime/types#presence-action enum.
+
+- string clientId := The clientId string.
+
+- string or binary data := The optional payload data for the members such as member status, binary is supported when using MessagePack.
+
+- string connectionId := An optional member connection identifier if required to disambiguate multiple connected and entered members having the same clientId. When there are multiple members with the same clientId entered to the channel there will be multiple corresponding @ENTER@ events.<br><br>
+If the connectionId of an already-entered member changes (eg in the situation that a new connection inherits from another connection, the new (clientId, connectionId) combination is not considered to be a new member but it is indicated as an @UPDATE@ of the already-entered member, with a change in the value of connectionId.
+
+h2(#message-acknowledgement). Message acknowledgement protocol
+
+The Ably client API allows a caller to provide a success callback when publishing messages, or presence updates, to the Ably service. The callback is called, either with success or a failure code, once the Ably service has indicated whether or not it has processed the message successfully. The callback is not simply an indication that the message sent without error; it is confirmation that the service has processed the message sufficiently that its onward delivery to relevant attached clients is now guaranteed.
+
+In the Comet transport, success or failure is indicated on a per-call basis with an @ACK@ or @NACK@ Message body in the HTTP response to the @send@ API call.
+
+In the WebSocket transport, the service indicates success or failure to the client with the message acknowledgement protocol. This is a simple series of @ACK@ or @NACK@ responses, each addressing a contiguous sequence (by @msgSerial@) of messages.
+
+An @ACK@ message contains a @msgSerial@ and @count@ value. Receipt of this message signifies that the messages whose serial numbers are:
+
+bc[json]. { msgSerial ... msgSerial + count - 1 }
+
+have been processed successfully.
+
+Similarly, a @NACK@ message contains a @msgSerial@ and @count@ value and usually also an @error@ value. Receipt of this message signifies that the messages whose serial numbers are:
+
+bc[json]. { msgSerial ... msgSerial + count - 1 }
+
+have encountered processing failures. The client library must call the callback, if supplied, with the contained error value, or with an error value that indicates an internal error.
+
+@ACK@ responses are sent so as to be responsive to the client but also to avoid sending a response for every single published message; when the client is publishing at a high rate the @ACK@ responses will be sent periodically with an interval of 500ms (say) so many hundreds of messages my be covered in a single @ACK@ response.
+
+@NACK@ responses are sent as soon as an error has arisen, and in any event only cover multiple messages to the extent that those messages are subject to the same underlying failure (since the error information is provided once for the group of @NACK@'d messages, not individually.
+
+It is a protocol error if the system sends an @ACK@ or @NACK@ that skips past one or more @msgSerial@ without there having been either and @ACK@ or @NACK@; but a client in this situation should treat this case as implicitly @NACK@ing the skipped messages.
+
+It is also a protocol error if the system sends an @ACK@ or @NACK@ that covers a @msgSerial@ that was covered by an earlier @ACK@ or @NACK@; in such cases the client library must silently ignore the response insofar as it relates to @msgSerial@s that were covered previously (whether the response is the same now or different).


### PR DESCRIPTION
- Updates the client lib spec to v1.2, adding in a diff and v1.1 folder
- Adds seperate versioning for client lib folder and doc folders, so as to allow the version of the spec to change prior to the version of the rest of the docs. This can be easily extended to other folders in the future if needed

The 1.2 spec changes have been taken from https://github.com/ably/docs/pull/843.