### PR TITLE
DOC-452: PaginatedResult partial can link to itself rather than to types

### DIFF
--- a/content/partials/types/_paginated_result.textile
+++ b/content/partials/types/_paginated_result.textile
@@ -18,16 +18,16 @@ h6.
   csharp: First
 
 bq(definition).
-  default:  first(callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result resultPage))
-  ruby:     "PaginatedResult":/realtime/types#paginated-result first
-  php:      "PaginatedResult":/realtime/types#paginated-result first()
-  python:   "PaginatedResult":/realtime/types#paginated-result first()
+  default:  first(callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":#paginated-result resultPage))
+  ruby:     "PaginatedResult":#paginated-result first
+  php:      "PaginatedResult":#paginated-result first()
+  python:   "PaginatedResult":#paginated-result first()
   csharp:   Task<PaginatedResult<T>> FirstAsync()
-  java:     "PaginatedResult":/realtime/types#paginated-result first()
+  java:     "PaginatedResult":#paginated-result first()
   swift,objc: first(callback: (ARTPaginatedResult?, ARTErrorInfo?) -> Void)
-  go:       First() ("PaginatedResult":/realtime/types#paginated-result, error)
+  go:       First() ("PaginatedResult":#paginated-result, error)
 
-Returns a new @PaginatedResult@ for the first page of results. <span lang="ruby">When using the Realtime library, the @first@ method returns a "Deferrable":/realtime/types#deferrable and yields a "PaginatedResult":/realtime/types#paginated-result.</span><span lang="csharp">The method is asynchronous and returns a Task which needs to be awaited to get the "PaginatedResult":/realtime/types#paginated-result.</span>
+Returns a new @PaginatedResult@ for the first page of results. <span lang="ruby">When using the Realtime library, the @first@ method returns a "Deferrable":/realtime/types#deferrable and yields a "PaginatedResult":#paginated-result.</span><span lang="csharp">The method is asynchronous and returns a Task which needs to be awaited to get the "PaginatedResult":#paginated-result.</span>
 
 h6.
   default: hasNext
@@ -71,16 +71,16 @@ h6.
   csharp: Next
 
 bq(definition).
-  default:  next(callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result resultPage))
-  ruby:     "PaginatedResult":/realtime/types#paginated-result next
-  php:      "PaginatedResult":/realtime/types#paginated-result next()
-  python:   "PaginatedResult":/realtime/types#paginated-result next()
-  csharp:   Task<"PaginatedResult":/realtime/types#paginated-result<T>> NextAsync()
-  java:     "PaginatedResult":/realtime/types#paginated-result next()
+  default:  next(callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":#paginated-result resultPage))
+  ruby:     "PaginatedResult":#paginated-result next
+  php:      "PaginatedResult":#paginated-result next()
+  python:   "PaginatedResult":#paginated-result next()
+  csharp:   Task<"PaginatedResult":#paginated-result<T>> NextAsync()
+  java:     "PaginatedResult":#paginated-result next()
   swift,objc: next(callback: (ARTPaginatedResult?, ARTErrorInfo?) -> Void)
-  go:       Next() ("PaginatedResult":/realtime/types#paginated-result, error)
+  go:       Next() ("PaginatedResult":#paginated-result, error)
 
-Returns a new @PaginatedResult@ loaded with the next page of results. If there are no further pages, then <span lang="default">@null@</span><span lang="csharp">a blank PaginatedResult will be returned</span><span lang="java">@Null@</span><span lang="python">@None@</span><span lang="objc,swift">@nil@</span> is returned. <span lang="csharp">The method is asynchronous and return a Task which needs to be awaited to get the @PaginatedResult@</span><span lang="ruby">When using the Realtime library, the @first@ method returns a "Deferrable":/realtime/types#deferrable and yields a "PaginatedResult":/realtime/types#paginated-result.</span>
+Returns a new @PaginatedResult@ loaded with the next page of results. If there are no further pages, then <span lang="default">@null@</span><span lang="csharp">a blank PaginatedResult will be returned</span><span lang="java">@Null@</span><span lang="python">@None@</span><span lang="objc,swift">@nil@</span> is returned. <span lang="csharp">The method is asynchronous and return a Task which needs to be awaited to get the @PaginatedResult@</span><span lang="ruby">When using the Realtime library, the @first@ method returns a "Deferrable":/realtime/types#deferrable and yields a "PaginatedResult":#paginated-result.</span>
 
 <div lang="go">
   <!-- TODO: GO_REPLACEMENT. Once functions are added to go, remove divs-->


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR changes the `PaginatedResult` partial to link to itself. The same partial is used in `realtime/types` so redirecting users there isn't necessary when they're viewing it within context. See [JIRA](https://ably.atlassian.net/browse/DOC-452) for further information.

## Review

To review this PR, check any page using the paginated result partial, for example:

[Realtime/channels](https://ably-docs-pr-1258.herokuapp.com/realtime/channels#paginated-result)