### PR TITLE
[WEB-408] - Support SEO metadata

### DIFF
--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -51,6 +51,15 @@ View this page's Textile markup for an example of the jump to navigation.
 
 Note that if you have referenced an anchor that has language specific content, the jump to navigation will automatically update to reflect the new content for that anchor whenever a language is selected, and ignore the text you have provided. Also, if an anchor is longer visible because it is contained within a language block, the corresponding navigation item will be hidden.
 
+h3(#seo-metadata). SEO focussed metadata
+
+The following metadata attributes are supported:
+
+bc[yaml]. ---
+meta_description: "Description for this page rendeded in HTML meta description field"
+meta_keywords: "Keywords for this page rendeded in HTML meta keywords field"
+meta_image: "/images/path/to/file/in/assets/folder.png"
+
 h3(#special-metadata). Special Metadata
 
 Certain pages have additional pieces of metadata which can be used to help the website display unique information.

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -33,6 +33,10 @@ level: easy
 reading_time: 10
 tags:
     - Message History
+
+meta_description: "Learn how to publish messages and later retrieve them using the History API"
+meta_keywords: "Ably, History"
+meta_image: "/images/ably-logo.png"
 ---
 
 

--- a/content/tutorials/index.textile
+++ b/content/tutorials/index.textile
@@ -3,6 +3,9 @@ title: Tutorials
 section: root
 index: 30
 hide_from_website: true
+meta_description: "Ably Realtime Tutorials"
+meta_keywords: "Ably, Realtime Tutorials"
+meta_image: "/images/ably-logo.png"
 ---
 
 h3. Index of tutorials

--- a/layouts/_head.html.erb
+++ b/layouts/_head.html.erb
@@ -13,6 +13,28 @@
     <title>Ably API Documentation - <%= @item[:title] %></title>
     <link rel="shortcut icon" href="/favicon.ico">
 
+    <meta property="og:site_name" content="Ably Realtime">
+    <meta name="twitter:site" content="@ablyrealtime">
+    <meta property="og:type" content="website">
+
+    <meta property="og:title" content="<%= @item[:title] %>">
+    <meta name="twitter:title" content="<%= @item[:title] %>">
+
+
+    <% if @item[:meta_description] %>
+    <meta name="description" content="<%= @item[:meta_description] %>">
+    <meta property="og:description" content="<%= @item[:meta_description] %>">
+    <meta name="twitter:description" content="<%= @item[:meta_description] %>">
+    <% end %>
+
+    <% if @item[:meta_image] %>
+    <meta property="og:image" content="<%= @item[:meta_image] %>">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="<%= @item[:meta_image] %>">
+    <% end %>
+
+    <% if @item[:meta_keywords] %><meta name="keywords" content="<%= @item[:meta_keywords] %>"><% end %>
+
     <link rel="stylesheet" type="text/css" href="/vendor/prettify/prettify.css" media="screen">
     <link rel="stylesheet" type="text/css" href="/stylesheet.css" media="screen">
 


### PR DESCRIPTION
Content team need to add metadata to the docs content published.  This is a blocker for them so I wanted to unblock them.

Note there is an associated website PR to come.

See https://github.com/ably/website/pull/3524.