### PR TITLE
DOC-459: Update go code blocks to add support for CipherParams and ChannelOptions

### DIFF
--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -124,11 +124,24 @@ The Ably REST client library provides a straightforward API for "publishing":/re
 ```
 
 ```[go]
-  rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+  rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   err = channel.Publish("example", "message data")
-  page, err := channel.History(nil)
-  fmt.Println("Last published message: %s\n", page.Messages[0].Data)
+  err = channel.Publish(context.Background(), "example", "message data")
+  pages, err := channel.History().Pages(context.Background())
+  if err != nil {
+      panic(err)
+  }
+  for pages.Next(context.Background()) {
+      for _, message := range pages.Items() {
+          fmt.Println("--- Channel history ---")
+          fmt.Println(jsonify(message))
+          fmt.Println("--------")
+      }
+  }
+  if err := pages.Err(); err != nil {
+      panic(err)
+  }
 ```
 
 ```[flutter]
@@ -177,10 +190,6 @@ h4(#set-channel). Setting channel options and encryption
 
 A set of "channel options":#channel-options may also be passed to configure a channel for encryption. Find out more about "symmetric message encryption":/rest/encryption.
 
-<div lang="go">
-p(alert). *Currently @ChannelOptions@ and @CipherParams@ are not supported in Go.*
-</div>
-
 bc[jsall]. Crypto.generateRandomKey(function(err, key) {
   var options = { cipher: { key: key } };
   var channel = rest.channels.get('channelName', options);
@@ -214,6 +223,13 @@ ARTRestChannel *channel = [rest.channels get:@"channelName" options:options];
 bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = rest.channels.get("channelName", options: options)
+
+bc[go]. cipher := ably.CipherParams{
+       Key:       key,
+       KeyLength: 128,
+       Algorithm: ably.CipherAES,
+    }
+channel := rest.Channels.Get("channelName", ably.ChannelWithCipher(cipher))
 
 h3(#publishing). Publishing to a channel
 
@@ -274,9 +290,9 @@ To publish to a channel, make use of the "publish":#publish method of the channe
 ```
 
 ```[go]
-  rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+  rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
-  err = channel.Publish("example", "message data")
+  channel.Publish(context.Background(), "example", "message data")
 ```
 
 ```[flutter]
@@ -357,10 +373,22 @@ To get the history of a channel, make use of the "history":#history method of th
 ```
 
 ```[go]
-  rest, err := ably.NewRestClient(ably.NewClientOptions("{{API_KEY}}"))
+  rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
-  page, err := channel.History(nil)
-  fmt.Println("Last published message: %s\n", page.Messages[0].Data)
+  pages, err := channel.History().Pages(context.Background())
+  if err != nil {
+     panic(err)
+  }
+  for pages.Next(context.Background()) {
+     for _, message := range pages.Items() {
+         fmt.Println("--- Channel history ---")
+         fmt.Println(jsonify(message))
+         fmt.Println("--------")
+     }
+  }
+  if err := pages.Err(); err != nil {
+     panic(err)
+  }
 ```
 
 h3(#batch-publish). Batch publishing

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -129,7 +129,6 @@ The Ably REST client library provides a straightforward API for "publishing":/re
       panic(err)
   }
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
-  err = channel.Publish(context.Background(), "example", "message data")
   if err := channel.Publish(ctx, "example", "message data"); err != nil {
       panic(err)
   }
@@ -295,6 +294,9 @@ To publish to a channel, make use of the "publish":#publish method of the channe
 
 ```[go]
   rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
+  if err != nil {
+      panic(err)
+  }
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   channel.Publish(context.Background(), "example", "message data")
   if err := channel.Publish(ctx, "example", "message data"); err != nil {
@@ -381,6 +383,9 @@ To get the history of a channel, make use of the "history":#history method of th
 
 ```[go]
   rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
+  if err != nil {
+      panic(err)
+  }
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   pages, err := channel.History().Pages(context.Background())
   if err != nil {

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -298,7 +298,6 @@ To publish to a channel, make use of the "publish":#publish method of the channe
       panic(err)
   }
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
-  channel.Publish(context.Background(), "example", "message data")
   if err := channel.Publish(ctx, "example", "message data"); err != nil {
       panic(err)
   }

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -125,16 +125,20 @@ The Ably REST client library provides a straightforward API for "publishing":/re
 
 ```[go]
   rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
+  if err != nil {
+      panic(err)
+  }
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
-  err = channel.Publish("example", "message data")
   err = channel.Publish(context.Background(), "example", "message data")
+  if err := channel.Publish(ctx, "example", "message data"); err != nil {
+      panic(err)
+  }
   pages, err := channel.History().Pages(context.Background())
   if err != nil {
       panic(err)
   }
   for pages.Next(context.Background()) {
       for _, message := range pages.Items() {
-          fmt.Println("--- Channel history ---")
           fmt.Println(jsonify(message))
           fmt.Println("--------")
       }
@@ -293,6 +297,9 @@ To publish to a channel, make use of the "publish":#publish method of the channe
   rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
   channel := rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}")
   channel.Publish(context.Background(), "example", "message data")
+  if err := channel.Publish(ctx, "example", "message data"); err != nil {
+      panic(err)
+  }
 ```
 
 ```[flutter]
@@ -381,7 +388,6 @@ To get the history of a channel, make use of the "history":#history method of th
   }
   for pages.Next(context.Background()) {
      for _, message := range pages.Items() {
-         fmt.Println("--- Channel history ---")
          fmt.Println(jsonify(message))
          fmt.Println("--------")
      }

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -30,11 +30,7 @@ Ably client libraries support built-in symmetric encryption of message content, 
 
 h2(#getting-started). Getting started
 
-"Channels":/rest/channels can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. <span lang="default">Below is a simple example:</span><span lang="go"></span>
-
-<div lang="go">
-p(alert). *Unfortunately at present it is not possible to setup channel options in Go.*
-</div>
+"Channels":/rest/channels can be easily configured to automatically encrypt and decrypt all message payloads using the secret @key@ provided in the "channel options":/rest/types#channel-options. Below is a simple example:
 
 ```[jsall]
   Ably.Rest.Crypto.generateRandomKey(function(err, key) {
@@ -88,6 +84,15 @@ p(alert). *Unfortunately at present it is not possible to setup channel options 
   let options = ARTChannelOptions(cipherKey: <key>)
   let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}", options: options)
   channel.publish("unencrypted", data: "encrypted secret payload")
+```
+
+```[go] 
+  cipher := ably.CipherParams{
+        Key:       key,
+        KeyLength: 128,
+        Algorithm: ably.CipherAES,
+  }
+  channel := rest.Channels.Get("channelName", ably.ChannelWithCipher(cipher))
 ```
 
 Note that the @key@ should not be a pass-phrase, but a cryptographic key - generated from a secure random source, 128 or 256 bits long, binary or base64-encoded. If you wish to encrypt messages with a pass-phrase (for example, one entered by a user), you should use a "key derivation function":https://en.wikipedia.org/wiki/Key_derivation_function to transform that into a key. The client libraries are also capable of "generating a random key":#generate-random-key for you.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR updates Go code blocks to add support for `CipherParams` and `ChannelOptions`. See [JIRA](https://ably.atlassian.net/browse/DOC-459) for further information.

## Review

Two pages have been updated in this PR:
* [REST channels](https://ably-docs-pr-1254.herokuapp.com/rest/channels)
* [REST encryption](https://ably-docs-pr-1254.herokuapp.com/rest/encryption)
