### PR TITLE
DOC-654: time interval can't be changed on Swift.

### DIFF
--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -70,8 +70,6 @@ Using approaches similar to these, an optimal resolution of updates can be ident
 
 The SDK provides a set of extensible interfaces for implementing custom logic for battery optimization. The SDK also provides a set of default constraints and policies, which developers can use to handle common use cases.
 
-**Note:** For Swift, it is not possible to change the time interval for location updates in @CLLocationManager@ from the Apple @CoreLocation@ framework. For further details see the "Apple documentation":https://developer.apple.com/documentation/corelocation/cllocationmanager.
-
 h2(#resolution). Resolution
 
 Resolution governs how often to sample locations, at what level of positional accuracy, and how often to send updates to subscribers.
@@ -79,7 +77,7 @@ Resolution governs how often to sample locations, at what level of positional ac
 @Resolution@ is made up of:
 
 - @Accuracy@ := The general priority for accuracy of location updates, used to govern any trade-off between power usage and positional accuracy. The highest positional accuracy will be achieved by specifying @Accuracy.MAXIMUM@, but at the expense of significantly increased power usage. Conversely, the lowest power usage will be achieved by specifying @Accuracy.MINIMUM@ but at the expense of significantly decreased positional accuracy.
-- @desiredInterval@ := Desired time between updates, in milliseconds. Lowering this value increases the temporal resolution. Location updates whose timestamp differs from the last captured update timestamp by less that this value are to be filtered out. Used to govern the frequency of updates requested from the underlying location provider, as well as the frequency of messages broadcast to subscribers.
+- @desiredInterval@ := Desired time between updates, in milliseconds. Lowering this value increases the temporal resolution. Location updates whose timestamp differs from the last captured update timestamp by less that this value are to be filtered out. Used to govern the frequency of updates requested from the underlying location provider, as well as the frequency of messages broadcast to subscribers. **Note:** For Swift, it is not possible to change the time interval for location updates in @CLLocationManager@ from the Apple @CoreLocation@ framework. For further details see the "Apple documentation":https://developer.apple.com/documentation/corelocation/cllocationmanager.
 - @minimumDisplacement@ := Minimum positional granularity required, in metres. Lowering this value increases the spatial resolution. Location updates whose position differs from the last known position by a distance smaller than this value are to be filtered out. Used to configure the underlying location provider, as well as to filter the broadcast of updates to subscribers.
 
 h3(#request-different-resolution). Request a different Resolution 

--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -70,7 +70,7 @@ Using approaches similar to these, an optimal resolution of updates can be ident
 
 The SDK provides a set of extensible interfaces for implementing custom logic for battery optimization. The SDK also provides a set of default constraints and policies, which developers can use to handle common use cases.
 
-**Note:** For Swift, it is not possible to change the time interval for location updates in @CLLocationManager@ from Apple @CoreLocation@ framework. For further details see the "Apple documentation":https://developer.apple.com/documentation/corelocation/cllocationmanager.
+**Note:** For Swift, it is not possible to change the time interval for location updates in @CLLocationManager@ from the Apple @CoreLocation@ framework. For further details see the "Apple documentation":https://developer.apple.com/documentation/corelocation/cllocationmanager.
 
 h2(#resolution). Resolution
 

--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -70,6 +70,8 @@ Using approaches similar to these, an optimal resolution of updates can be ident
 
 The SDK provides a set of extensible interfaces for implementing custom logic for battery optimization. The SDK also provides a set of default constraints and policies, which developers can use to handle common use cases.
 
+**Note:** For Swift, it is not possible to change the time interval for location updates in @CLLocationManager@ from Apple @CoreLocation@ framework. For further details see the "Apple documentation":https://developer.apple.com/documentation/corelocation/cllocationmanager.
+
 h2(#resolution). Resolution
 
 Resolution governs how often to sample locations, at what level of positional accuracy, and how often to send updates to subscribers.


### PR DESCRIPTION
## Description

Add note on Swift SDK limitations. The associated PR does not have a description, but the code comment is:

```
It's not possible to change time interval for location updates in `CLLocationManager` from Apple `CoreLocation` framework.
         Documentation: https://developer.apple.com/documentation/corelocation/cllocationmanager
```

Ticket to update docs:

* [DOC-654](https://ably.atlassian.net/browse/DOC-654)

## Review

In the Resolution section, see `desiredInterval` - time interval cannot be changed in the Swift SDK.

* [Page to review](https://ably-docs-doc-654-locat-i3lfik.herokuapp.com/asset-tracking/#resolution)
