### PR TITLE
DOC-384: Update attach vs subscribe best practice section

### DIFF
--- a/content/root/best-practice-guide.textile
+++ b/content/root/best-practice-guide.textile
@@ -83,9 +83,13 @@ h2(#for-experienced-developers). For experienced developers
 
 In order to make the best use of Ably, you need to be aware of the following information:
 
-h3(#all-attached-channels-receive-messages). Channels that you attach to, automatically receive messages from Ably even without a subscribe listener
+h3(#attach-vs-subscribe). Attaching versus subscribing to a channel
 
-Once a channel is attached, assuming the client has permission to subscribe to messages, Ably will immediately start sending published messages to that client irrespective of whether there are any subscribe listeners registered on that client or not. A common misunderstanding is that only after a client has "subscribed":/realtime/messages#message-subscription to a channel will Ably start sending messages to that client. This is not the case as registering a listener with a channel subscribe operation is a client-side operation only and is not communicated to Ably.
+It is important to understand the difference between attaching and subscribing to a channel, and that messages are sent to clients as soon as they attach to a channel.
+
+The "@attach@":/realtime/channels#attach method attaches a client to the channel. Published messages are immediately sent to clients if they have subscribe capabilities to that channel, regardless of whether or not the client has subscribed to the channel. 
+
+The "@subscribe@":/realtime/channels#subscribe method registers a subscribe listener for messages received on the channel. @subscribe@ is a client-side operation, meaning Ably is unaware of whether or not a client is subscribed to the channel. @attach@ is called implicitly by the @subscribe@ method.
 
 h3(#using-subscribe-filters). Use separate channels to filter messages for different sets of subscribers
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR updates the attach vs subscribe section of the best practice guide to be more explicit.

## Review

View the [best practice guide](https://ably-docs-pr-1236.herokuapp.com/best-practice-guide#attach-vs-subscribe) to review this PR.
