### PR TITLE
DOC-369: Update Ruby connection example to generate demo API key in Quickstart

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -231,9 +231,9 @@ ably.connection.on(ConnectionState.connected, new ConnectionStateListener()
 
 bc[ruby]. EventMachine.run do
   ably = Ably::Realtime.new(key: '{{API_KEY}}')
-end
-ably.connection.on(:connected) do
-  puts "Connected to Ably!"
+  ably.connection.on(:connected) do
+    puts "Connected to Ably!"
+  end
 end
 
 bc[swift]. let ably = ARTRealtime(key: "{{API_KEY}}")

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -230,7 +230,7 @@ ably.connection.on(ConnectionState.connected, new ConnectionStateListener()
 });
 
 bc[ruby]. EventMachine.run do
-  ably = Ably::Realtime.new(api_key)
+  ably = Ably::Realtime.new(key: '{{API_KEY}}')
 end
 ably.connection.on(:connected) do
   puts "Connected to Ably!"


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR fixes the Ruby connection example code so that it generates a demo API key when published. See [JIRA](https://ably.atlassian.net/browse/DOC-369) for further information.

## Review

Run the website locally against this PR and check that the Ruby code block generates a demo API key.
