### PR TITLE
DOC-383: Add unsubscribe versus detach section

### DIFF
--- a/content/root/best-practice-guide.textile
+++ b/content/root/best-practice-guide.textile
@@ -91,6 +91,16 @@ The "@attach@":/realtime/channels#attach method attaches a client to the channel
 
 The "@subscribe@":/realtime/channels#subscribe method registers a subscribe listener for messages received on the channel. @subscribe@ is a client-side operation, meaning Ably is unaware of whether or not a client is subscribed to the channel. @attach@ is called implicitly by the @subscribe@ method.
 
+h3(#detach-vs-unsubscribe). Detaching versus unsubscribing from a channel
+
+It is important to understand the difference between detaching and unsubscribing from a channel, and that messages will continue to be sent to clients if they only call the @unsubscribe()@ method.
+
+The "@detach()@":/realtime/channels#detach method detaches a client from the channel. The client will no longer receive any messages published to the channel.
+
+The "@unsubscribe()@":/realtime/channels#unsubscribe method removes message listeners for the channel. @unsubscribe()@ is a client-side operation, meaning Ably is unaware of whether or not a client has unsubscribed from the channel. Messages will continue to be streamed to the client until @detach()@ is called.
+
+Calling @subscribe()@ for a channel "implicitly attaches":/realtime/channels#implicit-attach the client to the channel as well. It is important to note that if you call @subscribe()@ followed by @unsubscribe()@, the client remains attached to the channel.
+
 h3(#using-subscribe-filters). Use separate channels to filter messages for different sets of subscribers
 
 By default, all data published to a channel is pushed by Ably to every subscriber attached to that channel. Only on the client side can subscribers filter messages by their message name and so 'avoid' receiving all published messages. But, if you have messages that don't need to be sent to some clients at all, you're often better off using a separate channel for them rather than implementing a filter. Because this way, you won't be sending unnecessary messages that count towards your monthly message quota. This may be economical, but it isn't always the best solution as in some cases you may wish to trigger different listeners for different events and so setting up a single channel and filtering the messages client side would be more sensible. An example is shown below:

--- a/content/root/best-practice-guide.textile
+++ b/content/root/best-practice-guide.textile
@@ -99,7 +99,7 @@ The "@detach()@":/realtime/channels#detach method detaches a client from the cha
 
 The "@unsubscribe()@":/realtime/channels#unsubscribe method removes message listeners for the channel. @unsubscribe()@ is a client-side operation, meaning Ably is unaware of whether or not a client has unsubscribed from the channel. Messages will continue to be streamed to the client until @detach()@ is called.
 
-Calling @subscribe()@ for a channel "implicitly attaches":/realtime/channels#implicit-attach the client to the channel as well. It is important to note that if you call @subscribe()@ followed by @unsubscribe()@, the client remains attached to the channel.
+Calling "@subscribe()@":/realtime/channels#subscribe for a channel "implicitly attaches":/realtime/channels#implicit-attach the client to the channel as well. It is important to note that if you call @subscribe()@ followed by @unsubscribe()@, the client remains attached to the channel.
 
 h3(#using-subscribe-filters). Use separate channels to filter messages for different sets of subscribers
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR adds an unsubscribe versus detach section to the best practice guide to explain the differences and things to be aware of. See [JIRA](https://ably.atlassian.net/browse/DOC-383) for further information.

## Review

View the [best practice guide](https://ably-docs-pr-1252.herokuapp.com/best-practice-guide#detach-vs-unsubscribe) to review this PR.
