### PR TITLE
Add publish data to tutorial frontmatter

### DIFF
--- a/content/tutorials/_ably-nexmo.textile
+++ b/content/tutorials/_ably-nexmo.textile
@@ -1,27 +1,30 @@
 ---
-title: Show SMS notifications in the browser
-excerpt: Learn how to show SMS Notifications in the Browser using Ably and Nexmo in Angular and NodeJS
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
 - Author_name: Nexmo
-  author_profile_url: https://www.nexmo.com/
   author_image: tutorials/nexmo.jpg
-level: easy
-reading_time: 30
-languages:
-  - javascript
-  - nodejs
-libraries:
-    - Angular
-url: https://www.nexmo.com/blog/2018/08/07/sms-notifications-browser-with-angular-node-ably-dr
-index: 96
+  author_profile_url: https://www.nexmo.com/
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Learn how to show SMS Notifications in the Browser using Ably and Nexmo in
+  Angular and NodeJS
 external: true
+group: sdk
+index: 96
+languages:
+- javascript
+- nodejs
+last_updated: '2020-04-02T17:23:17+01:00'
+level: easy
+libraries:
+- Angular
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-  - SMS
+- SMS
+title: Show SMS notifications in the browser
+url: https://www.nexmo.com/blog/2018/08/07/sms-notifications-browser-with-angular-node-ably-dr
 ---
 
 <!-- external article -->

--- a/content/tutorials/_live-flight-tracking.textile
+++ b/content/tutorials/_live-flight-tracking.textile
@@ -1,28 +1,31 @@
 ---
-title: Building a live flight location tracking app
-excerpt: Build a live flight tracker in React Native using an open data stream from Ably Hub
-section: tutorials
-category:
-    - api-hub
-    - channels
-group: sdk
-platform: mobile
 authors:
-- author_name: Abraham Agiri Junior
-  author_image: tutorials/abraham-agiri-junior.jpg
+- author_image: tutorials/abraham-agiri-junior.jpg
+  author_name: Abraham Agiri Junior
   author_profile_url: https://github.com/codeekage
-level: medium
-reading_time: 60
-languages:
-    - javascript
-libraries:
-    - React Native
-url: https://dev.to/ablydev/building-a-live-flight-tracking-app-in-react-native-2hj8
-index: 2
+category:
+- api-hub
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Build a live flight tracker in React Native using an open data stream from
+  Ably Hub
 external: true
+group: sdk
+index: 2
+languages:
+- javascript
+last_updated: '2020-04-02T18:06:55+01:00'
+level: medium
+libraries:
+- React Native
+platform: mobile
+reading_time: 60
+section: tutorials
 tags:
-    - Hub
-    - Geolocation tracking
+- Hub
+- Geolocation tracking
+title: Building a live flight location tracking app
+url: https://dev.to/ablydev/building-a-live-flight-tracking-app-in-react-native-2hj8
 ---
 
 <!-- external article -->

--- a/content/tutorials/_live-geo-tracking.textile
+++ b/content/tutorials/_live-geo-tracking.textile
@@ -1,27 +1,30 @@
 ---
-title: Building a live geo-location tracking app
-excerpt: Build a live geo-location tracking app in VueJS using Ably's channels and presence features
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
-- author_name: Johnson Ogwuru
-  author_image: tutorials/johnson-ogwuru.jpg
+- author_image: tutorials/johnson-ogwuru.jpg
+  author_name: Johnson Ogwuru
   author_profile_url: https://github.com/ogwurujohnson
-level: medium
-reading_time: 60
-languages:
-    - javascript
-libraries:
-    - VueJS
-url: https://dev.to/ablydev/implementing-a-real-time-location-tracker-with-vuejs-and-ably-3523
-index: 1
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Build a live geo-location tracking app in VueJS using Ably's channels and
+  presence features
 external: true
+group: sdk
+index: 1
+languages:
+- javascript
+last_updated: '2020-04-02T18:06:55+01:00'
+level: medium
+libraries:
+- VueJS
+platform: browser
+reading_time: 60
+section: tutorials
 tags:
-    - Geolocation
-    - Tracking
+- Geolocation
+- Tracking
+title: Building a live geo-location tracking app
+url: https://dev.to/ablydev/implementing-a-real-time-location-tracker-with-vuejs-and-ably-3523
 ---
 
 <!-- external article -->

--- a/content/tutorials/_multi-lingual-chat.textile
+++ b/content/tutorials/_multi-lingual-chat.textile
@@ -1,25 +1,28 @@
 ---
-title: Building a multilingual chat app
-excerpt: Learn how to build a multilingual chat app using IBM's Translation API and Ably so users can chat in any language they like
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
-- author_name: Sarah Chima
-  author_image: tutorials/sarah-chima.jpg
+- author_image: tutorials/sarah-chima.jpg
+  author_name: Sarah Chima
   author_profile_url: https://github.com/sarahchima
-level: easy
-reading_time: 25
-languages:
-    - javascript
-    - nodejs
-url: https://hackernoon.com/build-a-multi-lingual-chatbot-with-ibm-translation-api-and-ably-dsx36gp
-index: 3
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Learn how to build a multilingual chat app using IBM's Translation API and
+  Ably so users can chat in any language they like
 external: true
+group: sdk
+index: 3
+languages:
+- javascript
+- nodejs
+last_updated: '2020-04-02T18:06:55+01:00'
+level: easy
+platform: browser
+reading_time: 25
+section: tutorials
 tags:
-    - Chat
+- Chat
+title: Building a multilingual chat app
+url: https://hackernoon.com/build-a-multi-lingual-chatbot-with-ibm-translation-api-and-ably-dsx36gp
 ---
 
 <!-- external article -->

--- a/content/tutorials/_multiplayer-vr-web.textile
+++ b/content/tutorials/_multiplayer-vr-web.textile
@@ -1,26 +1,29 @@
 ---
-title: Building a multiplayer VR game
-excerpt: Learn how to build a multiplayer Virtual Reality game using Ably and the A-Frame library
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-level: easy
-reading_time: 30
-languages:
-    - javascript
-url: https://medium.freecodecamp.org/how-to-build-a-multiplayer-vr-web-app-7b989964fb38
-index: 150
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Learn how to build a multiplayer Virtual Reality game using Ably and the
+  A-Frame library
 external: true
+group: sdk
+index: 150
+languages:
+- javascript
+last_updated: '2020-04-16T11:00:52+01:00'
+level: easy
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - Multiplayer game
-    - Virtual reality
+- Multiplayer game
+- Virtual reality
+title: Building a multiplayer VR game
+url: https://medium.freecodecamp.org/how-to-build-a-multiplayer-vr-web-app-7b989964fb38
 ---
 
 <!-- external article -->

--- a/content/tutorials/_nest-realtime-app.textile
+++ b/content/tutorials/_nest-realtime-app.textile
@@ -1,27 +1,30 @@
 ---
-title: Building a reatlime voting app in Nest.js
-excerpt: Learn how to build a realtime voting app in Nest.js and show the votes casted in a live graph
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
-- author_name: Olususi Kayode Oluyemi
-  author_image: tutorials/yemiwebby.jpg
+- author_image: tutorials/yemiwebby.jpg
+  author_name: Olususi Kayode Oluyemi
   author_profile_url: https://github.com/yemiwebby
-level: easy
-reading_time: 15
-languages:
-    - javascript
-libraries:
-    - NestJS
-url: https://medium.com/hackernoon/building-real-time-web-applications-using-nest-js-and-ably-d85887e81f06
-index: 140
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Learn how to build a realtime voting app in Nest.js and show the votes casted
+  in a live graph
 external: true
+group: sdk
+index: 140
+languages:
+- javascript
+last_updated: '2020-04-02T18:00:26+01:00'
+level: easy
+libraries:
+- NestJS
+platform: browser
+reading_time: 15
+section: tutorials
 tags:
-    - Voting
-    - NestJS
+- Voting
+- NestJS
+title: Building a reatlime voting app in Nest.js
+url: https://medium.com/hackernoon/building-real-time-web-applications-using-nest-js-and-ably-d85887e81f06
 ---
 
 <!-- external article -->

--- a/content/tutorials/_realtime-voting-angular.textile
+++ b/content/tutorials/_realtime-voting-angular.textile
@@ -1,28 +1,31 @@
 ---
-title: Building a realtime voting app in Angular
-excerpt: Learn how to build a realtime voting app in Angular and show the votes casted in a live graph
-section: tutorials
-category:
-    - channels
-group: sdk
-platform: browser
 authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-level: easy
-reading_time: 5
-languages:
-    - javascript
-libraries:
-    - Angular
-url: https://hackernoon.com/build-a-realtime-voting-app-in-less-than-10-min-336ec364b5da
-index: 130
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+category:
+- channels
+date_published: '2020-03-06T09:30:08+00:00'
+excerpt: Learn how to build a realtime voting app in Angular and show the votes casted
+  in a live graph
 external: true
+group: sdk
+index: 130
+languages:
+- javascript
+last_updated: '2020-04-16T11:00:52+01:00'
+level: easy
+libraries:
+- Angular
+platform: browser
+reading_time: 5
+section: tutorials
 tags:
-    - Voting
-    - Angular
+- Voting
+- Angular
+title: Building a realtime voting app in Angular
+url: https://hackernoon.com/build-a-realtime-voting-app-in-less-than-10-min-336ec364b5da
 ---
 
 <!-- external article -->

