### PR TITLE
CSharp API usage correction

### DIFF
--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -69,7 +69,7 @@ ably.connection.on('connected', new ConnectionStateListener() {
 });
 
 bc[csharp]. AblyRealtime ably = new AblyRealtime("{{API_KEY}}");
-ably.Connection.On(ConnectionState.Connected, args => {
+ably.Connection.On(ConnectionEvent.Connected, args => {
   Console.WriteLine("Connected, that was easy");
 });
 

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -186,7 +186,7 @@ ably.connection.on(.connected) {
 }
 
 bc[csharp]. var ably = new AblyRealtime("{{API_KEY}}");
-ably.Connection.On(ConnectionState.Connected, args =>
+ably.Connection.On(ConnectionEvent.Connected, args =>
 {
   Console.Out.WriteLine("That was simple, you're now connected to Ably in realtime");
 });


### PR DESCRIPTION
Small CSharp API usage correction.  In the latest version of the SDK when
establishing a callback for 'Connection' events the first parameter should
be a 'ConnetionEvent' and not a 'ConnectionState'.

I have only changed this for the latest version of the docs.  I need to do
more research and see if this applies to older versions of the SDK.