### PR TITLE
Edx 45 menu items

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -48,6 +48,7 @@ const shouldUpdateScroll = ({ prevRouterProps, routerProps: { location } }) => {
 
   const plainCurr = curr.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
   const plainPrev = prev.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
+  console.log(plainCurr, plainPrev);
 
   return (
     plainCurr !== plainPrev && // If the current location is a variant of the previous location, do not update scroll

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -12,7 +12,7 @@ import {
 
 import sprites from '@ably/ui/core/sprites.svg';
 
-const PAGE_OFFSET = 94;
+const PAGE_OFFSET = 128;
 
 const offsetScroll = () => window.scrollBy(0, -PAGE_OFFSET);
 
@@ -31,9 +31,14 @@ const onClientEntry = () => {
 };
 
 const versionRegex = /\/versions\/v\d+\.\d+/;
-const languageRegex = /\/language\/\w+/;
+const languageRegex = /\?lang=\w+/;
 const hashRegex = /(\/?#.*)$/;
 
+/**
+ *  The 'shouldUpdateScroll' function does not pertain to the offsetScroll event listener above
+ *  `shouldUpdateScroll` is specific to Gatsby
+ *  `offsetScroll` is a simple event listener with no dependencies (other than 'window')
+ */
 const shouldUpdateScroll = ({ prevRouterProps, routerProps: { location } }) => {
   if (!prevRouterProps || !location) {
     return false;
@@ -43,11 +48,13 @@ const shouldUpdateScroll = ({ prevRouterProps, routerProps: { location } }) => {
 
   const plainCurr = curr.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
   const plainPrev = prev.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
+  console.log(plainCurr, plainPrev);
 
   return (
     plainCurr !== plainPrev && // If the current location is a variant of the previous location, do not update scroll
-    !(location.href.indexOf('#') > -1)
-  ); // If we're going to any hash link on page B from page A, do not update scroll; we want to visit the specific section
+    !(curr.indexOf('#') > -1) &&
+    !(prev.indexOf('#') > -1) // If we're going to or from any hash link on page B from page A, do not update scroll; we want to visit the specific section
+  );
 };
 
 export { onClientEntry, shouldUpdateScroll };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -48,7 +48,6 @@ const shouldUpdateScroll = ({ prevRouterProps, routerProps: { location } }) => {
 
   const plainCurr = curr.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
   const plainPrev = prev.replace(versionRegex, '').replace(languageRegex, '').replace(hashRegex, '');
-  console.log(plainCurr, plainPrev);
 
   return (
     plainCurr !== plainPrev && // If the current location is a variant of the previous location, do not update scroll

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ChildPropTypes } from '../../react-utilities';
 
-const Article = ({ columns = 3, children }) => <article className={`col-span-${columns}`}>{children}</article>;
+const Article = ({ columns = 3, children }) => <article className={`mt-12 col-span-${columns}`}>{children}</article>;
 
 Article.propTypes = {
   columns: PropTypes.number,

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -8,7 +8,7 @@ const Layout = ({ languages, children }) => (
     <header>
       <Header languages={languages} />
     </header>
-    <main className={`pt-128 grid grid-cols-5`}>{children}</main>
+    <main className={`${languages && languages.length > 1 ? 'pt-128' : 'pt-96'} grid grid-cols-5`}>{children}</main>
   </>
 );
 

--- a/src/components/Sidebar/SidebarItem.js
+++ b/src/components/Sidebar/SidebarItem.js
@@ -33,7 +33,7 @@ const AccordionHeadingPropTypes = {
 const InteractableAccordionHeading = ({ label, level }) => (
   <div className={`flex justify-between`}>
     {label}
-    <AccordionItemHeading className="bg-containers-three w-28" aria-level={level || ROOT_LEVEL}>
+    <AccordionItemHeading aria-level={level || ROOT_LEVEL}>
       <AccordionItemButton>
         <AccordionItemState>
           {({ expanded }) => <ExpandableIndicator className={'h-full mx-8'} expanded={expanded} />}

--- a/src/components/Sidebar/StickySidebar.js
+++ b/src/components/Sidebar/StickySidebar.js
@@ -3,7 +3,7 @@ import { spacing, mq, colors } from '../../styles';
 
 // Source: Voltaire. See Ably UI if we need shared component.
 const NAV_HEIGHT_DESKTOP = 64;
-const DISTANCE_FROM_TOP_DESKTOP = spacing.large.value;
+const DISTANCE_FROM_TOP_DESKTOP = 0;
 
 const StickySidebar = styled.aside`
   transition: transform 0.3s;

--- a/src/components/Sidebar/StickySidebar.js
+++ b/src/components/Sidebar/StickySidebar.js
@@ -30,7 +30,7 @@ const StickySidebar = styled.aside`
     width: 100%;
     height: 10%;
     bottom: 0;
-    background: linear-gradient(0deg, white 0%, rgba(0, 0, 0, 0) 100%);
+    background: linear-gradient(0deg, white 0%, rgba(255, 255, 255, 0) 100%);
     touch-action: none;
     pointer-events: none;
   }

--- a/src/components/Sidebar/styles.js
+++ b/src/components/Sidebar/styles.js
@@ -11,7 +11,7 @@ const SidebarHeadingStyle = css`
   text-decoration: none;
   margin-left: ${({ $leaf, indent }) => `${($leaf ? 4 : 0) + (indent ?? 0)}px`};
 
-  color: ${({ active }) => (active ? colors.text.linkHoverAlternate : colors.text.main)};
+  color: ${({ active }) => (active ? colors.text.linkHoverAlternate : colors.text.link)};
   border-left: ${({ active, $leaf }) =>
     active
       ? `${$leaf ? 1 : 2}px solid ${colors.text.linkHoverAlternateMuted}`
@@ -25,9 +25,6 @@ const SidebarHeadingStyle = css`
   ${mq.minWidth.small} {
     padding: ${spacing.xsmall} ${spacing.small};
   }
-
-  border-image: linear-gradient(to left, white, ${colors.containers.one} 25%, ${colors.containers.one} 75%, white) 1;
-  border-bottom: 1px solid;
 `;
 
 export { SidebarHeadingStyle };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "strictNullChecks": true,                            /* When type checking, take into account `null` and `undefined`. */
     "resolveJsonModule": true,                           /* Enable importing .json files */
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "outDir": "./dist"
+  },
+  "include": ["./src/**/*", "./data/**/*"],
+  "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Replacing all menu items with styled menu items that match our style guide.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-45).

## Review

Check that menu items render correctly per https://www.figma.com/file/4KdtIEGY2BfZPq5tT1u6D3/Migration-Guide?node-id=21%3A346

Verify that updated scrolling behaviour makes sense (in code or by checking): intended behaviour is that:
* Gatsby never takes over scrolling when moving between variations of a particular page (e.g. different language variations)
* Gatsby never takes over scrolling when moving to or from a specific section link (e.g. #channel-states)
* Gatsby scrolls user to top when viewing a completely new page.

Other changes:
* `    background: linear-gradient(0deg, white 0%, rgba(255, 255, 255, 0) 100%);` - this ensures that the gradient 'scroll more' hint works on older Safari versions, cf. https://stackoverflow.com/questions/38391457/linear-gradient-to-transparent-bug-in-latest-safari
* TSConfig has been fixed so it won't throw false positive errors, by giving it an output directory & include/exclude paths