### PR TITLE
Add quotation marks to make sure the code can run (Javascript)

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -147,7 +147,7 @@ The following is an example of creating an Ably JWT:
   var base64Header = btoa(header);
   var base64Claims = btoa(claims);
   /* Apply the hash specified in the header */
-  var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
+  var signature = hash((base64Header + "." + base64Claims), "{{API_KEY_SECRET}}");
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 
@@ -408,7 +408,7 @@ The following is an example of creating an Ably JWT:
   var base64Header = btoa(header);
   var base64Claims = btoa(claims);
   /* Apply the hash specified in the header */
-  var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
+  var signature = hash((base64Header + "." + base64Claims), "{{API_KEY_SECRET}}");
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 

--- a/content/core-features/versions/v1.1/authentication.textile
+++ b/content/core-features/versions/v1.1/authentication.textile
@@ -144,7 +144,7 @@ The following is an example of creating an Ably JWT:
   var base64Header = btoa(header);
   var base64Claims = btoa(claims);
   /* Apply the hash specified in the header */
-  var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
+  var signature = hash((base64Header + "." + base64Claims), "{{API_KEY_SECRET}}");
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 
@@ -405,7 +405,7 @@ The following is an example of creating an Ably JWT:
   var base64Header = btoa(header);
   var base64Claims = btoa(claims);
   /* Apply the hash specified in the header */
-  var signature = hash((base64Header + "." + base64Claims), {{API_KEY_SECRET}});
+  var signature = hash((base64Header + "." + base64Claims), "{{API_KEY_SECRET}}");
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 


### PR DESCRIPTION
I noticed a few spots where the API key was not a string literal, so if a user tried to run it, it won't actually work. Adding quotation marks will fix it.

Going from
```js
var signature = hash((base64Header + "." + base64Claims), pSgEzQDIR1JKtCYC);
```

to
```js
var signature = hash((base64Header + "." + base64Claims), "pSgEzQDIR1JKtCYC");
```