--- a/content/tutorials/android-push-notifications.textile
+++ b/content/tutorials/android-push-notifications.textile
@@ -1,34 +1,36 @@
 ---
-title: Implementing Push Notifications on Android devices
-alt_tile: Implementing Push Notifications on Android devices
-excerpt: Learn how to setup, send and receive Push Notifications on Android devices
-section: tutorials
-category:
-    - channels
-    - push-notifications
-group: sdk
-platform: mobile
-index: 23
-authors:
-- author_name: Amit Surana
-  author_bio: ""
-  author_profile_url: https://github.com/amsurana
-  author_image: "https://avatars1.githubusercontent.com/u/817920?s=460&v=4"
-- author_name: Tom Camp
-  author_bio: ""
-  author_profile_url: https://github.com/tomczoink
-  author_image: "https://avatars3.githubusercontent.com/u/9784119?s=460&v=4"
-level: easy
-reading_time: 20
-languages:
-  - android
-  - java
-  - nodejs
-  - javascript
 ably_product: push-notifications
+alt_tile: Implementing Push Notifications on Android devices
+authors:
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/817920?s=460&v=4
+  author_name: Amit Surana
+  author_profile_url: https://github.com/amsurana
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/9784119?s=460&v=4
+  author_name: Tom Camp
+  author_profile_url: https://github.com/tomczoink
+category:
+- channels
+- push-notifications
+date_published: '2020-01-27T17:30:32+00:00'
+excerpt: Learn how to setup, send and receive Push Notifications on Android devices
+group: sdk
+index: 23
+languages:
+- android
+- java
+- nodejs
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: easy
+platform: mobile
+reading_time: 20
+section: tutorials
 tags:
-  - Android
-  - Push Notifications
+- Android
+- Push Notifications
+title: Implementing Push Notifications on Android devices
 ---
 
 Ably can deliver Push Notifications to Android devices using "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/. Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a connection to Ably, as the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -1,31 +1,33 @@
 ---
-title: Channel Enumeration using the REST API
-excerpt: Learn how to enumerate through live channels and see their metadata
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/5908687?s=460&v=4
+  author_name: Simon Woolf
+  author_profile_url: https://github.com/SimonWoolf
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/18176755?s=460&v=4
+  author_name: Mark Lewin
+  author_profile_url: https://github.com/marklewin
 category:
-    - channels
+- channels
+date_published: '2018-10-05T11:15:57+01:00'
+excerpt: Learn how to enumerate through live channels and see their metadata
 group: sdk
 index: 14
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-- author_name: Simon Woolf
-  author_bio: ""
-  author_profile_url: "https://github.com/SimonWoolf"
-  author_image: "https://avatars1.githubusercontent.com/u/5908687?s=460&v=4"
-- author_name: Mark Lewin
-  author_bio: ""
-  author_profile_url: "https://github.com/marklewin"
-  author_image: "https://avatars.githubusercontent.com/u/18176755?s=460&v=4"
 languages:
-  - javascript
+- javascript
+last_updated: '2021-07-23T15:47:14+01:00'
 level: easy
+platform: browser
 reading_time: 5
+section: tutorials
 tags:
-  - Channel metadata
+- Channel metadata
+title: Channel Enumeration using the REST API
 ---
 
 "Ably's global platform":https://ably.com/platform organizes all message traffic within an application into named "channels":/core-features/channels. Clients attach to the channels they are interested in. They can then publish messages to those channels or subscribe to receive messages from them.

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -1,23 +1,25 @@
 ---
-title: Subscribing to Channel Lifecycle Events
-excerpt: Learn how to access channel metadata and make use of it in your apps
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
 category:
-    - channels
+- channels
+date_published: '2018-10-10T10:35:02+01:00'
+excerpt: Learn how to access channel metadata and make use of it in your apps
 group: sdk
 index: 17
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
 level: easy
+platform: browser
 reading_time: 5
+section: tutorials
 tags:
-    - Channel metadata
+- Channel metadata
+title: Subscribing to Channel Lifecycle Events
 ---
 
 "Ably's global platform":https://ably.com/platform organizes all of the message traffic within its applications into named "channels":/core-features/channels. Channels are the “unit” of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcasted to all subscribers.

--- a/content/tutorials/channel-occupancy-events.textile
+++ b/content/tutorials/channel-occupancy-events.textile
@@ -1,31 +1,34 @@
 ---
-title: Subscribing to Inband Channel Occupancy Events
-excerpt: Learn how to access inband channel occupancy events and make use of occupancy metrics in your apps
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/9784119?s=460&v=4
+  author_name: Tom Camp
+  author_profile_url: https://github.com/tomczoink
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/25511700?s=460&v=4
+  author_name: Tony Bedford
+  author_profile_url: https://github.com/tbedford
 category:
-    - channels
+- channels
+date_published: '2018-10-09T14:05:25+01:00'
+excerpt: Learn how to access inband channel occupancy events and make use of occupancy
+  metrics in your apps
 group: sdk
 index: 17
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-- author_name: Tom Camp
-  author_bio: ""
-  author_profile_url: "https://github.com/tomczoink"
-  author_image: "https://avatars3.githubusercontent.com/u/9784119?s=460&v=4"
-- author_name: Tony Bedford
-  author_bio: ""
-  author_profile_url: "https://github.com/tbedford"
-  author_image: "https://avatars.githubusercontent.com/u/25511700?s=460&v=4"
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
 level: easy
+platform: browser
 reading_time: 15
+section: tutorials
 tags:
-    - Inband occupancy events
+- Inband occupancy events
+title: Subscribing to Inband Channel Occupancy Events
 ---
 
 "Ably's global platform":https://ably.com/platform organizes all of the message traffic within its applications into named "channels":/core-features/channels. Channels are the "unit" of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcast to all subscribers.

--- a/content/tutorials/channel-rewind.textile
+++ b/content/tutorials/channel-rewind.textile
@@ -1,23 +1,26 @@
 ---
-title: Retrieving historical data with Channel Rewind
-excerpt: Learn how to get historical data on channel subscribe using the Channel Rewind parameter
-section: tutorials
-group: sdk
-category:
-    - channels
-index: 32
-platform: browser
 authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+category:
+- channels
+date_published: '2019-11-13T17:48:09+00:00'
+excerpt: Learn how to get historical data on channel subscribe using the Channel Rewind
+  parameter
+group: sdk
+index: 32
 languages:
-  - javascript
+- javascript
+last_updated: '2021-07-21T13:16:13+01:00'
 level: easy
+platform: browser
 reading_time: 5
+section: tutorials
 tags:
-    - Channel Rewind
+- Channel Rewind
+title: Retrieving historical data with Channel Rewind
 ---
 
 The Ably Realtime service organizes the message traffic within applications into named channels. Channels are the “unit” of message distribution; clients attach to any number of channels to subscribe to messages, and every message published to a channel is broadcasted to all its subscribers.

--- a/content/tutorials/encryption.textile
+++ b/content/tutorials/encryption.textile
@@ -1,26 +1,28 @@
 ---
-title: Encrypting and Decrypting your Ably messages
 alt_title: Encrypting and Decrypting  your Ably messages
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: ://avatars3.githubusercontent.com/u/24491408?s=400&v=4
+  author_name: Abraham Jr. Agiri
+  author_profile_url: https://github.com/codeekage
 category:
-    - channels
+- channels
+date_published: '2019-12-16T12:47:53+01:00'
+excerpt: Learn how to encrypt and decrypt messages that you share using Ably
 group: sdk
 index: 21
-excerpt: Learn how to encrypt and decrypt messages that you share using Ably
-platform: browser
-authors:
-- author_name: Abraham Jr. Agiri
-  author_bio: ""
-  author_profile_url: https://github.com/codeekage
-  author_image: ://avatars3.githubusercontent.com/u/24491408?s=400&v=4
 languages:
-  - javascript
-  - java
-  - nodejs
+- javascript
+- java
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
 level: easy
+platform: browser
 reading_time: 10
+section: tutorials
 tags:
-    - Encryption
+- Encryption
+title: Encrypting and Decrypting your Ably messages
 ---
 
 Ably's "encryption feature":/realtime/encryption enables you to send encrypted messages on channels that can later be retrieved and decrypted using a common cryptographic key known only to the client and server. This has the advantage that Ably demonstrably has no access to the un-encrypted contents of your messages, but also means that each app is responsible for enabling the distribution of keys to clients independently of Ably.

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -1,44 +1,44 @@
 ---
-title: Retrieving Message History
-excerpt: Learn how to publish messages and later retrieve them using the History API
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+  author_name: Piotr Kazmierczak
+  author_profile_url: https://github.com/piotrekkazmierczak
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+  author_name: Bartłomiej Wereszczyński
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
+  author_name: Shelin Hime
+  author_profile_url: https://github.com/ShelinHime
 category:
-    - channels
+- channels
+date_published: '2016-09-03T17:13:35+01:00'
+excerpt: Learn how to publish messages and later retrieve them using the History API
 group: sdk
 index: 11
-platform: mixed
-authors:
-- author_name: Piotr Kazmierczak
-  author_bio: ""
-  author_profile_url: https://github.com/piotrekkazmierczak
-  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
-- author_name: Bartłomiej Wereszczyński
-  author_bio: ""
-  author_profile_url: https://github.com/bartlomiejwereszczynski
-  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
-- author_name: Shelin Hime
-  author_bio: ""
-  author_profile_url: https://github.com/ShelinHime
-  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
-  - javascript
-  - java
-  - android
-  - python
-  - php
-  - ruby
-  - swift
-
+- javascript
+- java
+- android
+- python
+- php
+- ruby
+- swift
+last_updated: '2021-11-19T16:35:45+00:00'
 level: easy
