### PR TITLE
DOC-299: Correct and update webhook batched event payload examples

### DIFF
--- a/content/partials/general/events/_batched_events.textile
+++ b/content/partials/general/events/_batched_events.textile
@@ -1,8 +1,8 @@
 Each batched message will have the following fields:
 
-- name := the event type, aka "@presence.message@", "@channel.message@", "@channel.closed@", etc
+- name := the event type, for example @presence.message@, @channel.message@ or @channel.closed@
 - webhookId := an internal unique ID for the configured webhook
-- source := the source for the webhook, namely "@channel.message@", "@channel.presence@", "@channel.lifecycle@"
+- source := the source for the webhook, which will be @channel.message@, @channel.presence@ or @channel.lifecycle@
 - timestamp := a timestamp represented as milliseconds since the epoch for the presence event
 - data := an object containing the data of the event defined below in "JSONPath format":https://goessner.net/articles/JsonPath/
 
@@ -20,19 +20,20 @@ The following is an example of a batched @message@ payload:
 {
   "items": [{
     "webhookId": "ABcDEf",
-    "source": "channel.lifecycle",
-    "timestamp": 1562124922426,
+    "source": "channel.message",
     "serial": "a7bcdEFghIjklm123456789:4",
+    "timestamp": 1562124922426,
     "name": "channel.message",
     "data": {
-      "channelId": "channelName",
+      "channelId": "chat-channel-4",
       "site": "eu-west-1-A",
       "messages": [{
         "id": "ABcDefgHIj:1:0",
+        "clientId": "user-3",
         "connectionId": "ABcDefgHIj",
         "timestamp": 1123145678900,
-        "data": "some message data",
-        "name": "my message name"
+        "data": "the message data",
+        "name": "a message name"
       }]
     }
   }]
@@ -71,19 +72,19 @@ The following is an example of a batched @presence@ payload:
 {
   "items": [{
     "webhookId": "ABcDEf",
-    "source": "channel.lifecycle",
-    "timestamp": 1562124922426,
+    "source": "channel.presence",
     "serial": "a7bcdEFghIjklm123456789:4",
+    "timestamp": 1562124922426,
     "name": "presence.message",
     "data": {
-      "channelId": "education",
+      "channelId": "education-channel",
       "site": "eu-west-1-A",
       "presence": [{
         "id": "ABcDefgHIj:1:0",
+        "clientId": "bob",
         "connectionId": "ABcDefgHIj",
         "timestamp": 1123145678900,
-        "clientId": "bob",
-        "data": "some message data",
+        "data": "the message data",
         "action": 4
       }]
     }
@@ -117,6 +118,8 @@ For @channel lifecycle@ events, @data@ will contain:
 - data.channelId := name of the channel that the presence event belongs to
 - data.status := a "@ChannelStatus@":/realtime/channel-metadata#channel-details object
 
+The @name@ of a @channel.lifecycle@ event will be @channel.opened@ or @channel.closed@.
+
 The following is an example of a batched @channel lifecycle@ payload:
 
 ```[json]
@@ -128,8 +131,8 @@ The following is an example of a batched @channel lifecycle@ payload:
     "serial": "a7bcdEFghIjklm123456789:4",
     "name": "channel.opened",
     "data": {
-      "channelId": "channelName",
-      "name": "channelName",
+      "channelId": "chat-channel-5",
+      "name": "chat-channel-5",
       "status": {
         "isActive": true,
         "occupancy": {


### PR DESCRIPTION
This PR corrects errors in the `source` for the batched webhook examples. There are also some minor changes to readability in the examples and associated text.

The updated page can be viewed [here](http://ably-docs-pr-1108.herokuapp.com/general/events/#examples) and compared to the live version [here](https://ably.com/documentation/general/events#examples).