### PR TITLE
DOC-531: Remove broken SSE tutorial live demo section

### DIFF
--- a/content/tutorials/sse-and-http-streaming.textile
+++ b/content/tutorials/sse-and-http-streaming.textile
@@ -204,19 +204,14 @@ For the Event Stream endpoint, just replace the URL with @https://realtime.ably.
 
 bq. The @/event-stream@ endpoint will give an SSE response if the @Accept@ header is set to @text/event-stream@. The @/sse@ endpoint is provided as an easier way of forcing an SSE response.
 
-h2(#live-demo). Live demo
-
-blang[javascript].
-  You can see the full code for this tutorial in the "GitHub repo":https://github.com/ably/tutorials/tree/sse-javascript.
-
-blang[python].
-  You can see the full code for this tutorial in the "GitHub repo":https://github.com/ably/tutorials/tree/sse-python.
-
-<iframe src="https://ably-sse-tutorial-demo.glitch.me/" height="400px" width="100%" frameBorder="0" ></iframe>
-
 h2(#conclusion). Conclusion
 
-In this tutorial, we have seen how to subscribe to real-time events using SSE and Ably.
-For further readings, you can visit the full "documentation":/sse or checkout a "quick video":https://youtu.be/Z4ni7GsiIbs.
+In this tutorial you have seen how to subscribe to realtime events using SSE and Ably.
 
+blang[javascript].
+  You can see the full code for this tutorial on "GitHub":https://github.com/ably/tutorials/tree/sse-javascript.
 
+blang[python].
+  You can see the full code for this tutorial on "GitHub":https://github.com/ably/tutorials/tree/sse-python.
+
+For further reading, view the "documentation":/sse or a "short video":https://youtu.be/Z4ni7GsiIbs.

--- a/content/tutorials/sse-and-http-streaming.textile
+++ b/content/tutorials/sse-and-http-streaming.textile
@@ -208,10 +208,6 @@ h2(#conclusion). Conclusion
 
 In this tutorial you have seen how to subscribe to realtime events using SSE and Ably.
 
-blang[javascript].
-  You can see the full code for this tutorial on "GitHub":https://github.com/ably/tutorials/tree/sse-javascript.
+You can see the full code for this tutorial on <span lang="javascript">"GitHub":https://github.com/ably/tutorials/tree/sse-javascript</span><span lang="python">"GitHub":https://github.com/ably/tutorials/tree/sse-python</span>.
 
-blang[python].
-  You can see the full code for this tutorial on "GitHub":https://github.com/ably/tutorials/tree/sse-python.
-
-For further reading, view the "documentation":/sse or a "short video":https://youtu.be/Z4ni7GsiIbs.
+For further reading, view the "SSE documentation":/sse or a "short video":https://youtu.be/Z4ni7GsiIbs.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR removes the live demo section of the SSE demo as it was pointing to an inaccessible Glitch project that is currently not working. See [JIRA](https://ably.atlassian.net/browse/DOC-531) for further information.

## Review

View the [SSE tutorial](https://ably-docs-pr-1249.herokuapp.com/tutorials/sse-and-http-streaming) to review this PR.