+meta_description: Learn how to publish messages and later retrieve them using the
+  History API
+meta_image: /images/ably-logo.png
+meta_keywords: Ably, History
+platform: mixed
 reading_time: 10
+section: tutorials
 tags:
-    - Message History
-
-meta_description: "Learn how to publish messages and later retrieve them using the History API"
-meta_keywords: "Ably, History"
-meta_image: "/images/ably-logo.png"
+- Message History
+title: Retrieving Message History
 ---
-
 
 Ably's "history feature":/realtime/history enables you to store messages published on channels that can later be retrieved using the "channel history API":/realtime/history.
 

--- a/content/tutorials/ios-push-notifications.textile
+++ b/content/tutorials/ios-push-notifications.textile
@@ -1,33 +1,35 @@
 ---
-title: Implementing Push Notifications on iOS devices
-section: tutorials
-index: 61
-alt_title: Implementing Push Notifications on iOS devices
-excerpt: Learn how to setup, send and receive Ably Push Notifications on iOS devices
-category:
-    - channels
-    - push-notifications
-group: sdk
-platform: mobile
-authors:
-- author_name: Christopher Batin
-  author_bio: ""
-  author_profile_url: "https://github.com/cjbatin"
-  author_image: "tutorials/christopher-batin.jpg"
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-level: easy
-reading_time: 30
-languages:
-  - swift
-  - nodejs
-  - javascript
-tags:
-  - Push Notifications
-  - iOS
 ably_product: push-notification
+alt_title: Implementing Push Notifications on iOS devices
+authors:
+- author_bio: ''
+  author_image: tutorials/christopher-batin.jpg
+  author_name: Christopher Batin
+  author_profile_url: https://github.com/cjbatin
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+category:
+- channels
+- push-notifications
+date_published: '2020-01-12T17:18:24+00:00'
+excerpt: Learn how to setup, send and receive Ably Push Notifications on iOS devices
+group: sdk
+index: 61
+languages:
+- swift
+- nodejs
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: easy
+platform: mobile
+reading_time: 30
+section: tutorials
+tags:
+- Push Notifications
+- iOS
+title: Implementing Push Notifications on iOS devices
 ---
 
 Ably can deliver Push Notifications to iOS devices using "Apple’s Push Notification service":https://developer.apple.com/notifications/. Push Notifications, unlike our "channel-based Pub/Sub messaging":/realtime/channels/, do not require the device to maintain a consistent connection to Ably because the underlying platform or OS is responsible for maintaining its own battery efficient transport to receive Push Notifications. Therefore, Push Notifications are commonly used to display visual notifications to users or launch a background process for an app in a battery efficient manner.

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -1,25 +1,28 @@
 ---
-title: Implementing JWT Authentication
-excerpt: Learn how to issue Ably JWTs for your users, configure their capabilities (permissions) and authenticate clients using these tokens
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
 category:
-    - channels
+- channels
+date_published: '2018-04-25T16:49:28+02:00'
+excerpt: Learn how to issue Ably JWTs for your users, configure their capabilities
+  (permissions) and authenticate clients using these tokens
 group: sdk
 index: 55
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-level: medium
-reading_time: 20
 languages:
-  - javascript
-  - nodejs
+- javascript
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 20
+section: tutorials
 tags:
-    - JWT
-    - Authentication
+- JWT
+- Authentication
+title: Implementing JWT Authentication
 ---
 
 Ably supports two types of authentication schemes. "Basic authentication":/core-features/authentication#basic-authentication uses one of your private API keys and is the simplest scheme designed for use by your servers. "Token authentication":/core-features/authentication#token-authentication is mostly used by your device and browser clients whereby a short-lived secure token is issued to them by your auth servers. "JSON Web Token authentication":/core-features/authentication#token-authentication is an extension of the token based authentication scheme in Ably.

--- a/content/tutorials/live-bitcoin-pricing.textile
+++ b/content/tutorials/live-bitcoin-pricing.textile
@@ -1,33 +1,36 @@
 ---
-title: Build a live bitcoin pricing chart
 alt_title: Build a live bitcoin pricing chart
-excerpt: Learn how to build a live bitcoin pricing chart in Angular using Ably and KendoUI
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
+- author_bio: ''
+  author_image: tutorials/kendo-ui.jpg
+  author_name: KendoUI
+  author_profile_url: https://www.telerik.com/kendo-ui
 category:
-    - channels
-    - api-hub
+- channels
+- api-hub
+date_published: '2019-09-04T14:35:51+01:00'
+excerpt: Learn how to build a live bitcoin pricing chart in Angular using Ably and
+  KendoUI
 group: sdk
 index: 95
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-- author_name: KendoUI
-  author_bio: ""
-  author_profile_url: https://www.telerik.com/kendo-ui
-  author_image: "tutorials/kendo-ui.jpg"
-level: easy
-reading_time: 15
 languages:
-  - typescript
+- typescript
+last_updated: '2021-09-30T16:49:39+01:00'
+level: easy
+platform: browser
+reading_time: 15
+section: tutorials
 tags:
-     - Bitcoin
-     - Hub
-     - Angular
-     - KendoUI
-     - Graphs
+- Bitcoin
+- Hub
+- Angular
+- KendoUI
+- Graphs
+title: Build a live bitcoin pricing chart
 ---
 
 Realtime experiences are governing the tech world today. There is an increasing need for realtime data - an event trigger telling everyone around the world within milliseconds of it happening. While moving this realtime data around poses to be a huge technical challenge, displaying this realtime data visually so a human can infer it usefully is another challenge. So, the DevRel teams at Ably and Kendo UI came together to work on a small application to demonstrate how such challenges can be overcome by using the right SaaS products.

--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -1,28 +1,30 @@
 ---
-title: Building a game of Snake using an MQTT based controller
-excerpt: Learn how to build a game of snake using Ably's MQTT adapter
-section: tutorials
+ably_product: adapters
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/9784119?s=460&v=4
+  author_name: Tom Camp
+  author_profile_url: https://github.com/tomczoink
 category:
-    - channels
+- channels
+date_published: '2018-03-16T12:19:21+00:00'
+excerpt: Learn how to build a game of snake using Ably's MQTT adapter
 group: mqtt
 index: 104
-platform: browser
-authors:
-- author_name: Tom Camp
-  author_bio: ""
-  author_profile_url: https://github.com/tomczoink
-  author_image: "https://avatars3.githubusercontent.com/u/9784119?s=460&v=4"
-level: easy
-reading_time: 10
 languages:
-  - javascript
-  - go
-  - python
-ably_product: adapters
+- javascript
+- go
+- python
+last_updated: '2021-11-19T16:35:45+00:00'
+level: easy
+platform: browser
+reading_time: 10
+section: tutorials
 tags:
-    - MQTT
-    - Multiplayer game
-    - Protocol Adapter
+- MQTT
+- Multiplayer game
+- Protocol Adapter
+title: Building a game of Snake using an MQTT based controller
 ---
 
 blang[javascript].

--- a/content/tutorials/newsfeed-react.textile
+++ b/content/tutorials/newsfeed-react.textile
@@ -1,26 +1,29 @@
 ---
-title: Building a live news feed app
 alt_title: Building a live news feed app
-excerpt: Learn how to build a live newsfeed app in ReactJS as seen on popular social media sites
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/13391028?s=460&v=4
+  author_name: Apoorv Vardhan
+  author_profile_url: https://github.com/vardhanapoorv
 category:
-    - channels
+- channels
+date_published: '2019-09-05T01:53:35+05:30'
+excerpt: Learn how to build a live newsfeed app in ReactJS as seen on popular social
+  media sites
 group: sdk
 index: 100
-platform: browser
-authors:
-- author_name: Apoorv Vardhan
-  author_bio: ""
-  author_profile_url: https://github.com/vardhanapoorv
-  author_image: https://avatars3.githubusercontent.com/u/13391028?s=460&v=4
-level: beginner
-reading_time: 40
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: beginner
 libraries:
-  - React
+- React
+platform: browser
+reading_time: 40
+section: tutorials
 tags:
-    - Newsfeed
+- Newsfeed
+title: Building a live news feed app
 ---
 
 In this tutorial, we will see how to use the "Ably Realtime client library":/realtime to build a realtime news feed with React. Ably enables realtime data sharing using Pub/Sub messaging architecture via a concept called "channels":/core-features/channels.

--- a/content/tutorials/peer-to-peer-vue.textile
+++ b/content/tutorials/peer-to-peer-vue.textile
@@ -1,28 +1,30 @@
 ---
-title: Realtime Peer to Peer Demo with Vue.js
 alt_title: Realtime Peer to Peer Demo with Vue.js
-excerpt: Learn to build your own peer to peer apps with Ably and Vue.js
-section: tutorials
+authors:
+- author_bio: Developer advocate at Ably
+  author_image: ://avatars2.githubusercontent.com/u/3490640?s=460&v=4
+  author_name: Jo Franchetti
+  author_profile_url: https://github.com/thisisjofrank
 category:
-    - channels
+- channels
+date_published: '2020-06-25T10:03:12+01:00'
+excerpt: Learn to build your own peer to peer apps with Ably and Vue.js
 group: sdk
 index: 106
