### PR TITLE
DOC-326: Add a section on detaching to channels docs

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -24,6 +24,7 @@ jump_to:
     - Publishing to multiple channels#multi-publish
     - Transient Publishing#transient-publish
     - Channel states#channel-states
+    - Detaching from a channel#channel-detach
     - Handling failures#handling-failures
     - Channel namespaces#channel-namespaces
     - Presence#presence-api
@@ -812,6 +813,55 @@ Previously registered listeners can be removed individually or all together.
     // cancel stream subscription on the listener to stop receiving the events
     stateChangeListener.cancel();
 ```
+
+
+h3(#channel-detach). Detaching from a channel
+
+A client can detach from a channel so that they no longer receive any messages published to that channel. Detaching is different to unsubscribing from a channel as "@unsubscribe()@":#unsubscribe is a client-side operation, meaning Ably is unaware of whether or not a client has unsubscribed from the channel. Messages will continue to be streamed to the client until "@detach()@":#detach is called.
+
+bc[jsall]. channel.detach();
+channel.on('detached', function(stateChange) {
+  console.log('detached from the channel ' + channel.name);
+};
+
+bc[ruby]. channel.detach
+channel.on(:detached) do |channel_state_change|
+  puts "detached from the channel #{channel.name}"
+end
+
+bc[java]. channel.detach();
+channel.on(ChannelEvent.detached, new ChannelStateListener() {
+  @Override
+  public void onChannelStateChanged(ChannelState state, ErrorInfo reason) {
+    System.out.println("detached from the channel " + channel.name);
+    if (reason != null) System.out.println(reason.toString());
+  }
+});
+
+bc[csharp]. Channel.Detach();
+channel.On(ChannelEvent.Detached, stateChange => {
+  Console.WriteLine("detached from the channel " + channel.Name)
+});
+
+bc[objc]. [channel detach]
+[channel on:ARTChannelEventDetached callback:^(ARTChannelStateChange *stateChange) {
+  NSLog(@"detached from the channel ", channel.name);
+}];
+
+bc[swift]. channel.detach()
+channel.on(.detached) { stateChange in
+  print("detached from the channel \(channel.name)")
+}
+
+bc[flutter]. channel.detach();
+final stateChangeListener = channel
+  .on(ably.ChannelEvent.detached)
+  .listen((ably.ChannelStateChange state) {
+    print('detached from the channel ${channel.name}');
+  }
+);
+
+A channel will automatically close when there are no more realtime clients attached to it and approximately one minute has passed since the last client detached and since the last message was published to the channel.
 
 h3(#handling-failures). Handling channel failures
 

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -817,7 +817,7 @@ Previously registered listeners can be removed individually or all together.
 
 h3(#channel-detach). Detaching from a channel
 
-A client can detach from a channel so that they no longer receive any messages published to that channel. Detaching is different to unsubscribing from a channel as "@unsubscribe()@":#unsubscribe is a client-side operation, meaning Ably is unaware of whether or not a client has unsubscribed from the channel. Messages will continue to be streamed to the client until "@detach()@":#detach is called.
+A client can detach from a channel so that it no longer receives any messages published to that channel. Detaching is different to unsubscribing from a channel because "@unsubscribe()@":#unsubscribe is a client-side operation. The Ably platform does not know that a client has unsubscribed and will continue to stream messages to that client until "@Detach()@":#detach is called.
 
 bc[jsall]. channel.detach();
 channel.on('detached', function(stateChange) {


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR adds a section to the realtime channel documentation on detaching from channels. See [JIRA](https://ably.atlassian.net/browse/DOC-326) for further information. 

## Review

View the [channels](https://ably-docs-pr-1262.herokuapp.com/realtime/channels) documentation to review the PR.
