### PR TITLE
docs: add missing time unit

### DIFF
--- a/content/root/how-ably-works.textile
+++ b/content/root/how-ably-works.textile
@@ -51,7 +51,7 @@ Presence provides awareness of other clients that are connected to Ably and pres
 
 There are three presence operations, @enter@ for new members, @update@ allowing the payload data associated with a member to be updated and announced to everyone, and @leave@ for members that have requested to leave or who have left implicitly as a result of their connection being disconnected.
 
-The complete set of members present and their optional payload is stored by Ably in server RAM in at least three locations. Like messages, presence events such as @enter@ and @leave@ are persisted in RAM for 2 minutes, and optionally to disk in three locations for 24 - 72 if the "channel is configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app
+The complete set of members present and their optional payload is stored by Ably in server RAM in at least three locations. Like messages, presence events such as @enter@ and @leave@ are persisted in RAM for 2 minutes, and optionally to disk in three locations for 24 - 72 hours if the "channel is configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app
 
 h3(#reactor). Reactor
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

While looking through "how ably works", I've noticed in the presence section, that we do not specify a time unit for how long presence events are stored on disk. I assume this should be `hours`.

## Review

See diff