-platform: browser
-authors:
-- author_name: Jo Franchetti
-  author_bio: "Developer advocate at Ably"
-  author_profile_url: https://github.com/thisisjofrank
-  author_image: ://avatars2.githubusercontent.com/u/3490640?s=460&v=4
-level: medium
 languages:
-  - javascript
+- javascript
+last_updated: '2021-09-30T16:49:39+01:00'
+level: medium
 libraries:
-  - Vue.js
+- Vue.js
+platform: browser
+section: tutorials
 tags:
-    - peer to peer
-    - Pub/Sub
-    - Multiplayer game
-    - Vue.js
+- peer to peer
+- Pub/Sub
+- Multiplayer game
+- Vue.js
+title: Realtime Peer to Peer Demo with Vue.js
 ---
 
 In this tutorial we will walk through building a basic Peer to Peer demo in a Static Web App which uses Ably channels. This basic demo can be built upon to make games, chat apps and more, basically any kind of communication where you'd rather not have to configure a central server!

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -1,25 +1,28 @@
 ---
-title: Tracking connected clients with Presence
-excerpt: Learn how to track who and which devices are online or offline, and what the status of each user is.
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/5908687?s=460&v=4
+  author_name: Simon Woolf
+  author_profile_url: https://github.com/SimonWoolf
 category:
-    - channels
+- channels
+date_published: '2016-11-01T23:57:06+00:00'
+excerpt: Learn how to track who and which devices are online or offline, and what
+  the status of each user is.
 group: sdk
 index: 15
-platform: mixed
-authors:
-- author_name: Simon Woolf
-  author_bio: ""
-  author_profile_url: "https://github.com/SimonWoolf"
-  author_image: "https://avatars1.githubusercontent.com/u/5908687?s=460&v=4"
 languages:
-  - javascript
-  - ruby
-  - nodejs
+- javascript
+- ruby
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
 level: medium
+platform: mixed
 reading_time: 15
+section: tutorials
 tags:
-  - Presence
+- Presence
+title: Tracking connected clients with Presence
 ---
 
 Presence enables clients to be aware of other clients that are currently “present” on a channel. Each member present on a channel has a self-assigned name — a "@client ID@" — along with an optional payload that can be used to describe the member’s status or attributes. Presence allows you to quickly build apps such as chat rooms and multiplayer games by automatically keeping track of who is present in real time across any device.

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -1,38 +1,40 @@
 ---
-title: Publish/Subscribe messaging app
-excerpt: Learn how to publish and subscribe to messages on channels in just 5 minutes.
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+  author_name: Piotr Kazmierczak
+  author_profile_url: https://github.com/piotrekkazmierczak
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+  author_name: Bartłomiej Wereszczyński
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
+  author_name: Shelin Hime
+  author_profile_url: https://github.com/ShelinHime
 category:
-    - channels
+- channels
+date_published: '2016-07-22T02:38:02+01:00'
+excerpt: Learn how to publish and subscribe to messages on channels in just 5 minutes.
 group: sdk
 index: 10
-platform: mixed
-authors:
-- author_name: Piotr Kazmierczak
-  author_bio: ""
-  author_profile_url: https://github.com/piotrekkazmierczak
-  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
-- author_name: Bartłomiej Wereszczyński
-  author_bio: ""
-  author_profile_url: https://github.com/bartlomiejwereszczynski
-  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
-- author_name: Shelin Hime
-  author_bio: ""
-  author_profile_url: https://github.com/ShelinHime
-  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
-  - javascript
-  - java
-  - android
-  - python
-  - php
-  - ruby
-  - swift
-  - go
+- javascript
+- java
+- android
+- python
+- php
+- ruby
+- swift
+- go
+last_updated: '2021-11-19T16:35:45+00:00'
 level: easy
+platform: mixed
 reading_time: 5 — 10
+section: tutorials
 tags:
-    - Pub/Sub
+- Pub/Sub
+title: Publish/Subscribe messaging app
 ---
 
 The Ably Realtime service organizes the message traffic within applications into named channels. Channels are the “unit” of message distribution; clients attach to any number of channels to subscribe to messages, and every message published to a channel is broadcasted to all subscribers. This scalable and resilient messaging pattern is commonly called "pub/sub":https://ably.com/topic/pub-sub.

--- a/content/tutorials/pubnub-adapter.textile
+++ b/content/tutorials/pubnub-adapter.textile
@@ -1,28 +1,31 @@
 ---
-title: Migrating from PubNub
+ably_product: adapters
 alt_title: Migrating from PubNub
-excerpt: Learn how to use our protocol adapters to migrate a simple app from PubNub to Ably by changing only the settings of your PubNub client
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/5908687?s=460&v=4
+  author_name: Simon Woolf
+  author_profile_url: https://github.com/SimonWoolf
 category:
-    - channels
+- channels
+date_published: '2016-11-23T17:49:53+00:00'
+excerpt: Learn how to use our protocol adapters to migrate a simple app from PubNub
+  to Ably by changing only the settings of your PubNub client
 group: sdk
 index: 15
-platform: browser
-authors:
-- author_name: Simon Woolf
-  author_bio: ""
-  author_profile_url: "https://github.com/SimonWoolf"
-  author_image: "https://avatars1.githubusercontent.com/u/5908687?s=460&v=4"
-level: easy
-reading_time: 5
 languages:
-  - javascript
-  - android
-  - ruby
-  - nodejs
-ably_product: adapters
+- javascript
+- android
+- ruby
+- nodejs
+last_updated: '2021-09-30T16:49:39+01:00'
+level: easy
+platform: browser
+reading_time: 5
+section: tutorials
 tags:
-    - Protocol Adapter
+- Protocol Adapter
+title: Migrating from PubNub
 ---
 
 Ably provides the flexibility to migrate from PubNub progressively or all at once. The fastest we’ve seen someone migrate is a few hours.

--- a/content/tutorials/pusher-adapter.textile
+++ b/content/tutorials/pusher-adapter.textile
@@ -1,27 +1,30 @@
 ---
-title: Migrating from Pusher
+ably_product: adapters
 alt_title: Migrating from Pusher
-excerpt: Learn how to use our protocol adapters to migrate a simple app from Pusher to Ably by changing only the settings of your Pusher client
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/5908687?s=460&v=4
+  author_name: Simon Woolf
+  author_profile_url: https://github.com/SimonWoolf
 category:
-    - channels
+- channels
+date_published: '2016-11-23T17:49:53+00:00'
+excerpt: Learn how to use our protocol adapters to migrate a simple app from Pusher
+  to Ably by changing only the settings of your Pusher client
 group: sdk
 index: 15
-platform: browser
-authors:
-- author_name: Simon Woolf
-  author_bio: ""
-  author_profile_url: "https://github.com/SimonWoolf"
-  author_image: "https://avatars1.githubusercontent.com/u/5908687?s=460&v=4"
-level: easy
-reading_time: 5
 languages:
-  - javacript
-  - ruby
-  - nodejs
-ably_product: adapters
+- javacript
+- ruby
+- nodejs
+last_updated: '2021-09-30T16:49:39+01:00'
+level: easy
+platform: browser
+reading_time: 5
+section: tutorials
 tags:
-  - Protocol Adapter
+- Protocol Adapter
+title: Migrating from Pusher
 ---
 
 Ably provides the flexibility to migrate from Pusher progressively or all at once. The fastest we’ve seen someone migrate is a few hours.

--- a/content/tutorials/queue-amqp-neutrino-profanity.textile
+++ b/content/tutorials/queue-amqp-neutrino-profanity.textile
@@ -1,26 +1,31 @@
 ---
-title: Build a safe text generating app using AMQP message queues and the Neutrino Profanity Filter API
-excerpt: Learn how to use our messages queues to consume realtime data over AMQP and use Neutrino's Profanity Filter API to strip out bad words before republishing the message
-section: tutorials
+ably_product: reactor
+authors:
+- author_bio: ''
+  author_image: https://avatars0.githubusercontent.com/u/43789?s=460&v=4
+  author_name: Matthew O'Riordan
+  author_profile_url: https://github.com/mattheworiordan
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-02-02T21:32:25+00:00'
+excerpt: Learn how to use our messages queues to consume realtime data over AMQP and
+  use Neutrino's Profanity Filter API to strip out bad words before republishing the
+  message
 group: sdk
 index: 101
-platform: browser
-authors:
-- author_name: "Matthew O'Riordan"
-  author_bio: ""
-  author_profile_url: "https://github.com/mattheworiordan"
-  author_image: "https://avatars0.githubusercontent.com/u/43789?s=460&v=4"
-level: medium
-reading_time: 25
 languages:
-  - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 25
+section: tutorials
 tags:
-    - Reactor Integration
-    - AMQP
+- Reactor Integration
+- AMQP
+title: Build a safe text generating app using AMQP message queues and the Neutrino
+  Profanity Filter API
 ---
 
 "Ably Reactor Queues":https://ably.com/integrations are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-amqp-wolfram-alpha.textile
+++ b/content/tutorials/queue-amqp-wolfram-alpha.textile
@@ -1,26 +1,29 @@
 ---
