### PR TITLE
Remove review app restrictions from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,12 +5,6 @@
   },
   "env": {
   },
-  "formation": {
-    "web": {
-      "quantity": 1,
-      "size": "free"
-    }
-  },
   "addons": [
   ],
   "buildpacks": [


### PR DESCRIPTION
## Description

It is currently not possible to generate a review app for pull requests on this repo because we specify that we want the review apps to be on "free" dynos. We don't need this restriction and currently it prevents us from building review apps.

## Review

The review app for the PR should build and be accessible.

* [https://ably-docs-pr-1171.herokuapp.com/](https://ably-docs-pr-1171.herokuapp.com/)
