### PR TITLE
DOC-295: Add missing code into JWT tutorial text

### DIFF
--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -149,7 +149,15 @@ app.get('/auth', function (req, res) {
 ```
 The above code is invoked when a client application hits the '/auth' route on your auth server. We have just used the "jsonwebtoken":https://www.npmjs.com/package/jsonwebtoken npm library to sign a JSON Web Token using the Ably API key which we obtained from our dashboard. The callback function returns an error parameter and the @tokenId@. We then simply check for the error if any, otherwise simply send the JWT back to the client in order to confirm its authentication with Ably.
 
-Note that a cache-control has been added to the response header in order to prevent a chached token from being obtained. This makes sure we never obtain a token which has potentially expired.
+Note that a cache-control has been added to the response header in order to prevent a cached token from being obtained. This makes sure we never obtain a token which has potentially expired.
+
+Set the web server to listen on a port. 3000 is used in the following code example.
+
+```[javascript]
+app.listen(3000, function () {
+    console.log('Web server listening on port 3000');
+});
+```
 
 "See this step in Github":https://github.com/ably/tutorials/commit/jwt-node-step2
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR just adds two small lines of code into the JWT tutorial. Previously it was a requirement to look at the GitHub Step 2 commit in order to get the full code. With this change all code is available within the tutorial itself.

See [JIRA](https://ably.atlassian.net/browse/DOC-295) for further information.

## Review

View the [JWT tutorial](https://ably-docs-pr-1176.herokuapp.com/tutorials/jwt-authentication) to review this change. Following the steps should no longer require copying any code from GitHub.
