### PR TITLE
channel wildcard clarification

### DIFF
--- a/content/partials/shared/_channel_namespaces.textile
+++ b/content/partials/shared/_channel_namespaces.textile
@@ -6,6 +6,8 @@ For example, the following channels are all part of the "public" namespace:
 * @public:events@
 * @public:news:americas@
 
+*Note* that wildcards are not supported in channel namespaces.
+
 The namespace attributes that can be configured are:
 
 * **Persist all messages** - if enabled, all messages within this namespace will be stored according to the storage rules for your account (24 hours for free accounts). You can access stored messages via the "history API":/realtime/history . Please note that for each message stored, an additional message is deducted from your monthly allocation.

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -143,7 +143,7 @@ In order to "publish":/realtime/messages#message-publish, "subscribe":/realtime/
 
 h3(#obtaining-channel). Obtaining a channel instance
 
-A @Channel@ object is a reference to a single channel. A channel instance is obtained from the "@channels@ collection":/realtime/usage/#channels of the <span lang="ruby">@Realtime::Client@</span><span lang="default">@Realtime@</span><span lang="objc,swift">@ARTRealtime@</span><span lang="csharp">@AblyRealtime@</span> instance, and is uniquely identified by its unicode string name. Find out more about "channel naming":https://faqs.ably.com/what-restrictions-are-there-on-channel-names
+A @Channel@ object is a reference to a single channel. A channel instance is obtained from the "@channels@ collection":/realtime/usage/#channels of the <span lang="ruby">@Realtime::Client@</span><span lang="default">@Realtime@</span><span lang="objc,swift">@ARTRealtime@</span><span lang="csharp">@AblyRealtime@</span> instance, and is uniquely identified by its unicode string name. You can only connect to one channel in a single operation, so wildcards are not supported. Find out more about "channel naming":https://faqs.ably.com/what-restrictions-are-there-on-channel-names
 
 bc[jsall](code-editor:realtime/channel). var channel = realtime.channels.get('channelName');
 

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -165,7 +165,7 @@ In order to publish, retrieve message history or access presence history, you mu
 
 h3(#obtain-channel). Obtaining a channel instance
 
-A @Channel@ object is a reference to a single channel. A channel instance is obtained from the "@channels@ collection":/rest/usage/#channels of the <span lang="ruby">@Rest::Client@</span><span lang="php">@AblyRest@</span><span lang="default">@Rest@</span> instance, and is uniquely identified by its unicode string name. Find out more about "channel naming":https://faqs.ably.com/what-restrictions-are-there-on-channel-names
+A @Channel@ object is a reference to a single channel. A channel instance is obtained from the "@channels@ collection":/rest/usage/#channels of the <span lang="ruby">@Rest::Client@</span><span lang="php">@AblyRest@</span><span lang="default">@Rest@</span> instance, and is uniquely identified by its unicode string name. You can only connect to one channel in a single operation, so wildcards are not supported. Find out more about "channel naming":https://faqs.ably.com/what-restrictions-are-there-on-channel-names
 
 bc[jsall]. var channel = rest.channels.get('channelName');
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

[The GitHub issue](https://github.com/ably/docs/issues/836) provides more context as there was some initial confusion as to whether wildcard but wildcards are [**not** supported](https://github.com/ably/docs/issues/836#issuecomment-599473068). 

There's some [occasional customer confusion](https://github.com/ably/docs/issues/836#issuecomment-725290103) so added a simple clarification line to the channel pages.

* [Quick wins](https://ably.atlassian.net/browse/DOC-609)
* [DOC-207](https://ably.atlassian.net/browse/DOC-207).

## Review

Check clarification that channels doesn't support wildcards:

* [REST - Channels](https://ably-docs-doc-207-chann-xzpugw.herokuapp.com/rest/channels/)
* [Realtime - Channels](https://ably-docs-doc-207-chann-xzpugw.herokuapp.com/realtime/channels/)
