### PR TITLE
[FEA-495] hub product code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ editors can simply skip to [Forking and running locally](#forking-and-running-lo
 If you will be creating or modifying code within this repository that is to be uploaded automatically
 to [JSBin](https://jsbin.ably.io/), for our "Try it now code editor", then you will need to create yourself a JSBin config file:
 
-### Ably staff members
-
-To obtain the API key you need to run this command in the terminal, you must ensure you have installed the hero-cli tools (Instructions on [installing the Heroku toolbelt](https://devcenter.heroku.com/articles/heroku-cli) )
+To obtain the API key you need to run this command in the terminal, you must ensure you have installed the `heroku-cli`  tools (Instructions on [installing the Heroku toolbelt](https://devcenter.heroku.com/articles/heroku-cli) ) and postgresl ([PostgreSQL Downloads](https://www.postgresql.org/download/))
 
 ```bash
 $ heroku pg:psql -a ably-jsbin -c "select name, api_key from ownership"
@@ -92,7 +90,7 @@ This will output a huge list that looks similar to this, as each file is checked
 ```bash
 Published new JsBin for hub-product/http-javascript at https://jsbin.ably.io:443/ujehow/1/edit?javascript,live
 Copied https://jsbin.ably.io:443/ujehow/1/edit?javascript,live to clipboard
-	create  [0.49s]  output/code/realtime/channel-deltas-sse/index.html
+    create  [0.49s]  output/code/realtime/channel-deltas-sse/index.html
     update  [1.10s]  output/sse/index.html
     update  [1.02s]  output/concepts/socketio/index.html
 ```
@@ -102,13 +100,13 @@ This process has added a record to `jsbin.yaml` Please notice the `ID` string in
 ```yaml
 ---
 jsbin_hash:
-	Rh81oraUHHJ3PrrvwdJAOrVBqA8=: ujehow <-- hash: ID
-  	eBxLJU1YqdX+JW9JQY70S4iQfmU=: omedab
-  	pzHKfCW4/o2wDnCfbg1m0Pkl7v8=: ovucin
+    Rh81oraUHHJ3PrrvwdJAOrVBqA8=: ujehow <-- hash: ID
+    eBxLJU1YqdX+JW9JQY70S4iQfmU=: omedab
+    pzHKfCW4/o2wDnCfbg1m0Pkl7v8=: ovucin
 jsbin_id:
-	adapters/pusher-pub-sub: eBxLJU1YqdX+JW9JQY70S4iQfmU=
-	adapters/pubnub-pub-sub: pzHKfCW4/o2wDnCfbg1m0Pkl7v8=
-	hub-product/http-javascript: Rh81oraUHHJ3PrrvwdJAOrVBqA8= <-- file: hash
+    adapters/pusher-pub-sub: eBxLJU1YqdX+JW9JQY70S4iQfmU=
+    adapters/pubnub-pub-sub: pzHKfCW4/o2wDnCfbg1m0Pkl7v8=
+    hub-product/http-javascript: Rh81oraUHHJ3PrrvwdJAOrVBqA8= <-- file: hash
 ---
 ```
 

--- a/content/code/hub-product/http-javascript.code
+++ b/content/code/hub-product/http-javascript.code
@@ -1,4 +1,5 @@
 [--- Javascript ---]
+
 // This can be used to get the history of a product
 
 var channel = encodeURI('{{{FULLYQUALIFIEDCHANNEL}}}')

--- a/content/code/hub-product/http-javascript.code
+++ b/content/code/hub-product/http-javascript.code
@@ -1,0 +1,51 @@
+[--- Javascript ---]
+// This can be used to get the history of a product
+
+var channel = encodeURI('{{{FULLYQUALIFIEDCHANNEL}}}')
+$.ajax({
+        url: 'https://rest.ably.io/channels/' + channel + '/messages',
+        xhrFields: {
+            withCredentials: true
+        },
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader('Authorization', 'Basic ' + btoa('{{{HUBAPIKEY}}}'));
+        },
+        success: function(data){
+            alert(data);
+        }
+})
+var channel = encodeURI('{{{FULLYQUALIFIEDCHANNEL}}}' )
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably Channel Example</h1>
+
+<p>In this example, we demonstrate the simplest way to attach a channel and subscribe to channel state events. See <a href="https://www.ably.io/documentation/realtime/channels">our Realtime Channel documentation</a> for more details.
+
+<div class="row">
+  <input id="attach" type="submit" value="Attach channel">
+  <input id="detach" type="submit" value="Detach channel">
+</div>
+
+<div class="row" id="channel-status"></div>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+[--- /CSS ---]

--- a/content/code/hub-product/native-sdks-javascript.code
+++ b/content/code/hub-product/native-sdks-javascript.code
@@ -1,0 +1,41 @@
+[--- Javascript ---]
+var ably = new Ably.Realtime("{{{HUBAPIKEY}}}");
+var channel = ably.channels.get('{{{FULLYQUALIFIEDCHANNEL}}}');
+
+channel.subscribe(function(message) {
+  alert(message.data);
+});
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably Channel Example</h1>
+
+<p>In this example, we demonstrate the simplest way to attach a channel and subscribe to channel state events. See <a href="https://www.ably.io/documentation/realtime/channels">our Realtime Channel documentation</a> for more details.
+
+<div class="row">
+  <input id="attach" type="submit" value="Attach channel">
+  <input id="detach" type="submit" value="Detach channel">
+</div>
+
+<div class="row" id="channel-status"></div>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+[--- /CSS ---]

--- a/content/code/hub-product/native-sdks-nodejs.code
+++ b/content/code/hub-product/native-sdks-nodejs.code
@@ -1,0 +1,41 @@
+[--- Javascript ---]
+var ably = new Ably.Realtime("{{{HUBAPIKEY}}}");
+var channel = ably.channels.get('{{{FULLYQUALIFIEDCHANNEL}}}');
+
+channel.subscribe(function(message) {
+  alert(message.data);
+});
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably Channel Example</h1>
+
+<p>In this example, we demonstrate the simplest way to attach a channel and subscribe to channel state events. See <a href="https://www.ably.io/documentation/realtime/channels">our Realtime Channel documentation</a> for more details.
+
+<div class="row">
+  <input id="attach" type="submit" value="Attach channel">
+  <input id="detach" type="submit" value="Detach channel">
+</div>
+
+<div class="row" id="channel-status"></div>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+[--- /CSS ---]

--- a/content/code/hub-product/sse-nodejs.code
+++ b/content/code/hub-product/sse-nodejs.code
@@ -1,0 +1,44 @@
+[--- Javascript ---]
+const EventSource = require('eventsource');
+const channelName = '{{{FULLYQUALIFIEDCHANNEL}}}';
+const uri = `https://realtime.ably.io/event-stream?key={{{HUBAPIKEY}}}&channel=${channelName}`;
+const evtSource = new EventSource(uri);
+evtSource.addEventListener('message', msg => {
+    console.log('Message: ', msg.data);
+});
+
+// This protocol is still in private beta. Get in touch if you want early access
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Ably Channel Example</h1>
+
+<p>In this example, we demonstrate the simplest way to attach a channel and subscribe to channel state events. See <a href="https://www.ably.io/documentation/realtime/channels">our Realtime Channel documentation</a> for more details.
+
+<div class="row">
+  <input id="attach" type="submit" value="Attach channel">
+  <input id="detach" type="submit" value="Detach channel">
+</div>
+
+<div class="row" id="channel-status"></div>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+
+.row {
+  margin-bottom: 1em;
+}
+[--- /CSS ---]

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -95,3 +95,6 @@ jsbin_id:
   realtime/channel-deltas-size: mZcTN8McM4HXm+nDeiZqLj9gq8w=
   realtime/channel-deltas-sse: z5j/4vBDEdZ/R6Hzt+c+dY1Eyo4=
   realtime/channel-deltas-sse-enveloped: ruTStktK7MqqJ2dQ9q8+rz+Nvvw=
+  hub-product/native-sdks-javascript: GsnJtmn4pFAbhRKQ71GGpA4v2oE=
+  hub-product/sse-nodejs: 0BAC+Z8wHIg2vA4STRUfbKrg5W8=
+  hub-product/http-javascript: Rh81oraUHHJ3PrrvwdJAOrVBqA8=

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -47,6 +47,9 @@ jsbin_hash:
   DTeaZcISYUkQhi78OpQO6G2mEho=: opekiw
   89LGzghiZ2Rb3Bq5eH7gT1FaKZA=: alaqab
   k3IGETt2JYAphAszpI3Z+xKhp+U=: axuhud
+  GsnJtmn4pFAbhRKQ71GGpA4v2oE=: iqabam
+  0BAC+Z8wHIg2vA4STRUfbKrg5W8=: uticun
+  Rh81oraUHHJ3PrrvwdJAOrVBqA8=: uwiqor
 jsbin_id:
   adapters/pusher-pub-sub: DTeaZcISYUkQhi78OpQO6G2mEho=
   adapters/pubnub-pub-sub: 89LGzghiZ2Rb3Bq5eH7gT1FaKZA=


### PR DESCRIPTION
*Hub products that require JsBin assets.*

Please note:
- These samples are based on an existing .code example, where the javascript portion was replaced with the respective code snippet
- The HTML section will need to be reviewed we may require copy updates.
- ANY script change will need to be communicated upstream, so that the website UI matches the JSBin content. We may need to merge this branch early (to QA the TRY IT button has the correct URL) WDYT?
- The snippet tokens (aka API_KEY and FULLY_QUALIFIED_CHANNEL_NAME) will not be dynamically replaced. The *channel name* (if it is present) is replaced at runtime, and our JSBin assets require pre-rendered assets. (ask @fliptopbox or @kennethkalmer for details) 

*These assets will not be available to the website until they have been published.*
