### PR TITLE
Add push log metachannel

### DIFF
--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -39,7 +39,7 @@ h3(#features). Key features
 * User-centric device registration allowing devices to be grouped by user ("@clientId@":/realtime/authentication#identified-clients)
 * Filters can be applied to notifications such as client ID, connection ID or device type, or alternatively you can push message directly to devices or users via our API.
 * Realtime metrics for your delivered and undelivered push notifications.
-* Error logging on a dedicated metachannel: ("@[meta]log:push@ ":/realtime/channel-metadata#metachannels)
+* Error logging on a dedicated metachannel ("@[meta]log:push@":/realtime/channel-metadata#metachannels)
 
 h2(#tutorials). Tutorials
 

--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -39,6 +39,7 @@ h3(#features). Key features
 * User-centric device registration allowing devices to be grouped by user ("@clientId@":/realtime/authentication#identified-clients)
 * Filters can be applied to notifications such as client ID, connection ID or device type, or alternatively you can push message directly to devices or users via our API.
 * Realtime metrics for your delivered and undelivered push notifications.
+* Error logging on a dedicated metachannel: ("@[meta]log:push@ ":/realtime/channel-metadata#metachannels)
 
 h2(#tutorials). Tutorials
 

--- a/content/realtime/channel-metadata.textile
+++ b/content/realtime/channel-metadata.textile
@@ -33,6 +33,7 @@ Metachannels are a namespace of channels which all start with the @[meta]@ quali
 There are a number of metachannels available, which are:
 
 - [meta]log := This metachannel is used to broadcast log messages (usually error messages) for events that occur within the application's context
+- [meta]log:push := This metachannel broadcasts log messages (usually error messages) for push notification events withing the application's context
 - [meta]channel.lifecycle := This metachannel carries messages about channel lifecycle and metadata
 - [meta]connection.lifecycle := This metachannel carries messages about the lifecycle of realtime connections
 

--- a/content/realtime/channel-metadata.textile
+++ b/content/realtime/channel-metadata.textile
@@ -33,7 +33,7 @@ Metachannels are a namespace of channels which all start with the @[meta]@ quali
 There are a number of metachannels available, which are:
 
 - [meta]log := This metachannel is used to broadcast log messages (usually error messages) for events that occur within the application's context
-- [meta]log:push := This metachannel broadcasts log messages (usually error messages) for push notification events withing the application's context
+- [meta]log:push := This metachannel broadcasts log messages (usually error messages) for push notification events within the application's context
 - [meta]channel.lifecycle := This metachannel carries messages about channel lifecycle and metadata
 - [meta]connection.lifecycle := This metachannel carries messages about the lifecycle of realtime connections
 


### PR DESCRIPTION
I think the only major customer visible changes outside of the dashboard is the push metachannel. This isn't currently enabled and is gated on https://ably.atlassian.net/browse/FEA-408.