### PR TITLE
Replace existing tutorial step 1 partial

### DIFF
--- a/content/partials/tutorials/_step-1-create-app-and-api-key.textile
+++ b/content/partials/tutorials/_step-1-create-app-and-api-key.textile
@@ -1,8 +1,8 @@
-h2(#setup-ably-account). Step 1 - Create an Ably app and API key
+h2(#setup-ably-account). Step 1 - Create your Ably app and API key
 
 To follow this tutorial, you will need an Ably account. "Sign up for a free account":https://ably.com/signup if you don't already have one.
 
-Access to the "Ably global messaging platform":https://ably.com/platform requires an "API key":/glossary#api-key for authentication. An API key exists within the context of an "Ably application":/glossary#apps and each application can have multiple API keys so that you can assign different "capabilities":/glossary#capability and manage access to "channels":/glossary#channels and "queues":/glossary#queues.
+Access to the "Ably global messaging platform":https://ably.com/platform requires an "API key":/glossary#api-key for authentication. API keys exist within the context of an "Ably application":/glossary#apps and each application can have multiple API keys so that you can assign different "capabilities":/glossary#capability and manage access to "channels":/glossary#channels and "queues":/glossary#queues.
 
 You can either create a new application for this tutorial, or use an existing one.
 

--- a/content/partials/tutorials/_step-1-setup-free-account.textile
+++ b/content/partials/tutorials/_step-1-setup-free-account.textile
@@ -1,11 +1,23 @@
-h2(#setup-ably-account). Step 1 - Set up a free account with Ably
+h2(#setup-ably-account). Step 1 - Create an Ably app and API key
 
-In order to run these tutorials locally, you will need an "Ably API key":https://knowledge.ably.com/setting-up-and-managing-api-keys. If you are not already signed up, you should "sign up now for a free Ably account":https://ably.com/signup.  Once you have an Ably account:
+To follow this tutorial, you will need an Ably account. "Sign up for a free account":https://ably.com/signup if you don't already have one.
 
-# "Log into your app dashboard":https://knowledge.ably.com/how-do-i-access-my-app-dashboard
-# Under "Your apps", click on "Manage app" for any app you wish to use for this tutorial, or create a new one with the "Create New App" button
-# Click on the "API Keys" tab
-# Copy the secret "API Key" value from your Root key and store it so that you can use it later in this tutorial
+Access to the "Ably global messaging platform":https://ably.com/platform requires an "API key":/glossary#api-key for authentication. An API key exists within the context of an "Ably application":/glossary#apps and each application can have multiple API keys so that you can assign different "capabilities":/glossary#capability and manage access to "channels":/glossary#channels and "queues":/glossary#queues.
+
+You can either create a new application for this tutorial, or use an existing one.
+
+To *create a new application* and generate an API key:
+
+# "Log in to your Ably account dashboard":https://ably.com/login
+# Click the "Create New App" button
+# Give it a name and click "Create app"
+# Copy your private API key and store it somewhere. You will need it for this tutorial.
+
+To *use an existing application* and API key:
+
+# Select an application from "Your apps" in the dashboard
+# In the API keys tab, choose an API key to use for this tutorial. The default "Root" API key has full access to capabilities and channels. 
+# Copy the Root API key and store it somewhere. You will need it for this tutorial.
 <a href="/images/tutorials/ably-account/copy-api-key.png" target="_blank">
   <img src="/images/tutorials/ably-account/copy-api-key.png" style="width: 100%" alt="Copy API Key screenshot">
 </a>

--- a/content/tutorials/android-push-notifications.textile
+++ b/content/tutorials/android-push-notifications.textile
@@ -37,7 +37,7 @@ In this tutorial, we'll see how to set up and send Push Notifications to your An
 
 To enable Push Notifications on your device, it must be registered with FCM first. This can be done in two ways; you can either have the device register itself directly with Ably or delegate the registration work to your app server, which would then register the device with Ably on its behalf. In this tutorial we'll demonstrate how to directly register with Ably.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#step2). Step 2 - Enabling Push in your Ably app
 

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -30,7 +30,7 @@ Many times, developers find it helpful to be aware of specific metadata related 
 
 Channel enumeration, as decribed above, is part of the Channel Status API, and can be currently implemented via our "REST API":/rest-api only; however, you can still use our "REST client library":/rest to send requests to the REST API as you'll see further down this tutorial.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#permissions). Step 2 - Setting the right permissions on your API key
 

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -24,7 +24,7 @@ tags:
 
 Many times, developers find it helpful to be aware of specific metadata related to their channels. This metadata can be accessed using our "Channel Metadata API":/realtime/channel-metadata. This API allows you to subscribe to the "channel lifecycle events":/realtime/channel-metadata#lifecycle-events and "channel occupancy events":/realtime/channel-metadata#occupancy-realtime or send one off REST requests to the "Channel Status API":/rest/channel-status to query "channel enumeration":/rest/channel-metadata/enumeration-rest, i.e., listing all the active channels associated with a particular API key in an app or to query the status and occupancy data associated with the channel. In this tutorial, we'll see how to subscribe to the channel lifecycle events.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#permissions). Step 2 - Setting the right permissions on your API key
 

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -34,7 +34,7 @@ In addition to the messages on a channel, the channel can be configured to also 
 
 Channel "occupancy":realtime/channel-metadata#occupancy reveals the number and type of occupants of a particular channel. This includes the number of connections, publishers, subscribers, presence connections, presence members, and presence subscribers. When you subscribe to the inband occupancy events via the realtime library, you'll receive updates whenever the occupancy changes, in other words, the count of one of these parameters changes. However, you can alternatively make a one-off request via the "Ably REST library":/rest/channel-status, to retrieve the occupancy data for the channel in question.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#permissions). Step 2 - Setting the right permissions on your API key
 

--- a/content/tutorials/channel-rewind.textile
+++ b/content/tutorials/channel-rewind.textile
@@ -36,7 +36,7 @@ Channel Rewind is simply a parameter you add when attaching to channels on Ably.
 
 In this tutorial we'll look at implementing the rewind feature for a weather monitoring app and see examples using Ably's native protocol, SSE and MQTT.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#subscribe-to-weather-data-stream). Step 2 - Subscribe to weather data stream on the Ably Hub
 

--- a/content/tutorials/encryption.textile
+++ b/content/tutorials/encryption.textile
@@ -27,7 +27,7 @@ Ably's "encryption feature":/realtime/encryption enables you to send encrypted m
 
 Using our "encryption API":/realtime/encryption is easy.  Let's get started.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 blang[java].
   "See setup in Github":https://github.com/ably/tutorials/commit/encryption-java-setup-step

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -49,7 +49,7 @@ Using our "history API":/realtime/history is trivial.  Let's get started.
 bq. You can now persist the last realtime message on a channel for 365 days. *State Persistence* allows you to instantly retrieve realtime messages sent in the past, helping with long-term state synchronization. "Read how to enable State Persistence":/realtime/channels/channel-parameters/rewind#state-persistence.
 
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Configure all channels within a namespace to persist messages to disk
 

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -69,7 +69,7 @@ Visit @localhost:3000@ in your browser
     <img src="/images/tutorials/jwt-auth/jwt-auth-output.png" style="width: 100%" alt="JWT Demo">
 </a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Setting up the server
 

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -47,7 +47,7 @@ blang[python].
 
 You'll be using a keyboard in this tutorial as input for the controller, but in actuality what device or language you use as the controller doesn't matter so long as it supports MQTT.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Set up your device
 

--- a/content/tutorials/newsfeed-react.textile
+++ b/content/tutorials/newsfeed-react.textile
@@ -29,7 +29,7 @@ For the purpose of this tutorial, we'll not discuss storage of messages or other
 
 "React":https://reactjs.org is a JavaScript library for building user interfaces. It is component-based and declarative which makes it easy to build complex UI with it.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#create-react-app). Step 2 - Create a React App
 

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -30,7 +30,7 @@ The optional payload can be a string, JSON object, JSON array, or binary data, s
 
 "Using our Presence API":/realtime/presence is easy. Let's get started.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2.
   default: Step 2 - Install Ably

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -43,7 +43,7 @@ Messages published can contain string, JSON object, JSON array or binary data pa
 
 "Publishing and subscribing for messages on channels with our channel API":/realtime/channels is trivial. Let's get started.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#step-2).
   default: Step 2 - Install Ably

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -37,7 +37,7 @@ Full usage notes for the adapter are available separately in a support article: 
 
 To take advantage of "Ably features not supported by the PubNub client libraries":https://ably.com/compare/ably-vs-pubnub such as "connection state recovery":https://knowledge.ably.com/connection-state-recovery you’ll need to fully migrate over to Ably. But in this tutorial, we'll see how you can get started using the PubNub protocol adapter.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2.
   default: Step 2 - Point your client libraries to Ably

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -36,7 +36,7 @@ Full usage notes for the adapter are available separately in a support article: 
 
 To take advantage of "Ably features not supported by the Pusher client libraries":https://ably.com/compare/ably-vs-pusher such as "connection state recovery":https://knowledge.ably.com/connection-state-recovery you’ll need to fully migrate over to Ably. But in this tutorial, we'll see how you can get started using the Pusher protocol adapter.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2.
   default: Step 2 - enable Pusher protocol support

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -44,7 +44,7 @@ The diagram may look complicated, but fortunately getting the app up and running
 <i>P.S. If you want to skip ahead and try out the completed tutorial now, install it in one-click on Heroku for free:</i>
 <a href="https://heroku.com/deploy?template=https://github.com/ably/tutorials/tree/queue-neutrino-profanity-nodejs"><img src="https://www.herokucdn.com/deploy/button.svg"></a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Install Ably on your server
 

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -44,7 +44,7 @@ The diagram may look complicated, but fortunately getting the app up and running
 <i>P.S. If you want to skip ahead and try out the completed tutorial now, install it in one-click on Heroku for free:</i>
 <a href="https://heroku.com/deploy?template=https://github.com/ably/tutorials/tree/queue-wolfram-alpha-nodejs"><img src="https://www.herokucdn.com/deploy/button.svg"></a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Install Ably on your server
 

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -44,7 +44,7 @@ The diagram may look complicated, but fortunately getting the app up and running
 <i>P.S. If you want to skip ahead and try out the completed tutorial now, install it in one-click on Heroku for free:</i>
 <a href="https://heroku.com/deploy?template=https://github.com/ably/tutorials/tree/queue-stomp-neutrino-profanity-nodejs"><img src="https://www.herokucdn.com/deploy/button.svg"></a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Install Ably on your server
 

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -31,7 +31,7 @@ React Native lets you build mobile apps using only JavaScript. It uses the same 
 
 "Ably's global platform":https://ably.com/platform provides developers everything they need to create, deliver and manage complex projects. Ably solves the hardest parts so they don’t have to. Our 100% data delivery guarantee offers unique peace of mind to stream data between apps, websites, and servers anywhere on earth in milliseconds.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2.
   default: Step 2 - Setting Up React Native

--- a/content/tutorials/reactjs-realtime-commenting.textile
+++ b/content/tutorials/reactjs-realtime-commenting.textile
@@ -30,7 +30,7 @@ React is a JavaScript library for building user interfaces. It is component-base
 
 <img src="/images/tutorials/react-commenting/react_logo.png" style="width: 50%" alt="React logo">
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Create a React App
 

--- a/content/tutorials/reactor-event-cloudflare.textile
+++ b/content/tutorials/reactor-event-cloudflare.textile
@@ -34,7 +34,7 @@ We'll be building a postal service delivery game using React and "Reactor Functi
   <img src="/images/tutorials/reactor/reactor-event-cloudflare-game-screenshot.png" style="width: 100%" alt="screenshot of the game we will be making">
 </a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step2 - Building the Game
 

--- a/content/tutorials/reactor-event-ifttt.textile
+++ b/content/tutorials/reactor-event-ifttt.textile
@@ -41,7 +41,7 @@ You'll need an Ably account, login or sign up for free at "https://ably.com/":ht
 You'll also need an IFTTT account, login or sign up at "https://ifttt.com/":https://ifttt.com/.
 Finally you'll need an account with Slack and a workspace to send messages to, sign in or create a workspace at "https://slack.com/signin":https://slack.com/signin
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 <%= partial partial_version('tutorials/_create-reactor-rule-event') %>
 

--- a/content/tutorials/tfl-live-tracking-fitbit.textile
+++ b/content/tutorials/tfl-live-tracking-fitbit.textile
@@ -32,7 +32,7 @@ For the purpose of this tutorial, we'll not discuss storage of messages or other
 
 "Getting started with Fitbit SDK":https://dev.fitbit.com/getting-started/ is a guide to get started for developing apps and clockface apps for Fitbit.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#create-clockface-app). Step 2 - Create a clock face
 

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -38,7 +38,7 @@ Ably supports two types of authentication schemes, "basic authentication":core-f
 
 Clients should be "configured":realtime/types#client-options with an @authUrl@ or @authCallback@, which the Ably client SDK will use to either generate a new token or renew an expired token, as required. @authUrl@ is used in this tutorial since the client is web based and your cookies would be automatically sent to your server if it's on the same domain. @authCallback@ should be used on other platforms to give you more control over how this request is made to your servers.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Install Ably on your server
 

--- a/content/tutorials/web-rtc-data-channels.textile
+++ b/content/tutorials/web-rtc-data-channels.textile
@@ -31,7 +31,7 @@ In this tutorial, we will build a WebRTC chat using data channels, allowing us t
 </a>
 
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#choosing-webrtc-library).
  default: Step 2 - Choosing a WebRTC library

--- a/content/tutorials/web-rtc-file-transfer.textile
+++ b/content/tutorials/web-rtc-file-transfer.textile
@@ -33,7 +33,7 @@ This is very similar to our initial lesson on data channels.
   <img src="/images/tutorials/webrtc/file-transfer.gif" style="width: 100%" alt="Demo image">
 </a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#choosing-webrtc-library).
   default: Step 2 - Choosing a WebRTC library

--- a/content/tutorials/web-rtc-screen-sharing.textile
+++ b/content/tutorials/web-rtc-screen-sharing.textile
@@ -30,7 +30,7 @@ You can find the latest info about WebRTC browser support on the "Can I use":htt
 In this lesson, we will learn how to share our screen using WebRTC and Ably.
 
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#choosing-webrtc-library).
   default: Step 2 - Choosing a WebRTC library

--- a/content/tutorials/web-rtc-video-calling.textile
+++ b/content/tutorials/web-rtc-video-calling.textile
@@ -24,7 +24,7 @@ tags:
 In this lesson, we will take a look at implementing Video calling using WebRTC and Ably.
 With the advent of WebRTC and the increasing capacity of browsers to handle peer-to-peer communications in real time, its easier now than ever to build realtime video calling apps.
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2(#choosing-webrtc-library).
   default: Step 2 - Choosing a WebRTC library

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -43,7 +43,7 @@ The diagram may look complicated, but fortunately getting the app up and running
 <i>P.S. If you want to skip ahead and try out the completed tutorial now, install it in one-click on Heroku for free:</i>
 <a href="https://heroku.com/deploy?template=https://github.com/ably/tutorials/tree/webhook-chuck-norris-ruby-rails"><img src="https://www.herokucdn.com/deploy/button.svg"></a>
 
-<%= partial partial_version('tutorials/_step-1-setup-free-account') %>
+<%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
 h2. Step 2 - Install Rails
 


### PR DESCRIPTION
[DOC-345](https://ably.atlassian.net/browse/DOC-345)

Update step 1 tutorial partial to reflect changed UI, choose either to create an app or use an existing one, and clarify info about Ably apps and API keys.

Ensure that tutorials using the existing partial now use the new one.