### PR TITLE
Presence.history: remove untilAttach param

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -594,7 +594,7 @@ h3(#realtime-channel). Channel
 ** @(RTL10d)@ A test should exist that publishes messages from one client, and upon confirmation of message delivery, a history request should be made on another client to ensure all messages are available
 * @(RTL12)@ An attached channel may receive an additional @ATTACHED@ @ProtocolMessage@ from Ably at any point. (This is typically triggered following a transport being resumed to indicate a partial loss of message continuity on that channel, in which case the @ProtocolMessage@ will have a @resumed@ flag set to false). If and only if the @resumed@ flag is false, this should result in the channel emitting an @UPDATE@ event with a @ChannelStateChange@ object. The @ChannelStateChange@ object should have both @previous@ and @current@ attributes set to @attached@, the @reason@ attribute set to to the @error@ member of the @ATTACHED@ @ProtocolMessage@ (if any), and the @resumed@ attribute set per the @RESUMED@ bitflag of the @ATTACHED@ @ProtocolMessage@. (Note that @UPDATE@ should be the only event emitted: in particular, the library must not emit an @ATTACHED@ event if the channel was already attached, see @RTL2g@).
 * @(RTL15)@ @Channel#properties@ attribute is a @ChannelProperties@ object representing properties of the channel state. @properties@ is a publicly accessible member of the channel, but it is an experimental and unstable API. It has the following attributes:
-** @(RTL15a)@ @attachSerial@ is unset when the channel is instanced, and is updated with the @channelSerial@ from each @ATTACHED@ @ProtocolMessage@ received from Ably with a matching @channel@ attribute. The @attachSerial@ value is used for @untilAttach@ queries, see "RTL10b":#RTL10b and "RTP12b":#RTP12b.
+** @(RTL15a)@ @attachSerial@ is unset when the channel is instanced, and is updated with the @channelSerial@ from each @ATTACHED@ @ProtocolMessage@ received from Ably with a matching @channel@ attribute. The @attachSerial@ value is used for @untilAttach@ queries, see "RTL10b":#RTL10b
 * @(RTL13)@ If the channel receives a server initiated @DETACHED@ message when it is in the @ATTACHING@, @ATTACHED@ or @SUSPENDED@ state (i.e. the client has not explicitly requested a detach putting the channel into the @DETACHING@ state), then the following applies:
 ** @(RTL13a)@ If the channel is in the @ATTACHED@ or @SUSPENDED@ states, an attempt to reattach the channel should be made immediately by sending a new @ATTACH@ message and the channel should transition to the @ATTACHING@ state with the error emitted in the @ChannelStateChange@ event.
 ** @(RTL13b)@ If the attempt to re-attach fails, or if the channel was already in the @ATTACHING@ state, the channel will transition to the @SUSPENDED@ state and the error will be emitted in the @ChannelStateChange@ event. An attempt to re-attach the channel automatically will then be made after the period defined in @ClientOptions#channelRetryTimeout@. When re-attaching the channel, the channel will transition to the @ATTACHING@ state. If that request to attach fails i.e. it times out or a @DETACHED@ message is received, then the process described here in @RTL13b@ will be repeated, indefinitely
@@ -689,7 +689,6 @@ h3(#realtime-presence). Presence
 *** @(RTP11c3)@ @connectionId@ filters members by the provided @connectionId@
 * @(RTP12)@ @Presence#history@ function:
 ** @(RTP12a)@ Supports all the same params as REST @Presence#history@
-** @(RTP12b)@ Additionally supports the param @untilAttach@, which if true, will only retrieve messages prior to the moment that the channel was attached or emitted an @UPDATE@ indicating loss of continuity. This bound is specified by passing the querystring param @fromSerial@ with the @Channel#properties.attachSerial@ assigned to the channel in the @ATTACHED@ @ProtocolMessage@ (see "RTL15a":#RTL15a). If the @untilAttach@ param is specified when the channel is not attached, it will result in an error
 ** @(RTP12c)@ Returns a @PaginatedResult@ page containing the first page of messages in the @PaginatedResult#items@ attribute returned from the history request
 ** @(RTP12d)@ A test should exist that registers presence with a few clients, and upon confirmation of entering the channel for all clients, a presence history request should be made using another client to ensure all presence events are available
 * @(RTP13)@ @Presence#syncComplete@ attribute is @true@ if the initial @SYNC@ operation has completed for the members present on the channel
@@ -1729,7 +1728,6 @@ class RealtimePresence:
     end: Time, // RTP12a
     direction: .Backwards | .Forwards api-default .Backwards, // RTP12a
     limit: int api-default 100, // RTP12a
-    untilAttach: Bool default false // RTP12b
   ) => io PaginatedResult<PresenceMessage> // RTP12c
   subscribe((PresenceMessage) ->) => io // RTP6a
   subscribe(PresenceAction, (PresenceMessage) ->) => io // RTP6b

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -399,7 +399,7 @@ bq(definition).
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash option) -> yields "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>
   java:    "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] option)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false)
