### PR TITLE
[EDX-42] GUI colours

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,17 +3,12 @@
       "eslint:recommended",
       "plugin:prettier/recommended",
       "plugin:jest/recommended",
-      "plugin:jest/style",
-      "plugin:react/recommended",
-      "plugin:react-hooks/recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended"
+      "plugin:jest/style"
     ],
     "plugins": [
       "jest",
       "prettier",
-      "react",
-      "@typescript-eslint"
+      "react"
     ],
     "rules": {
       "react/display-name": 0
@@ -44,5 +39,18 @@
       "react": {
         "version": "detect"
       }
-    }
+    },
+    "overrides": [
+      // Typescript
+      {
+          "files": ["*.ts", "*.tsx"],
+          "extends": [
+            "plugin:react/recommended",
+            "plugin:react-hooks/recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended"
+          ],
+          "plugins": ["@typescript-eslint"]
+      }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,12 +5,15 @@
       "plugin:jest/recommended",
       "plugin:jest/style",
       "plugin:react/recommended",
-      "plugin:react-hooks/recommended"
+      "plugin:react-hooks/recommended",
+      "plugin:@typescript-eslint/eslint-recommended",
+      "plugin:@typescript-eslint/recommended"
     ],
     "plugins": [
       "jest",
       "prettier",
-      "react"
+      "react",
+      "@typescript-eslint"
     ],
     "rules": {
       "react/display-name": 0
@@ -24,7 +27,7 @@
     "globals": {
       "mockMatchMedia": true
     },
-    "parser": "babel-eslint",
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
       "ecmaFeatures": {
         "jsx": true

--- a/src/components/blocks/external-references/A.js
+++ b/src/components/blocks/external-references/A.js
@@ -5,13 +5,13 @@ import Html from '../Html';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
 import { DOCUMENTATION_NAME } from '../../../../data/transform/constants';
 
-import '@ably/ui/core/styles.css';
+import './styles.css';
 
 const onPageNav = /[#?]/;
 
 // eslint-disable-next-line react/prop-types
 const StyledGatsbyLink = ({ children, ...props }) => (
-  <Link className="ui-link" {...props}>
+  <Link className="docs-link" {...props}>
     {children}
   </Link>
 );
@@ -32,7 +32,7 @@ const A = ({ data, attribs }) => {
       </StyledGatsbyLink>
     );
   }
-  return GenericHtmlBlock('a')({ data, attribs: { ...attribs, className: 'ui-link' } });
+  return GenericHtmlBlock('a')({ data, attribs: { ...attribs, className: 'docs-link' } });
 };
 
 A.propTypes = {

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'gatsby';
+import { GatsbyLinkProps, Link } from 'gatsby';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Html from '../Html';
@@ -9,9 +9,8 @@ import './styles.css';
 
 const onPageNav = /[#?]/;
 
-// eslint-disable-next-line react/prop-types
-const StyledGatsbyLink = ({ children, ...props }) => (
-  <Link className="docs-link" {...props}>
+const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<{}>, 'ref'>) => (
+  <Link className="docs-link" to={to} {...props}>
     {children}
   </Link>
 );
@@ -27,7 +26,7 @@ const A = ({ data, attribs }) => {
       href = `/${DOCUMENTATION_NAME}${attribs.href}`;
     }
     return (
-      <StyledGatsbyLink {...{ ...attribs, to: href }}>
+      <StyledGatsbyLink to={href} {...{ ...attribs }}>
         <Html data={data} />
       </StyledGatsbyLink>
     );

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -1,21 +1,22 @@
 import { GatsbyLinkProps, Link } from 'gatsby';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import Html from '../Html';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
 import { DOCUMENTATION_NAME } from '../../../../data/transform/constants';
+import { HtmlComponentProps } from '../../html-component-props';
 
 import './styles.css';
 
 const onPageNav = /[#?]/;
 
-const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<{}>, 'ref'>) => (
+const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'>) => (
   <Link className="docs-link" to={to} {...props}>
     {children}
   </Link>
 );
 
-const A = ({ data, attribs }) => {
+const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
   if (
     attribs.href &&
     /^(\/|#|https?:\/\/(?:www.)?ably.com\/docs).*/.test(attribs.href) &&

--- a/src/components/blocks/external-references/__snapshots__/A.test.js.snap
+++ b/src/components/blocks/external-references/__snapshots__/A.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Different data provided to link elements results in different components Successfully renders Gatsby links 1`] = `
 <a
-  className="ui-link"
+  className="docs-link"
   href="https://www.ably.com/docs/lorem"
 >
   Lorem ipsum
@@ -11,7 +11,7 @@ exports[`Different data provided to link elements results in different component
 
 exports[`Different data provided to link elements results in different components Successfully renders normal links 1`] = `
 <a
-  className="ui-link"
+  className="docs-link"
   href="https://www.example.com"
 >
   Lorem ipsum

--- a/src/components/blocks/external-references/styles.css
+++ b/src/components/blocks/external-references/styles.css
@@ -1,0 +1,1 @@
+@import '@ably/ui/core/styles.css';

--- a/src/components/blocks/external-references/styles.css
+++ b/src/components/blocks/external-references/styles.css
@@ -14,10 +14,10 @@
     }
     .docs-link:hover {
         color: var(--color-gui-hover);
-        text-decoration-color: var(--color-active-orange);
+        text-decoration-color: var(--color-gui-hover);
         -webkit-text-decoration-line: underline;
         text-decoration-line: underline;
-        text-decoration-thickness: 0.125rem;
+        text-decoration-thickness: 0.0625rem;
         text-underline-offset: 4px;
     }
 }

--- a/src/components/blocks/external-references/styles.css
+++ b/src/components/blocks/external-references/styles.css
@@ -1,1 +1,23 @@
 @import '@ably/ui/core/styles.css';
+@layer components {
+    .docs-link {
+        color: var(--color-gui-default);
+    }
+    .docs-link:viewed {
+        color: var(--color-gui-viewed);
+    }
+    .docs-link:active {
+        color: var(--color-gui-active);
+    }
+    .docs-link:focus {
+        color: var(--color-gui-focus);
+    }
+    .docs-link:hover {
+        color: var(--color-gui-hover);
+        text-decoration-color: var(--color-active-orange);
+        -webkit-text-decoration-line: underline;
+        text-decoration-line: underline;
+        text-decoration-thickness: 0.125rem;
+        text-underline-offset: 4px;
+    }
+}

--- a/src/components/blocks/software/Code.js
+++ b/src/components/blocks/software/Code.js
@@ -30,7 +30,7 @@ import HtmlDataTypes from '../../../../data/types/html';
 import { ChildPropTypes } from '../../../react-utilities';
 
 const SelectedLanguage = ({ language }) =>
-  language ? <div className="doc-language-label">{language.label}</div> : null;
+  language ? <div className="docs-language-label">{language.label}</div> : null;
 
 SelectedLanguage.propTypes = {
   language: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),

--- a/src/components/blocks/software/Pre.js
+++ b/src/components/blocks/software/Pre.js
@@ -7,7 +7,7 @@ import '@ably/ui/core/styles.css';
 const Pre = ({ data, language, languages, altData, attribs }) => {
   const withModifiedClassname = {
     ...attribs,
-    className: `doc-pre-container`,
+    className: `docs-pre-container`,
   };
   return (
     <pre {...withModifiedClassname}>

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -9,7 +9,6 @@ const Pre = ({ data, language, languages, altData, attribs }: PreProps): ReactEl
     ...attribs,
     className: `docs-pre-container`,
   };
-  console.log(altData);
   return (
     <pre {...withModifiedClassname}>
       {language ? (

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import PropType from 'prop-types';
+import React, { ReactElement } from 'react';
 import Html from '../Html';
 import LocalLanguageAlternatives from '../wrappers/LocalLanguageAlternatives';
 import '@ably/ui/core/styles.css';
+import { PreProps } from './pre-props';
 
-const Pre = ({ data, language, languages, altData, attribs }) => {
+const Pre = ({ data, language, languages, altData, attribs }: PreProps): ReactElement => {
   const withModifiedClassname = {
     ...attribs,
     className: `docs-pre-container`,
   };
+  console.log(altData);
   return (
     <pre {...withModifiedClassname}>
       {language ? (
@@ -20,14 +21,6 @@ const Pre = ({ data, language, languages, altData, attribs }) => {
       )}
     </pre>
   );
-};
-
-Pre.propTypes = {
-  data: PropType.array,
-  language: PropType.string,
-  languages: PropType.array,
-  altData: PropType.object,
-  attribs: PropType.object,
 };
 
 export default Pre;

--- a/src/components/blocks/software/__snapshots__/Code.test.js.snap
+++ b/src/components/blocks/software/__snapshots__/Code.test.js.snap
@@ -7,7 +7,7 @@ exports[`Different langs provided to Code elements results in different renderin
   language="JS"
 >
   <div
-    className="doc-language-label"
+    className="docs-language-label"
   >
     JS
   </div>

--- a/src/components/blocks/software/__snapshots__/Pre.test.js.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Different langs provided to Code elements results in different rendering Successfully renders Code elements with language 1`] = `
 <pre
-  className="doc-pre-container"
+  className="docs-pre-container"
 >
   <menu
     className="docs-horizontal-menu"

--- a/src/components/blocks/software/pre-props.ts
+++ b/src/components/blocks/software/pre-props.ts
@@ -1,0 +1,7 @@
+import { HtmlComponentProps } from '../../html-component-props';
+
+export type PreProps = HtmlComponentProps<'pre'> & {
+  language: string;
+  languages: string[];
+  altData?: Record<string, HtmlComponentProps<any>>[];
+};

--- a/src/components/blocks/software/styles.css
+++ b/src/components/blocks/software/styles.css
@@ -4,11 +4,11 @@
     @apply bg-cool-black p-32 overflow-auto;
   }
 
-  .doc-pre-container {
+  .docs-pre-container {
     @apply bg-cool-black text-white p-0 rounded-lg border border-cool-black mb-32;
   }
 
-  .doc-language-label {
+  .docs-language-label {
       @apply absolute top-4 right-4 bg-charcoal-grey p-4 ui-text-menu3;
       color: #D9D9DA;
   }

--- a/src/components/blocks/wrappers/CopyLink.js
+++ b/src/components/blocks/wrappers/CopyLink.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ChildPropTypes } from '../../../react-utilities';
 import styled from 'styled-components';
 import AILink from '../../../styles/svg/ai-link';
-import { secondary, tertiary } from '../../../styles/colors';
+import { gui, secondary } from '../../../styles/colors';
 
 const StyledLinkCopyButton = styled.button`
   height: 100%;
@@ -15,11 +15,13 @@ const StyledLinkCopyButton = styled.button`
   }
 `;
 
+const successColor = ({ copySuccess }) => (copySuccess ? gui.success : copySuccess === null ? '#fff' : gui.error);
+
 const LinkHoverPopup = styled.div`
   display: inline-block;
   position: absolute;
-  background-color: ${({ copySuccess }) =>
-    copySuccess ? tertiary.backgroundGreen : copySuccess === null ? '#fff' : tertiary.warningRed};
+  background-color: ${successColor};
+
   box-shadow: 0px 2px 20px 0px rgba(0, 0, 0, 0.3);
   border-radius: 4px;
   color: ${secondary.cableGrey};
@@ -41,9 +43,7 @@ const LinkHoverPopup = styled.div`
     bottom: 64px;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
-    border-bottom: 10px solid
-      ${({ copySuccess }) =>
-        copySuccess ? tertiary.backgroundGreen : copySuccess === null ? '#fff' : tertiary.warningRed};
+    border-bottom: 10px solid ${successColor};
     z-index: inherit;
     transition: border-bottom 1000ms linear;
   }

--- a/src/components/blocks/wrappers/__snapshots__/CopyLink.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/CopyLink.test.js.snap
@@ -60,7 +60,7 @@ exports[`CopyLink displays statically as expected Snapshot of CopyLink with ID i
 
 exports[`LinkHoverPopup displays statically as expected Snapshot of LinkHoverPopup is the same 1`] = `
 <div
-  className="sc-gsnTZi umynZ"
+  className="sc-gsnTZi LulRR"
 >
   Hover popup
 </div>
@@ -68,7 +68,7 @@ exports[`LinkHoverPopup displays statically as expected Snapshot of LinkHoverPop
 
 exports[`LinkHoverPopup displays statically as expected Snapshot of LinkHoverPopup with Failure is the same 1`] = `
 <div
-  className="sc-gsnTZi dTwtyh"
+  className="sc-gsnTZi epoIIV"
 >
   Failure
 </div>
@@ -76,7 +76,7 @@ exports[`LinkHoverPopup displays statically as expected Snapshot of LinkHoverPop
 
 exports[`LinkHoverPopup displays statically as expected Snapshot of LinkHoverPopup with Success is the same 1`] = `
 <div
-  className="sc-gsnTZi fCKVBl"
+  className="sc-gsnTZi jownJl"
 >
   Success
 </div>

--- a/src/components/html-component-props.ts
+++ b/src/components/html-component-props.ts
@@ -1,7 +1,8 @@
 import { Component, FunctionComponent, JSXElementConstructor } from 'react';
 
-export type Attribs<
+export type HtmlComponentProps<
   T extends keyof JSX.IntrinsicElements | JSXElementConstructor<typeof Component | FunctionComponent>,
 > = {
   attribs: React.ComponentProps<T>;
+  data: HtmlComponentProps<any>[];
 };

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -17,9 +17,9 @@ export const secondary = {
   subtleOrange: '#fde9d7',
 };
 
-export const tertiary = {
-  warningRed: '#FFCCCB',
-  backgroundGreen: '#98FB98',
+export const gui = {
+  error: '#FB0C0C',
+  success: '#11CB24',
 };
 
 export const containers = {


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Updates GUI colors to be in line with migration guide: https://www.figma.com/file/4KdtIEGY2BfZPq5tT1u6D3/Migration-Guide?node-id=0%3A410

* [Jira ticket](https://ably.atlassian.net/browse/EDX-42).

## Review

Ensure that new colors match guidelines provided by Lenka here:

"I raised this with Jamie and he decided to change the colour of the hyperlinks to our GUI Blue Default and display the underline only on hover. I already updated the Migration Guide. You can use our Active Blue, Focus Blue etc. for other states."

Ensure references to the pre-migration GUI colors are no longer used in the code base.