### PR TITLE
DOC-530: Correct navigation headings for authentication API reference

### DIFF
--- a/content/rest/authentication.textile
+++ b/content/rest/authentication.textile
@@ -20,9 +20,9 @@ jump_to:
     - Basic Authentication
     - Token Authentication
     - Identified clients
-  Channel API properties:
+  Auth API properties:
     - clientId#client-id
-  Channel API methods:
+  Auth API methods:
     - authorize
     - createTokenRequest#create-token-request
     - requestToken#request-token


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR corrects the "Jump To" labels for the REST authentication API reference.

## Review

To review this PR, check the [REST authentication page](https://ably-docs-pr-1247.herokuapp.com/documentation/rest/authentication).
