### PR TITLE
Fix Ruby code sample in the quick start

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -145,8 +145,7 @@ ably.connection.on(ConnectionState.connected, new ConnectionStateListener()
   }
 });
 
-bc[ruby].
-EventMachine.run do
+bc[ruby]. EventMachine.run do
   ably = Ably::Realtime.new(api_key)
 end
 ably.connection.on(:connected) do


### PR DESCRIPTION
Caused by a formatting regression from 82ff1a415a9d where removing trailing whitespace broke the code sample.

Broken:
![Ably API Documentation - Quickstart Guide 2020-08-10 15-24-00](https://user-images.githubusercontent.com/8756/89793253-8cbdb980-db1d-11ea-820e-6aec1ae98d61.png)

Fixed:
![Ably API Documentation - Quickstart Guide 2020-08-10 15-24-27](https://user-images.githubusercontent.com/8756/89793292-9c3d0280-db1d-11ea-8d9b-30ce51ed8e16.png)
