### PR TITLE
Remove references to ably-js-react-native from tutorials

### DIFF
--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -77,14 +77,13 @@ If all goes well, you should see a screen that says “Welcome to React Native�
 Next, you will install the required libraries for this app.
 
 ```[sh]
-npm install ably ably-react-native express body-parser --save
+npm install ably express body-parser --save
 ```
 In the above bash command, you installed 4 packages. Here is the explanation of what the four packages are used for:
 
 # Express: This is a Node.js web framework which we’ll use to create our API.
 # Body-parser: This library is used by Express to parse body requests.
-# Ably: This library is the official @Ably@ library for Node js
-# Ably-react-native: This library is the official @Ably@ library for React Native
+# Ably: This library is the official @Ably@ library for JavaScript
 
 "See this step in Github":https://github.com/ably/tutorials/commit/b321b24c694cd9d3d67b9724132eb46da7fa1821
 


### PR DESCRIPTION
As part of work to deprecate `ably-js-react-native` (see [ably-js issue](https://github.com/ably/ably-js/issues/743)) this PR replaces all references to the react-native SDK.