-title: Building a Q/A app using the Wolfram Alpha API and AMQP message queues
-excerpt: Learn how to use our messages queues to consume realtime data over AMQP and communicate with Wolfram Alpha API to get answers to questions in real time
-section: tutorials
+ably_product: reactor
+authors:
+- author_bio: ''
+  author_image: https://avatars0.githubusercontent.com/u/43789?s=460&v=4
+  author_name: Matthew O'Riordan
+  author_profile_url: https://github.com/mattheworiordan
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-02-02T21:32:25+00:00'
+excerpt: Learn how to use our messages queues to consume realtime data over AMQP and
+  communicate with Wolfram Alpha API to get answers to questions in real time
 group: sdk
 index: 100
-platform: browser
-authors:
-- author_name: "Matthew O'Riordan"
-  author_bio: ""
-  author_profile_url: "https://github.com/mattheworiordan"
-  author_image: "https://avatars0.githubusercontent.com/u/43789?s=460&v=4"
-level: medium
-reading_time: 25
 languages:
-  - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 25
+section: tutorials
 tags:
-    - Reactor Integration
-    - AMQP
+- Reactor Integration
+- AMQP
+title: Building a Q/A app using the Wolfram Alpha API and AMQP message queues
 ---
 
 "Ably Reactor Queues":https://ably.com/integrations are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/queue-stomp-neutrino-profanity.textile
+++ b/content/tutorials/queue-stomp-neutrino-profanity.textile
@@ -1,26 +1,31 @@
 ---
-title: Build a safe text generating app using STOMP message queues and the Neutrino Profanity Filter API
-excerpt: Learn how to use our messages queues to consume realtime data over STOMP and use Neutrino's Profanity Filter API to strip out bad words before republishing the message
-section: tutorials
+ably_product: reactor
+authors:
+- author_bio: ''
+  author_image: https://avatars0.githubusercontent.com/u/43789?s=460&v=4
+  author_name: Matthew O'Riordan
+  author_profile_url: https://github.com/mattheworiordan
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-02-02T21:32:25+00:00'
+excerpt: Learn how to use our messages queues to consume realtime data over STOMP
+  and use Neutrino's Profanity Filter API to strip out bad words before republishing
+  the message
 group: sdk
 index: 102
-platform: browser
-authors:
-- author_name: "Matthew O'Riordan"
-  author_bio: ""
-  author_profile_url: "https://github.com/mattheworiordan"
-  author_image: "https://avatars0.githubusercontent.com/u/43789?s=460&v=4"
-level: medium
-reading_time: 25
 languages:
-  - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 25
+section: tutorials
 tags:
-    - STOMP
-    - Reactor Integration
+- STOMP
+- Reactor Integration
+title: Build a safe text generating app using STOMP message queues and the Neutrino
+  Profanity Filter API
 ---
 
 "Ably Reactor Queues":https://ably.com/integrations are traditional message queues that provide a reliable and straightforward mechanism for customers to consume, process, store, augment or reroute data from our realtime platform efficiently by your servers.

--- a/content/tutorials/react-native-presence-publish-subscribe.textile
+++ b/content/tutorials/react-native-presence-publish-subscribe.textile
@@ -1,26 +1,29 @@
 ---
-title: Building a chat app in React Native
-excerpt: Learn how to create your very own chat app which can run on both iOS and Android devices
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2017-11-01T20:38:28+01:00'
+excerpt: Learn how to create your very own chat app which can run on both iOS and
+  Android devices
 group: sdk
 index: 103
-platform: mobile
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: medium
-reading_time: 30
 languages:
-  - javascript
+- javascript
+last_updated: '2021-06-17T14:50:50+01:00'
+level: medium
 libraries:
-  - React Native
+- React Native
+platform: mobile
+reading_time: 30
+section: tutorials
 tags:
-    - Chat
-    - React Native
+- Chat
+- React Native
+title: Building a chat app in React Native
 ---
 
 Messaging apps are on the increase recently. The past few years have brought apps like WhatsApp, Telegram, Facebook Messenger, Slack etc. People seem to prefer chat-based applications because they allow for Realtime Interaction. They also add a personal touch to the experience.

--- a/content/tutorials/reactjs-realtime-commenting.textile
+++ b/content/tutorials/reactjs-realtime-commenting.textile
@@ -1,33 +1,36 @@
 ---
-title: Building a Realtime Commenting App
-excerpt: Learn how to build a live commenting system for your website, using Ably and React
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/6279134?s=460&v=4
+  author_name: Chimezie Enyinnaya
+  author_profile_url: https://github.com/ammezie
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/6791378?v=4
+  author_name: Marsielko
+  author_profile_url: https://github.com/marsielko/
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/18176755?v=4
+  author_name: Mark Lewin
+  author_profile_url: https://github.com/marklewin/
 category:
-    - channels
+- channels
+date_published: '2017-10-28T04:07:47+01:00'
+excerpt: Learn how to build a live commenting system for your website, using Ably
+  and React
 group: sdk
 index: 60
-platform: mobile
-authors:
-- author_name: Chimezie Enyinnaya
-  author_bio: ""
-  author_profile_url: https://github.com/ammezie
-  author_image: https://avatars2.githubusercontent.com/u/6279134?s=460&v=4
-- author_name: Marsielko
-  author_bio: ""
-  author_profile_url: https://github.com/marsielko/
-  author_image: https://avatars.githubusercontent.com/u/6791378?v=4
-- author_name: Mark Lewin
-  author_bio: ""
-  author_profile_url: https://github.com/marklewin/
-  author_image: https://avatars.githubusercontent.com/u/18176755?v=4
-level: medium
-reading_time: 30
 languages:
-  - javascript
+- javascript
+last_updated: '2021-09-30T16:49:39+01:00'
+level: medium
 libraries:
-  - React
+- React
+platform: mobile
+reading_time: 30
+section: tutorials
 tags:
-    - Realtime commenting
+- Realtime commenting
+title: Building a Realtime Commenting App
 ---
 
 In this tutorial, you will learn how to use Ably's "Realtime client library":/realtime to build a live commenting web app. When a website visitor leaves a comment, you will publish the comment to an Ably channel and also subscribe to that channel to see comments as they are added in realtime.

--- a/content/tutorials/reactor-event-aws.textile
+++ b/content/tutorials/reactor-event-aws.textile
@@ -1,27 +1,31 @@
 ---
-title: Pizza ordering app with AWS Lambda Functions
+ably_product: reactor
 alt_title: Pizza ordering app with AWS Lambda Functions
-excerpt: Learn how to use the AWS Lambda - Reactor Integration to consume realtime data and automatically respond to requests for pizza from your serverless function
-section: tutorials
+authors:
+- author_bio: Software engineer. Web front and back end, UI/UX, design. Making myself
+    obsolete since 1841.
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+  author_name: Nathan Ridley
+  author_profile_url: https://github.com/axefrog
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-11-30T08:31:50+10:00'
+excerpt: Learn how to use the AWS Lambda - Reactor Integration to consume realtime
+  data and automatically respond to requests for pizza from your serverless function
 group: sdk
 index: 100
-platform: browser
-authors:
-- author_name: Nathan Ridley
-  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
-  author_profile_url: https://github.com/axefrog
-  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
-level: medium
-reading_time: 40
 languages:
-  - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 40
+section: tutorials
 tags:
-  - Reactor Integration
-  - AWS Lambda
+- Reactor Integration
+- AWS Lambda
+title: Pizza ordering app with AWS Lambda Functions
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-azure.textile
+++ b/content/tutorials/reactor-event-azure.textile
@@ -1,28 +1,32 @@
 ---
-title: Pizza ordering app with Azure Functions
+ably_product: reactor
 alt_title: Pizza ordering app with Azure Functions
-excerpt: Learn how to use the Azure Function - Reactor Integration to consume realtime data and automatically respond to requests for pizza from your serverless function
-section: tutorials
+authors:
+- author_bio: Software engineer. Web front and back end, UI/UX, design. Making myself
+    obsolete since 1841.
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+  author_name: Nathan Ridley
+  author_profile_url: https://github.com/axefrog
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-12-23T17:31:18+10:00'
+excerpt: Learn how to use the Azure Function - Reactor Integration to consume realtime
+  data and automatically respond to requests for pizza from your serverless function
 group: sdk
 index: 100
-platform: browser
-authors:
-- author_name: Nathan Ridley
-  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
-  author_profile_url: https://github.com/axefrog
-  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
-level: medium
-reading_time: 40
 languages:
-  - javascript
-  - nodejs
-ably_product: reactor
+- javascript
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 40
+section: tutorials
 tags:
-    - Reactor Integration
-    - Azure function
+- Reactor Integration
+- Azure function
+title: Pizza ordering app with Azure Functions
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-cloudflare.textile
+++ b/content/tutorials/reactor-event-cloudflare.textile
@@ -1,27 +1,30 @@
 ---
-title: Building a realtime logistics service simulator with Cloudflare Workers
+ably_product: reactor
 alt_title: Build a realtime logistics service simulator with Cloudflare Workers
-excerpt: Learn how to use the Cloudflare Workers - Reactor Integration by building a 2D game in React
-section: tutorials
+authors:
+- author_bio: I'm a software developer who loves writing and in love with open source
+  author_image: ://avatars3.githubusercontent.com/u/24491408?s=400&v=4
+  author_name: Abraham Jr. Agiri
+  author_profile_url: https://github.com/codeekage
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2020-02-27T10:43:49+00:00'
+excerpt: Learn how to use the Cloudflare Workers - Reactor Integration by building
+  a 2D game in React
 group: sdk
 index: 103
