### PR TITLE
DOC-367: Update quickstart JSBins

### DIFF
--- a/content/code/quick-start-guide/close.code
+++ b/content/code/quick-start-guide/close.code
@@ -1,0 +1,34 @@
+[--- Javascript ---]
+const ably = new Ably.Realtime('{{API_KEY}}');
+
+$('input[type=button]').on('click', () => {
+  ably.connection.close();
+});
+  
+ably.connection.on((stateChange) => {
+  let li = $('<li>').html(`${Date.now()} - Current state is: <b> ${stateChange.current}`);
+  $('ul#conn-state').append(li);
+}); 
+[--- /Javascript ---]
+
+[--- HTML ---]
+<script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
+<script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
+<h1>Quickstart: close connection to Ably</h1>
+<input type="button" value="Close connection">
+<ul id="conn-state"></ul>
+[--- /HTML ---]
+
+[--- CSS ---]
+body {
+  font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1 {
+  background: url('//jsbin-files.ably.io/images/logo.png') no-repeat;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 8px 0 0 120px;
+  height: 42px;
+}
+[--- /CSS ---]

--- a/content/code/quick-start-guide/connect.code
+++ b/content/code/quick-start-guide/connect.code
@@ -1,15 +1,15 @@
 [--- Javascript ---]
-var ably = new Ably.Realtime('{{API_KEY}}');
+const ably = new Ably.Realtime('{{API_KEY}}');
 
-ably.connection.on('connected', function() {
-  $('#message').text('✓ That was simple, you are now connected to Ably');
+ably.connection.on('connected', () => {
+  $('#message').text('Connected to Ably!');
 });
 [--- /Javascript ---]
 
 [--- HTML ---]
 <script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
 <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
-<h1>Ably Quickstart Connect Example</h1>
+<h1>Quickstart: connect to Ably</h1>
 <div id="message" style="color: green"></div>
 [--- /HTML ---]
 

--- a/content/code/quick-start-guide/send-message.code
+++ b/content/code/quick-start-guide/send-message.code
@@ -1,24 +1,24 @@
 [--- Javascript ---]
-var ably = new Ably.Realtime('{{API_KEY}}'),
-    channel = ably.channels.get('{{RANDOM_CHANNEL_NAME}}');
+const ably = new Ably.Realtime('{{API_KEY}}'),
+channel = ably.channels.get('{{RANDOM_CHANNEL_NAME}}');
 
-channel.subscribe('greeting', function(message) {
-  $('#result').text('✓ Received message from Ably: ' + message.data);
+ably.connection.on('connected', () => {
+  $('input[type=button]').val('Connected to Ably! Press to publish a message');
 });
 
-ably.connection.on('connected', function() {
-  $('input[type=button]').val('Connected. Press to publish a message');
+channel.subscribe('greeting', (message) => {
+  $('#result').text(`Received message from Ably: ${message.data}`);
 });
 
-$('input[type=button]').on('click', function() {
-  channel.publish('greeting', 'Wow, that was received quickly');
+$('input[type=button]').on('click', () => {
+  channel.publish('greeting', 'Hello! That was fast!');
 });
 [--- /Javascript ---]
 
 [--- HTML ---]
 <script src="//jsbin-files.ably.io/js/jquery-1.8.3.min.js"></script>
 <script type="text/javascript" src="//cdn.ably.io/lib/ably.min-1.js"></script>
-<h1>Ably Quickstart Publish &amp; Subscribe Example</h1>
+<h1>Quickstart: subscribe and publish to an Ably channel</h1>
 
 <input type="button" value="Connecting...">
 <div id="result" style="color: green; padding: 10px"></div>

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -388,12 +388,12 @@ blang[default].
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
 
-bc[javascript]. ably.connection.close();
+bc[javascript](code-editor:quick-start-guide/close). ably.connection.close();
 ably.connection.on('closed', function() {
   alert("Closed the connection to Ably.");
 });
 
-bc[nodejs]. ably.connection.close();
+bc[nodejs](code-editor:quick-start-guide/close). ably.connection.close();
 ably.connection.on('closed', function() {
   console.log("Closed the connection to Ably.");
 });

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -1,7 +1,6 @@
 ---
 jsbin_hash:
   EjhhGNY3f3dw55pyTen7hGEhUow=: ififuj
-  d6fvP62mwfb3LX3MOzxPRwODVBU=: utonoq
   rnwPhTS4IMwf/LJyYfbrJnK4Axc=: ojerak
   dqNcZL3zwOeS3PmMAzJ54wVDkNg=: utizit
   1vHSWAcT6EJzqWwQU4oqY1onx1o=: akimez
@@ -42,7 +41,6 @@ jsbin_hash:
   QADUGa6c8pcib9e+Czit19wHETI=: onijin
   HbyD52zmVfj27E1EsBUlyVn9EkY=: amaxew
   Xu0FjrJZjl/Oxr9hv1ZWD82yiTE=: inefeh
-  MvDC9w1XTiyfcd9vGClYSssTbTU=: eqeqec
   "/VQ66fOcReuA8eyOJP6/E/v+xp8=": opaxot
   OTMMZzdUaYsYbRwPkrn4aY11tKg=: ikipux
   KZ9734OD+af3VmZake2eFxwf6lY=: inosey
@@ -52,6 +50,9 @@ jsbin_hash:
   JBhBicGaDe4vMA5Y3PdBu9gMN7A=: anayel
   lgC4i71UUfqvCftEUQNHMUq8t/8=: utaxih
   1f1wl7jfk2OQF3HFM01l66ypmu0=: ajuguh
+  3HIxwJwWfJZJlAlejxASFl9zvxA=: oxodoy
+  BsKgJaaic2VTvDxUEUmZf6+XMBk=: uhexob
+  bqM4roMRpROpr/A/A8biHErAhDU=: ikihox
 jsbin_id:
   adapters/pusher-pub-sub: drepn65beftIQMEP6LTte1/ESz8=
   adapters/pubnub-pub-sub: gjQAv5zouWj9oLED14FTOYVI6G4=
@@ -61,8 +62,8 @@ jsbin_id:
   authentication/create-token-request: kFnXKC5pn2k5Gy2OSDw6Pj7ovcI=
   authentication/request-token: Sk2WNF5kJGRUZwA9nia6rje02EY=
   client-lib-development-guide/example: EjhhGNY3f3dw55pyTen7hGEhUow=
-  quick-start-guide/connect: d6fvP62mwfb3LX3MOzxPRwODVBU=
-  quick-start-guide/send-message: MvDC9w1XTiyfcd9vGClYSssTbTU=
+  quick-start-guide/connect: BsKgJaaic2VTvDxUEUmZf6+XMBk=
+  quick-start-guide/send-message: bqM4roMRpROpr/A/A8biHErAhDU=
   reactor/webhook-hmac-sha-256: "/VQ66fOcReuA8eyOJP6/E/v+xp8="
   realtime/auth-client-id: 5OROLMuOoAwxZ5F9Ebftdan6mBg=
   realtime/auth-token-callback: rWB5AMPDnMIuLfet9MwXTM6PGaE=
@@ -105,3 +106,4 @@ jsbin_id:
   hub-product/http-javascript: 0HU+2TZ9fEE+6JeSRJ2uF5s434g=
   hub-product/native-sdks-nodejs: BPSTRD26NL+yQYPNYB9lgA30fFE=
   website-examples/simple-chat.code: JBhBicGaDe4vMA5Y3PdBu9gMN7A=
+  quick-start-guide/close: 3HIxwJwWfJZJlAlejxASFl9zvxA=


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR updates the existing JSBins for the quickstart to modern JavaScript. It also adds a new JSBin for closing a connection to Ably. See [JIRA](https://ably.atlassian.net/browse/DOC-367) for further information. 

Note: I have raised [this JIRA](https://ably.atlassian.net/browse/DOC-456) to look at removing JQuery from JSBin as a future improvement.

## Review

The [quickstart](https://ably-docs-pr-1166.herokuapp.com/quick-start-guide/) should be checked to ensure the new JSBins are correctly linked.

The new JSBins can be checked from that page or individually using:
* [Connect](https://jsbin.ably.com/uhexob/1/edit)
* [Publish and subscribe](https://jsbin.ably.com/ikihox/1/edit)
* [Close](https://jsbin.ably.com/oxodoy/1/edit)
