### PR TITLE
Ensure relative image links for OpenGraph are absolute

### DIFF
--- a/layouts/_head.html.erb
+++ b/layouts/_head.html.erb
@@ -28,9 +28,9 @@
     <% end %>
 
     <% if @item[:meta_image] %>
-    <meta property="og:image" content="<%= @item[:meta_image] %>">
+    <meta property="og:image" content="<%= image_url(@item[:meta_image]) %>">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="<%= @item[:meta_image] %>">
+    <meta name="twitter:image" content="<%= image_url(@item[:meta_image]) %>">
     <% end %>
 
     <% if @item[:meta_keywords] %><meta name="keywords" content="<%= @item[:meta_keywords] %>"><% end %>

--- a/lib/helpers/link_helper.rb
+++ b/lib/helpers/link_helper.rb
@@ -1,6 +1,6 @@
 module LinkHelper
   CANONICAL_ROOT = 'https://www.ably.io/' unless defined?(CANONICAL_ROOT)
-  DOCS_ROOT = 'https://docs.ably.io/' unless defined?(DOCS_ROOT)
+  DOCS_ROOT = 'https://docs.ably.com/' unless defined?(DOCS_ROOT)
 
   def link(text, target, attributes = {})
     target = "/#{target}" unless target.match(/^(\w+:\/\/|\/)/)
@@ -17,7 +17,7 @@ module LinkHelper
   end
 
   def image_url(image_path)
-    return image_path if image_path.match(/^http/)
+    return image_path if image_path.match(/^http/i)
     "#{DOCS_ROOT}#{image_path.gsub(%r{^/}, '')}"
   end
 end

--- a/lib/helpers/link_helper.rb
+++ b/lib/helpers/link_helper.rb
@@ -1,5 +1,6 @@
 module LinkHelper
   CANONICAL_ROOT = 'https://www.ably.io/' unless defined?(CANONICAL_ROOT)
+  DOCS_ROOT = 'https://docs.ably.io/' unless defined?(DOCS_ROOT)
 
   def link(text, target, attributes = {})
     target = "/#{target}" unless target.match(/^(\w+:\/\/|\/)/)
@@ -13,6 +14,11 @@ module LinkHelper
     else
       "#{CANONICAL_ROOT}documentation#{clean_item.gsub("/root", "")}".gsub(%r{/$}, '')
     end
+  end
+
+  def image_url(image_path)
+    return image_path if image_path.match(/^http/)
+    "#{DOCS_ROOT}#{image_path.gsub(%r{^/}, '')}"
   end
 end
 


### PR DESCRIPTION
Fixes an issue with opengraph images that didn't work correctly with https://github.com/ably/docs/pull/1016.  A separate PR will fix this in full on the website.

![screenshot_2021-01-19_07-03-22_pm](https://user-images.githubusercontent.com/43789/105074761-1ab4ad80-5a89-11eb-9c76-3fbc3cbba018.png)

As this is a static site builder, we have to hard code a URL unfortunately.  Given the docs site is designed for development use, compromising to use the docs well know host name is OK.