### PR TITLE
Only allow channels.release() for channels in an inactive( initialized, detached, or failed) state

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -213,7 +213,9 @@ h3(#rest-channels). Channels
 ** @(RSN3b)@ If options are provided, the options are set on the @Channel@
 ** @(RSN3c)@ Accessing an existing @Channel@ with options in the form @Channels#get(channel, options)@ will update the options on the channel and then return the existing @Channel@ object. (Note that this is soft-deprecated and may be removed in a future release, so should not be implemented in new client libraries. The supported way to update a set of @ChannelOptions@ is @Channel#setOptions@)
 * @(RSN4)@ @Channels#release@ function:
-** @(RSN4a)@ Releases the channel resource i.e. it's deleted and can then be garbage collected
+** @(RSN4a)@ Takes one argument, the channel name, and releases the corresponding channel entity (that is, deletes it to allow it to be garbage collected)
+** @(RSN4b)@ Calling @release()@ with a channel name that does not correspond to an extant channel entity must return without error
+** @(RSN4c)@ Calling @release()@ with a channel name that corresponds to a channel that is in any state other than @INITIALIZED@, @DETACHED@, or @FAILED@ must, instead of releasing the channel, raise an error with code @90001@
 
 h3(#rest-channel). Channel
 


### PR DESCRIPTION
Fixes https://github.com/ably/docs/issues/437

Example implementation in https://github.com/ably/ably-js/pull/672