### PR TITLE
Move deviceSecret to LocalDevice, out of DeviceDetails

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1892,7 +1892,6 @@ class DeviceDetails:
   metadata: JsonObject
   platform: DevicePlatform
   push: DevicePushDetails
-  deviceSecret: String?
 
 class DevicePushDetails:
   errorReason: ErrorInfo?
@@ -1901,6 +1900,7 @@ class DevicePushDetails:
 
 class LocalDevice extends DeviceDetails:
   deviceIdentityToken: String
+  deviceSecret: String
 
 class Push:
   admin: PushAdmin // RSH1


### PR DESCRIPTION
## Description

The feature spec currently contradicts itself regarding DeviceDetails, and its led to inconsistency between SDKs. In one section, it doesn’t specify `DeviceDetails.deviceSecret`, but in the interface definition, it does, deviceSecret: String?. From reading RSH8b (below), we should put deviceSecret in LocalDevice, not in DeviceDetails.

> (RSH8b) The LocalDevice id and deviceSecret attributes are generated, and persisted as part of the LocalDevice state, when required by step (RSH3a2b) in the Activation State Machine. At that time, the clientId attribute is also initialised, if the client is identified according to (RSA7).

Unfortunately, ably-java and cocoa have diverged. Cocoa has put the deviceSecret in deviceDetails (wrong, but followed the interface definition), and java has put the deviceSecret in LocalDevice (correct, followed the feature spec point).

I'll create a github issue on Ably-cocoa to fix this.
