### PR TITLE
Fix: corrects case for JavaScript on selector

### DIFF
--- a/lib/documentation_languages.rb
+++ b/lib/documentation_languages.rb
@@ -1,6 +1,6 @@
 module Ably
   DOCUMENTATION_LANGUAGES = {
-    'javascript' => { name: 'Javascript', extension: 'js' },
+    'javascript' => { name: 'JavaScript', extension: 'js' },
     'java' => { name: 'Java', extension: 'java' },
     'android' => { name: 'Android', extension: 'java' },
     'python' => { name: 'Python', extension: 'py' },


### PR DESCRIPTION
## Description

On the language selector the case for JavaScript was incorrectly specified as "Javascript". This PR changes only the text displayed on the selector.

## Review

Go to any page such as Channels that has the code selector. Check that the JavaScript entry on the selector displays JavaScript.

* [Page to review](https://ably-docs-fix-doc-229-c-txkawm.herokuapp.com/realtime/channels/)