### PR TITLE
Fix compliance claims in comparison pages

### DIFF
--- a/content/compare/fanout-vs-pubnub.textile
+++ b/content/compare/fanout-vs-pubnub.textile
@@ -105,7 +105,7 @@ h4. PubNub
 
 * PubNub, on the other hand, offers TLS and AES256 encryption, plus support for BYOE (bring-your-own-encryption) models.
 * PubNub Functions support ﬂexible authorization schemes via any OAuth and LDAP model.
-* HIPAA Compliance, SOC 2 Type II Compliant, Privacy Shield certified, and "GDPR compliant":https://www.pubnub.com/products/security/gdpr.
+* HIPAA Compliance, SOC 2 Type 2 Compliant, Privacy Shield certified, and "GDPR compliant":https://www.pubnub.com/products/security/gdpr.
 * PubNub interestingly offers EU And US-Only Data Storage by Routing data streams and store messages solely within the EU for added PII compliance.
 * PubNub also offers an access manager, which boasts of fine-grain access control API for data streams which allows you to Segment permissions by channel, user, or channel group.
 

--- a/content/partials/compare/security/_pubnub_details.textile
+++ b/content/partials/compare/security/_pubnub_details.textile
@@ -2,6 +2,6 @@ h4. PubNub
 
 * PubNub, on the other hand, offers TLS and AES256 encryption, plus support for BYOE (bring-your-own-encryption) models.
 * PubNub Functions support ﬂexible authorization schemes via any OAuth and LDAP model.
-* HIPAA Compliance, SOC 2 Type II Compliant, Privacy Shield certified, and "GDPR compliant":https://www.pubnub.com/products/security/gdpr.
+* HIPAA Compliance, SOC 2 Type 2 Compliant, Privacy Shield certified, and "GDPR compliant":https://www.pubnub.com/products/security/gdpr.
 * PubNub interestingly offers EU And US-Only Data Storage by Routing data streams and store messages solely within the EU for added PII compliance.
 * PubNub also offers an access manager, which boasts of fine-grain access control API for data streams which allows you to Segment permissions by channel, user, or channel group.

--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -600,12 +600,12 @@ AblyCompare:
           pusher: '“Pusher is committed to complying with the requirements of the GDPR long-term.”'
         extra: 'EU GDPR is regulation introduced to protect consumers and their data.<br/><br/>"Learn more about GDPR":https://en.wikipedia.org/wiki/General_Data_Protection_Regulation'
       soc:
-        description: 'SOC 2 Type II compliant'
+        description: 'SOC 2 Type 2 compliant'
         compare:
-          ably: '*Yes.*<br/><br/>Ably is SOC 2 Type II compliant. We are SOC 2 Type I third-party certified and are in the process of completing a full third-party formal audit for SOC 2 Type II, certification coming in 2020.'
+          ably: '*Yes.*'
           pubnub: '*Yes.*'
           pusher: '*No.*'
-        extra: 'SOC 2 Type II is a standard designed to help measure how well service organizations conduct and regulate information. The purpose of SOC standards is to provide confidence and peace of mind for organizations when they engage third-party cloud vendors.<br/><br/>"Learn more about SOC 2 Type II":https://en.wikipedia.org/wiki/SSAE_16'
+        extra: 'SOC 2 Type 2 is a standard designed to help measure how well service organizations conduct and regulate information. The purpose of SOC standards is to provide confidence and peace of mind for organizations when they engage third-party cloud vendors.<br/><br/>"Learn more about SOC 2 Type 2":https://en.wikipedia.org/wiki/SSAE_16'
       hipaa:
         description: 'HIPAA compliant'
         compare:

--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -613,13 +613,6 @@ AblyCompare:
           pubnub: '*Yes.*'
           pusher: '*No.*<br/><br/>Pusher does not currently sign Business Associate Agreements with customers.'
         extra: 'HIPAA stipulates how Personally Identifiable Information in healthcare in the USA should be protected.<br/><br/>"Learn more about HIPAA":https://en.wikipedia.org/wiki/Health_Insurance_Portability_and_Accountability_Act'
-      iso:
-        description: 'ISO 27001 compliant'
-        compare:
-          ably: '*Yes.*<br/><br/>Ably is ISO 27001 compliant. Formal third-party certification by will be attained in the future.'
-          pubnub: '*No.*'
-          pusher: '*No.*'
-        extra: 'ISO 27001 is an information security standard that shows companies have met specific requirements around information security.<br/><br/>"Learn more about ISO 27001":https://en.wikipedia.org/wiki/ISO/IEC_27001'
   value:
     description: 'Value'
     sections:


### PR DESCRIPTION
See: [DOC-320](https://ably.atlassian.net/browse/DOC-320)

Removed the ISO 27001 entry, updated the SOC 2 compliance (we're now compliant), and fixed the SOC syntax (it's type 1 or 2, not I or II).

The [other comparisons](https://ably.com/compare/all) also need looking at, but those aren't part of the docs repo (they're hosted in [Contentful](http://contentful.com/) and managed by the Content team).