### PR TITLE
Minor typo fix

### DIFF
--- a/content/core-features/channels.textile
+++ b/content/core-features/channels.textile
@@ -4,7 +4,7 @@ section: core-features
 index: 23
 ---
 
-Ably aggregates all it's data into named units of distribution, referred to as "channels". Channels offer a way to implement the Publish-Subscribe (Pub/Sub) architectural pattern, which is a popular pattern used for realtime data delivery.
+Ably aggregates all its data into named units of distribution, referred to as "channels". Channels offer a way to implement the Publish-Subscribe (Pub/Sub) architectural pattern, which is a popular pattern used for realtime data delivery.
 
 The Publish-Subscribe messaging pattern lets any number of publishers publish data to a channel, which could be subscribed to by any number of subscribers. The key thing to note about Pub/Sub is that publishers and subscribers are completely decoupled as explained "further down this page":/channels#understanding-decoupled-clients. Once subscribed, the subscribers no longer have to poll the server or data provider to check if there is any new data that they need to be aware of; instead, they will be notified of it as it becomes available.
 

--- a/content/core-features/versions/v1.1/channels.textile
+++ b/content/core-features/versions/v1.1/channels.textile
@@ -4,7 +4,7 @@ section: core-features
 index: 23
 ---
 
-Ably aggregates all it's data into named units of distribution, referred to as "channels". Channels offer a way to implement the Publish-Subscribe (Pub/Sub) architectural pattern, which is a popular pattern used for realtime data delivery.
+Ably aggregates all its data into named units of distribution, referred to as "channels". Channels offer a way to implement the Publish-Subscribe (Pub/Sub) architectural pattern, which is a popular pattern used for realtime data delivery.
 
 The Publish-Subscribe messaging pattern lets any number of publishers publish data to a channel, which could be subscribed to by any number of subscribers. The key thing to note about Pub/Sub is that publishers and subscribers are completely decoupled as explained "further down this page":/channels#understanding-decoupled-clients. Once subscribed, the subscribers no longer have to poll the server or data provider to check if there is any new data that they need to be aware of; instead, they will be notified of it as it becomes available.
 


### PR DESCRIPTION
## Description

- First commit to check access. 
- Fixes minor typo: "it's" is *always* "it is" (which is not what we want here).

## Review

* [page to review](https://ably-docs-tony-minor-fi-quv3zv.herokuapp.com/core-features/channels/)