### PR TITLE
Revert "[WEB-381] Add GA tracking to docs.ably.io"

### DIFF
--- a/layouts/_head.html.erb
+++ b/layouts/_head.html.erb
@@ -1,14 +1,6 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=OwoW8XUrrg19PuKAgJa7-g&gtm_preview=env-2&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-TZ37KKW');</script>
-    <!-- End Google Tag Manager -->
-
     <meta charset="utf-8">
     <title>Ably API Documentation - <%= @item[:title] %></title>
     <link rel="shortcut icon" href="/favicon.ico">
@@ -36,10 +28,6 @@
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TZ37KKW&gtm_auth=OwoW8XUrrg19PuKAgJa7-g&gtm_preview=env-2&gtm_cookies_win=x"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <div class="canonical-modal">
       <div class="box-centered">
         <p>


### PR DESCRIPTION
Reverts ably/docs#905

Closes #931 

docs.ably.io should have its own GA property, this will be addressed in a separate PR if necessary.