### PR TITLE
Add redirects for old webhook/function pages

### DIFF
--- a/content/general/events.textile
+++ b/content/general/events.textile
@@ -14,6 +14,10 @@ jump_to:
     - Payload encoding#encoding
     - Webhook Security#security
     - Examples#examples
+redirect_from:
+  - general/versions/v0.8/webhooks.textile
+  - general/versions/v1.0/webhooks.textile
+  - general/versions/v1.0/functions.textile
 ---
 
 Reactor Events allow you to configure rules that react to "messages being published":/realtime/messages or "presence events emitted":/realtime/presence (such as members entering or leaving) on "channels":/realtime/channels. These rules can notify HTTP endpoints, serverless functions or other services for each event as they arise, or in batches.

--- a/data/redirects.yaml
+++ b/data/redirects.yaml
@@ -1,1 +1,4 @@
---- {}
+---
+general/versions/v0.8/webhooks.textile: "/general/events"
+general/versions/v1.0/webhooks.textile: "/general/events"
+general/versions/v1.0/functions.textile: "/general/events"


### PR DESCRIPTION
The old pages we had for webhooks and functions will now re-direct to the event pages that cover everything needed.