### PR TITLE
Document correct header `X-Ably-DeviceToken` and add note about wrongly documented `X-Ably-DeviceIdentityToken`

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1104,7 +1104,7 @@ h3(#activation-state-machine). Activation State Machine
 h3(#push-device-authentication). Push device authentication
 
 * @(RSH6)@ In platforms that support receiving push notifications, and have undergone push registration, are capable of authenticating themselves to the Ably server in order that certain push admin operations can be authorized.
-** @(RSH6a)@ If a device has completed activation and has a @deviceIdentityToken@ then push device authentication is performed for a request by adding an @X-Ably-DeviceIdentityToken@ request header whose value is the @deviceIdentityToken@.
+** @(RSH6a)@ If a device has completed activation and has a @deviceIdentityToken@ then push device authentication is performed for a request by adding an @X-Ably-DeviceToken@ request header whose value is the @deviceIdentityToken@. This header has always been @X-Ably-DeviceToken@, but has previously been mistakenly documented as @X-Ably-DeviceIdentityToken@ in the hope of renaming it to avoid confusion with APNs device token. It was never renamed.
 ** @(RSH6b)@ If a device has not completed but has a @deviceSecret@ then push device authentication is performed for a request by adding an @X-Ably-DeviceSecret@ request header whose value is the @deviceSecret@.
 
 h3(#push-channels). Push channels

--- a/content/client-lib-development-guide/versions/v1.1/features.textile
+++ b/content/client-lib-development-guide/versions/v1.1/features.textile
@@ -1046,7 +1046,7 @@ h3(#activation-state-machine). Activation State Machine
 h3(#push-device-authentication). Push device authentication
 
 * @(RSH6)@ In platforms that support receiving push notifications, and have undergone push registration, are capable of authenticating themselves to the Ably server in order that certain push admin operations can be authorized.
-** @(RSH6a)@ If a device has completed activation and has a @deviceIdentityToken@ then push device authentication is performed for a request by adding an @X-Ably-DeviceIdentityToken@ request header whose value is the @deviceIdentityToken@.
+** @(RSH6a)@ If a device has completed activation and has a @deviceIdentityToken@ then push device authentication is performed for a request by adding an @X-Ably-DeviceToken@ request header whose value is the @deviceIdentityToken@. This header has always been @X-Ably-DeviceToken@, but has previously been mistakenly documented as @X-Ably-DeviceIdentityToken@ in the hope of renaming it to avoid confusion with APNs device token. It was never renamed.
 ** @(RSH6b)@ If a device has not completed but has a @deviceSecret@ then push device authentication is performed for a request by adding an @X-Ably-DeviceSecret@ request header whose value is the @deviceSecret@.
 
 h3(#push-channels). Push channels


### PR DESCRIPTION
By looking inside ably-java, ably-cocoa and go-services repo, we can see that there are no usages of `X-Ably-DeviceIdentityToken`, only `X-Ably-DeviceToken`. This PR fixes the feature spec header string, but also adds a note about this mistaken documentation for future reference.

WDYT @paddybyers, I think you have the most context here.