### PR TITLE
remove RSN4c, add RTS4b (channels#release)

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -235,6 +235,7 @@ h3(#rest-channels). Channels
 * @(RSN4)@ @Channels#release@ function:
 ** @(RSN4a)@ Takes one argument, the channel name, and releases the corresponding channel entity (that is, deletes it to allow it to be garbage collected)
 ** @(RSN4b)@ Calling @release()@ with a channel name that does not correspond to an extant channel entity must return without error
+** @(RSN4c)@ This clause has been deleted
 
 h3(#rest-channel). Channel
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -492,7 +492,6 @@ h3(#realtime-channels). Channels
 *** @(RTS3c1)@ If a new set of @ChannelOptions@ is supplied to @Channels#get@ that would trigger a reattachment of the channel if supplied to @Channel#setOptions@ per "@RTL16a@":#RTL16a, it must raise an error, informing the user that they must use @Channel#setOptions@ instead
 * @(RTS4)@ @Channels#release@ function:
 ** @(RTS4a)@ Detaches the channel and then releases the channel resource i.e. it's deleted and can then be garbage collected
-** @(RTS4b)@ Calling @release()@ with a channel name that corresponds to a channel that is in any state other than @INITIALIZED@, @DETACHED@, or @FAILED@ must, instead of releasing the channel, raise an error with code @90001@
 
 h3(#realtime-channel). Channel
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -235,7 +235,7 @@ h3(#rest-channels). Channels
 * @(RSN4)@ @Channels#release@ function:
 ** @(RSN4a)@ Takes one argument, the channel name, and releases the corresponding channel entity (that is, deletes it to allow it to be garbage collected)
 ** @(RSN4b)@ Calling @release()@ with a channel name that does not correspond to an extant channel entity must return without error
-** @(RSN4c)@ This clause has been deleted
+** @(RSN4c)@ This clause has been deleted.
 
 h3(#rest-channel). Channel
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -235,7 +235,6 @@ h3(#rest-channels). Channels
 * @(RSN4)@ @Channels#release@ function:
 ** @(RSN4a)@ Takes one argument, the channel name, and releases the corresponding channel entity (that is, deletes it to allow it to be garbage collected)
 ** @(RSN4b)@ Calling @release()@ with a channel name that does not correspond to an extant channel entity must return without error
-** @(RSN4c)@ Calling @release()@ with a channel name that corresponds to a channel that is in any state other than @INITIALIZED@, @DETACHED@, or @FAILED@ must, instead of releasing the channel, raise an error with code @90001@
 
 h3(#rest-channel). Channel
 
@@ -492,6 +491,7 @@ h3(#realtime-channels). Channels
 *** @(RTS3c1)@ If a new set of @ChannelOptions@ is supplied to @Channels#get@ that would trigger a reattachment of the channel if supplied to @Channel#setOptions@ per "@RTL16a@":#RTL16a, it must raise an error, informing the user that they must use @Channel#setOptions@ instead
 * @(RTS4)@ @Channels#release@ function:
 ** @(RTS4a)@ Detaches the channel and then releases the channel resource i.e. it's deleted and can then be garbage collected
+** @(RTS4b)@ Calling @release()@ with a channel name that corresponds to a channel that is in any state other than @INITIALIZED@, @DETACHED@, or @FAILED@ must, instead of releasing the channel, raise an error with code @90001@
 
 h3(#realtime-channel). Channel
 


### PR DESCRIPTION
`channels#release` in should raise error in `realtime` for specific states and should return without error in `rest`

[RSN4c](https://docs.ably.io/client-lib-development-guide/features/#RSN4c) should be put under [RTS4](https://docs.ably.io/client-lib-development-guide/features/#RTS4)

Discussion: https://ably-real-time.slack.com/archives/C030C5YLY/p1615715227000800