### PR TITLE
DOC-578: Reword use of native SDKs to client library SDKs for tutorial homepage

### DIFF
--- a/config/tutorials/tutorials.json
+++ b/config/tutorials/tutorials.json
@@ -1,18 +1,16 @@
 {
-
   "favorites": {
     "title": "No results for the filter",
     "desc": "However we do have these exceptional examples of tutorials that might help you.",
     "filenames": [
-        "publish-subscribe.textile",
-        "token-authentication.textile",
-        "_multiplayer-vr-web.textile",
-        "mqtt-snake.textile",
-        "_live-flight-tracking.textile",
-        "_multi-lingual-chat.textile"
+      "publish-subscribe.textile",
+      "token-authentication.textile",
+      "_multiplayer-vr-web.textile",
+      "mqtt-snake.textile",
+      "_live-flight-tracking.textile",
+      "_multi-lingual-chat.textile"
     ]
   },
-
   "categories": [
     {
       "id": "channels",
@@ -39,11 +37,10 @@
       "desc": "Fun tutorials on how to make use of various libraries and JS frameworks with Ably."
     }
   ],
-
   "groups": {
     "sdk": {
       "id": "sdk",
-      "name": "Using native Ably SDKs",
+      "name": "Using Ably Client Library SDKs",
       "desc": "A selection of tutorials demonstrating the use of Realtime and/or REST libraries within devices such as browsers, desktops, mobiles or servers."
     },
     "sse": {


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR updates the tutorial homepage to refer to "Ably Client Library SDKs" instead of "Ably native SDKs" to conform to the writing style guide.

## Review

Run this branch locally against the website and visit `/tutorials` to review this PR.
