### PR TITLE
DOC-482: Fix quickstart JavaScript URL

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -48,7 +48,7 @@ blang[javascript].
 
   To get started with your project, reference the SDK within the @<head>@ of an HTML page:
 
-  bc[html]. <script src="//cdn.ably.com/lib/ably.min-1.js"></script>
+  bc[html]. <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
 
   The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
 

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -489,6 +489,7 @@ This guide introduced the basic concepts of Ably and illustrated how easy it is 
 * Find out more about the "Realtime Client Library SDK":/realtime.
 * Find out more about the "REST Client Library SDK":/rest.
 * Try out some "tutorials":https://ably.com/tutorials.
+* Provision Ably applications using the "Control API":/control-api.
 
 
 <script src="//cdn.ably.io/lib/ably.min-1.js" crossorigin="anonymous"></script>

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -488,8 +488,8 @@ This guide introduced the basic concepts of Ably and illustrated how easy it is 
 * Read more about "how Ably works":/how-ably-works.
 * Find out more about the "Realtime Client Library SDK":/realtime.
 * Find out more about the "REST Client Library SDK":/rest.
-* Try out some "tutorials":https://ably.com/tutorials.
-* Provision Ably applications using the "Control API":/control-api.
+* Try out some "tutorials":/tutorials.
+* Provision Ably apps using the "Control API":/control-api.
 
 
 <script src="//cdn.ably.io/lib/ably.min-1.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR fixes the URL for the JavaScript CDN in the quickstart guide. See [JIRA](https://ably.atlassian.net/browse/DOC-482) for further information.

## Review

To review this PR, visit [this page](http://ably-docs-pr-1196.herokuapp.com/quick-start-guide) and view the page in JavaScript.
