### PR TITLE
Fix link that causes doc crash

### DIFF
--- a/content/tutorials/realtime-cryptocurrency-app-flutter.textile
+++ b/content/tutorials/realtime-cryptocurrency-app-flutter.textile
@@ -31,7 +31,6 @@ redirect_from:
   - /tutorials/realtime-cryptocurrency-app-flutter/
   - /tutorials/flutter-cryptocurrency-app/
   - /tutorials/flutter-cryptocurrency-app
-  - /tutorials/realtime-cryptocurrency-app-flutter /
 
 ---
 

--- a/data/redirects.yaml
+++ b/data/redirects.yaml
@@ -14,5 +14,8 @@
 "/realtime/channels-messages": "/realtime/channels"
 "/realtime/versions/v0.8/channels-messages": "/realtime/versions/v0.8/channels"
 "/realtime/channel-params": "/realtime/channels/channel-parameters/overview"
+"/tutorials/realtime-cryptocurrency-app-flutter/": "/tutorials/realtime-cryptocurrency-app-flutter"
+"/tutorials/flutter-cryptocurrency-app/": "/tutorials/realtime-cryptocurrency-app-flutter"
+"/tutorials/flutter-cryptocurrency-app": "/tutorials/realtime-cryptocurrency-app-flutter"
 "/rest/channels-messages": "/rest/channels"
 "/rest/versions/v0.8/channels-messages": "/rest/versions/v0.8/channels"


### PR DESCRIPTION
## Description

Fixes link that causes doc tool crash when run locally. 

This crash does NOT occur if testing and reviewing locally with website, it occurs only if you run the nanoc tool.

Details in [DOC-260](https://ably.atlassian.net/browse/DOC-260).

## Review

Checkout branch locally and run `bundle exec nanoc live -p 4000`, and then `nanoc check elinks` nanoc should NOT crash.