### PR TITLE
Push notifications documentation improvements

### DIFF
--- a/content/general/push/activate-subscribe.textile
+++ b/content/general/push/activate-subscribe.textile
@@ -32,7 +32,7 @@ In this section, we will run you through all of the features that a push notific
 
 h2(#prerequisites). Prerequisites
 
-Before you can configure your devices to receive push notifications, you must first enable push in your Ably app by adding the third party push service credentials and/or certificates to your app push dashboard. These credentials are then used by Ably to authenticate with the respective third party push service (such as APNs) and delivery all queued notifications.
+Before you can configure your devices to receive push notifications, you must first enable push in your Ably app by adding the third party push service credentials and/or certificates to your app push dashboard. These credentials are then used by Ably to authenticate with the respective third party push service (such as APNs) and deliver all queued notifications.
 
 If you have not already done so, you can sign up for a free account with "Apple's Push Notification service":https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html and Google's "Firebase Cloud Messaging service":https://firebase.google.com/docs/cloud-messaging/.
 

--- a/content/general/push/admin.textile
+++ b/content/general/push/admin.textile
@@ -31,7 +31,7 @@ redirect_from:
 
 The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
-The push admin API is accessible via the @push@ attribute of the realtime client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
+The push admin API is accessible via the "@push@":https://ably.com/documentation/realtime/channels#properties attribute of the realtime or rest client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
 
 ```[jsall]
 var rest = new Ably.Rest({ key: apiKey });

--- a/content/general/push/admin.textile
+++ b/content/general/push/admin.textile
@@ -31,7 +31,7 @@ redirect_from:
 
 The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
-The push admin API is accessible via the "@push@":https://ably.com/documentation/realtime/channels#properties attribute of the realtime or rest client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
+The push admin API is accessible via the @push@ attribute of the "realtime":realtime/channels#properties or "rest":realtime/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
 
 ```[jsall]
 var rest = new Ably.Rest({ key: apiKey });

--- a/content/general/push/admin.textile
+++ b/content/general/push/admin.textile
@@ -31,7 +31,7 @@ redirect_from:
 
 The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
-The push admin API is accessible via the @push@ attribute of the "realtime":realtime/channels#properties or "rest":realtime/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
+The push admin API is accessible via the @push@ attribute of the "realtime":/realtime/channels#properties or "rest":/rest/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
 
 ```[jsall]
 var rest = new Ably.Rest({ key: apiKey });


### PR DESCRIPTION
2 fixes:

- Typo: deliver instead of delivery
- Correction: Both realtime and rest have the `push` property.