### PR TITLE
[WEB-1743] Generic rendering of code blocks (part 1 of 2)

### DIFF
--- a/app/assets/stylesheets/documentation.scss
+++ b/app/assets/stylesheets/documentation.scss
@@ -435,6 +435,10 @@ $code-block-background: #F6F6F6;
     background-color: #FDE9D7;
   }
 
+  pre code {
+    background-color: unset;
+  }
+
   /* code block that potentially has a language nav above it if a language is not supported */
   .with-lang-nav {
     display: none;

--- a/content/asset-tracking/example-apps.textile
+++ b/content/asset-tracking/example-apps.textile
@@ -5,7 +5,7 @@ index: 10
 meta_description: "Ably Asset Tracking SDKs provide an easy way to track multiple assets with realtime location updates powered by the Ably realtime network and Mapbox Navigation SDK with location enhancement."
 meta_keywords: "Ably, Asset Tracking SDK, Mapbox, Mapbox Navigation SDK, Ably realtime, map matching, location tracking, Publishing SDK, Subscribing SDK"
 languages:
-  - android
+  - kotlin
   - swift
   - javascript
 jump_to:
@@ -16,7 +16,7 @@ jump_to:
 
 Asset Tracking SDK repositories provide example apps for subscribing and publishing. You can test out the sample apps using the emulator provided with the developer tools for your platform.
 
-blang[android].
+blang[kotlin].
   h2(#using). Using the example apps
 
   The following procedure uses Android Studio by way of example, you can also use other tools such as Gradle.

--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -5,7 +5,7 @@ index: 0
 meta_description: "The Ably Asset Tracking solution provides a way to track multiple assets in realtime."
 meta_keywords: "Ably, Asset Tracking SDK, Mapbox, Mapbox Navigation SDK, Mapbox location enhancement, Ably realtime, map matching, location tracking, Publishing SDK, Subscribing SDK"
 languages:
-  - android
+  - kotlin
   - swift
   - javascript
 jump_to:
@@ -114,7 +114,7 @@ The SDK provides default resolution constraints consisting of:
 
 The following example shows how the default resolution constraints are populated:
 
-```[android]
+```[kotlin]
 // Prepare Resolution Constraints for an asset that will be used in the Resolution Policy
 val exampleConstraints = DefaultResolutionConstraints(
     DefaultResolutionSet( // this constructor provides one Resolution for all states

--- a/content/asset-tracking/using-the-sdks.textile
+++ b/content/asset-tracking/using-the-sdks.textile
@@ -5,7 +5,7 @@ index: 20
 meta_description: "Ably Asset Tracking SDKs provide an easy way to track multiple assets with realtime location updates powered by the Ably realtime network and Mapbox Navigation SDK with location enhancement."
 meta_keywords: "Ably, Asset Tracking SDK, Mapbox, Mapbox Navigation SDK, Ably realtime, map matching, location tracking, Publishing SDK, Subscribing SDK"
 languages:
-  - android
+  - kotlin
   - swift
   - javascript
 jump_to:
@@ -44,7 +44,7 @@ You need to have a suitable development environment installed, for example:
 
 * Android - "Android Studio":https://developer.android.com/studio or "Gradle":https://gradle.org/ (requires Android SDK to be installed)
 * iOS - "Xcode":https://developer.apple.com/xcode/
-* JavaScript - any suitable environment of your choice 
+* JavaScript - any suitable environment of your choice
 
 You also need to have suitable credentials for the various SDK components:
 
@@ -64,7 +64,7 @@ You can find information on installing the Ably Asset Tracking SDKs in the follo
 
 h2(#authentication). Authentication
 
-blang[android,javascript].
+blang[kotlin,javascript].
   The client requires authentication in order to establish a connection with Ably. There are three methods that can be used:
 
   1. Basic authentication
@@ -79,7 +79,7 @@ blang[android,javascript].
 
   The following example demonstrates establishing a connection using basic authentication:
 
-  ```[android]
+  ```[kotlin]
   val publisher = Publisher.publishers() // get the Publisher builder in default state
     .connection(ConnectionConfiguration(Authentication.basic(CLIENT_ID, ABLY_API_KEY)))
   ```
@@ -96,7 +96,7 @@ blang[android,javascript].
 
   The following example demonstrates establishing a connection using token authentication:
 
-  ```[android]
+  ```[kotlin]
   val publisher = Publisher.publishers() // get the Publisher builder in default state
       .connection(ConnectionConfiguration(Authentication.tokenRequest(CLIENT_ID) { requestParameters ->
           // get TokenRequest from your server
@@ -107,7 +107,7 @@ blang[android,javascript].
   ```[javascript]
   /* authURL is the endpoint for your authentication server. It returns either
     a `TokenRequest` or a `Token` */
-  const subscriber = new Subscriber({ 
+  const subscriber = new Subscriber({
     authUrl: 'http://my.website/auth',
     clientId: 'CLIENT_ID'
   })
@@ -119,7 +119,7 @@ blang[android,javascript].
 
   The following example demonstrates establishing a connection using JWT authentication:
 
-  ```[android]
+  ```[kotlin]
   val publisher = Publisher.publishers() // get the Publisher builder in default state
     .connection(ConnectionConfiguration(Authentication.jwt(CLIENT_ID) { tokenParameters ->
           // get JWT from your server
@@ -129,7 +129,7 @@ blang[android,javascript].
 
   ```[javascript]
   // authURL is the endpoint for your authentication server. It returns a JWT
-  const subscriber = new Subscriber({ 
+  const subscriber = new Subscriber({
     authUrl: 'http://my.website/auth',
     clientId: 'CLIENT_ID'
   })
@@ -148,7 +148,7 @@ blang[swift].
   .start()
   ```
 
-blang[android,swift].
+blang[kotlin,swift].
   h2(#publishing-sdk). Using the Publishing SDK
 
   Common operations you need to carry out on the publisher include:
@@ -164,8 +164,8 @@ blang[android,swift].
 
   The required methods are:
 
-  - connection := Called to provide Ably connection information, such as API keys, and any other configuration parameters as needed. 
-  - map := Called to provide Mapbox configuration, such as API keys, any other configuration parameters as needed. 
+  - connection := Called to provide Ably connection information, such as API keys, and any other configuration parameters as needed.
+  - map := Called to provide Mapbox configuration, such as API keys, any other configuration parameters as needed.
   - resolutionPolicy := Sets the policy factory to be used to define the target resolution for publishers created from this builder.
   - androidContext := Called to provide the Android runtime context (on Android only).
 
@@ -176,7 +176,7 @@ blang[android,swift].
 
   The following code example creates some example "resolution constraints":/asset-tracking#resolution-constraints:
 
-  ```[android] 
+  ```[kotlin]
   // Prepare Resolution Constraints for an asset that will be used in the Resolution Policy
   val exampleConstraints = DefaultResolutionConstraints(
       DefaultResolutionSet( // this constructor provides one Resolution for all states
@@ -206,7 +206,7 @@ blang[android,swift].
 
   The next step is create a default "resolution":/asset-tracking#resolution to be used:
 
-  ```[android]
+  ```[kotlin]
   // Prepare the default resolution for the Resolution Policy
   val defaultResolution = Resolution(Accuracy.BALANCED,
                                      desiredInterval = 1000L,
@@ -222,7 +222,7 @@ blang[android,swift].
 
   Once these are created you can then initialize the publisher with the constraints and default resolution, and start the publisher:
 
-  ```[android]
+  ```[kotlin]
   // Initialize and Start the Publisher
   val publisher = Publisher.publishers() // get the Publisher builder in default state
       .connection(ConnectionConfiguration(Authentication.basic(CLIENT_ID, ABLY_API_KEY))) // provide Ably configuration with credentials
@@ -246,7 +246,7 @@ blang[android,swift].
 
 h3(#publisher-start-tracking). Start tracking
 
-blang[android].  
+blang[kotlin].
   You can start tracking an asset by calling the @track@ method of the publisher. You need to supply the tracking identifier of the asset to be tracked, and optionally any "resolution constraints":/asset-tracking#resolution-constraints that need to be applied.
 
 blang[swift].
@@ -254,7 +254,7 @@ blang[swift].
 
 The following code example demonstrates how to start tracking an asset:
 
-```[android]
+```[kotlin]
 // Start tracking an asset
 publisher.track(
     Trackable(
@@ -283,7 +283,7 @@ h3(#publisher-stop-tracking). Stop tracking
 
 You can stop tracking a trackable (asset) that is registered with the publisher using the @remove@ method, as shown in the following code:
 
-```[android]
+```[kotlin]
 publisher.remove(trackable)
 ```
 
@@ -302,12 +302,12 @@ Common operations you will need to carry out on the subscriber include:
 
 h3(#subscriber-initializing-sdk). Initializing the Subscriber
 
-blang[android,swift].
+blang[kotlin,swift].
   During initialization of the subscriber various methods can be called to configure the @Subscriber@.
 
   The required methods are:
 
-  - connection := Called to provide Ably connection information, such as API keys, and any other configuration parameters as needed. 
+  - connection := Called to provide Ably connection information, such as API keys, and any other configuration parameters as needed.
   - trackingId := Sets the asset to be tracked, using the unique tracking identifier of the asset.
 
   The optional methods are:
@@ -321,7 +321,7 @@ blang[javascript].
 
   The following code example demonstrates initializing and starting the subscriber:
 
-```[android]
+```[kotlin]
 // Initialize and Start the Subscriber
 val subscriber = Subscriber.subscribers() // Get an AssetSubscriber
     .connection(ConnectionConfiguration(Authentication.basic(CLIENT_ID, ABLY_API_KEY))) // provide Ably configuration with credentials
@@ -368,7 +368,7 @@ h3(#subscriber-subscribe). Subscribe to updates
 
 You can subscribe to updates from the publisher, specifying a function that is called when each update is received. This is shown in the following example:
 
-```[android]
+```[kotlin]
 // Listen for location updates
 subscriber.locations
     .onEach { } // provide a function to be called when enhanced location updates are received
@@ -378,7 +378,7 @@ subscriber.locations
 ```[swift]
 // Override subscriber method of SubscriberDelegate to be notified of location updates
 class MySubscriberDelegate: SubscriberDelegate {
-  ...  
+  ...
   override func subscriber(sender: Subscriber, didUpdateEnhancedLocation location: CLLocation) {
     print("Location update received. Coordinates: \(location.coordinate)");
   }
@@ -399,10 +399,10 @@ subscriber.onLocationUpdate((locationUpdate) => {
 
 h3(#subscriber-subscribe-asset-state-changes). Subscribe to asset state changes
 
-blang[android,javascript].
+blang[kotlin,javascript].
   You can subscribe to asset state changes from the publisher, specifying a function that is called when each state change is received. This is shown in the following example:
 
-  ```[android]
+  ```[kotlin]
   // Listen for asset state changes
   subscriber.trackableStates
       .onEach { } // provide a function to be called when the asset changes its state
@@ -421,24 +421,24 @@ blang[android,javascript].
 
 blang[swift].
   To listen to asset state change events from the publisher, you must provide a class that implements some or all of the methods in @SubscriberDelegate@:
-  
+
   ```[swift]
   class MySubscriberDelegate: SubscriberDelegate {
     // Implement some or all of the delegate methods
     override func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
         /* Handle the change */
     }
-    
+
     override func subscriber(sender: Subscriber, didFailWithError error: ErrorInformation) {
         /* Handle the error */
     }
-    
+
     override func subscriber(sender: Subscriber, didUpdateEnhancedLocation location: CLLocation) {
         /* Handle the location update */
     }
   }
   ```
-  
+
   You can achieve this by using one of the following approaches:
 
   * Create a separate class that implements the required @SubscriberDelegate@, as shown in the example above. Reference that class by either:
@@ -452,7 +452,7 @@ blang[swift].
 
 h3(#request-a-different-resolution). Request a different resolution
 
-blang[android].
+blang[kotlin].
   The subscriber can always request a different resolution preference by calling the @resolutionPreference@ method, passing in the required @Resolution@. This is shown in the following example:
 
 blang[swift].
@@ -461,7 +461,7 @@ blang[swift].
 blang[javascript].
   The subscriber can request a different resolution by calling the @sendChangeRequest@ method, passing in the required @accuracy@, @desiredInterval@, and @minimumDisplacement@ property values. This is shown in the following example:
 
-```[android]
+```[kotlin]
 // Request a different resolution when needed.
 subscriber.resolutionPreference(Resolution(Accuracy.MAXIMUM, desiredInterval = 100L, minimumDisplacement = 2.0))
 // change request submitted successfully
@@ -494,7 +494,7 @@ await subscriber.sendChangeRequest({
 
 blang[javascript].
   h3(#subscriber-subscribe-asset-state-changes). Stop receiving updates
-  
+
   Stop receiving updates from the publisher by calling the @stop()@ method:
 
   ```[javascript]

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1481,7 +1481,7 @@ Please note the following conventions:
 * @Stringifiable@ is a type used for unknown configuration parameters that need to be coerced to strings when used, see "RTC1f":#RTC1f for definition
 * @JSONObject@ and @JSONArray@ denote any type or interface in the target language that represents an "RFC4627":https://www.ietf.org/rfc/rfc4627.txt @object@ or @array@ value respectively. Such types serialize to, and may be deserialized from, the corresponding JSON text. In the specification text above, values of these types are collectively referred to as "JSON-encodable".
 
-```[python]
+```
 class Rest:
   constructor(keyStr: String) // RSC1
   constructor(tokenStr: String) // RSC1

--- a/lib/documentation_languages.rb
+++ b/lib/documentation_languages.rb
@@ -3,6 +3,7 @@ module Ably
     'javascript' => { name: 'JavaScript', extension: 'js' },
     'java' => { name: 'Java', extension: 'java' },
     'android' => { name: 'Android', extension: 'java' },
+    'kotlin' => { name: 'Kotlin', extension: 'kt' },
     'python' => { name: 'Python', extension: 'py' },
     'php' => { name: 'PHP', extension: 'php' },
     'ruby' => { name: 'Ruby', extension: 'ruby' },


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

JIRA https://ably.atlassian.net/browse/WEB-1743
For part two see: https://github.com/ably/website/pull/4004

## Description
Need a 'generic' rendering of code blocks for unsupported languages

It would be good to have a "Generic" or "Plain" code block type for source code that doesn't require syntax highlighting but is still rendered in monospace, with appropriate line breaks. (Currently, if you leave out the language type then, in the website, line breaks disappear and in docs.ably.com, everything is highlighted in the same way as inline code is).


## Review

Instructions on how to review the PR. 

- Visit `/documentation/client-lib-development-guide/features#idl`
- You should see unstyled code block (as per JIRA request)

## Documentation Output
![2021-08-23-173440_719x305_scrot](https://user-images.githubusercontent.com/944315/130484207-556e3ba8-e6fd-443a-8910-cd1e3a43953f.png)

This was achieved by removing the textile language code `[python]` and leaving it naked
![2021-08-23-172947_824x342_scrot](https://user-images.githubusercontent.com/944315/130483658-f517651a-5b20-4832-85ee-dedd0ef430db.png)

## Website Output (see part 2)
![2021-08-23-172919_952x385_scrot](https://user-images.githubusercontent.com/944315/130483437-59ed9fb2-9c8d-42ef-a5b1-8c33ca85f969.png)



* [Page to review](link)
