### PR TITLE
Quick start guide changes to support paid campaign experiment

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -42,6 +42,10 @@ p(tip#terms). The terms used in the guide such as 'connection', 'channel', 'mess
 
 You're currently viewing the guide in <span lang="javascript">JavaScript</span><span lang="nodejs">Node.js</span><span lang="java">Java</span><span lang="ruby">Ruby</span><span lang="objc">Objective-C</span><span lang="python">Python</span><span lang="php">PHP</span><span lang="swift">Swift</span><span lang="csharp">C# .NET</span><span lang="flutter">Flutter</span><span lang="go">Go</span>. If you would like to view it in another language, use the selector above to change it. 
 
+h2(#step-0). Create an Ably account
+
+The following code sample uses a demo API key to authenticate however you can use your own API key if you already have an account, or "sign up":https://ably.com/signup for a free account to obtain one. Just ensure that the key provides the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
+
 h2(#step-1). Add the Ably Client Library SDK
 
 blang[javascript].
@@ -52,6 +56,10 @@ blang[javascript].
   bc[html]. <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
 
   The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
+
+  ```[sh]
+  npm install ably
+  ```
 
 blang[nodejs].
   The Ably Client Library SDK is available as an "NPM module":https://www.npmjs.com/package/ably.
@@ -243,9 +251,7 @@ blang[go].
 h2(#step-2). Connect to Ably
 
 blang[default].
-  Clients need to authenticate with Ably to establish a realtime connection. The following code sample uses a demo API key to authenticate and print the message @Connected to Ably!@ when you've successfully connected.
-
-  Alternatively, you can use your own API key if you already have an account, or "sign up":https://ably.com/signup for a free account to obtain one. Just ensure that the key provides the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
+  Clients need to authenticate with Ably to establish a realtime connection, typically over "WebSockets":https://ably.com/topic/websockets. The following code sample prints the message @Connected to Ably!@ when you've successfully connected.
 
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create a realtime connection to Ably. Use the language selector above to select a language with realtime support.


### PR DESCRIPTION
## Description

- Add a dedicated signup step
- Mention WebSocket related to connecting
- Small unrelated change to add missing `npm` command

## Review

- Open the quick start guide page
