### PR TITLE
Warn about using experimental W3C Push API

### DIFF
--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -23,7 +23,9 @@ The following Ably client library SDKs provide support for activating and receiv
 
 * "Android SDK":https://github.com/ably/ably-java
 * "iOS Objective-C and Swift SDK":https://github.com/ably/ably-cocoa
-* Experimental "W3C Push API":https://www.w3.org/TR/push-api/ compatible browser push notification support in the "JavaScript SDK":https://github.com/ably/ably-js. "Get in touch":https://ably.com/contact for access to this experimental feature
+* Experimental "W3C Push API":https://www.w3.org/TR/push-api/ push notification support for compatible browsers, in the "JavaScript SDK":https://github.com/ably/ably-js.
+
+**Note**: Our W3C Push API is still in development and should not be used in production applications. We welcome feedback and are particularly interested in which browsers you require support for. "Get in touch":https://ably.com/contact for access to this experimental feature.
 
 All Ably client library SDKs, that adhere to the "v1.1 specification support":/client-lib-development-guide/features/, support "push publishing":/general/push/publish and "push admin":/general/push/admin functionality.
 

--- a/content/partials/general/push/_push_intro.textile
+++ b/content/partials/general/push/_push_intro.textile
@@ -44,4 +44,4 @@ Ably currently offers support for push notifications on the following platforms:
 
 - "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running macOS
 - "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
-- Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). "Get in touch":https://ably.com/contact if you want to use this.
+- Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser).

--- a/content/partials/general/push/_push_intro.textile
+++ b/content/partials/general/push/_push_intro.textile
@@ -44,4 +44,4 @@ Ably currently offers support for push notifications on the following platforms:
 
 - "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running macOS
 - "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
-- Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser).
+- Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). You must request access to use this API.


### PR DESCRIPTION
## Description

Make it clear that the W3C Push API is experimental, requires us to grant access to it, and that we're interested in feedback.

Removed the "Contact us" link from the partial that populates the table at `/general/push/#platform-support`, to encourage the reader to read the note in `/general/push/#download`.

* [DOC-204](https://ably.atlassian.net/browse/DOC-204).

## Review

Read sections 4 and 4.1 in the review app:

* [Push API platform support](https://ably-docs-pr-1254.herokuapp.com/general/push/#platform-support)
