### PR TITLE
DOC-546: Remove "step" from quickstart headings

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -18,11 +18,11 @@ languages:
   - go
 jump_to:
   Help with:
-    - Add the Ably Client Library SDK#step-1
+    - Add the Ably SDK#step-1
     - Connect to Ably#step-2
     - Subscribe to a channel#step-3
     - Publish a message#step-4
-    - Close a connection to Ably#step-5
+    - Close a connection#step-5
     - Next steps#next-steps
 ---
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR removes the "Step X:" from all quickstart headings. This is because the headings are already numbered causing repetition. See [JIRA](https://ably.atlassian.net/browse/DOC-546) for further information.

## Review

View the [quickstart](https://ably-docs-pr-1236.herokuapp.com/quick-start-guide) to check the headings have been removed.
