### PR TITLE
Quick start guide "Create an Ably Account works" tweaks

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -47,7 +47,7 @@ h2(#step-0). Create an Ably account
 
 "Sign up":https://ably.com/signup for a free account to get your own API key.
 
-The following code sample uses a demo API key to authenticate; however, you can use your API key. Ensure that the key provides the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
+The following code sample uses a demo API key to authenticate. Alternatively, you can use your Ably API key if you have an Ably account. Ensure that your Ably API key includes the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
 
 h2(#step-1). Add the Ably Client Library SDK
 

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -45,7 +45,9 @@ You're currently viewing the guide in <span lang="javascript">JavaScript</span><
 
 h2(#step-0). Create an Ably account
 
-The following code sample uses a demo API key to authenticate however you can use your own API key if you already have an account, or "sign up":https://ably.com/signup for a free account to obtain one. Just ensure that the key provides the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
+"Sign up":https://ably.com/signup for a free account to get your own API key.
+
+The following code sample uses a demo API key to authenticate; however, you can use your API key. Ensure that the key provides the subscribe and publish "capabilities":/core-features/authentication#capabilities-explained.
 
 h2(#step-1). Add the Ably Client Library SDK
 


### PR DESCRIPTION

## Description

Updated the textual content to first call out signing up.

The subsequent paragraph provides alternatives e.g. use the demo API key.
