### PR TITLE
replace OS X with macOS

### DIFF
--- a/content/general/versions/v1.0/push.textile
+++ b/content/general/versions/v1.0/push.textile
@@ -61,7 +61,7 @@ h2(#platform-support). Platform support
 
 Ably currently offers beta support for push notifications on the following platforms:
 
-- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS, desktop devices running OS X and Safari
+- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS, desktop devices running macOS and Safari
 - "Google Cloud Messaging":https://developers.google.com/cloud-messaging/ := supported on all Android and iOS devices, although we use GCM exclusively for Android message delivery
 - "Firebase Cloud Messaging":https://developers.google.com/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
 

--- a/content/partials/general/push/_push_intro.textile
+++ b/content/partials/general/push/_push_intro.textile
@@ -44,6 +44,6 @@ h2(#platform-support). Platform support
 
 Ably currently offers support for push notifications on the following platforms:
 
-- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running OS X
+- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running macOS
 - "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
 - Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). "Get in touch":https://ably.com/contact if you want to use this.

--- a/content/partials/versions/v1.1/general/push/_push_intro.textile
+++ b/content/partials/versions/v1.1/general/push/_push_intro.textile
@@ -44,6 +44,6 @@ h2(#platform-support). Platform support
 
 Ably currently offers support for push notifications on the following platforms:
 
-- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running OS X
+- "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running macOS
 - "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
 - Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). "Get in touch":https://ably.com/contact if you want to use this.


### PR DESCRIPTION
Just a very small change, because OS X was renamed to macOS in 2016.