### PR TITLE
DOC-390: Add an occupancy topic to core features

### DIFF
--- a/content/core-features/occupancy.textile
+++ b/content/core-features/occupancy.textile
@@ -1,0 +1,17 @@
+---
+title: Occupancy
+section: core-features
+index: 29
+meta_description: "The occupancy feature returns metrics relating to clients connected to a channel."
+meta_keywords: "occupancy, metrics, occupancy metrics"
+---
+
+The occupancy feature enables you to view the number of occupants connected to a channel and specific metrics about their connections.
+
+The metrics returned by the occupancy feature include the number of clients connected to a channel, the number of those authorized to subscribe to messages on the channel and the number of those clients authorized to publish to the channel. The occupancy metrics also include the number of connections authorized to subscribe to presence events, the number authorized to publish presence events and the number of connections currently entered into "presence":/core-features/presence on the channel.
+
+Channel occupancy can be queried in a number of ways. Occupancy can be viewed as part of "channel enumeration":/rest-api#enumeration-rest, configured as an "integration rule source":/general/events#sources or as "inband channel occupancy events":/realtime/inband-occupancy. 
+
+h2(#occupancy-presence). Occupancy and presence
+
+Occupancy differs from "presence":/core-features/presence in that presence enables a client to identify themselves to other clients subscribed to presence events on a channel, as well as to update their member data for subscribers to view. Presence events are emitted when a client enters or leaves a channel or when they update their member data. Occupancy provides a count of the clients connected to a channel, broken down into specific metric categories. Occupancy data can be viewed at a specific point in time when using channel enumeration, or emitted as events when metrics change using an integration rule source or inband channel occupancy.

--- a/content/core-features/presence.textile
+++ b/content/core-features/presence.textile
@@ -8,3 +8,7 @@ index: 27
   <img src="/images/diagrams/Channels-Presence.gif" style="width: 100%" alt="Presence representation">
 </a>
  Furthermore, if persistence is enabled on the presence channel, you can also retrieve "presence history":/rest/history#presence-history for the channel, i.e, static data about historical presence states of your clients/devices. This operation also can be done using both Ably's "Realtime":/realtime and "REST":/rest libraries.
+
+h2(#occupancy-presence). Occupancy and presence
+
+"Occupancy":/core-features/occupancy differs from presence in that presence enables a client to identify themselves to other clients subscribed to presence events on a channel, as well as to update their member data for subscribers to view. Presence events are emitted when a client enters or leaves a channel or when they update their member data. Occupancy provides a count of the clients connected to a channel, broken down into specific metric categories. Occupancy data can be viewed at a specific point in time when using channel enumeration, or emitted as events when metrics change using an integration rule source or inband channel occupancy.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR adds an occupancy topic to the core features and a paragraph detailing the difference between presence and occupancy to avoid confusion between the two features. See [JIRA](https://ably.atlassian.net/browse/DOC-390) for further information.

## Review

View the new [occupancy topic](http://ably-docs-pr-1209.herokuapp.com/core-features/occupancy) to review this PR.