### PR TITLE
Add `// reserved for internal use` comments to `ARTPresenceAbsent` and `Absent` enum cases

### DIFF
--- a/content/partials/types/_presence_action.textile
+++ b/content/partials/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent,
+        ARTPresenceAbsent, // internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent
+      case Absent // internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/types/_presence_action.textile
+++ b/content/partials/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent, // internal use
+        ARTPresenceAbsent, // reserved for internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent // internal use
+      case Absent // reserved for internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v0.8/types/_presence_action.textile
+++ b/content/partials/versions/v0.8/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent, // internal use
+        ARTPresenceAbsent, // reserved for internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -123,7 +123,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent // internal use
+      case Absent // reserved for internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v0.8/types/_presence_action.textile
+++ b/content/partials/versions/v0.8/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent,
+        ARTPresenceAbsent, // internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -123,7 +123,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent
+      case Absent // internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v1.0/types/_presence_action.textile
+++ b/content/partials/versions/v1.0/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent,
+        ARTPresenceAbsent, // internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent
+      case Absent // internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v1.0/types/_presence_action.textile
+++ b/content/partials/versions/v1.0/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent, // internal use
+        ARTPresenceAbsent, // reserved for internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent // internal use
+      case Absent // reserved for internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v1.1/types/_presence_action.textile
+++ b/content/partials/versions/v1.1/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent,
+        ARTPresenceAbsent, // internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent
+      case Absent // internal use
       case Present
       case Enter
       case Leave

--- a/content/partials/versions/v1.1/types/_presence_action.textile
+++ b/content/partials/versions/v1.1/types/_presence_action.textile
@@ -112,7 +112,7 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent, // internal use
+        ARTPresenceAbsent, // reserved for internal use
         ARTPresencePresent,
         ARTPresenceEnter,
         ARTPresenceLeave,
@@ -122,7 +122,7 @@ blang[objc,swift].
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent // internal use
+      case Absent // reserved for internal use
       case Present
       case Enter
       case Leave


### PR DESCRIPTION
This makes it consistent with all other languages. For example, nodeJS has:
```js
var PresenceActions = [
  'absent', // (reserved for internal use)
  'present',
  'enter',
  'leave',
  'update'
]
```

Please see [Presence action](https://ably.com/documentation/realtime/presence#presence-action) and toggle between the different languages in the black top bar at the top to compare languages:

![CleanShot 2021-09-13 at 11 44 08](https://user-images.githubusercontent.com/24711048/133070361-b95da0fe-e67e-4c16-8cdf-111cefe388c3.png)