+  csharp:  Task<"PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false [deprecated])
 
 Gets a "paginated":#paginated-result set of historical presence events for this channel.
 
@@ -417,7 +417,6 @@ h4. <span lang="default">@options@ parameters</span><span lang="objc,swift">@ART
 - <span lang="default">end</span><span lang="ruby">:end</span><span lang="csharp">End</span> := _current time_ latest <span lang="csharp">@DateTimeOffset@ or </span><span lang="ruby">@Time@ or </span>time in milliseconds since the epoch for any presence events retrieved<br>__Type: <span lang="default">@Long@</span><span lang="ruby">@Int or @Time@</span><span lang="csharp">@DateTimeOffset@</span>__
 - <span lang="default">direction</span><span lang="ruby">:direction</span><span lang="csharp">Direction</span> := _backwards_ <span lang="ruby">@:@</span>@forwards@ or <span lang="ruby">@:@</span>@backwards@<br>__Type: <span lang="default">@String@</span><span lang="ruby">@Symbol@</span><span lang="csharp">@Direction@ enum</span>__
 - <span lang="default">limit</span><span lang="ruby">:limit</span><span lang="csharp">Limit</span> := _100_ maximum number of presence events to retrieve up to 1,000<br>__Type: @Integer@__
-- <span lang="default">untilAttach</span><span lang="ruby">:until_attach</span> := _false_ when true, ensures presence event history is up until the point of the channel being attached. See "continuous history":#continuous-history for more info. Requires the @direction@ to be @backwards@ (the default). If the @Channel@ is not attached, or if @direction@ is set to @forwards@, this option will result in an error<br>__Type: @Boolean@__
 
 blang[jsall,objc,swift].
   h4. Callback result

