### PR TITLE
Add agents client option

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -86,6 +86,9 @@ h3(#restclient). RestClient
 *** @(RSC7d3)@ Where the library is unable to specify a header when making a request (such as for @JSONP@ requests), the @Agent@ library identifier should be sent via an @agent@ query param whose value is the URI-encoded @Agent@ library identifier.
 *** @(RSC7d4)@ Where possible, product versions should be represented as a valid "semantic version":https://semver.org/. This is best-effort as we recognise that strict SemVer is not always available, or otherwise possible to derive from information available at runtime, especially in the case of products that represent operating system versions.
 *** @(RSC7d5)@ Products must be added to the canonical @agents@ data file in our common repository. See "Agents in ably-common":https://github.com/ably/ably-common/tree/main/protocol#agents for more information.
+*** @(RSC7d6)@ Libraries may offer a @ClientOptions#agents@ property, for use only by other Ably-authored SDKs, on a need-to-have basis.
+**** @(RSC7d6a)@ The product/version key-value pairs supplied to that property should be injected into all @Agent@ library identifiers emitted by connections made as a result of REST or Realtime instances created using those @ClientOptions@.
+**** @(RSC7d6b)@ An API commentary must be provided for this property. This commentary must make it clear that this interface is only to be used by Ably-authored SDKs.
 * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
 * @(RSC8)@ Supports two protocols:
 ** @(RSC8a)@ "MessagePack":https://msgpack.org/ binary protocol (this is the default for environments having a suitable level or support for binary data)
@@ -1561,6 +1564,7 @@ class ClientOptions:
   maxFrameSize: Int default 524288 // TO3l8
   plugins: Dict<PluginType, Plugin> // TO3o
   idempotentRestPublishing: bool default true // RSL1k1, RTL6a1, TO3n
+  agents: [String: String?]? // RSC7d6 - interface only offered by some libraries
 
 class AuthOptions: // RSA8e
   authCallback: ((TokenParams) -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b


### PR DESCRIPTION
The `agents` client option will only be offered by SDKs which need to be subsequently wrapped by other SDKs (i.e. other Ably SDKs are dependent upon them).

Currently we know that this means:
- [ably-java](https://github.com/ably/ably-java) and [ably-cocoa](https://github.com/ably/ably-cocoa): wrapped by [ably-flutter](https://github.com/ably/ably-flutter), [ably-asset-tracking-android](https://github.com/ably/ably-asset-tracking-android) and [ably-asset-tracking-swift](https://github.com/ably/ably-asset-tracking-swift).
- [ably-js](https://github.com/ably/ably-js): wrapped by [ably-asset-tracking-js](https://github.com/ably/ably-asset-tracking-js)

The prototype for this interface is in `ably-java` [here](https://github.com/ably/ably-java/blob/main/lib/src/main/java/io/ably/lib/types/ClientOptions.java#L215), implemented via https://github.com/ably/ably-java/pull/671.

To assist reviewers: the rendered output for this PR (temporarily available) is [here](https://ably-docs-pr-1155.herokuapp.com/client-lib-development-guide/features/#RSC7d6) for the spec points and [here](https://ably-docs-pr-1155.herokuapp.com/client-lib-development-guide/features/#idl) for the IDL.