### PR TITLE
DOC-271: Fix typo in how ably works

### DIFF
--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -14,7 +14,7 @@ jump_to:
     - Any internet device
 ---
 
-Ably's global realtime service enables Internet enabled devices, such as a browser, phone, server or IoT sensor, to stream data in realtime between to any other Internet connected device in milliseconds. The Ably platform brings enterprise scale messaging to developers by delivering a "highly-available service":https://knowledge.ably.com/ablys-uptime-guarantee, "message delivery guarantees":https://knowledge.ably.com/message-durability-and-qos-quality-of-service and "low-latencies globally":https://knowledge.ably.com/round-trip-latency-and-performance (typically less than 60ms).
+Ably's realtime platform enables data to be streamed between Internet-connected devices such as browsers, phones, servers and IoT (Internet of Things) devices in milliseconds. The Ably platform provides developers with enterprise scale messaging by delivering a "highly-available service":https://knowledge.ably.com/ablys-uptime-guarantee, "message delivery guarantees":https://knowledge.ably.com/message-durability-and-qos-quality-of-service and low latency on a global basis. "Round trip latencies":https://knowledge.ably.com/round-trip-latency-and-performance are typically less than 60ms.
 
 h2. Key concepts
 

--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -2,6 +2,8 @@
 title: How Ably works
 section: root
 index: 20
+meta_description: "An introduction to Ably and its key concepts."
+meta_keywords: "introduction, channels, persistence, messages, presence, state recovery, redundancy"
 jump_to:
   Concepts:
     - Channels


### PR DESCRIPTION
This PR corrects a typo in "How Ably Works" and rewords the opening paragraph for improved readability. It also adds `meta_keywords` and `meta_description` to the page.

The page can be reviewed [here](https://ably-docs-pr-1130.herokuapp.com/how-ably-works/).