### PR TITLE
DOC-552: Correct API key format

### DIFF
--- a/content/rest-api/token-request-spec.textile
+++ b/content/rest-api/token-request-spec.textile
@@ -13,7 +13,7 @@ However, if you are using the "REST API token endpoint directly":/rest-api/#requ
 
 h3(#api-key-format). API key format
 
-API keys are issued and managed from "within your account dashboard":https://faqs.ably.com/setting-up-and-managing-api-keys. The API key string available in your dashboard is structured as a triple @<app ID>:<key ID>:<key value>@, where:
+API keys are issued and managed from "within your account dashboard":https://faqs.ably.com/setting-up-and-managing-api-keys. The API key string available in your dashboard is structured as a triple @<app ID>.<key ID>:<key value>@, where:
 
 - app ID := (public) identifier for the application
 - key ID := (public) identifier for the key in question: this uniquely identifies the key and is a system-assigned, URL-safe, identifier


### PR DESCRIPTION
## Description

This PR corrects the API key format from using a`:` as the first separator to a `.`.
