### PR TITLE
DOC-662: Remove statement about enterprise-only from Kafka connector

### DIFF
--- a/content/general/kafka-connector.textile
+++ b/content/general/kafka-connector.textile
@@ -18,7 +18,7 @@ If you need to send data from Ably to Kafka instead, use a "Kafka rule":/general
 
 h2(#development-status). Development status
 
-This feature is "Enterprise only":https://ably.com/pricing, and currently in Preview.
+This feature is currently in Preview.
 
 h2(#install). Install the connector
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR removes the 'enterprise-only' note from the Kafka Connector documentation. 

## Review

View the [Kafka Connector](https://ably-docs-pr-1294.herokuapp.com/general/kafka-connector/) page to review this PR.
