### PR TITLE
DOC-460: Remove occurrences of passing channel options as nil in Go

### DIFF
--- a/content/api-streamer/producer.textile
+++ b/content/api-streamer/producer.textile
@@ -137,7 +137,7 @@ The following example shows a mock data stream by repeating the publish action a
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   interval := setInterval(func() {
             err = channel.Publish("example", "message data")
   }, 3000, false)

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -125,7 +125,7 @@ The Ably REST client library provides a straightforward API for "publishing":/re
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   err = channel.Publish("example", "message data")
   page, err := channel.History(nil)
   fmt.Println("Last published message: %s\n", page.Messages[0].Data)
@@ -167,7 +167,7 @@ bc[objc]. ARTRestChannel *channel = [realtime.channels get:@"channelName"];
 
 bc[swift]. let channel = realtime.channels.get("channelName")
 
-bc[go]. channel := rest.Channels.Get("channelName", nil)
+bc[go]. channel := rest.Channels.Get("channelName")
 
 bc[flutter]. final channel = rest.channels.get('channelName');
 
@@ -275,7 +275,7 @@ To publish to a channel, make use of the "publish":#publish method of the channe
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   err = channel.Publish("example", "message data")
 ```
 
@@ -358,7 +358,7 @@ To get the history of a channel, make use of the "history":#history method of th
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   page, err := channel.History(nil)
   fmt.Println("Last published message: %s\n", page.Messages[0].Data)
 ```

--- a/content/rest/history.textile
+++ b/content/rest/history.textile
@@ -120,7 +120,7 @@ The Ably REST client library provides a straightforward API to retrieve "paginat
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   err = channel.Publish("example", "message data")
   page, err := channel.History(nil)
   fmt.Println("Last published message: %s\n", page.Messages[0].Data)

--- a/content/rest/messages.textile
+++ b/content/rest/messages.textile
@@ -110,7 +110,7 @@ The Ably REST client library provides a straightforward API for "publishing":/re
 
 ```[go]
   rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
-  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}", nil)
+  channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   err = channel.Publish("example", "message data")
   page, err := channel.History(nil)
   fmt.Println("Last published message: %s\n", page.Messages[0].Data)


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR removes all instances where channel options are passed as `nil` in the Go code samples. This is because passing them as `nil` will return an error. See [JIRA](https://ably.atlassian.net/browse/DOC-460) for further information.

## Review

To review this PR, check the following pages viewed in Go:
* [API Streamer](https://ably-docs-pr-1246.herokuapp.com/documentation/api-streamer/producer)
* [rest/channels](https://ably-docs-pr-1246.herokuapp.com/documentation/rest/channels)
* [rest/history](https://ably-docs-pr-1246.herokuapp.com/documentation/rest/history)
* [rest/messages](https://ably-docs-pr-1246.herokuapp.com/documentation/rest/messages)