-platform: browser
-authors:
-- author_name: Abraham Jr. Agiri
-  author_bio: "I'm a software developer who loves writing and in love with open source"
-  author_profile_url: https://github.com/codeekage
-  author_image: ://avatars3.githubusercontent.com/u/24491408?s=400&v=4
-level: medium
-reading_time: 10
 languages:
-  - javascript
-ably_product: reactor
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 10
+section: tutorials
 tags:
-    - Cloudflare
-    - Reactor Integration
+- Cloudflare
+- Reactor Integration
+title: Building a realtime logistics service simulator with Cloudflare Workers
 ---
 
 The "Ably Reactor":https://ably.com/integrations provides a way to trigger events and to stream data from Ably's pub/sub channels. This tutorial will go over how to use the Ably Reactor with "Cloudflare workers":https://developers.cloudflare.com/workers/quickstart/.

--- a/content/tutorials/reactor-event-google.textile
+++ b/content/tutorials/reactor-event-google.textile
@@ -1,28 +1,33 @@
 ---
-title: Pizza ordering app with Google Cloud Functions
+ably_product: reactor
 alt_title: Pizza ordering app with Google Cloud Functions
-excerpt: Learn how to use the Google Cloud Function - Reactor Integration to consume realtime data and automatically respond to requests for pizza from your serverless function
-section: tutorials
+authors:
+- author_bio: Software engineer. Web front and back end, UI/UX, design. Making myself
+    obsolete since 1841.
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+  author_name: Nathan Ridley
+  author_profile_url: https://github.com/axefrog
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-12-23T17:31:18+10:00'
+excerpt: Learn how to use the Google Cloud Function - Reactor Integration to consume
+  realtime data and automatically respond to requests for pizza from your serverless
+  function
 group: sdk
 index: 100
-platform: browser
-authors:
-- author_name: Nathan Ridley
-  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
-  author_profile_url: https://github.com/axefrog
-  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
-level: medium
-reading_time: 40
 languages:
-  - javascript
-  - nodejs
-ably_product: reactor
+- javascript
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 40
+section: tutorials
 tags:
-    - Reactor Integration
-    - Google Cloud Function
+- Reactor Integration
+- Google Cloud Function
+title: Pizza ordering app with Google Cloud Functions
 ---
 
 The Ably Realtime service provides a "pub/sub" (publish/subscribe) messaging system with which you can build sophisticated workflows and dataflow pipelines to meet the needs of your application. This can be as simple as publishing messages to named channels of your choice, and having users and server processes subscribe to those channels and respond with further messages as needed. But what if you don't have a server to coordinate all of this, or simply don't want to manage that side of things?

--- a/content/tutorials/reactor-event-ifttt.textile
+++ b/content/tutorials/reactor-event-ifttt.textile
@@ -1,28 +1,31 @@
 ---
-title: Building a bridge simulator game with realtime Slack alerts via IFTTT
+ably_product: reactor
 alt_title: Building a bridge simulator game with realtime Slack alerts via IFTTT
-excerpt: Learn how to use the IFTTT - Reactor Integration to build a game and trigger IFTTT events and send alerts on Slack
-section: tutorials
+authors:
+- author_bio: Developer advocate at Ably
+  author_image: ://avatars2.githubusercontent.com/u/3490640?s=460&v=4
+  author_name: Jo Franchetti
+  author_profile_url: https://github.com/thisisjofrank
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2020-02-26T16:28:42+00:00'
+excerpt: Learn how to use the IFTTT - Reactor Integration to build a game and trigger
+  IFTTT events and send alerts on Slack
 group: sdk
 index: 105
-platform: browser
-authors:
-- author_name: Jo Franchetti
-  author_bio: "Developer advocate at Ably"
-  author_profile_url: https://github.com/thisisjofrank
-  author_image: ://avatars2.githubusercontent.com/u/3490640?s=460&v=4
-level: medium
-reading_time: 10
 languages:
-  - javascript
-ably_product: reactor
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 10
+section: tutorials
 tags:
-    - IFTTT
-    - Reactor Integration
-    - Webhooks
+- IFTTT
+- Reactor Integration
+- Webhooks
+title: Building a bridge simulator game with realtime Slack alerts via IFTTT
 ---
 
 The "Ably Reactor":https://ably.com/integrations provides a way to trigger events and to stream data from Ably's pub/sub channels. This tutorial will go over how to use the Ably Reactor with the "IfThisThenThat Webhooks service":https://ifttt.com/maker_webhooks. IfThisThenThat (IFTTT) allows you to create chains of conditional statements called Applets. These Applets can be triggered by events on your Ably Channel. They in turn can trigger other web services such as email, social media, chat apps, IoT devices etc.

--- a/content/tutorials/reactor-event-zapier.textile
+++ b/content/tutorials/reactor-event-zapier.textile
@@ -1,28 +1,31 @@
 ---
-title: Building an IoT based realtime attendance system for Slack using Zapier
+ably_product: reactor
 alt_title: Building an IoT based realtime attendance system for Slack using Zapier
-excerpt: Learn how to build an IoT based realtime attendance system for Slack channels using Ably and Zapier
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/5900152?s=460&v=4
+  author_name: Srushtika Neelakantam
+  author_profile_url: https://github.com/Srushtika
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2020-02-21T17:02:04+00:00'
+excerpt: Learn how to build an IoT based realtime attendance system for Slack channels
+  using Ably and Zapier
 group: mqtt
 index: 104
-platform: browser
-authors:
-- author_name: Srushtika Neelakantam
-  author_bio: ""
-  author_profile_url: "https://github.com/Srushtika"
-  author_image: "https://avatars3.githubusercontent.com/u/5900152?s=460&v=4"
-level: medium
-reading_time: 30
 languages:
-  - cplusplus
+- cplusplus
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - Reactor Integration
-    - Webhooks
-    - Zapier
-ably_product: reactor
+- Reactor Integration
+- Webhooks
+- Zapier
+title: Building an IoT based realtime attendance system for Slack using Zapier
 ---
 
 In this tutorial, we'll see how to build an IoT based realtime attendance system that sends a message to a Slack channel upon detecting an access card. 

--- a/content/tutorials/reactor-firehose-kinesis.textile
+++ b/content/tutorials/reactor-firehose-kinesis.textile
@@ -1,27 +1,30 @@
 ---
-title: Using Reactor Firehose with Amazon Kinesis
+ably_product: reactor
 alt_title: Using Reactor Firehose with Amazon Kinesis
-excerpt: Learn how to use Reactor Firehose to stream Ably messages into Amazon Kinesis and process them using an AWS Lambda and Ably pub/sub
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/18176755?s=460&v=4
+  author_name: Mark Lewin
+  author_profile_url: https://github.com/marklewin
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2021-10-28T16:47:41+01:00'
+excerpt: Learn how to use Reactor Firehose to stream Ably messages into Amazon Kinesis
+  and process them using an AWS Lambda and Ably pub/sub
 group: sdk
 index: 120
-platform: browser
-authors:
-- author_name: Mark Lewin
-  author_bio: ""
-  author_profile_url: "https://github.com/marklewin"
-  author_image: "https://avatars.githubusercontent.com/u/18176755?s=460&v=4"
-level: medium
-reading_time: 20
 languages:
-    - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 20
+section: tutorials
 tags:
-    - Reactor Integration
-    - AWS Lambda
+- Reactor Integration
+- AWS Lambda
+title: Using Reactor Firehose with Amazon Kinesis
 ---
 
 "Reactor Firehose":/general/firehose enables "Enterprise customers":https://ably.com/pricing to send messages published by the Ably platform directly to a "third party streaming or queuing service":/general/firehose#services. 
@@ -600,5 +603,3 @@ h2. Next steps
 4. Try out other tutorials on working with Ably integrations. Visit our "tutorials":/tutorials page and select the Reactor Integrations tab.
 5. Gain a good technical overview of "how the Ably realtime platform works":/how-ably-works.
 6. "Get in touch if you need help":https://ably.com/contact.
-
-

--- a/content/tutorials/reactor-firehose-sqs.textile
+++ b/content/tutorials/reactor-firehose-sqs.textile
@@ -1,27 +1,30 @@
 ---
-title: Using Reactor Firehose with Amazon SQS
+ably_product: reactor
 alt_title: Using Reactor Firehose with Amazon SQS
-excerpt: Learn how to use Reactor Firehose to stream Ably messages into Amazon SQS and process them using an AWS Lambda and Ably pub/sub
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars.githubusercontent.com/u/18176755?s=460&v=4
+  author_name: Mark Lewin
+  author_profile_url: https://github.com/marklewin
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2021-09-27T09:29:12+01:00'
+excerpt: Learn how to use Reactor Firehose to stream Ably messages into Amazon SQS
+  and process them using an AWS Lambda and Ably pub/sub
 group: sdk
 index: 120
-platform: browser
-authors:
-- author_name: Mark Lewin
-  author_bio: ""
-  author_profile_url: "https://github.com/marklewin"
-  author_image: "https://avatars.githubusercontent.com/u/18176755?s=460&v=4"
-level: medium
-reading_time: 20
 languages:
-    - nodejs
-ably_product: reactor
+- nodejs
+last_updated: '2021-11-19T13:03:16+00:00'
+level: medium
+platform: browser
+reading_time: 20
+section: tutorials
 tags:
