### PR TITLE
[DOC-11] Fix keyName channel id and device id syntax

### DIFF
--- a/content/rest-api/index.textile
+++ b/content/rest-api/index.textile
@@ -323,7 +323,7 @@ Routes providing access to the messaging service within a channel scope.
 
 h3(#publish). Publish one or more messages on a channel
 
-h6. POST rest.ably.io/channels/@<channel id>@/messages
+h6. POST rest.ably.io/channels/@<channelId>@/messages
 
 Publish a message on a channel. Note that since the REST API is stateless, publication using this API is outside the context of any specific connection.
 
@@ -473,7 +473,7 @@ When successful, returns an object with @channel@ and @messageId@ properties, in
 
 h3(#message-history). Retrieve message history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/messages
+h6. GET rest.ably.io/channels/@<channelId>@/messages
 
 If a channel is "configured to persist messages":http://support.ably.com/support/solutions/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for.
 
@@ -508,7 +508,7 @@ bc[json]. [{
 
 h3(#presence). Retrieve instantaneous presence status for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence
+h6. GET rest.ably.io/channels/@<channelId>@/presence
 
 Obtain the set of members currently present for a channel.
 
@@ -544,7 +544,7 @@ bc[json]. [{
 
 h3(#presence-history). Retrieve presence state history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence/history
+h6. GET rest.ably.io/channels/@<channelId>@/presence/history
 
 Obtain the history of presence messages for a channel.
 
@@ -668,7 +668,7 @@ h3(#update-device-registration). Update a device registration
 
 Device registrations can be either upserted (the existing registration is replaced entirely) with a "@PUT@":#put-device-registration operation, or specific attributes of an existing registration can be updated using a "@PATCH@":#patch-device-registration operation:
 
-h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration. The @PUT@ operation will replace the existing device registration, however please bear in mind that a registered device in Ably is largely immutable. As such, only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -715,7 +715,7 @@ A successful request returns the updated device details.
 
 An unsuccessful request returns an error.
 
-h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration, except only fields to be changed should be provided. Any fields provided replace existing values. Please bear in mind that fields whose values are structured (JSON-like arrays or objects) types will replace existing values as opposed to be merged into existing values. @metadata@ and @push.recipient@ are examples of these types. Currently only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -753,7 +753,7 @@ An unsuccessful request returns an error.
 
 h3(#get-device-registration). Get details from a registered device
 
-h6. GET rest.ably.io/push/deviceRegistrations/@<device id>@
+h6. GET rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 Obtain the details for a device registered for receiving push registrations.
 
@@ -839,7 +839,7 @@ bc[json]. [{
 
 h3(#reset-update-token). Reset a registered device's update token
 
-h6. POST rest.ably.io/push/deviceRegistrations/@<device id>@/resetUpdateToken
+h6. POST rest.ably.io/push/deviceRegistrations/@<deviceId>@/resetUpdateToken
 
 Example request:
 
@@ -861,7 +861,7 @@ A unsuccessful request returns an error.
 
 h3(#delete-device-registration). Unregister a single device for push notifications
 
-h6. DELETE rest.ably.io/push/deviceRegistrations/@<device id>@
+h6. DELETE rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 Unregisters a single device by its device ID. All its subscriptions for receiving push notifications through channels will also be deleted.
 

--- a/content/rest-api/index.textile
+++ b/content/rest-api/index.textile
@@ -1143,7 +1143,7 @@ h3(#request-token). Request an access token
 
 <!-- TODO: Review the suitability of the documentation that describes the token request and the token body response and provide suitable links -->
 
-h6. POST rest.ably.io/keys/@keyName@/requestToken
+h6. POST rest.ably.io/keys/@<keyName>@/requestToken
 
 This is the means by which clients obtain access tokens to use the service. The construction of an Ably "@TokenRequest@":/rest-api/token-request-spec is described in the "Authentication Ably TokenRequest spec documentation":/rest-api/token-request-spec. The resulting @token response@ object contains the token properties as defined in "Ably TokenRequest spec":/rest-api/token-request-spec.
 

--- a/content/rest-api/versions/v0.8/index.textile
+++ b/content/rest-api/versions/v0.8/index.textile
@@ -309,7 +309,7 @@ Routes providing access to the messaging service within a channel scope.
 
 h3(#publish). Publish one or more messages on a channel
 
-h6. POST rest.ably.io/channels/@<channel id>@/messages
+h6. POST rest.ably.io/channels/@<channelId>@/messages
 
 Publish a message on a channel. Note that since the REST API is stateless, publication using this API is outside the context of any specific connection.
 
@@ -355,7 +355,7 @@ Nothing when successful, else returns an error.
 
 h3(#message-history). Retrieve message history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/messages
+h6. GET rest.ably.io/channels/@<channelId>@/messages
 
 If a channel is "configured to persist messages":http://support.ably.com/support/solutions/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for.
 
@@ -390,7 +390,7 @@ bc[json]. [{
 
 h3(#presence). Retrieve instantaneous presence status for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence
+h6. GET rest.ably.io/channels/@<channelId>@/presence
 
 Obtain the set of members currently present for a channel.
 
@@ -426,7 +426,7 @@ bc[json]. [{
 
 h3(#presence-history). Retrieve presence state history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence/history
+h6. GET rest.ably.io/channels/@<channelId>@/presence/history
 
 Obtain the history of presence messages for a channel.
 

--- a/content/rest-api/versions/v0.8/index.textile
+++ b/content/rest-api/versions/v0.8/index.textile
@@ -467,7 +467,7 @@ h3(#request-token). Request an access token
 
 <!-- TODO: Review the suitability of the documentation that describes the token request and the token body response and provide suitable links -->
 
-h6. POST rest.ably.io/keys/@keyName@/requestToken
+h6. POST rest.ably.io/keys/@<keyName>@/requestToken
 
 This is the means by which clients obtain access tokens to use the service. The construction of a token request is described in the "Authentication token request spec documentation":/core-features/authentication#token-request-spec. The resulting @token response@ object contains the token properties as defined in "token request spec":/core-features/authentication#token-request-spec.
 

--- a/content/rest-api/versions/v1.0/index.textile
+++ b/content/rest-api/versions/v1.0/index.textile
@@ -321,7 +321,7 @@ Routes providing access to the messaging service within a channel scope.
 
 h3(#publish). Publish one or more messages on a channel
 
-h6. POST rest.ably.io/channels/@<channel id>@/messages
+h6. POST rest.ably.io/channels/@<channelId>@/messages
 
 Publish a message on a channel. Note that since the REST API is stateless, publication using this API is outside the context of any specific connection.
 
@@ -428,7 +428,7 @@ Nothing when successful, else returns an error.
 
 h3(#message-history). Retrieve message history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/messages
+h6. GET rest.ably.io/channels/@<channelId>@/messages
 
 If a channel is "configured to persist messages":http://support.ably.com/support/solutions/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for.
 
@@ -463,7 +463,7 @@ bc[json]. [{
 
 h3(#presence). Retrieve instantaneous presence status for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence
+h6. GET rest.ably.io/channels/@<channelId>@/presence
 
 Obtain the set of members currently present for a channel.
 
@@ -499,7 +499,7 @@ bc[json]. [{
 
 h3(#presence-history). Retrieve presence state history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence/history
+h6. GET rest.ably.io/channels/@<channelId>@/presence/history
 
 Obtain the history of presence messages for a channel.
 
@@ -623,7 +623,7 @@ h3(#update-device-registration). Update a device registration
 
 Device registrations can be either upserted (the existing registration is replaced entirely) with a "@PUT@":#put-device-registration operation, or specific attributes of an existing registration can be updated using a "@PATCH@":#patch-device-registration operation:
 
-h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration. The @PUT@ operation will replace the existing device registration, however please bear in mind that a registered device in Ably is largely immutable. As such, only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -670,7 +670,7 @@ A successful request returns the updated device details.
 
 An unsuccessful request returns an error.
 
-h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration, except only fields to be changed should be provided. Any fields provided replace existing values. Please bear in mind that fields whose values are structured (JSON-like arrays or objects) types will replace existing values as opposed to be merged into existing values. @metadata@ and @push.recipient@ are examples of these types. Currently only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -708,7 +708,7 @@ An unsuccessful request returns an error.
 
 h3(#get-device-registration). Get details from a registered device
 
-h6. GET rest.ably.io/push/deviceRegistrations/@<device id>@
+h6. GET rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 Obtain the details for a device registered for receiving push registrations.
 
@@ -794,7 +794,7 @@ bc[json]. [{
 
 h3(#reset-update-token). Reset a registered device's update token
 
-h6. POST rest.ably.io/push/deviceRegistrations/@<device id>@/resetUpdateToken
+h6. POST rest.ably.io/push/deviceRegistrations/@<deviceId>@/resetUpdateToken
 
 Example request:
 
@@ -816,7 +816,7 @@ A unsuccessful request returns an error.
 
 h3(#delete-device-registration). Unregister a single device for push notifications
 
-h6. DELETE rest.ably.io/push/deviceRegistration/@<device id>@
+h6. DELETE rest.ably.io/push/deviceRegistration/@<deviceId>@
 
 Unregisters a single device by its device ID. All its subscriptions for receiving push notifications through channels will also be deleted.
 

--- a/content/rest-api/versions/v1.0/index.textile
+++ b/content/rest-api/versions/v1.0/index.textile
@@ -1098,7 +1098,7 @@ h3(#request-token). Request an access token
 
 <!-- TODO: Review the suitability of the documentation that describes the token request and the token body response and provide suitable links -->
 
-h6. POST rest.ably.io/keys/@keyName@/requestToken
+h6. POST rest.ably.io/keys/@<keyName>@/requestToken
 
 This is the means by which clients obtain access tokens to use the service. The construction of an Ably "@TokenRequest@":/rest-api/token-request-spec is described in the "Authentication Ably TokenRequest spec documentation":/rest-api/token-request-spec. The resulting @token response@ object contains the token properties as defined in "Ably TokenRequest spec":/rest-api/token-request-spec.
 

--- a/content/rest-api/versions/v1.1/index.textile
+++ b/content/rest-api/versions/v1.1/index.textile
@@ -323,7 +323,7 @@ Routes providing access to the messaging service within a channel scope.
 
 h3(#publish). Publish one or more messages on a channel
 
-h6. POST rest.ably.io/channels/@<channel id>@/messages
+h6. POST rest.ably.io/channels/@<channelId>@/messages
 
 Publish a message on a channel. Note that since the REST API is stateless, publication using this API is outside the context of any specific connection.
 
@@ -473,7 +473,7 @@ When successful, returns an object with @channel@ and @messageId@ properties, in
 
 h3(#message-history). Retrieve message history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/messages
+h6. GET rest.ably.io/channels/@<channelId>@/messages
 
 If a channel is "configured to persist messages":http://support.ably.com/support/solutions/articles/3000030057-what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":http://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for.
 
@@ -508,7 +508,7 @@ bc[json]. [{
 
 h3(#presence). Retrieve instantaneous presence status for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence
+h6. GET rest.ably.io/channels/@<channelId>@/presence
 
 Obtain the set of members currently present for a channel.
 
@@ -544,7 +544,7 @@ bc[json]. [{
 
 h3(#presence-history). Retrieve presence state history for a channel
 
-h6. GET rest.ably.io/channels/@<channel id>@/presence/history
+h6. GET rest.ably.io/channels/@<channelId>@/presence/history
 
 Obtain the history of presence messages for a channel.
 
@@ -668,7 +668,7 @@ h3(#update-device-registration). Update a device registration
 
 Device registrations can be either upserted (the existing registration is replaced entirely) with a "@PUT@":#put-device-registration operation, or specific attributes of an existing registration can be updated using a "@PATCH@":#patch-device-registration operation:
 
-h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration. The @PUT@ operation will replace the existing device registration, however please bear in mind that a registered device in Ably is largely immutable. As such, only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -715,7 +715,7 @@ A successful request returns the updated device details.
 
 An unsuccessful request returns an error.
 
-h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<device id>@
+h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration, except only fields to be changed should be provided. Any fields provided replace existing values. Please bear in mind that fields whose values are structured (JSON-like arrays or objects) types will replace existing values as opposed to be merged into existing values. @metadata@ and @push.recipient@ are examples of these types. Currently only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -753,7 +753,7 @@ An unsuccessful request returns an error.
 
 h3(#get-device-registration). Get details from a registered device
 
-h6. GET rest.ably.io/push/deviceRegistrations/@<device id>@
+h6. GET rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 Obtain the details for a device registered for receiving push registrations.
 
@@ -839,7 +839,7 @@ bc[json]. [{
 
 h3(#reset-update-token). Reset a registered device's update token
 
-h6. POST rest.ably.io/push/deviceRegistrations/@<device id>@/resetUpdateToken
+h6. POST rest.ably.io/push/deviceRegistrations/@<deviceId>@/resetUpdateToken
 
 Example request:
 
@@ -861,7 +861,7 @@ A unsuccessful request returns an error.
 
 h3(#delete-device-registration). Unregister a single device for push notifications
 
-h6. DELETE rest.ably.io/push/deviceRegistrations/@<device id>@
+h6. DELETE rest.ably.io/push/deviceRegistrations/@<deviceId>@
 
 Unregisters a single device by its device ID. All its subscriptions for receiving push notifications through channels will also be deleted.
 

--- a/content/rest-api/versions/v1.1/index.textile
+++ b/content/rest-api/versions/v1.1/index.textile
@@ -1143,7 +1143,7 @@ h3(#request-token). Request an access token
 
 <!-- TODO: Review the suitability of the documentation that describes the token request and the token body response and provide suitable links -->
 
-h6. POST rest.ably.io/keys/@keyName@/requestToken
+h6. POST rest.ably.io/keys/@<keyName>@/requestToken
 
 This is the means by which clients obtain access tokens to use the service. The construction of an Ably "@TokenRequest@":/rest-api/token-request-spec is described in the "Authentication Ably TokenRequest spec documentation":/rest-api/token-request-spec. The resulting @token response@ object contains the token properties as defined in "Ably TokenRequest spec":/rest-api/token-request-spec.
 


### PR DESCRIPTION
[DOC-11] Enforce syntax consistency for API requests that require substitution.

[DOC-11]: https://ably.atlassian.net/browse/DOC-11