### PR TITLE
DOC-480: Refer to "per second" limits as instantaneous rate limits

### DIFF
--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -135,7 +135,7 @@ Token request limits relate to the rate and size of "token requests":/core-featu
 
 h3(#token-rate). Token request rate
 
-The token request rate is the maximum rate at which token requests can be made. The hourly token request limit is the number of token requests that can be made per hour to Ably. 
+The token request rate limit is the maximum rate at which token requests can be made. The hourly token request limit is the number of token requests that can be made per hour to Ably. 
 
 If the token request rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to token requests. The hourly token request limit is a "time-based limit":#time, meaning no additional token requests will be accepted until the following hour if the hard limit is hit.
 
@@ -156,7 +156,7 @@ Connection limits relate to the "realtime connections":/realtime/connection to A
 
 h3(#connection-rate). Connection rate
 
-The connection rate is the maximum rate at which new "realtime connections":/realtime/connection can be made to Ably.
+The connection rate limit is the maximum rate at which new "realtime connections":/realtime/connection can be made to Ably.
 
 The limit is calculated based on the hard limit for "peak connections":#peak-connections, with a minimum value of 50 per second for self-service and business accounts.
 
@@ -170,13 +170,13 @@ The number of channels per connection is a "quantity-based limit":#quantity. If 
 
 h3(#outbound-message). Outbound message rate
 
-The outbound message rate is the maximum rate at which messages can be published on a "realtime connection":/realtime/connection.
+The outbound message rate limit is the maximum rate at which messages can be published on a "realtime connection":/realtime/connection.
 
 If the outbound message rate is exceeded for a connection, a "local instantaneous rate limit":#local-rates will be applied to that connection.
 
 h3(#inbound-message). Inbound message rate
 
-The inbound message rate is the maximum rate at which messages can be received on a "realtime connection":/realtime/connection.
+The inbound message rate limit is the maximum rate at which messages can be received on a "realtime connection":/realtime/connection.
 
 If the inbound message rate is exceeded for a connection, a "local rate limit":#local-rates will be applied to that connection.
 
@@ -217,7 +217,7 @@ The number of presence members is a "quantity-based limit":#quantity. Any client
 
 h3(#channel-create). Channel creation rate
 
-The channel creation rate is the maximum rate at which channels can be created across your Ably account.
+The channel creation rate limit is the maximum rate at which channels can be created across your Ably account.
 
 The limit is calculated based on the hard limit for "peak channels":#peak-channels, with a minimum value of 50 per second for self-service and business accounts.
 
@@ -225,7 +225,7 @@ If the channel creation rate is exceeded, a "global instantaneous rate limit":#g
 
 h3(#message-publish-rate). Message publish rate
 
-The message rate is the maximum rate at which messages can be published for each channel.
+The message rate limit is the maximum rate at which messages can be published for each channel.
 
 If the message publish rate is exceeded for a channel, a "local instantaneous rate limit":#local-rates on publishing will be applied to that channel.
 
@@ -269,7 +269,7 @@ For example, with a free account you could have one queue with a length of 10,00
 
 h3(#queue-publish). Queue publish rate
 
-The queue publish rate is the maximum rate at which messages can be published to a queue.
+The queue publish rate limit is the maximum rate at which messages can be published to a queue.
 
 If the queue publish rate is exceeded, a "global instantaneous rate limit":#global-rates on publishing to queues is applied.
 
@@ -298,13 +298,13 @@ Webhook batch concurrency is the number of webhook batches that can be processed
 
 h3(#firehose-messages). Firehose message rate
 
-The Firehose message rate is the maximum rate at which Firehose messages can be streamed.
+The Firehose message rate limit is the maximum rate at which Firehose messages can be streamed.
 
 If the Firehose message rate is exceeded, a "global instantaneous rate limit":#global-rates on publishing to Firehose is applied.
 
 h3(#function-invocations). Function invocation rate
 
-The function invocation rate is the maximum rate at which functions can be invoked. This includes AWS Lambda, Google Cloud and Azure functions that can be triggered by "events":https://ably.com/documentation/general/events.
+The function invocation rate limit is the maximum rate at which functions can be invoked. This includes AWS Lambda, Google Cloud and Azure functions that can be triggered by "events":https://ably.com/documentation/general/events.
 
 If the function invocation rate is exceeded, a "global instantaneous rate limit":#global-rates on function invocations is applied.
 

--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -325,30 +325,30 @@ If the API request rate is exceeded, a "global instantaneous rate limit":#global
 
 h2(#control-api). Control API limits
 
-Control API limits relate to the rate of requests that can be made using the "Control API":/control-api.
+Control API limits relate to the number of requests that can be made using the "Control API":/control-api per hour.
 
 |_=. Limit |_=. Free |_=. Self-service |_=. Business |_=. Enterprise |
-| "Authenticated account request rate":#authenticated-account (per hour) | 4000 | 4000 | 4000 | 4000 |
-| "Authenticated access token request rate":#authenticated-token (per hour) | 2000 | 2000 | 2000 | 2000 |
-| "Unauthenticated request rate":#unauthenticated (per hour) | 60 | 60 | 60 | 60 |
+| "Authenticated account requests":#authenticated-account (per hour) | 4000 | 4000 | 4000 | 4000 |
+| "Authenticated access token requests":#authenticated-token (per hour) | 2000 | 2000 | 2000 | 2000 |
+| "Unauthenticated requests":#unauthenticated (per hour) | 60 | 60 | 60 | 60 |
 
-h3(#authenticated-account). Authenticated account request rate
+h3(#authenticated-account). Authenticated account requests
 
-The authenticated account request rate is the maximum number of requests that can be made using the "Control API":/control-api per hour from "authenticated":/control-api#authentication users.
+The authenticated account request limit is the maximum number of requests that can be made using the "Control API":/control-api per hour from "authenticated":/control-api#authentication users.
 
-The authenticated account request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@. 
+The authenticated account request limit is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@. 
 
-h3(#authenticated-token). Authenticated access token request rate
+h3(#authenticated-token). Authenticated access token requests
 
-The authenticated access token request rate is the maximum number of requests that can be made for each "access token":/control-api#authentication using the "Control API":/control-api per hour.
+The authenticated access token request limit is the maximum number of requests that can be made for each "access token":/control-api#authentication using the "Control API":/control-api per hour.
 
-The authenticated access token request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made using that access token until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@.
+The authenticated access token request limit is a "time-based limit":#time. If the limit is hit, no more requests can be made using that access token until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @429@.
 
-h3(#unauthenticated). Unauthenticated request rate
+h3(#unauthenticated). Unauthenticated requests
 
-The unauthenticated request rate is the maximum number of requests that can be made using the "Control API":/control-api from an unauthenticated user per hour. This limit is applied per IP address.
+The unauthenticated request limit is the maximum number of requests that can be made using the "Control API":/control-api from an unauthenticated user per hour. This limit is applied per IP address.
 
-The unauthenticated request rate is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @401@.
+The unauthenticated request limit is a "time-based limit":#time. If the limit is hit, no more requests can be made until the following hour. Any request attempts that exceed the limit will be rejected with the HTTP status code @401@.
 
 h2. Next steps
 

--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -24,7 +24,7 @@ You can view the limits for your package in the "account dashboard":https://ably
 
 h2(#overview). Overview
 
-Limits are either "time-based":#time, "quantity-based":#quantity or "rates":#rates. The effect of hitting or exceeding a limit varies depending on its type. 
+Limits are either "time-based":#time, "quantity-based":#quantity or "instantaneous rates":#rates. The effect of hitting or exceeding a limit varies depending on its type.
 
 Limits are also categorized as local or global depending on whether they relate to a single resource, or the aggregate of all resources of a given type:
 
@@ -38,19 +38,19 @@ Certain limits have both a soft and a hard limit:
 
 All notifications regarding limit warnings, rate limiting and exceeded limits are logged. Current and historic notifications can be viewed in your "account":https://ably.com/accounts/any/notifications. This includes details such as how much a limit was exceeded by and the expiry date of any blocks.
 
-h3(#rates). Rate limits
+h3(#rates). Instantaneous rate limits
 
-Rate limits relate to the frequency of a given operation at a moment in time and are expressed as a number of operations per second. How local rate limits and global rate limits are applied differs.
+Instantaneous rate limits relate to the frequency of a given operation at a moment in time and are expressed as a number of operations per second. How local instantaneous rate limits and global instantaneous rate limits are applied differs.
 
-h4(#local-rates). Local rate limits
+h4(#local-rates). Local instantaneous rate limits
 
-Local rate limits reject operations in excess of their hard limit and return an error code. For example, the limit on a self-service package for the message publish rate on an individual channel is 50 messages per second. Any message publish attempts in excess of the 50 messages per second will be rejected and an error code will be returned to the publisher.
+Local instantaneous rate limits reject operations in excess of their hard limit and return an error code. For example, the limit on a self-service package for the message publish rate on an individual channel is 50 messages per second. Any message publish attempts in excess of the 50 messages per second will be rejected and an error code will be returned to the publisher.
 
-h4(#global-rates). Global rate limits
+h4(#global-rates). Global instantaneous rate limits
 
-Global rate limits apply rate suppression to operations that exceed their hard limits. Rate suppression is calculated on a rolling probabilistic basis. For example, the limit on a self-service package for publishing messages into a queue is 100 messages per second. If a queue rule is attempting to publish 200 messages per second into the queue, each message will have a 50% chance of being rejected. The suppression probability is continuously updated based on the publishing rate.
+Global instantaneous rate limits apply rate suppression to operations that exceed their hard limits. Rate suppression is calculated on a rolling probabilistic basis. For example, the limit on a self-service package for publishing messages into a queue is 100 messages per second. If a queue rule is attempting to publish 200 messages per second into the queue, each message will have a 50% chance of being rejected. The suppression probability is continuously updated based on the publishing rate.
 
-Global rate limits only have a hard limit. Once the hard limit rate has been exceeded then message suppression will occur. As soon as the rate drops below the hard limit threshold, the suppression probability will decrease to zero.
+Global instantaneous rate limits only have a hard limit. Once the hard limit rate has been exceeded then message suppression will occur. As soon as the rate drops below the hard limit threshold, the suppression probability will decrease to zero.
 
 h3(#time). Time-based limits
 
@@ -105,23 +105,23 @@ The peak channels limit is a "quantity-based limit":#quantity. If the hard limit
 
 h3(#messages). Messages
 
-Message counts and rates are the number of "messages":/glossary#messages published and received in your account per second, per hour and in total for a month. 
+Message counts and rates are the number of "messages":/glossary#messages published and received in your account. 
 
 * The total messages for a month are set based on your quota. 
-* The hourly message rate is calculated using the total message limit divided by 72.
-* The per-second message rate is calculated using the hourly message rate multiplied by 2.5, divided into seconds. For example, if the hourly message rate is 208,000 then the per-second message rate will be @(208,000 x 2.5) / 60 / 60 = 145@.
+* The hourly message limit is calculated using the total message limit divided by 72.
+* The message rate is calculated using the hourly limit multiplied by 2.5, divided into seconds. For example, if the hourly limit is 208,000 then the message rate will be @(208,000 x 2.5) / 60 / 60 = 145@.
 
-If the per-second message rate is exceeded, a "global rate limit":#global-rates will be applied to message delivery and publishing. The hourly and total message limits are "time-based":#time. If the hard limit is hit for those, message delivery and publishing will be blocked until the following hour or month.
+If the message rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to message delivery and publishing. The hourly and total message limits are "time-based":#time. If the hard limit is hit for those, message delivery and publishing will be blocked until the following hour or month.
 
 h3(#bandwidth). Bandwidth
 
-Bandwidth is the amount of data transferred through "messages":/glossary#messages per second, per hour and in total for a month. 
+Bandwidth is the amount of data transferred through "messages":/glossary#messages. 
 
 * The total bandwidth is calculated using the average message size of 2KiB multiplied by the total message count. 
-* The hourly bandwidth rate is calculated using the total bandwidth limit divided by 72.
-* The per-second bandwidth rate is calculated using the hourly bandwidth limit multiplied by 2.5, divided into seconds.
+* The hourly bandwidth limit is calculated using the total bandwidth limit divided by 72.
+* The bandwidth rate is calculated using the hourly bandwidth limit multiplied by 2.5, divided into seconds.
 
-If the per-second bandwidth rate is exceeded, a "global rate limit":#global-rates will be applied to message delivery and publishing. The hourly and total bandwidth limits are "time-based":#time. If the hard limit is hit for those, message delivery and publishing will be blocked until the following hour or month.
+If the bandwidth rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to message delivery and publishing. The hourly and total bandwidth limits are "time-based":#time. If the hard limit is hit for those, message delivery and publishing will be blocked until the following hour or month.
 
 h2(#token). Token request limits
 
@@ -129,15 +129,15 @@ Token request limits relate to the rate and size of "token requests":/core-featu
 
 |_/2=. Limit |_\2=. Free |_\2=. Self-service |_\2=. Business |_\2=. Enterprise |
 |_. Soft |_. Hard |_. Soft |_. Hard |_. Soft |_. Hard |_. Soft |_. Hard |
-| "Token request rate":#token-rate (per hour) | 60,000 | 72,000 | 0.4 * hard limit | "Connection rate":#connection-rate per hour / 1000 | 0.2 * hard limit | "Connection rate":#connection-rate per hour / 1000 |\2. Custom |
+| "Token requests":#token-rate (per hour) | 60,000 | 72,000 | 0.4 * hard limit | "Connection rate":#connection-rate per hour / 1000 | 0.2 * hard limit | "Connection rate":#connection-rate per hour / 1000 |\2. Custom |
 | "Token request rate":#token-rate (per second) | - | 50 | - | 0.4 * hourly limit | - | 0.2 * hourly limit |\2. Custom |
 | "Token request size":#token-size |\8=. 128KiB |
 
 h3(#token-rate). Token request rate
 
-The token request rate is the maximum number of token requests that can be made to Ably per second and per hour.
+The token request rate is the maximum rate at which token requests can be made. The hourly token request limit is the number of token requests that can be made per hour to Ably. 
 
-If the per-second token request rate is exceeded, a "global rate limit":#global-rates will be applied to token requests. The hourly token request limit is a "time-based limit":#time, meaning no additional token requests will be accepted until the following hour if the hard limit is hit.
+If the token request rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to token requests. The hourly token request limit is a "time-based limit":#time, meaning no additional token requests will be accepted until the following hour if the hard limit is hit.
 
 h3(#token-size). Token request size
 
@@ -156,11 +156,11 @@ Connection limits relate to the "realtime connections":/realtime/connection to A
 
 h3(#connection-rate). Connection rate
 
-The connection rate is the number of new "realtime connections":/realtime/connection that can be made to Ably per second.
+The connection rate is the maximum rate at which new "realtime connections":/realtime/connection can be made to Ably.
 
 The limit is calculated based on the hard limit for "peak connections":#peak-connections, with a minimum value of 50 per second for self-service and business accounts.
 
-If the connection rate is exceeded, a "global rate limit":#global-rates will be applied to new connection attempts.
+If the connection rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to new connection attempts.
 
 h3(#connection-channels). Number of channels
 
@@ -170,13 +170,13 @@ The number of channels per connection is a "quantity-based limit":#quantity. If 
 
 h3(#outbound-message). Outbound message rate
 
-The outbound message rate is the maximum number of messages that can be published per second on a "realtime connection":/realtime/connection.
+The outbound message rate is the maximum rate at which messages can be published on a "realtime connection":/realtime/connection.
 
-If the outbound message rate is exceeded for a connection, a "local rate limit":#local-rates will be applied to that connection.
+If the outbound message rate is exceeded for a connection, a "local instantaneous rate limit":#local-rates will be applied to that connection.
 
 h3(#inbound-message). Inbound message rate
 
-The inbound message rate is the maximum number of messages that can be received per second on a "realtime connection":/realtime/connection.
+The inbound message rate is the maximum rate at which messages can be received on a "realtime connection":/realtime/connection.
 
 If the inbound message rate is exceeded for a connection, a "local rate limit":#local-rates will be applied to that connection.
 
@@ -217,17 +217,17 @@ The number of presence members is a "quantity-based limit":#quantity. Any client
 
 h3(#channel-create). Channel creation rate
 
-The channel creation rate is the number of channels that can be created per second.
+The channel creation rate is the maximum rate at which channels can be created across your Ably account.
 
 The limit is calculated based on the hard limit for "peak channels":#peak-channels, with a minimum value of 50 per second for self-service and business accounts.
 
-If the channel creation rate is exceeded, a "global rate limit":#global-rates will be applied to channel creation.
+If the channel creation rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to channel creation.
 
 h3(#message-publish-rate). Message publish rate
 
-The message rate is the maximum rate at which messages can be published per second for each channel.
+The message rate is the maximum rate at which messages can be published for each channel.
 
-If the message publish rate is exceeded for a channel, a "local rate limit":#local-rates on publishing will be applied to that channel.
+If the message publish rate is exceeded for a channel, a "local instantaneous rate limit":#local-rates on publishing will be applied to that channel.
 
 h2(#message). Message limits
 
@@ -269,9 +269,9 @@ For example, with a free account you could have one queue with a length of 10,00
 
 h3(#queue-publish). Queue publish rate
 
-The queue publish rate is the maximum rate at which messages can be published to a queue, per second.
+The queue publish rate is the maximum rate at which messages can be published to a queue.
 
-If the queue publish rate is exceeded, a "global rate limit":#global-rates on publishing to queues is applied.
+If the queue publish rate is exceeded, a "global instantaneous rate limit":#global-rates on publishing to queues is applied.
 
 h3(#queue-ttl). Queue TTL
 
@@ -298,15 +298,15 @@ Webhook batch concurrency is the number of webhook batches that can be processed
 
 h3(#firehose-messages). Firehose message rate
 
-The Firehose message rate is the maximum amount of Firehose messages that can be streamed per second.
+The Firehose message rate is the maximum rate at which Firehose messages can be streamed.
 
-If the Firehose message rate is exceeded, a "global rate limit":#global-rates on publishing to Firehose is applied.
+If the Firehose message rate is exceeded, a "global instantaneous rate limit":#global-rates on publishing to Firehose is applied.
 
 h3(#function-invocations). Function invocation rate
 
-The function invocation rate is the maximum number of functions that can be invoked per second. This includes AWS Lambda, Google Cloud and Azure functions that can be triggered by "events":https://ably.com/documentation/general/events.
+The function invocation rate is the maximum rate at which functions can be invoked. This includes AWS Lambda, Google Cloud and Azure functions that can be triggered by "events":https://ably.com/documentation/general/events.
 
-If the function invocation rate is exceeded, a "global rate limit":#global-rates on function invocations is applied.
+If the function invocation rate is exceeded, a "global instantaneous rate limit":#global-rates on function invocations is applied.
 
 h3(#concurrent-functions). Function concurrency
 
@@ -314,14 +314,14 @@ Function concurrency is the maximum number of functions that can run at the same
 
 h2(#api). API request limits
 
-API request limits are the maximum number of REST API requests that can be made to Ably per second and per hour. This excludes "token requests":#token.
+API request limits are the maximum number of REST API requests that can be made to Ably. This excludes "token requests":#token.
 
 |_/2=. Limit |_\2=. Free |_\2=. Self-service |_\2=. Business |_\2=. Enterprise |
 |_. Soft |_. Hard |_. Soft |_. Hard |_. Soft |_. Hard |_. Soft |_. Hard |
-| API request rate (per hour) | 4,200 | 5,000 | 0.1 * hourly message soft limit | 0.1 * hourly message hard limit| 0.1 * hourly message soft limit | 0.1 * hourly message hard limit |\2. Custom |
+| API requests (per hour) | 4,200 | 5,000 | 0.1 * hourly message soft limit | 0.1 * hourly message hard limit| 0.1 * hourly message soft limit | 0.1 * hourly message hard limit |\2. Custom |
 | API request rate (per second) | - | 20 | - | >=50 | - | >=50 |\2. Custom |
 
-If the per-second API request rate is exceeded, a "global rate limit":#global-rates will be applied to API requests. The hourly API request limit is a "time-based limit":#time, meaning no additional API requests will be accepted until the following hour if the hard limit is hit.
+If the API request rate is exceeded, a "global instantaneous rate limit":#global-rates will be applied to API requests. The hourly API request limit is a "time-based limit":#time, meaning no additional API requests will be accepted until the following hour if the hard limit is hit.
 
 h2(#control-api). Control API limits
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR attempts to address [this comment](https://github.com/ably/docs/pull/1101#issuecomment-907109874) from the PR introducing limits. The intention is to be consistent with terminology and not refer to instantaneous rate limits as "per second limits".

## Review

This PR can be reviewed by viewing the [limits](http://ably-docs-pr-1199.herokuapp.com/general/limits) page.