-    - Reactor Integration
-    - AWS Lambda
+- Reactor Integration
+- AWS Lambda
+title: Using Reactor Firehose with Amazon SQS
 ---
 
 "Reactor Firehose":/general/firehose enables "Enterprise customers":https://ably.com/pricing to send messages published by the Ably platform directly to a "third party streaming or queuing service":/general/firehose#services so that they can be processed asynchronously. For example, you might want to persist messages to a database or use them to trigger some sort of workflow. But you want to achieve this without adding extra overhead to your servers or delaying the delivery of messages to subscribing clients.
@@ -458,5 +461,3 @@ h2. Next steps
 4. Try out other tutorials about working with Ably integrations. Visit our "tutorials":/tutorials page and select the Reactor Integrations tab.
 5. Gain a good technical overview of "how the Ably realtime platform works":/how-ably-works.
 6. "Get in touch if you need help":https://ably.com/contact.
-
-

--- a/content/tutorials/realtime-cryptocurrency-app-flutter.textile
+++ b/content/tutorials/realtime-cryptocurrency-app-flutter.textile
@@ -1,37 +1,39 @@
 ---
-title: Building a Realtime Cryptocurrency App with Flutter
-excerpt: Learn how to build a live cryptocurrency app using Ably's Flutter plugin
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/41123719?s=400&u=fc97994663600a1d0aa3ede643e6521cfc642580&v=4
+  author_name: Mais Alheraki
+  author_profile_url: https://github.com/pr-Mais
+- author_bio: ''
+  author_image: https://avatars1.githubusercontent.com/u/16635729?s=400&u=560ef06ac812702aaa94cd58ef3e57ebf9dffdc1&v=4
+  author_name: Thomas Burkhart
+  author_profile_url: https://github.com/escamoteur
 category:
-    - channels
+- channels
+date_published: '2021-01-07T01:53:03+03:00'
+excerpt: Learn how to build a live cryptocurrency app using Ably's Flutter plugin
 group: sdk
 index: 13
-platform: mobile
-authors:
-- author_name: Mais Alheraki
-  author_bio: ""
-  author_profile_url: "https://github.com/pr-Mais"
-  author_image: "https://avatars3.githubusercontent.com/u/41123719?s=400&u=fc97994663600a1d0aa3ede643e6521cfc642580&v=4"
-- author_name: Thomas Burkhart
-  author_bio: ""
-  author_profile_url: "https://github.com/escamoteur"
-  author_image: "https://avatars1.githubusercontent.com/u/16635729?s=400&u=560ef06ac812702aaa94cd58ef3e57ebf9dffdc1&v=4"
 languages:
-  - flutter
+- flutter
+last_updated: '2021-11-19T16:35:45+00:00'
 level: intermediate
+meta_description: Learn about realtime in Flutter by building a cryptocurrency app
+  that has a dashboard, chat room and Twitter feed.
+meta_image: /images/tutorials/flutter-cryptocurrency/header.jpg
+meta_keywords: Ably, Flutter, Realtime Cryptocurrency App
+platform: mobile
 reading_time: 20
-tags:
-    - Flutter
-    - Graphs
-    - Cryptocurrency
-meta_description: "Learn about realtime in Flutter by building a cryptocurrency app that has a dashboard, chat room and Twitter feed."
-meta_keywords: "Ably, Flutter, Realtime Cryptocurrency App"
-meta_image: "/images/tutorials/flutter-cryptocurrency/header.jpg"
 redirect_from:
-  - /tutorials/realtime-cryptocurrency-app-flutter/
-  - /tutorials/flutter-cryptocurrency-app/
-  - /tutorials/flutter-cryptocurrency-app
-
+- /tutorials/realtime-cryptocurrency-app-flutter/
+- /tutorials/flutter-cryptocurrency-app/
+- /tutorials/flutter-cryptocurrency-app
+section: tutorials
+tags:
+- Flutter
+- Graphs
+- Cryptocurrency
+title: Building a Realtime Cryptocurrency App with Flutter
 ---
 
 Learn how to implement realtime messaging in Flutter by building a cryptocurrency app that shows a live dashboard, chat room and Twitter feed.

--- a/content/tutorials/sse-and-http-streaming.textile
+++ b/content/tutorials/sse-and-http-streaming.textile
@@ -1,24 +1,26 @@
 ---
-title: Subscribing to a data stream using SSE and the Event Source API
-excerpt: Learn how to implement subscribe-only capabilities on your clients with SSE
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2019-06-04T17:12:06+01:00'
+excerpt: Learn how to implement subscribe-only capabilities on your clients with SSE
 group: sse
 index: 109
-platform: mixed
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
 languages:
-  - javascript
-  - python
+- javascript
+- python
+last_updated: '2021-11-03T17:28:13+00:00'
 level: easy
+platform: mixed
 reading_time: 5
+section: tutorials
 tags:
-    - SSE
+- SSE
+title: Subscribing to a data stream using SSE and the Event Source API
 ---
 
 Server-Sent Events (SSE) is a standard describing how servers can initiate data transmission towards clients once an initial client connection has been established. They are commonly used to send message updates or continuous data streams to a browser client and are designed to enhance cross-browser streaming through a JavaScript API called "EventSource":https://en.wikipedia.org/wiki/Server-sent_events. Using this API, a client can easily receive an event stream by sending a request to a particular URL endpoint. Basically, using SSE, a client can receive continuous event updates without needing to use any client library SDK or even an adapter like "MQTT":https://ably.com/documentation/mqtt.

--- a/content/tutorials/tfl-live-tracking-fitbit.textile
+++ b/content/tutorials/tfl-live-tracking-fitbit.textile
@@ -1,29 +1,32 @@
 ---
-title: Building a realtime London tube arrival tracking app for Fitbit
+ably_product: hub
 alt_title: Building a realtime London tube arrival tracking app for Fitbit
-excerpt: Learn how to build a FitBit Clockface app using the Ably TFL data stream to prompt users when to start for the station
-section: tutorials
+authors:
+- author_bio: Having fun building things
+  author_image: https://avatars0.githubusercontent.com/u/13391028?s=400&u=b08541c27f429191953e314e39b539066391ca2a&v=4
+  author_name: Apoorv Vardhan
+  author_profile_url: https://github.com/vardhanapoorv
 category:
-    - channels
-    - api-hub
+- channels
+- api-hub
+date_published: '2020-01-18T19:42:56+05:30'
+excerpt: Learn how to build a FitBit Clockface app using the Ably TFL data stream
+  to prompt users when to start for the station
 group: sdk
 index: 105
-platform: mobile
-authors:
-- author_name: Apoorv Vardhan
-  author_bio: "Having fun building things"
-  author_profile_url: "https://github.com/vardhanapoorv"
-  author_image: "https://avatars0.githubusercontent.com/u/13391028?s=400&u=b08541c27f429191953e314e39b539066391ca2a&v=4"
-level: medium
-reading_time: 30
 languages:
-  - javascript
-  - nodejs
+- javascript
+- nodejs
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: mobile
+reading_time: 30
+section: tutorials
 tags:
-  - Hub
-  - Live transit
-  - Smartwatch app
-ably_product: hub
+- Hub
+- Live transit
+- Smartwatch app
+title: Building a realtime London tube arrival tracking app for Fitbit
 ---
 
 In this tutorial, we will see how to use the "Ably Realtime client library":/realtime to build a realtime London Tube schedule clockface app for Fitbit. Ably enables realtime data sharing using Pub/Sub messaging architecture via a concept called "channels":/core-features/channels.

--- a/content/tutorials/token-authentication.textile
+++ b/content/tutorials/token-authentication.textile
@@ -1,37 +1,40 @@
 ---
-title: Implementing Token Authentication
-excerpt: Learn how clients can use token authentication and how to issue tokens with correct permissions server side
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
+  author_name: Piotr Kazmierczak
+  author_profile_url: https://github.com/piotrekkazmierczak
+- author_bio: ''
+  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
+  author_name: Bartłomiej Wereszczyński
+  author_profile_url: https://github.com/bartlomiejwereszczynski
+- author_bio: ''
+  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
+  author_name: Shelin Hime
+  author_profile_url: https://github.com/ShelinHime
 category:
-    - channels
+- channels
+date_published: '2016-09-11T14:03:38+01:00'
+excerpt: Learn how clients can use token authentication and how to issue tokens with
+  correct permissions server side
 group: sdk
 index: 50
-platform: mixed
-authors:
-- author_name: Piotr Kazmierczak
-  author_bio: ""
-  author_profile_url: https://github.com/piotrekkazmierczak
-  author_image: https://avatars2.githubusercontent.com/u/5469324?s=460&v=4
-- author_name: Bartłomiej Wereszczyński
-  author_bio: ""
-  author_profile_url: https://github.com/bartlomiejwereszczynski
-  author_image: https://avatars2.githubusercontent.com/u/8190023?s=460&v=4
-- author_name: Shelin Hime
-  author_bio: ""
-  author_profile_url: https://github.com/ShelinHime
-  author_image: https://avatars3.githubusercontent.com/u/6329153?s=460&v=4
 languages:
-  - java
-  - android
-  - python
-  - php
-  - ruby
-  - nodejs
-  - swift
+- java
+- android
+- python
+- php
+- ruby
+- nodejs
+- swift
+last_updated: '2021-11-19T16:35:45+00:00'
 level: medium
+platform: mixed
 reading_time: 20
+section: tutorials
 tags:
-    - Authentication
+- Authentication
+title: Implementing Token Authentication
 ---
 
 Ably supports two types of authentication schemes, "basic authentication":/core-features/authentication#basic-authentication using a private API key, which should be used on servers (not on user devices), and "token authentication":/core-features/authentication#token-authentication which should be used on user devices. In token authentication, your server can generate short-lived tokens and pass them to users when they need to communicate with Ably. These tokens can be limited to specific capabilities on specific channels. Make sure to follow the principle of least privilege, giving clients only the capabilities they need. 

