### PR TITLE
DOC-88: Add a note to Quickstart about using basic auth

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -197,7 +197,7 @@ blang[default].
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create a realtime connection to Ably. Use the language selector above to select a language with realtime support.
 
-*Note*: The connection example uses basic authentication to pass the API key from the application to Ably.
+*Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/core-features/authentication#token-authentication should be used instead.
 
 bc[javascript](code-editor:quick-start-guide/connect). var ably = new Ably.Realtime('{{API_KEY}}');
 ably.connection.on('connected', function() {


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR adds a note to the Quickstart about avoiding the use of basic authentication on the client-side. See [JIRA](https://ably.atlassian.net/browse/DOC-88) for further information.

## Review

The note can be reviewed in the [Quickstart](https://ably-docs-pr-1162.herokuapp.com/quick-start-guide/).
