### PR TITLE
Update link from ably-asset-tracking-cocoa to Swift

### DIFF
--- a/content/asset-tracking/using-the-sdks.textile
+++ b/content/asset-tracking/using-the-sdks.textile
@@ -36,7 +36,7 @@ h2(#repositories). SDK repositories
 The SDKs can be found in the following GitHub repositories:
 
 * "Android":https://github.com/ably/ably-asset-tracking-android
-* "iOS":https://github.com/ably/ably-asset-tracking-cocoa
+* "iOS":https://github.com/ably/ably-asset-tracking-swift
 * "JavaScript":https://github.com/ably/ably-asset-tracking-js
 
 h2(#prerequisites). Prerequisites
@@ -61,7 +61,7 @@ h2(#installing-sdk). Installing the SDK
 You can find information on installing the Ably Asset Tracking SDKs in the following resources:
 
 * "Instructions for Android":https://github.com/ably/ably-asset-tracking-android
-* "Instructions for iOS":https://github.com/ably/ably-asset-tracking-cocoa
+* "Instructions for iOS":https://github.com/ably/ably-asset-tracking-swift
 * "Instructions for JavaScript":https://github.com/ably/ably-asset-tracking-js
 
 h2(#publishing-sdk). Using the publishing SDK


### PR DESCRIPTION
Part of work from renaming `ably-asset-tracking-cocoa` to `ably-asset-tracking-swift` at https://github.com/ably/ably-asset-tracking-cocoa/issues/151