--- a/content/tutorials/vue-tictactoe.textile
+++ b/content/tutorials/vue-tictactoe.textile
@@ -1,26 +1,29 @@
 ---
-title: Building a multiplayer Tic Tac Toe game in Vue.js
-excerpt: Build a multiplayer Tic Tac Toe game using Ably and Vue.js
-section: tutorials
+authors:
+- author_bio: Software engineer. Web front and back end, UI/UX, design. Making myself
+    obsolete since 1841.
+  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
+  author_name: Nathan Ridley
+  author_profile_url: https://github.com/axefrog
 category:
-    - channels
+- channels
+date_published: '2018-05-17T09:39:35+10:00'
+excerpt: Build a multiplayer Tic Tac Toe game using Ably and Vue.js
 group: sdk
 index: 105
-platform: browser
-authors:
-- author_name: Nathan Ridley
-  author_bio: "Software engineer. Web front and back end, UI/UX, design. Making myself obsolete since 1841."
-  author_profile_url: https://github.com/axefrog
-  author_image: ://avatars1.githubusercontent.com/u/298883?s=460&v=4
-reading_time: 30
-level: medium
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
 libraries:
-  - Vue.js
+- Vue.js
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - Vue.js
-    - Multiplayer game
+- Vue.js
+- Multiplayer game
+title: Building a multiplayer Tic Tac Toe game in Vue.js
 ---
 
 This tutorial is for those of you who have a little familiarity with Vue.js and are looking for some examples of how you might use Ably Realtime in your own application.

--- a/content/tutorials/web-rtc-data-channels.textile
+++ b/content/tutorials/web-rtc-data-channels.textile
@@ -1,24 +1,26 @@
 ---
-title: 2. WebRTC tutorial series - Data channels
 alt_title: 2. WebRTC tutorial series - Data channels
-excerpt: Learn how to implement Data Channels with WebRTC and Ably
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2018-07-12T19:00:02+01:00'
+excerpt: Learn how to implement Data Channels with WebRTC and Ably
 group: sdk
 index: 161
-platform: browser
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: medium
-reading_time: 30
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-18T12:31:36+00:00'
+level: medium
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - WebRTC
+- WebRTC
+title: 2. WebRTC tutorial series - Data channels
 ---
 
 A WebRTC data channel lets you send text or binary data to a peer, over an active connection.

--- a/content/tutorials/web-rtc-file-transfer.textile
+++ b/content/tutorials/web-rtc-file-transfer.textile
@@ -1,24 +1,26 @@
 ---
-title: 5. WebRTC tutorial series - File Sharing
 alt_title: 5. WebRTC tutorial series - File Sharing
-excerpt: Learn how to implement file sharing using WebRTC and Ably
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2018-07-12T19:00:02+01:00'
+excerpt: Learn how to implement file sharing using WebRTC and Ably
 group: sdk
 index: 164
-platform: browser
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: easy
-reading_time: 5
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-18T12:31:36+00:00'
+level: easy
+platform: browser
+reading_time: 5
+section: tutorials
 tags:
-    - WebRTC
+- WebRTC
+title: 5. WebRTC tutorial series - File Sharing
 ---
 
 WebRTC Datachannels API allows developers to transmit arbitrary data directly between two users.

--- a/content/tutorials/web-rtc-introduction.textile
+++ b/content/tutorials/web-rtc-introduction.textile
@@ -1,24 +1,26 @@
 ---
-title: 1. WebRTC tutorial series - Introduction
 alt_title: 1. WebRTC tutorial series - Introduction
-excerpt: A real world guide to WebRTC concepts with Ably
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2018-07-12T19:00:02+01:00'
+excerpt: A real world guide to WebRTC concepts with Ably
 group: sdk
 index: 160
-platform: browser
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: easy
-reading_time: 5
 languages:
-  - javascript
+- javascript
+last_updated: '2021-03-16T17:30:04+00:00'
+level: easy
+platform: browser
+reading_time: 5
+section: tutorials
 tags:
-    - WebRTC
+- WebRTC
+title: 1. WebRTC tutorial series - Introduction
 ---
 
 "WebRTC":https://webrtc.org is a free, open project that provides browsers and mobile applications with Real-Time Communications (RTC) capabilities via simple APIs. The WebRTC components have been optimized to best serve this purpose. While WebRTC knows how to communicate with other peers, it doesn't know how to *discover* these other peers. Discovery is an inherent problem, this is where we'll utilise the "Ably Realtime Platform":https://ably.com/.

--- a/content/tutorials/web-rtc-screen-sharing.textile
+++ b/content/tutorials/web-rtc-screen-sharing.textile
@@ -1,24 +1,26 @@
 ---
-title: 4. WebRTC tutorial series - Screen Sharing
 alt_title: 4. WebRTC tutorial series - Screen Sharing
-excerpt: Learn how to implement screen sharing using WebRTC and Ably
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2018-07-12T19:00:02+01:00'
+excerpt: Learn how to implement screen sharing using WebRTC and Ably
 group: sdk
 index: 163
-platform: browser
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: medium
-reading_time: 30
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-18T12:31:36+00:00'
+level: medium
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - WebRTC
+- WebRTC
+title: 4. WebRTC tutorial series - Screen Sharing
 ---
 
 Screen sharing software allows people from various locations, view someone else's computer screen in real-time. When you share your screen, your guests can see exactly what’s happening on your computer desktop at the time it is happening.

--- a/content/tutorials/web-rtc-video-calling.textile
+++ b/content/tutorials/web-rtc-video-calling.textile
@@ -1,24 +1,26 @@
 ---
-title: 3. WebRTC tutorial series - Video Calling
 alt_title: 3. WebRTC tutorial series - Video Calling
-excerpt: Learn how to implement video calling using WebRTC and Ably
-section: tutorials
+authors:
+- author_bio: ''
+  author_image: tutorials/samuelayo.png
+  author_name: Samuel Ogundipe
+  author_profile_url: https://github.com/samuelayo
 category:
-    - channels
+- channels
+date_published: '2018-07-12T19:00:02+01:00'
+excerpt: Learn how to implement video calling using WebRTC and Ably
 group: sdk
 index: 162
-platform: browser
-authors:
-- author_name: Samuel Ogundipe
-  author_bio: ""
-  author_profile_url: https://github.com/samuelayo
-  author_image: "tutorials/samuelayo.png"
-level: medium
-reading_time: 30
 languages:
-  - javascript
+- javascript
+last_updated: '2021-11-18T12:31:36+00:00'
+level: medium
+platform: browser
+reading_time: 30
+section: tutorials
 tags:
-    - WebRTC
+- WebRTC
+title: 3. WebRTC tutorial series - Video Calling
 ---
 
 In this lesson, we will take a look at implementing Video calling using WebRTC and Ably.

--- a/content/tutorials/webhook-chuck-norris.textile
+++ b/content/tutorials/webhook-chuck-norris.textile
@@ -1,25 +1,29 @@
 ---
-title: Publishing jokes in realtime using custom Webhooks and the Chuck Norris API
-excerpt: Learn how to use the custom Webhooks feature to trigger HTTP requests when realtime data is published and then use the Chuck Norris API to publish jokes in real time
-section: tutorials
+ably_product: reactor
+authors:
+- author_bio: ''
+  author_image: https://avatars0.githubusercontent.com/u/43789?s=460&v=4
+  author_name: Matthew O'Riordan
+  author_profile_url: https://github.com/mattheworiordan
 category:
-    - channels
-    - reactor-integrations
+- channels
+- reactor-integrations
+date_published: '2017-02-03T02:04:01+00:00'
+excerpt: Learn how to use the custom Webhooks feature to trigger HTTP requests when
+  realtime data is published and then use the Chuck Norris API to publish jokes in
+  real time
 group: sdk
 index: 105
-platform: browser
-authors:
-- author_name: "Matthew O'Riordan"
-  author_bio: ""
-  author_profile_url: "https://github.com/mattheworiordan"
-  author_image: "https://avatars0.githubusercontent.com/u/43789?s=460&v=4"
-level: medium
-reading_time: 25
 languages:
-  - ruby
-ably_product: reactor
+- ruby
+last_updated: '2021-11-19T16:35:45+00:00'
+level: medium
+platform: browser
+reading_time: 25
+section: tutorials
 tags:
-    - Webhooks
+- Webhooks
+title: Publishing jokes in realtime using custom Webhooks and the Chuck Norris API
 ---
 
 "Ably Reactor Events":https://ably.com/integrations allow your servers to be notified or your server-less functions to be invoked via an HTTP request following "channel lifecycle events":/realtime/channel-metadata#lifecycle-events (such as channel creation), presence events (such as members entering or leaving) or messages being published.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Adds `date_published` and `last_updated` fields to the YAML front matter of all of the tutorial .textile files, based on each file's git history. As a side effect, it also lists each setting in alphabetical order.

The script used is shown in [this gist](https://gist.github.com/marklewin/9a9deb440b9902a9f4b1d0bf2ddc6f61).

[DOC-563](https://ably.atlassian.net/browse/DOC-563).

## Review

Check that the `date_published` and `last_updated` fields are present in all `.textile` files in `./content/tutorials`, with the exception of `index.textile`.