### PR TITLE
Update API key requirements

### DIFF
--- a/content/asset-tracking/using-the-sdks.textile
+++ b/content/asset-tracking/using-the-sdks.textile
@@ -51,9 +51,8 @@ You need to have a suitable development environment installed, for example:
 You also need to have suitable credentials for the various SDK components:
 
 * @ABLY_API_KEY@ - Your Ably API key
-* @MAPBOX_DOWNLOADS_TOKEN@ - Mapbox credentials
-* @MAPBOX_ACCESS_TOKEN@ - Mapbox credentials
-* @GOOGLE_MAPS_API_KEY@ - Google Maps credentials
+* @MAPBOX_ACCESS_TOKEN@ - Mapbox public key
+* @MAPBOX_DOWNLOADS_TOKEN@ - Mapbox private key
 
 On Android development systems you can set these values in your @~/.gradle/gradle.properties@ file.
 


### PR DESCRIPTION
See [DOC-357](https://ably.atlassian.net/browse/DOC-357)

Removed `GOOGLE_MAPS_API_KEY` (not required) and clarify difference between the two MapBox tokens.