### PR TITLE
Fix broken test API link

### DIFF
--- a/content/client-lib-development-guide/index.textile
+++ b/content/client-lib-development-guide/index.textile
@@ -55,7 +55,7 @@ h3. Sandbox environment for client library testing
 All of the Ably client libraries have test suites that run the test suite against temporary apps that are created during the test setup. Although Ably does not provide a public provisioning API for account management (in the production system this is available only through the website registration and dashboard) there is a limited API provided via the REST
 interface in the sandbox environment to enable test applications and keys to be provisioned automatically for each test run. Therefore, all tests are set up to run against the sandbox environment.
 
-See "Test API":test-api for details about the test routes provided in the REST API.
+See "Test API":/client-lib-development-guide/test-api for details about the test routes provided in the REST API.
 
 h3. Realtime protocol definition
 


### PR DESCRIPTION
Fixes a broken link to test API documentation on https://ably.com/documentation/client-lib-development-guide/