### PR TITLE
missing params key in js example on rewind documentation, added in

### DIFF
--- a/content/realtime/channels/channel-parameters/rewind.textile
+++ b/content/realtime/channels/channel-parameters/rewind.textile
@@ -41,7 +41,7 @@ To subscribe to a channel, getting the most recent message if available:
 ```[jsall]
   var realtime = new Ably.Realtime('{{API_KEY}}');
   realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
-    rewind: '1'
+    params: {rewind: '1'}
   }).subscribe(msg => console.log("Received message: ", msg));
 ```
 


### PR DESCRIPTION
The params key was missing from the JS demo in the rewind documentation which broke the demo, now added in