### PR TITLE
DOC-311: Fix broken link in asset tracking

### DIFF
--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -160,4 +160,4 @@ The following logic is used:
 h2(#see-also). See also
 
 * "Using the example apps":/asset-tracking/example-apps
-* "Using the SDKs":/asset-tracking/using-the-SDKs
+* "Using the SDKs":/asset-tracking/using-the-sdks


### PR DESCRIPTION
Fixes the link `Using the SDKs` on https://ably.com/documentation/asset-tracking#see-also 