### PR TITLE
Update the Pub/Sub tutorial for Go to 1.2.0

### DIFF
--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -386,12 +386,12 @@ blang[go].
     package main
 
     import "fmt"
-    import "ably"
+    import "github.com/ably/ably-go/ably"
 
     func main() {
-        client, err := ably.NewRealtimeClient(ably.NewClientOptions("INSERT-YOUR-API-KEY-HERE"))
+        client, err := ably.NewRealtimeClient(ably.WithKey("INSERT-YOUR-API-KEY-HERE"))
         if err != nil {
-            panic(err)
+          panic(err)
         }
     }
   ```
@@ -515,20 +515,19 @@ blang[go].
 
   ```[go]
     func main() {
-        client, err := ably.NewRealtimeClient(ably.NewClientOptions("INSERT-YOUR-API-KEY-HERE"))
+        client, err := ably.NewRealtimeClient(ably.WithKey("INSERT-YOUR-API-KEY-HERE"))
         if err != nil {
-            panic(err)
+          panic(err)
         }
 
         channel := client.Channels.Get("sport")
 
-        sub, err := channel.Subscribe()
+        _, err := channel.SubscribeAll(context.Background(), func(msg *ably.Message) {
+          fmt.Printf("Received message with data '%v'\n", msg.Data)
+        })
         if err != nil {
-            panic(err)
-        }
-
-        for msg := range sub.MessageChannel() {
-            fmt.Printf("Received message with name '%v' and data '%v'\n", msg.Name, msg.Data)
+          err := fmt.Errorf("subscribing to channel: %w", err)
+          fmt.Println(err)
         }
     }
   ```
@@ -710,26 +709,25 @@ blang[go].
 
   ```[go]
     func main() {
-        client, err := ably.NewRealtimeClient(ably.NewClientOptions("INSERT-YOUR-API-KEY-HERE"))
+        client, err := ably.NewRealtimeClient(ably.WithKey("INSERT-YOUR-API-KEY-HERE"))
         if err != nil {
-            panic(err)
+          panic(err)
         }
 
         channel := client.Channels.Get("sport")
 
-        sub, err := channel.Subscribe()
+        _, err := channel.SubscribeAll(context.Background(), func(msg *ably.Message) {
+          fmt.Printf("Received message with data '%v'\n", msg.Data)
+        })
         if err != nil {
-            panic(err)
+          err := fmt.Errorf("subscribing to channel: %w", err)
+          fmt.Println(err)
         }
 
         res, err := channel.Publish("team", "Man United")
         // await confirmation of publish
         if err = res.Wait(); err != nil {
             panic(err)
-        }
-
-        for msg := range sub.MessageChannel() {
-            fmt.Printf("Received message with name '%v' and data '%v'\n", msg.Name, msg.Data)
         }
     }
   ```


### PR DESCRIPTION
## Description

There were breaking changes to the Ably Go library with the release of v1.2.0. This PR updates the Go Pub/Sub tutorial to make use of the new library version.

## Review

Check that there's no formatting errors.

* [Pub/Sub tutorial for Go](https://ably-docs-pr-1138.herokuapp.com/tutorials/publish-subscribe/)
