### PR TITLE
DOC-479: Add use of Control API to authentication information 

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -218,7 +218,7 @@ h2(#capabilities-explained). Capabilities and Token Security explained
 
 "API keys":https://faqs.ably.com/what-is-an-app-api-key, like "Ably-compatible tokens":#tokens, have a set of capabilities assigned to them that specify which "operations":#capability-operations (such as subscribe or publish) can be performed on which channels. However, unlike tokens, API keys are long-lived, secret and typically not shared with un-trusted clients.
 
-API keys and their capabilities are "configured using the dashboard":https://faqs.ably.com/setting-up-and-managing-api-keys, they cannot be added or removed programmatically. Ably-compatible tokens on the other hand are designed to be shared with un-trusted clients, are short-lived, and significantly, they are configured and issued programmatically. See "selecting an authentication scheme":#selecting-auth to understand why token authentication, in most cases, is the preferred authentication scheme.
+API keys and their capabilities are "configured using the dashboard":https://faqs.ably.com/setting-up-and-managing-api-keys, or "using the Control API":/control-api. Ably-compatible tokens are designed to be shared with un-trusted clients, are short-lived, and can be configured and issued programmatically. See "selecting an authentication scheme":#selecting-auth to understand why token authentication is the preferred authentication scheme in many cases.
 
 h3(#capabilities-key). Capabilities with API keys
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR updates the authentication text to state that API Keys can be created programmatically using the Control API.

See [JIRA](https://ably.atlassian.net/browse/DOC-479) for further information.

## Review

View the [authentication page](https://ably-docs-pr-1285.herokuapp.com/core-features/authentication#capabilities-explained) to review this PR.
