### PR TITLE
Minor fix to dropdown in Quickstart

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -18,6 +18,7 @@ languages:
   - go
 jump_to:
   Help with:
+    - Create an Ably account#step-0
     - Add the Ably SDK#step-1
     - Connect to Ably#step-2
     - Subscribe to a channel#step-3


### PR DESCRIPTION
## Description

Minor fix to "jump to" dropdown.

## Review

Navigate to quickstart page. In the "jump to" selector select "Create Ably account" item - this should jump you down to the correct section. 

* [Quickstart](http://ably-docs-fix-toc-dropd-nmdqia.herokuapp.com/quick-start-guide/)
