### PR TITLE
Add beta notice to control api docs

### DIFF
--- a/content/control-api/curl-examples.textile
+++ b/content/control-api/curl-examples.textile
@@ -6,6 +6,7 @@ section: control-api
 index: 20
 jump_to:
   Help with:
+    - Development status#development-status
     - Examples - Applications#examples-apps
     - Examples - Queues#examples-queues
     - See also#see-also
@@ -19,6 +20,10 @@ In the code examples, you will need to set the following variables by any conven
 | ACCOUNT_ID | Your Ably Account ID (see "here":/control-api#account-id) |
 | ACCESS_TOKEN | Your Ably access token for the Control API (see "here":/control-api#authentication) |
 | APP_ID | The ID of the application you want to modify or retrieve information about (see "here":/control-api#app-id) |
+
+h2(#development-status). Development status
+
+Control API is currently in Beta.
 
 h2(#examples-apps). Applications
 

--- a/content/control-api/index.textile
+++ b/content/control-api/index.textile
@@ -6,6 +6,7 @@ section: control-api
 index: 0
 jump_to:
   Help with:
+    - Development status#development-status
     - OpenAPI Document#oas3
     - Authentication#authentication
     - Account and application IDs#ids
@@ -15,7 +16,7 @@ jump_to:
     - See also#see-also
 ---
 
-The Control API is a REST API that enables you to manage your Ably account programmatically. 
+The Control API is a REST API that enables you to manage your Ably account programmatically.
 
 Using the Control API you can manage:
 
@@ -28,6 +29,10 @@ Using the Control API you can manage:
 Repetitive operations such as creating or updating applications, enumerating queues, and other tasks can be automated using the Control API.
 
 In order to use the Control API you must first create an access token in the "Ably dashboard":https://ably.com/accounts/any. You can then use the Control API to manage many account functions without having to interact with the dashboard.
+
+h2(#development-status). Development status
+
+Control API is currently in Beta.
 
 h2(#oas3). OpenAPI (OAS3) document
 

--- a/content/control-api/testing-with-postman.textile
+++ b/content/control-api/testing-with-postman.textile
@@ -6,12 +6,17 @@ section: control-api
 index: 30
 jump_to:
   Help with:
+    - Development status#development-status
     - Importing into Postman#importing
     - Sending a request#send-request
     - See also#see-also
 ---
 
 The Control API is designed for programmatic access to your account. However, you can test individual requests using either a command line tool such as "Curl":https://curl.se/ or "HTTPie":https://httpie.io/, or a graphical tool such as "Postman":https://www.postman.com/ or "Paw":https://paw.cloud/. This topic shows you how to make requests using Postman.
+
+h2(#development-status). Development status
+
+Control API is currently in Beta.
 
 h2(#importing). Importing the OAS3 document into Postman
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Adds development status section to Control API docs. 

* [JIRA ticket](https://ably.atlassian.net/browse/DOC-393).

## Review

Check each page of the Control API docs. There should now be a development status section indicated Control API is in Beta.

* [Page to review](https://ably-docs-pr-1137.herokuapp.com/control-api/)
