### PR TITLE
Channel Enumeration API: add lots of warnings and caveats

### DIFF
--- a/content/partials/shared/_channel_enumeration.textile
+++ b/content/partials/shared/_channel_enumeration.textile
@@ -1,5 +1,7 @@
 This enumerates all active channels in the application. This is a paginated API following the same API conventions as other paginated APIs in the "Ably REST library":/rest.
 
+This API is intended for occasional use by your servers only; for example, to get an initial set of active channels to be kept up to date using the "channel lifecycle metachannel":realtime/channel-metadata#subscribing-to-metadata-events . It is heavily rate-limited: only a single in-flight channel enumeration call is permitted to execute at any one time. Further concurrent calls will be refused with an error with code @42912@.
+
 Example request:
 
 bc[sh]. curl https://rest.ably.io/channels \
@@ -11,13 +13,15 @@ The following parameters are supported:
 
 - limit := _100_ optionally specifies the maximum number of results to return. A limit greater than 1000 is unsupported<br>__Type: @integer@__
 - prefix := optionally limits the query to only those channels whose name starts with the given prefix<br>__Type: @string@__
-- by := _value_ optionally specifies whether to return just channel names (@by=id@) or "ChannelDetails":realtime/channel-metadata#channel-details (@by=value@)
+- by := _value_ optionally specifies whether to return just channel names (@by=id@) or "ChannelDetails":realtime/channel-metadata#channel-details (@by=value@ is the default, but if you do not actually need the extra information you get with that, we strongly recommend you use @by=id@, which will be faster)
 
 The credentials presented with the request must include the @channel-metadata@ permission for the wildcard resource @'*'@.
 
-Client libraries currently do not provide a dedicated API to enumerate channels, but make this available using the "request":/rest/usage#request method. When using this, you can simply iterate through the "PaginatedResults":rest/types#paginated-result to enumerate through the results.
+Client libraries do not provide a dedicated API to enumerate channels, but make this available using the "request":/rest/usage#request method. When using this, you can simply iterate through the "PaginatedResults":rest/types#paginated-result to enumerate through the results.
 
-@Enumeration@ is possible of all channels in an app, by repeated calls to the API, following the @next@ relative link on each successive call, until there is no @next@ relative link. However, the state of the app and the cluster itself can change during that enumeration. This API therefore has the following limitations:
+@Enumeration@ is possible of all channels in an app, by repeated calls to the API, following the @next@ relative link on each successive call, until there is no @next@ relative link. However, this is subject to several limitations:
 
-* channels that become active, or become inactive, between the first and last request in the sequence, might or might not appear in the result. The API guarantees that if a channel is continuously active from the time that the first request is made until the time that the last request completes, then it is guaranteed to be present in the result. Similarly, if a channel is continuously inactive between those times then it is guaranteed not to be present in the result;
-* cluster state changes, in this first release of this API, may cause a pagination sequence to become invalid, in which case the request will respond with an error with code @40011@. In this case, to get a complete result, it is necessary to start the enumeration again from the beginning. Other API options to deal with this possibility will be provided in later versions of this API. Enumerations that are satisfiable in the first response page do not have this issue.
+* Channels that become active, or become inactive, between the first and last request in the sequence, might or might not appear in the result. The API guarantees that if a channel is continuously active from the time that the first request is made until the time that the last request completes, then it is guaranteed to be present in the result. Similarly, if a channel is continuously inactive between those times then it is guaranteed not to be present in the result;
+* Since the state of the cluster may change between successive calls, a pagination sequence may become invalid, in which case the request will respond with an error with code @40011@. In this case, to get a complete result, it is necessary to start the enumeration again from the beginning. Other API options to deal with this possibility maybe provided in later versions of this API. Enumerations that are satisfiable in the first response page do not have this issue.
+* The API does not guarantee that the limit will be achieved even if that would be possible. For example, if you specify a limit of 100, the API may return only 37 results together with a @next@ link to get the next page, even if you have more than 37 channels. In the extreme case, the API may return 0 results with a next link. In particular this may be the case if you have a large number of active channels but are specifing a @prefix@ that excludes a significant proportion of them.
+* The API does not guarantee that there will be no duplicated results between different pages, especially if a channel is alive in multiple regions. (It does not _currently_ do so, but it may begin to do so with no warning or deprecation period, so your implementation should be able to cope with duplication)


### PR DESCRIPTION
context: https://github.com/ably/realtime/issues/3160

as we haven't yet decided on how enumeration will work with decoupling, I settled for adding caveats to allow us to return less results and/or duplicated results in the future, even if we don't currently do so.