### PR TITLE
EDX-39: Map index.textile files to root / paths instead of /index pages

### DIFF
--- a/data/transform/index.js
+++ b/data/transform/index.js
@@ -138,7 +138,10 @@ const splitDataAndMetaData = (text) => {
 const transformNanocTextiles =
   (node, content, id, type, { createNodesFromPath, createContentDigest, createNodeId }) =>
   (updateWithTransform) => {
-    const slug = node.relativePath.replace(/(.*)\.[^.]+$/, '$1').replace('root/', '');
+    const slug = node.relativePath
+      .replace(/(.*)\.[^.]+$/, '$1')
+      .replace('root/', '')
+      .replace(/index$/, '');
     if (node.sourceInstanceName === 'textile-partials') {
       content = `${content}\n`;
     }


### PR DESCRIPTION
## Description

Index.textile files should appear on root / paths instead of /index pages

* [Jira ticket](https://ably.atlassian.net/browse/EDX-39).

## Review

Instructions on how to review the PR. 

* Check that slugs are created in the appropriate way.