### PR TITLE
[FEA-547] Change jsbin domain from ably.io to ably.com (AUGUST)

### DIFF
--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -4,7 +4,7 @@ The instructions on this page are intended for Ably staff. Please see the [main 
 
 ## Publishing to JSBin
 
-The following steps apply if you will be creating or modifying code within this repository for our "Try it now" code editor in [JSBin](https://jsbin.ably.io/).
+The following steps apply if you will be creating or modifying code within this repository for our "Try it now" code editor in [JSBin](https://jsbin.ably.com/).
 
 > **Note**: The creation of code content for JSBin is further documented in our
 > [document formatting guide](content/client-lib-development-guide/documentation-formatting-guide.textile)
@@ -81,8 +81,8 @@ Executing one of the above commands checks each file and produces a long lists t
 
 ```bash
 ...
-Published new JSBin for hub-product/http-javascript at https://jsbin.ably.io:443/ujehow/1/edit?javascript,live
-Copied https://jsbin.ably.io:443/ujehow/1/edit?javascript,live to clipboard
+Published new JSBin for hub-product/http-javascript at https://jsbin.ably.com:443/ujehow/1/edit?javascript,live
+Copied https://jsbin.ably.com:443/ujehow/1/edit?javascript,live to clipboard
     create  [0.49s]  output/code/realtime/channel-deltas-sse/index.html
     update  [1.10s]  output/sse/index.html
     update  [1.02s]  output/concepts/socketio/index.html
@@ -107,9 +107,9 @@ jsbin_id:
 ---
 ```
 
-> **NOTE**: You can use this `ID` to view the JSBin for the associated code sample, by visiting `http://jsbin.ably.io/<ID>/edit`. For example, to view the JSBin with ID `ujehow`: [http:\/\/jsbin.ably.io/ujehow/edit](http://jsbin.ably.io/ujehow/edit)
+> **NOTE**: You can use this `ID` to view the JSBin for the associated code sample, by visiting `http://jsbin.ably.com/<ID>/edit`. For example, to view the JSBin with ID `ujehow`: [http:\/\/jsbin.ably.com/ujehow/edit](http://jsbin.ably.com/ujehow/edit)
 
-This process populates the code samples with working API keys dynamically. So for example, https://jsbin.ably.io/enagak/1/edit currently has an API key defined in the `apiKey` JavaScript variable. If you change the extension to `.textile` (`https://jsbin.ably.io/enagak/1.textile`), you now have a file you can copy and paste back into the docs repo, but **importantly**, it detects the presence of a real API key and replaces it with the placeholder `{{API_KEY}}`.
+This process populates the code samples with working API keys dynamically. So for example, https://jsbin.ably.com/enagak/1/edit currently has an API key defined in the `apiKey` JavaScript variable. If you change the extension to `.textile` (`https://jsbin.ably.com/enagak/1.textile`), you now have a file you can copy and paste back into the docs repo, but **importantly**, it detects the presence of a real API key and replaces it with the placeholder `{{API_KEY}}`.
 
 > **IMPORTANT**: You must commit the updated `jsbin.yaml` with your new assets when you push your changes to GitHub.
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -144,7 +144,7 @@ $(function () {
             .attr("class")
             .match(/open-jsbin-(\w+)/i)[1],
           btn = $(
-            '<a href="//jsbin.ably.io/' +
+            '<a href="//jsbin.ably.com/' +
               binId +
               '/1/edit?javascript,live" target="_blank" class="try-it-button">Try it</a>'
           );

--- a/config/config.rb
+++ b/config/config.rb
@@ -1,7 +1,7 @@
 module Ably
   module Docs
     class Config
-      JSBIN_HOST    = "jsbin.ably.io"
+      JSBIN_HOST    = "jsbin.ably.com"
       JSBIN_SSL     = true
       JSBIN_PORT    = 443
       JSBIN_API_KEY = "readonly"

--- a/config/jsbin_config.example.yaml
+++ b/config/jsbin_config.example.yaml
@@ -1,4 +1,4 @@
-host: jsbin.ably.io
+host: jsbin.ably.com
 ssl: true
 port: 443
 api_key: INSERT-API-KEY #Please see the ReadMe for more information on how to generate an API key

--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -213,7 +213,7 @@ h3(#code-editor). Try it now code editor
 
 p(tip). In order to publish code examples to JSBin, your "/config/jsbin_config.yaml":https://github.com/ably/docs/blob/main/config/jsbin_config.example.yaml must be set up with a valid JSBin API key.
 
-Code examples that run in your browser can be included in this documentation repo within the "/content/code folder":https://github.com/ably/docs/tree/main/content/code.  Every code example must contain JavaScript, HTML and CSS that will be launched in our "custom Ably JSBin":https://jsbin.ably.io.
+Code examples that run in your browser can be included in this documentation repo within the "/content/code folder":https://github.com/ably/docs/tree/main/content/code.  Every code example must contain JavaScript, HTML and CSS that will be launched in our "custom Ably JSBin":https://jsbin.ably.com.
 
 The following example shows how you can easily add a "Try it" button to your code example that will launch the code from the path you provide in our Ably JSBin code editor:
 

--- a/content/code-index.textile
+++ b/content/code-index.textile
@@ -5,7 +5,7 @@ index: 100
 hide_from_website: true
 ---
 
-h1. Code Examples in "Ably JSBin":http://jsbin.ably.io
+h1. Code Examples in "Ably JSBin":http://jsbin.ably.com
 
 <%= JsBins.all.map do |bin|
   %{* "#{bin.fetch(:path)}":#{bin.fetch(:jsbin_url)}}


### PR DESCRIPTION
Change jsbin domain from jsbin.ably.io to jsbin.ably.com.

## Review

* [Review app](https://ably-docs-pr-925.herokuapp.com/)