### PR TITLE
DOC-498: Fix incorrect lang property to display message parameter

### DIFF
--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -1101,7 +1101,7 @@ h4. Parameters
 - <div lang="objc,swift">data</div> := data payload for the message. The supported payload types are <span lang="objc">@NS@</span>@String@, <span lang="objc">@NS@</span>@Dictionary@ or <span lang="objc">@NS@</span>@Array@ objects that can be serialized to JSON, binary data as @NSData@, and @nil@.<br>__Type: @Object@__
 - <div lang="flutter">data</div> := data payload for the message. The supported payload types are String, Map, List, and null.<br>__Type: @Object@__
 
-- <span lang="flutter">message</span> := A message object to publish<br>__Type: "@Message@":#message__
+- <span lang="default">message</span> := A message object to publish<br>__Type: "@Message@":#message__
 
 - <span lang="default">messages</span> := An array of message objects to publish<br>__Type: "@Message []@":#message__
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR fixes a parameter that was incorrectly labelled as `Flutter` causing the parameter to be unlabelled in other languages.

## Review

Check the [`publish()` method parameters](http://ably-docs-doc-498-missi-2ww98b.herokuapp.com/realtime/channels/#publish) are all correctly labelled.
