### PR TITLE
DOC-476: Update description of rewind on history page to reflect parameters

### DIFF
--- a/content/code/realtime/rewind.code
+++ b/content/code/realtime/rewind.code
@@ -1,15 +1,14 @@
 [--- Javascript ---]
-var counter=0,
-    apiKey = 'xVLyHw.pE3iEw:Tywn31emhoRSvGlY',
-    realtime = new Ably.Realtime({ key: apiKey }),
-    publishChannel = realtime.channels.get('my_channel'),
-    channel2Messages = realtime.channels.get('[?rewind=2]my_channel'),
-    channel20sMessages = realtime.channels.get('[?rewind=20s]my_channel');
+let counter = 0;
+const apiKey = '{{API_KEY}}';
+const realtime = new Ably.Realtime({ key: apiKey });
+const channelOptions = {params: {rewind: '3'}};
+const channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', channelOptions);
 
 $('input#publish').on('click', function() {
   show('Publishing message', 'orange', '#channel-status');
   var currentNum=counter++;
-  publishChannel.publish('event', 'msg-' + currentNum, function(err) {
+  channel.publish('event', 'msg-' + currentNum, function(err) {
     if (err) {
       show('✗ Publish failed: ' + err.message, 'red', '#channel-status');
     } else {
@@ -18,16 +17,10 @@ $('input#publish').on('click', function() {
   });
 });
 
-$('input#subscribe-2').on('click', function() {
+$('input#subscribe').on('click', function() {
   show('Subscribing with rewind set to get at most 2 messages', 'orange', '#channel-status-sub1');
-
-  subscribeChannel(channel2Messages, '#channel-status-sub1');
-});
-
-$('input#subscribe-20s').on('click', function() {
-  show('Subscribing with rewind set to get at most 20 seconds of messages', 'orange', '#channel-status-sub2');
-
-  subscribeChannel(channel20sMessages, '#channel-status-sub2');
+  
+  subscribeChannel(channel, '#channel-status-sub1');
 });
 
 function subscribeChannel(channel, displayBox) {
@@ -57,8 +50,8 @@ function show(status, color, box) {
 </head>
 <body>
   <h1><a href="https://ably.com" target="_blank">Ably Rewind demo</a></h1>
-
-  <p>In this example, we demonstrate the simplest way to subscribe to a message using rewind in libraries older than v1.2. See <a href="https://ably.com/documentation/realtime/channels/channel-parameters/rewind">our Rewind documentation</a> for more details.
+  
+  <p>This example demonstrates the simplest way to subscribe to the last 3 messages using rewind. See <a href="https://ably.com/documentation/realtime/channels/channel-parameters/rewind">our Rewind documentation</a> for more details.
 
   <div class="row">
     <input id="publish" type="submit" value="Publish a message">
@@ -67,13 +60,8 @@ function show(status, color, box) {
   <ul class="row white-box" id="channel-status"></ul>
 
   <div class="row">
-    <input id="subscribe-2" type="submit" value="Subscribe with rewind to last 2 messages">
+    <input id="subscribe" type="submit" value="Subscribe with rewind to last 3 messages">
     <ul class="row white-box" id="channel-status-sub1"></ul>
-  </div>
-
-    <div class="row">
-    <input id="subscribe-20s" type="submit" value="Subscribe with rewind to last 2 messages">
-    <ul class="row white-box" id="channel-status-sub2"></ul>
   </div>
 </body>
 </html>

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -146,71 +146,63 @@ By using "rewind":/realtime/channels/channel-parameters/rewind or History's @unt
 
 h4(#rewind). Rewind
 
-If you wish to obtain history as part of attaching to a channel, you can use the "rewind channel parameter":/realtime/channels/channel-parameters/rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Check out the main "rewind documentation":/realtime/channels/channel-parameters/rewind for further details.
+If you wish to obtain history as part of attaching to a channel, you can use the "rewind channel parameter":/realtime/channels/channel-parameters/rewind. This will act as though you had attached to a channel from a certain message or time in the past, and play through all messages since that point. Rewind can only be used when first attaching to a channel.
 
-In current Ably libraries, or when using the "service without a library":https://ably.com/protocols, this is done by qualifying the channel name. There is a future library release planned in which it will be possible to specify channel params directly via the API. As an example, if the channel were @[some_metadata]my_channel@, you would specify the use of rewind via @[some_metadata?rewind=1]my_channel@. You can specify either a number of messages up to 100 to rewind to (for example @10@), or a time specifier of either seconds (@10s@), or minutes (@2m@) up to 2 minutes.
+A @rewind@ value that is a number (@n@) is a request to attach to the channel at a position @n@ messages before the present position. @rewind@ can also be a time interval, specifying a number of seconds (@15s@) or minutes (@1m@) to replay messages from.
 
-*Note* that this will only work whilst attaching to a channel.
+The following example will subscribe to the channel and relay the last 3 messages:
 
-```[javascript](code-editor:realtime/rewind)
-  var realtime = new Ably.Realtime('{{API_KEY}}');
-  var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
-  channel.subscribe(function(message) {
-    alert('Received: ' + message.data);
-  });
-```
-
-```[nodejs](code-editor:realtime/rewind)
-  var Ably = require('ably');
-  var realtime = new Ably.Realtime('{{API_KEY}}');
-  var channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
-  channel.subscribe(function(message) {
-    console.log("Received: "  message.data);
-  });
-```
-
-```[ruby]
-  realtime = Ably::Realtime.new('{{API_KEY}}')
-  channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}')
-  channel.subscribe do |message|
-    puts "Received: #{message.data}"
-  end
+```[jsall](code-editor:realtime/rewind)
+  const realtime = new Ably.Realtime('{{API_KEY}}');
+  realtime.channels.get('{{RANDOM_CHANNEL_NAME}}', {
+    params: {rewind: '3'}
+  }).subscribe(msg => console.log("Received message: ", msg));
 ```
 
 ```[java]
-  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
-  Channel channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+  final Map<String, String> params = new HashMap<>();
+  params.put("rewind", "3");
+  final ChannelOptions options = new ChannelOptions();
+  options.params = params;
+  final Channel channel = ably.channels.get("{{RANDOM_CHANNEL_NAME}}", options);
+
   channel.subscribe(new MessageListener() {
     @Override
     public void onMessage(Message message) {
-      System.out.println("New messages arrived. " + message.name);
+      System.out.println("Received `" + message.name + "` message with data: " + message.data);
     }
   });
 ```
 
+```[swift]
+  let options = ARTClientOptions(key: "{{API_KEY}}")
+  let client = ARTRealtime(options: options)
+  let channelOptions = ARTRealtimeChannelOptions()
+  channelOptions.params = [
+    "rewind": "3"
+  ]
+
+  let channel = client.channels.get(channelName, options: channelOptions)
+```
+
 ```[csharp]
-  AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
-  IRealtimeChannel channel = realtime.Channels.Get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
+  var clientOptions = new ClientOptions();
+  clientOptions.Key = "{{API_KEY}}";
+  clientOptions.Environment = AblyEnvironment;
+  var ably = new AblyRealtime(clientOptions);
+
+  var channelParams = new ChannelParams();
+  channelParams.Add("rewind", "3");
+  var channelOptions = new ChannelOptions();
+  channelOptions.Params = channelParams;
+  var channel = ably.Channels.Get("{{RANDOM_CHANNEL_NAME}}", channelOptions);
+
   channel.Subscribe(message => {
-    Console.WriteLine($"Message: {message.Name}:{message.Data} received");
+      Console.WriteLine(message.Data.ToString());
   });
 ```
 
-```[objc]
-ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
-ARTRealtimeChannel *channel = [realtime.channels get:@"[?rewind=1]{{RANDOM_CHANNEL_NAME}}"];
-[channel subscribe:^(ARTMessage *message) {
-    NSLog(@"Received: %@", message.data);
-}];
-```
-
-```[swift]
-let realtime = ARTRealtime(key: "{{API_KEY}}")
-let channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}")
-channel.subscribe { message in
-    print("Received: \(message.data)")
-}
-```
+**Note**: You can also qualify a channel name with rewind when using the service without a library, such as with "SSE":/realtime/channels/channel-parameters/rewind#rewind-example-sse or "MQTT":/realtime/channels/channel-parameters/rewind#rewind-examples-mqtt.
 
 h4(#until-attach). History with untilAttach
 

--- a/data/jsbins.yaml
+++ b/data/jsbins.yaml
@@ -43,7 +43,6 @@ jsbin_hash:
   YYdS87HP1pXlscCQeH7bDjlllQ4=: udodah
   "+gWBI8tP4uBD4eE+n8HD2B7P5Wk=": ejegiv
   n3l2XXF5kNR8UPW+WEsO1edSXuQ=: otuqeh
-  JOqXQFk6sbJlOgqqc6SkZWTqoLo=: uvahin
   "+y09W8bOjqjArHZ1DDU6PsaPAt4=": ereliz
   EZuljFh/oQj0cOkrUZpU7XoBjQM=: alohep
   aCl/jytvZrNnguSEukgdTXNIja4=: epovij
@@ -53,6 +52,7 @@ jsbin_hash:
   1PwNHxGwxm8UGfEsN5JLYfVuSo0=: onegoj
   JcpiggiSpOVcO8BmoP+iDlU77fU=: axohig
   NsYlcsN4Xezk25fyIPzPu7VxmA8=: eguyuq
+  FLiEnja2/y9WKipW/e/bsoq6Bcc=: ixecof
 jsbin_id:
   adapters/pusher-pub-sub: v3tOFMsUbkPgke38bR4BN+fNYH0=
   adapters/pubnub-pub-sub: 0+tgqnznFtwBG+0eOu4lefzXtBk=
@@ -94,7 +94,7 @@ jsbin_id:
   sse/sse: MpDgpT2wvuGs712waej3+FufE7A=
   sse/eventstream: aCl/jytvZrNnguSEukgdTXNIja4=
   rest/batch-presence: "+y09W8bOjqjArHZ1DDU6PsaPAt4="
-  realtime/rewind: JOqXQFk6sbJlOgqqc6SkZWTqoLo=
+  realtime/rewind: FLiEnja2/y9WKipW/e/bsoq6Bcc=
   authentication/jwt-token: CYvPkBTVXTgR0iDuAboyt3g2Jxo=
   realtime/connection-recover: n3l2XXF5kNR8UPW+WEsO1edSXuQ=
   realtime/channel-deltas: JcpiggiSpOVcO8BmoP+iDlU77fU=


### PR DESCRIPTION
## Description

This PR updates the description of the rewind feature on the realtime history page to reflect the use of channel parameters. It also updates the associated JSBin to reflect this too.

See [JIRA](https://ably.atlassian.net/browse/DOC-476) for further information.

## Review

View the [realtime/history](http://ably-docs-doc-476-histo-gnxoh9.herokuapp.com/realtime/history/#rewind) page to review this PR.
