### PR TITLE
Remove extraneous enclosing scopes from mqtt examples

### DIFF
--- a/content/mqtt/index.textile
+++ b/content/mqtt/index.textile
@@ -33,12 +33,12 @@ To use the Ably MQTT protocol adapter, you'll need to ensure you correctly confi
 For example, in the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt, you'd need to specify the following:
 
 bc[nodejs]. var options = {
-    keepalive: 30,
-    username: '{{API_KEY_NAME}}', /* API key's name */
-    password: '{{API_KEY_SECRET}}', /* API key's secret */
-    port: 8883
-  };
-  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+  keepalive: 30,
+  username: '{{API_KEY_NAME}}', /* API key's name */
+  password: '{{API_KEY_SECRET}}', /* API key's secret */
+  port: 8883
+};
+var client = mqtt.connect('mqtts:mqtt.ably.io', options);
 
 
 This will connect using TLS through MQTT to Ably.
@@ -48,23 +48,23 @@ h2(#pub-sub). Publishing and Subscribing with MQTT
 "Ably's channels":/realtime/channels correlate to topics in MQTT. An example of how to publish and subscribe with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be as follows:
 
 bc[nodejs]. const mqtt = require('mqtt');
-  const encoding = require('text-encoding');
-  var decoder = new encoding.TextDecoder();
-  var options = {
-    keepalive: 30,
-    username: '{{API_KEY_NAME}}', /* API key's name */
-    password: '{{API_KEY_SECRET}}', /* API key's secret */
-    port: 8883
-  };
-  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
-  client.on('message', function(topic, message) {
-    console.log(decoder.decode(message));
-  });
-  client.subscribe('my_channel', function (err) {
-    if (!err) {
-      client.publish('my_channel', 'my_message', { qos: 0 });
-    }
-  });
+const encoding = require('text-encoding');
+var decoder = new encoding.TextDecoder();
+var options = {
+  keepalive: 30,
+  username: '{{API_KEY_NAME}}', /* API key's name */
+  password: '{{API_KEY_SECRET}}', /* API key's secret */
+  port: 8883
+};
+var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+client.on('message', function(topic, message) {
+  console.log(decoder.decode(message));
+});
+client.subscribe('my_channel', function (err) {
+  if (!err) {
+    client.publish('my_channel', 'my_message', { qos: 0 });
+  }
+});
 
 
 h2(#decoding). Decoding MQTT communication
@@ -72,24 +72,24 @@ h2(#decoding). Decoding MQTT communication
 Any data published through or received by the MQTT adapter will be binary encoded, due to MQTT being a binary protocol. This means that you'll need to interpret the message to get the original contents out. For example, to interpret a message using "Ably Realtime":https://ably.com/documentation/realtime with JavaScript you'd need to do the following, using the "text-encoding NPM module's TextDecoder":https://www.npmjs.com/package/text-encoding to decode from binary to text:
 
 bc[javascript]. var ably = new Ably.Realtime('{{API_KEY}}');
-  var decoder = new TextDecoder();
-  var channel = ably.channels.get('my_channel');
-  channel.subscribe(function(message) {
-    var command = decoder.decode(message.data);
-  });
+var decoder = new TextDecoder();
+var channel = ably.channels.get('my_channel');
+channel.subscribe(function(message) {
+  var command = decoder.decode(message.data);
+});
 
 
 Or, if you wish to decode messages received through MQTT, you can use the following in NodeJS:
 
 bc[nodejs]. const encoding = require('text-encoding');
-  var decoder = new encoding.TextDecoder();
-  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
-  client.on('connect', function () {
-    client.subscribe('my_channel');
-  });
-  client.on('message', function (topic, message) {
-    console.log(decoder.decode(message));
-  });
+var decoder = new encoding.TextDecoder();
+var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+client.on('connect', function () {
+  client.subscribe('my_channel');
+});
+client.on('message', function (topic, message) {
+  console.log(decoder.decode(message));
+});
 
 
 In the above example, @command@ will now contain the message in its original string form.
@@ -126,23 +126,23 @@ On receiving this, the client is recommended to get a new token, then disconnect
 An example of this with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be:
 
 bc[nodejs]. var client = mqtt.connect('mqtts:mqtt.ably.io', options);
-  client.subscribe('[mqtt]tokenevents');
-  client.on('message', function(topic, message) {
-    if(topic === '[mqtt]tokenevents') {
-      /* some function that fetches a new token from an auth server */
-      getNewToken(function(err, newToken) {
-        if(err) {
-          // error handling
-          return;
-        }
-        /* reconnect with the new token */
-        client.end();
-        options.username = newToken;
-        client = mqtt.connect('mqtts:mqtt.ably.io', options);
-      });
-      return;
-    }
-  });
+client.subscribe('[mqtt]tokenevents');
+client.on('message', function(topic, message) {
+  if(topic === '[mqtt]tokenevents') {
+    /* some function that fetches a new token from an auth server */
+    getNewToken(function(err, newToken) {
+      if(err) {
+        // error handling
+        return;
+      }
+      /* reconnect with the new token */
+      client.end();
+      options.username = newToken;
+      client = mqtt.connect('mqtts:mqtt.ably.io', options);
+    });
+    return;
+  }
+});
 
 
 h3(#ssl). SSL

--- a/content/mqtt/index.textile
+++ b/content/mqtt/index.textile
@@ -32,15 +32,14 @@ To use the Ably MQTT protocol adapter, you'll need to ensure you correctly confi
 
 For example, in the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt, you'd need to specify the following:
 
-bc[nodejs]. {
-  var options = {
+bc[nodejs]. var options = {
     keepalive: 30,
     username: '{{API_KEY_NAME}}', /* API key's name */
     password: '{{API_KEY_SECRET}}', /* API key's secret */
     port: 8883
   };
   var client = mqtt.connect('mqtts:mqtt.ably.io', options);
-}
+p.
 
 This will connect using TLS through MQTT to Ably.
 
@@ -48,8 +47,7 @@ h2(#pub-sub). Publishing and Subscribing with MQTT
 
 "Ably's channels":/realtime/channels correlate to topics in MQTT. An example of how to publish and subscribe with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be as follows:
 
-bc[nodejs]. {
-  const mqtt = require('mqtt');
+bc[nodejs]. const mqtt = require('mqtt');
   const encoding = require('text-encoding');
   var decoder = new encoding.TextDecoder();
   var options = {
@@ -67,25 +65,23 @@ bc[nodejs]. {
       client.publish('my_channel', 'my_message', { qos: 0 });
     }
   });
-}
+p.
 
 h2(#decoding). Decoding MQTT communication
 
 Any data published through or received by the MQTT adapter will be binary encoded, due to MQTT being a binary protocol. This means that you'll need to interpret the message to get the original contents out. For example, to interpret a message using "Ably Realtime":https://ably.com/documentation/realtime with JavaScript you'd need to do the following, using the "text-encoding NPM module's TextDecoder":https://www.npmjs.com/package/text-encoding to decode from binary to text:
 
-bc[javascript]. {
-  var ably = new Ably.Realtime('{{API_KEY}}');
+bc[javascript]. var ably = new Ably.Realtime('{{API_KEY}}');
   var decoder = new TextDecoder();
   var channel = ably.channels.get('my_channel');
   channel.subscribe(function(message) {
     var command = decoder.decode(message.data);
   });
-}
+p.
 
 Or, if you wish to decode messages received through MQTT, you can use the following in NodeJS:
 
-bc[nodejs]. {
-  const encoding = require('text-encoding');
+bc[nodejs]. const encoding = require('text-encoding');
   var decoder = new encoding.TextDecoder();
   var client = mqtt.connect('mqtts:mqtt.ably.io', options);
   client.on('connect', function () {
@@ -94,7 +90,7 @@ bc[nodejs]. {
   client.on('message', function (topic, message) {
     console.log(decoder.decode(message));
   });
-}
+p.
 
 In the above example, @command@ will now contain the message in its original string form.
 
@@ -129,8 +125,7 @@ On receiving this, the client is recommended to get a new token, then disconnect
 
 An example of this with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be:
 
-bc[nodejs]. {
-  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+bc[nodejs]. var client = mqtt.connect('mqtts:mqtt.ably.io', options);
   client.subscribe('[mqtt]tokenevents');
   client.on('message', function(topic, message) {
     if(topic === '[mqtt]tokenevents') {
@@ -148,7 +143,7 @@ bc[nodejs]. {
       return;
     }
   });
-}
+p.
 
 h3(#ssl). SSL
 

--- a/content/mqtt/index.textile
+++ b/content/mqtt/index.textile
@@ -39,7 +39,7 @@ bc[nodejs]. var options = {
     port: 8883
   };
   var client = mqtt.connect('mqtts:mqtt.ably.io', options);
-p.
+
 
 This will connect using TLS through MQTT to Ably.
 
@@ -65,7 +65,7 @@ bc[nodejs]. const mqtt = require('mqtt');
       client.publish('my_channel', 'my_message', { qos: 0 });
     }
   });
-p.
+
 
 h2(#decoding). Decoding MQTT communication
 
@@ -77,7 +77,7 @@ bc[javascript]. var ably = new Ably.Realtime('{{API_KEY}}');
   channel.subscribe(function(message) {
     var command = decoder.decode(message.data);
   });
-p.
+
 
 Or, if you wish to decode messages received through MQTT, you can use the following in NodeJS:
 
@@ -90,7 +90,7 @@ bc[nodejs]. const encoding = require('text-encoding');
   client.on('message', function (topic, message) {
     console.log(decoder.decode(message));
   });
-p.
+
 
 In the above example, @command@ will now contain the message in its original string form.
 
@@ -143,7 +143,7 @@ bc[nodejs]. var client = mqtt.connect('mqtts:mqtt.ably.io', options);
       return;
     }
   });
-p.
+
 
 h3(#ssl). SSL
 

--- a/content/mqtt/index.textile
+++ b/content/mqtt/index.textile
@@ -32,14 +32,16 @@ To use the Ably MQTT protocol adapter, you'll need to ensure you correctly confi
 
 For example, in the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt, you'd need to specify the following:
 
-bc[nodejs]. var options = {
+```[nodejs]
+var options = {
   keepalive: 30,
   username: '{{API_KEY_NAME}}', /* API key's name */
   password: '{{API_KEY_SECRET}}', /* API key's secret */
   port: 8883
 };
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
 
+var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+```
 
 This will connect using TLS through MQTT to Ably.
 
@@ -47,7 +49,8 @@ h2(#pub-sub). Publishing and Subscribing with MQTT
 
 "Ably's channels":/realtime/channels correlate to topics in MQTT. An example of how to publish and subscribe with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be as follows:
 
-bc[nodejs]. const mqtt = require('mqtt');
+```[nodejs]
+const mqtt = require('mqtt');
 const encoding = require('text-encoding');
 var decoder = new encoding.TextDecoder();
 var options = {
@@ -56,41 +59,49 @@ var options = {
   password: '{{API_KEY_SECRET}}', /* API key's secret */
   port: 8883
 };
+
 var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+
 client.on('message', function(topic, message) {
   console.log(decoder.decode(message));
 });
+
 client.subscribe('my_channel', function (err) {
   if (!err) {
     client.publish('my_channel', 'my_message', { qos: 0 });
   }
 });
-
+```
 
 h2(#decoding). Decoding MQTT communication
 
 Any data published through or received by the MQTT adapter will be binary encoded, due to MQTT being a binary protocol. This means that you'll need to interpret the message to get the original contents out. For example, to interpret a message using "Ably Realtime":https://ably.com/documentation/realtime with JavaScript you'd need to do the following, using the "text-encoding NPM module's TextDecoder":https://www.npmjs.com/package/text-encoding to decode from binary to text:
 
-bc[javascript]. var ably = new Ably.Realtime('{{API_KEY}}');
+```[javascript] 
+var ably = new Ably.Realtime('{{API_KEY}}');
 var decoder = new TextDecoder();
 var channel = ably.channels.get('my_channel');
+
 channel.subscribe(function(message) {
   var command = decoder.decode(message.data);
 });
-
+```
 
 Or, if you wish to decode messages received through MQTT, you can use the following in NodeJS:
 
-bc[nodejs]. const encoding = require('text-encoding');
+```[nodejs]
+const encoding = require('text-encoding');
 var decoder = new encoding.TextDecoder();
 var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+
 client.on('connect', function () {
   client.subscribe('my_channel');
 });
+
 client.on('message', function (topic, message) {
   console.log(decoder.decode(message));
 });
-
+```
 
 In the above example, @command@ will now contain the message in its original string form.
 
@@ -125,8 +136,10 @@ On receiving this, the client is recommended to get a new token, then disconnect
 
 An example of this with the NodeJS "MQTT package":https://www.npmjs.com/package/mqtt would be:
 
-bc[nodejs]. var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+```[nodejs]
+var client = mqtt.connect('mqtts:mqtt.ably.io', options);
 client.subscribe('[mqtt]tokenevents');
+
 client.on('message', function(topic, message) {
   if(topic === '[mqtt]tokenevents') {
     /* some function that fetches a new token from an auth server */
@@ -143,7 +156,7 @@ client.on('message', function(topic, message) {
     return;
   }
 });
-
+```
 
 h3(#ssl). SSL
 


### PR DESCRIPTION
## Description

Removes enclosing scopes (`{}`) from the MQTT code snippets. These were unnecessary, and the examples look better without them.

![image](https://user-images.githubusercontent.com/25511700/156150255-16d72311-5b65-4930-8ffa-a3dcb688ee53.png)

## Review

Code samples on this page:

* [MQTT](https://ably-docs-mqtt-remove-s-r7kvzw.herokuapp.com/mqtt/)