### PR TITLE
DOC-437: Move Control API limits into the limits page

### DIFF
--- a/content/control-api/index.textile
+++ b/content/control-api/index.textile
@@ -12,7 +12,6 @@ jump_to:
     - Account and app IDs#ids
     - Obtain token details using the API#obtain-token
     - Quickstart#quickstart
-    - Rate limits#rate-limits
     - See also#see-also
 ---
 
@@ -29,6 +28,8 @@ Using the Control API you can manage:
 Repetitive operations such as creating or updating Ably apps, enumerating queues, and other tasks can be automated using the Control API.
 
 In order to use the Control API you must first create an access token in the "Ably dashboard":https://ably.com/accounts/any. You can then use the Control API to manage many account functions without having to interact with the dashboard.
+
+Note that the Control API has certain "limits":/general/limits#control-api on the number of API calls that can be made per hour.
 
 h2(#development-status). Development status
 
@@ -218,20 +219,6 @@ Sample response:
   ...
 ]
 ```
-
-h2(#rate-limits). Rate limits
-
-The Control API has certain limits on the number of API calls that can be made per hour. The limits are as follows:
-
-|_. Authenticated |_. Limit (requests per hour) |_. Scope |
-| True | 4000 | Limit is per account. The limit at the token level is 2000 calls per hour. This prevents an integration from using up all the limits. |
-| False | 60 | Limit is by IP address |
-
-If you hit a rate limit you receive an error message, as shown in the following table:
-
-|_. Authenticated |_. HTTP status code |_. Message example |
-| True | 429 | Rate limit exceeded; request rejected (nonfatal); metric = channel.maxRate; interval = 2021-05-11:12:43:6; permitted rate = 100; current rate = 100; scope = channel:[app:JrsUEQ:meta]channel.lifecycle |
-| False | 401 | Unauthorized |
 
 h2(#see-also). See also
 

--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -15,6 +15,7 @@ jump_to:
     - Queue limits#queues
     - Integration limits#integration
     - API limits#api
+    - Control API limits#control-api
 ---
 
 Limits are applied to all accounts in order to prevent any impact on service caused by deliberate or accidental abuse. Limits vary depending on the "package":https://ably.com/pricing associated with your account and upgrading to a package with additional message, connection or channel allowance increases any related limits. Enterprise package limits are customizable.
@@ -319,6 +320,33 @@ API request limits are the maximum number of REST API requests that can be made 
 | API request rate (per second) | - | 20 | - | >=50 | - | >=50 |\2. Custom |
 
 If the per-second API request rate is exceeded, a "global rate limit":#global-rates will be applied to API requests. The hourly API request limit is a "time-based limit":#time, meaning no additional API requests will be accepted until the following hour if the hard limit is hit.
+
+h2(#control-api). Control API limits
+
+Control API limits relate to the rate of requests that can be made using the "Control API":/control-api.
+
+|_=. Limit |_=. Free |_=. Self-service |_=. Business |_=. Enterprise |
+| "Authenticated account request rate":#authenticated-account (per hour) | 4000 | 4000 | 4000 | 4000 |
+| "Authenticated access token request rate":#authenticated-token (per hour) | 2000 | 2000 | 2000 | 2000 |
+| "Unauthenticated request rate":#unauthenticated (per hour) | 60 | 60 | 60 | 60 |
+
+h3(#authenticated-account). Authenticated account request rate
+
+The authenticated account request rate is the maximum number of requests that can be made using the "Control API":/control-api per hour from "authenticated":/control-api#authentication users.
+
+The authenticated account request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@. 
+
+h3(#authenticated-token). Authenticated access token request rate
+
+The authenticated access token request rate is the maximum number of requests that can be made for each "access token":/control-api#authentication using the "Control API":/control-api per hour.
+
+The authenticated access token request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made using that access token until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@.
+
+h3(#unauthenticated). Unauthenticated request rate
+
+The unauthenticated request rate is the maximum number of requests that can be made using the "Control API":/control-api from an unauthenticated user per hour. This limit is applied per IP address.
+
+The unauthenticated request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @401@.
 
 h2. Next steps
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR moves the Control API limits listed on the Control API page into a new section on the generic limits page.

See [JIRA](https://ably.atlassian.net/browse/DOC-437) for further information.

## Review

The limits section should no long appear in the [Control API page](). The limits should be covered on the [limits page]() instead.