--- a/content/realtime/presence.textile
+++ b/content/realtime/presence.textile
@@ -304,15 +304,15 @@ channel.presence.get { members, error in
 
 h3(#presence-history). Presence History
 
-The @Presence@ object exposes a "<span lang="default">@history@</span><span lang="csharp">@History@</span>":#history method allowing a client to retrieve historical presence events on the channel. Presence history can be used to return continuous presence event history up to the exact point a realtime channel was attached.
+The @Presence@ object exposes a "<span lang="default">@history@</span><span lang="csharp">@History@</span>":#history method allowing a client to retrieve historical presence events on the channel.
 
 History provides access to instantaneous "live" history as well as the longer term persisted history for presence channels. If "persisted history":/realtime/history#persisted-history is enabled for the channel, then presence events will "typically be stored for 24 - 72 hours":https://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for. If persisted history is not enabled, Ably retains the last two minutes of presence event history in memory.
 
-The following example retrieves the first two pages of historical presence events published up until the point the channel was attached.
+The following example retrieves the first two pages of historical presence events.
 
 bc[jsall]. channel.attach(function() {
   var presence = channel.presence;
-  presence.history({ untilAttach: true }, function(err, resultPage) {
+  presence.history({}, function(err, resultPage) {
     if(err) {
       console.log('Unable to get presence history; err = ' + err.message);
     } else {
@@ -325,7 +325,7 @@ bc[jsall]. channel.attach(function() {
 
 bc[ruby]. channel.attach do
   presence = channel.presence
-  presence.history(until_attach: true) do |result_page|
+  presence.history() do |result_page|
     puts "#{result_page.items.length} presence events received in first page"
     if result_page.has_next?
       result_page.next { |next_page| ... }
@@ -334,7 +334,7 @@ bc[ruby]. channel.attach do
 end
 
 ```[java]
-Param[] options = new Param[]{ new Param("untilAttach", "true") }
+Param[] options = new Param[]{}
 PaginatedResult<PresenceMessage> resultPage = channel.presence.history(options);
 System.out.println(resultPage.items().length + " presence events received in first page");
 if(resultPage.hasNext()) {
@@ -345,7 +345,7 @@ if(resultPage.hasNext()) {
 
 ```[csharp]
 PaginatedResult<PresenceMessage> resultPage;
-resultPage = await channel.Presence.HistoryAsync(untilAttach: true);
+resultPage = await channel.Presence.HistoryAsync(untilAttach: false);
 Console.WriteLine(resultPage.Items.Count + " presence events received in first page");
 if (resultPage.HasNext)
 {
@@ -356,7 +356,6 @@ if (resultPage.HasNext)
 
 ```[objc]
 ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-query.untilAttach = YES;
 [channel.presence history:query callback:^(ARTPaginatedResult<ARTPresenceMessage *> *resultPage,
                                            ARTErrorInfo *error) {
     NSLog(@"%lu presence events received in first page", [resultPage.items count]);
@@ -370,7 +369,6 @@ query.untilAttach = YES;
 
 ```[swift]
 let query = ARTRealtimeHistoryQuery()
-query.untilAttach = true
 channel.presence.history(query) { resultPage, error in
     let resultPage = resultPage!
     print("\(resultPage.items.count) presence events received in first page")
@@ -801,7 +799,7 @@ bq(definition).
   ruby:    "Deferrable":/realtime/types#deferrable history(Hash options) -> yields "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message>
   java:    "PaginatedResult":#paginated-result<"PresenceMessage":#presence-message> history("Param":#param[] options)
   objc,swift: history(query: ARTRealtimeHistoryQuery?, callback: ("ARTPaginatedResult":#paginated-result<"ARTPresenceMessage":#presence-message>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<PaginatedResult<PresenceMessage>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false)
+  csharp:  Task<PaginatedResult<PresenceMessage>> HistoryAsync("PaginatedRequestParams":#paginated-request-params query, bool untilAttach = false [deprecated])
 
 
 Gets a "paginated":#paginated-result set of historical presence message events for this channel. If the "channel is configured to persist messages to disk":https://support.ably.com/support/solutions/articles/3000030059-how-long-are-messages-stored-for, then the presence message event history will "typically be available for 24 - 72 hours":https://support.ably.com/solution/articles/3000030059-how-long-are-messages-stored-for. If not, presence message events are only retained in memory by the Ably service for two minutes.


### PR DESCRIPTION
Remove references to the untilAttach param in the docs for presence history.

Context: https://github.com/ably/realtime/issues/3069#issuecomment-707279282 . Literally no-one uses it, because there's no usecase for it, since you get a full presence sync when you attach. And it adds complexity to the server. So I intend to take advantage of the fact that no-one uses it to remove support for it without breaking anyone's code.

The only snag is that ably-dotnet for some reason includes `untilAttach` as a standalone parameter to the history() call rather than just being one of the other params, so that can't be removed without a breaking change. So for that client lib I've left it in the documentation and marked it as deprecated. We should add new versions of the method that don't take that param and make them the main documented versions.