### PR TITLE
fix: missing trailing `---` in formatting guide

### DIFF
--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -59,6 +59,7 @@ bc[yaml]. ---
 meta_description: "Description for this page rendeded in HTML meta description field"
 meta_keywords: "Keywords for this page rendeded in HTML meta keywords field"
 meta_image: "/images/path/to/file/in/assets/folder.png"
+ ---
 
 h3(#special-metadata). Special Metadata
 

--- a/content/client-lib-development-guide/documentation-formatting-guide.textile
+++ b/content/client-lib-development-guide/documentation-formatting-guide.textile
@@ -45,7 +45,7 @@ jump_to: # Optional YAML tag that will insert a "jump to" navigation based on YA
     - "Item 2" # auto-links to #item-2
     - "Item 3" # auto-links to #item-3
     - "Language specific content"#language-specific-content
- ---
+---
 
 View this page's Textile markup for an example of the jump to navigation.
 
@@ -59,7 +59,7 @@ bc[yaml]. ---
 meta_description: "Description for this page rendeded in HTML meta description field"
 meta_keywords: "Keywords for this page rendeded in HTML meta keywords field"
 meta_image: "/images/path/to/file/in/assets/folder.png"
- ---
+---
 
 h3(#special-metadata). Special Metadata
 


### PR DESCRIPTION
Spotted by @fliptopbox right after merging #1016.

Although this didn't cause a rendering issue on docs.ably.io, it might on the website. However, the formatting guide isn't directly accessible from the website navigation.