### PR TITLE
DOC-570: Document channel mode flags

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -216,6 +216,28 @@ bc[swift]. let key = ARTCrypto.generateRandomKey()
 let options = ARTChannelOptions(cipherKey: key)
 let channel = realtime.channels.get("channelName", options: options)
 
+h5(#setting-channel-mode-flags). Setting channel mode flags
+
+Channel mode flags enable a client to specify a subset of the permissions granted by their token or API key as "channel options":#setting-channel-options.
+
+The channel mode flags available are:
+
+| Flag | Description |
+| SUBSCRIBE | Can subscribe to receive messages on the channel. |
+| PUBLISH | Can publish messages to the channel. |
+| PRESENCE_SUBSCRIBE | Can subscribe to receive presence events on the channel. |
+| PRESENCE | Can register presence on the channel. |
+
+Channel mode flags are set as "channel options":#setting-channel-options: 
+
+bc[javascript]. const realtime = new Ably.Realtime('{{API_KEY}}');
+const channelOptions = {
+  modes: ['PUBLISH', 'SUBSCRIBE', 'PRESENCE']
+};
+const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}'), channelOptions);
+
+**Note**: Channel mode flags are flags and not permissions, so they cannot be enforced by an authentication server.
+
 h3(#subscribing). Subscribing to a channel
 
 To subscribe to a channel, use the "subscribe":#subscribe method of a channel:

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -218,11 +218,11 @@ let channel = realtime.channels.get("channelName", options: options)
 
 h5(#setting-channel-mode-flags). Setting channel mode flags
 
-Channel mode flags enable a client to specify a subset of the permissions granted by their token or API key as "channel options":#setting-channel-options.
+Channel mode flags enable a client to specify a subset of the "capabilities":/core-features/authentication#capabilities-explained granted by their token or API key as "channel options":#setting-channel-options. Channel mode flags offer the ability for clients to use different capabilities for different channels, however, as they are flags and not permissions they cannot be enforced by an authentication server.
 
 The channel mode flags available are:
 
-| Flag | Description |
+|_. Flag |_. Description |
 | SUBSCRIBE | Can subscribe to receive messages on the channel. |
 | PUBLISH | Can publish messages to the channel. |
 | PRESENCE_SUBSCRIBE | Can subscribe to receive presence events on the channel. |
@@ -236,7 +236,7 @@ const channelOptions = {
 };
 const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}'), channelOptions);
 
-**Note**: Channel mode flags are flags and not permissions, so they cannot be enforced by an authentication server.
+**Note**: Channel mode flags enable clients to be "present on a channel without subscribing to presence events":/best-practice-guide#being-present-without-subscribing-to-presence. 
 
 h3(#subscribing). Subscribing to a channel
 

--- a/content/root/best-practice-guide.textile
+++ b/content/root/best-practice-guide.textile
@@ -221,7 +221,7 @@ For servers:
 }
 ```
 
-Alternatively, you can use "channel mode flags":/realtime/channels#setting-channel-mode-flags to specify a subset of permissions available on the API key or token a client is using.
+Alternatively, you can use "channel mode flags":/realtime/channels#setting-channel-mode-flags to specify a subset of "capabilities":/core-features/authentication#capabilities-explained available on the API key or token a client is using.
 
 In the following example the client would be present on the channel without receiving presence notifications from other clients in the presence set:
 

--- a/content/root/best-practice-guide.textile
+++ b/content/root/best-practice-guide.textile
@@ -221,6 +221,19 @@ For servers:
 }
 ```
 
+Alternatively, you can use "channel mode flags":/realtime/channels#setting-channel-mode-flags to specify a subset of permissions available on the API key or token a client is using.
+
+In the following example the client would be present on the channel without receiving presence notifications from other clients in the presence set:
+
+```[javascript]. const realtime = new Ably.Realtime('{{API_KEY}}');
+const channelOptions = {
+  modes: ['PUBLISH', 'SUBSCRIBE', 'PRESENCE']
+};
+const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}'), channelOptions);
+```
+
+As this is server-side filtering, clients won't be receiving presence notifications which saves a potentially high volume of messages from being used.
+
 h3(#use-existing-presence-set). Using the synced presence set provided by the realtime library
 
 Monitoring presence events can be quite complex. For this reason, the @Presence@ object in the realtime library exposes a @get@ "method":/realtime/presence#get allowing a client to retrieve an array of all members present on the channel. The Ably client is responsible for keeping track of the presence set from the time that the channel is attached. An up-to-date presence set is pushed to the client following attach and this set is updated on each subsequent presence event. Thus @get@ returns the already-known presence set retained in memory and does not trigger a new request to the Ably service. You can simply use this method as shown below, instead of venturing into the complexity of building one of your own.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR documents channel mode flags in the realtime channels page and also updates the best practice guide for being present without subscribing.

## Review

To review this PR, see:

* [Realtime channels](http://ably-docs-doc-570-chann-qn6r5t.herokuapp.com/realtime/channels/#setting-channel-mode-flags)
* [Best practice guide](https://ably-docs-doc-570-chann-qn6r5t.herokuapp.com/best-practice-guide/#being-present-without-subscribing-to-presence)
