### PR TITLE
DOC-553: Add attach vs subscribe to realtime channels section

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -21,6 +21,7 @@ jump_to:
     - Channel lifecycle#channel-lifecycle
     - Channel metadata#channel-metadata
     - Implicit attach#implicit-attach
+    - Attach versus subscribe#attach-vs-subscribe
     - Publishing to multiple channels#multi-publish
     - Transient Publishing#transient-publish
     - Channel states#channel-states
@@ -591,6 +592,16 @@ channel.subscribe(name: 'action').listen((ably.Message message) {
 channel.publish(name: 'action', data: 'boom!');
 
 Normally, errors in attaching to a channel are communicated through the attach callback. For implicit attaches (and other cases where a channel is attached or reattached automatically, e.g. following the library reconnecting after a period in the @suspended@ state), there is no callback, so if you want to know what happens, you'll need to listen for channel state changes.
+
+h3(#attach-vs-subscribe). Difference between attaching and subscribing
+
+It is important to understand the difference between attaching and subscribing to a channel, and that messages are sent to clients as soon as they attach to a channel.
+
+Published messages are immediately sent to clients on "attaching":#attach to a channel as long as they have subscribe "capabilities":/core-features/authentication#capabilities-explained for that channel. Messages are sent regardless of whether or not the client has subscribed to the channel.
+
+"Subscribing":#subscribe to a channel registers a subscribe listener for messages received on the channel and is a client-side operation, meaning that Ably is unaware of whether or not a client is subscribed to a channel.
+
+As subscribing to a channel "implicitly attaches":#implicit-attach a client, it is important to note that if a client subscribes to and then "unsubscribes":#unsubscribe from a channel, the client remains attached. The client will continue to be sent published messages until they "detach":#detach from the channel.
 
 h3(#modifying-options). Modifying channel options
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR adds a section discussing the differences and things to be aware of between attaching, subscribing, unsubscribing and detaching from a channel. These topics were recently added to the best practice guide, however it makes sense to include them in the realtime documentation too. See [JIRA](https://ably.atlassian.net/browse/DOC-553) for further information.

## Review

View the [realtime channels](https://ably-docs-pr-1256.herokuapp.com/realtime/channels#attach-vs-subscribe) page to review this PR.
