### PR TITLE
[EDX-86]: Migrate realtime stats API reference

### DIFF
--- a/content/api/realtime-sdk/stats.textile
+++ b/content/api/realtime-sdk/stats.textile
@@ -1,0 +1,62 @@
+---
+title: Statistics
+meta_description: "Realtime Client Library SDK API reference section for the stats object."
+meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, stats, statistics"
+section: api
+index: 50
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - java
+  - swift
+  - objc
+  - csharp
+jump_to:
+  API reference:
+    - stats#stats
+  Types:
+    - Related Types#related-types
+---
+
+h6(#stats). stats
+
+bq(definition).
+  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
+  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
+  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
+  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
+  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
+
+This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
+
+<%= partial partial_version('realtime/_stats') %>
+
+h2(#related-types). Related types
+
+h3(#stats-type).
+  default: Stats object
+  objc,swift: ARTStats
+  java:    io.ably.lib.types.Stats
+  ruby:    Ably::Models::Stats
+  csharp:  IO.Ably.Stats
+
+<%= partial partial_version('types/_stats') %>
+
+h3(#stats-request-params).
+  csharp: IO.Ably.StatsRequestParams
+
+blang[csharp].
+  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
+
+h3(#stats-granularity).
+  objc,swift: ARTStatsGranularity
+  csharp: StatsIntervalGranularity
+
+<%= partial partial_version('types/_stats_granularity') %>
+
+h3(#param).
+  java:    io.ably.lib.types.Param
+
+blang[java].
+  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>

--- a/content/api/versions/v0.8/realtime-sdk/stats.textile
+++ b/content/api/versions/v0.8/realtime-sdk/stats.textile
@@ -13,8 +13,6 @@ languages:
 jump_to:
   API reference:
     - stats#stats
-  Types:
-    - Related Types#related-types
 ---
 
 h6(#stats). stats
@@ -45,7 +43,7 @@ h3(#stats-request-params).
   csharp: IO.Ably.StatsRequestParams
 
 blang[csharp].
-  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
+  <%= partial partial_version('types/_stats_request_params'), indent: 2, skip_first_indent: true %>
 
 h3(#stats-granularity).
   objc,swift: ARTStatsGranularity

--- a/content/api/versions/v1.0/realtime-sdk/stats.textile
+++ b/content/api/versions/v1.0/realtime-sdk/stats.textile
@@ -1,0 +1,62 @@
+---
+title: Statistics
+section: api
+index: 50
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - java
+  - swift
+  - objc
+  - csharp
+jump_to:
+  API reference:
+    - stats#stats
+  Types:
+    - Related Types#related-types
+---
+
+h1. Realtime API Reference
+
+h6(#stats). stats
+
+bq(definition).
+  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
+  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
+  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
+  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
+  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
+
+This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
+
+<%= partial partial_version('realtime/_stats') %>
+
+h2(#related-types). Related types
+
+h3(#stats-type).
+  default: Stats object
+  objc,swift: ARTStats
+  java:    io.ably.lib.types.Stats
+  ruby:    Ably::Models::Stats
+  csharp:  IO.Ably.Stats
+
+<%= partial partial_version('types/_stats') %>
+
+h3(#stats-request-params).
+  csharp: IO.Ably.StatsRequestParams
+
+blang[csharp].
+  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
+
+h3(#stats-granularity).
+  objc,swift: ARTStatsGranularity
+  csharp: StatsIntervalGranularity
+
+<%= partial partial_version('types/_stats_granularity') %>
+
+h3(#param).
+  java:    io.ably.lib.types.Param
+
+blang[java].
+  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>

--- a/content/api/versions/v1.1/realtime-sdk/stats.textile
+++ b/content/api/versions/v1.1/realtime-sdk/stats.textile
@@ -1,0 +1,60 @@
+---
+title: Statistics
+section: api
+index: 50
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - java
+  - swift
+  - objc
+  - csharp
+jump_to:
+  API reference:
+    - stats#stats
+  Types:
+    - Related Types#related-types
+---
+
+h6(#stats). stats
+
+bq(definition).
+  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
+  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
+  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
+  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
+  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
+
+This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
+
+<%= partial partial_version('realtime/_stats') %>
+
+h2(#related-types). Related types
+
+h3(#stats-type).
+  default: Stats object
+  objc,swift: ARTStats
+  java:    io.ably.lib.types.Stats
+  ruby:    Ably::Models::Stats
+  csharp:  IO.Ably.Stats
+
+<%= partial partial_version('types/_stats') %>
+
+h3(#stats-request-params).
+  csharp: IO.Ably.StatsRequestParams
+
+blang[csharp].
+  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
+
+h3(#stats-granularity).
+  objc,swift: ARTStatsGranularity
+  csharp: StatsIntervalGranularity
+
+<%= partial partial_version('types/_stats_granularity') %>
+
+h3(#param).
+  java:    io.ably.lib.types.Param
+
+blang[java].
+  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>

--- a/content/realtime/statistics.textile
+++ b/content/realtime/statistics.textile
@@ -10,15 +10,11 @@ languages:
   - swift
   - objc
   - csharp
-api_separator:
 jump_to:
   Help with:
     - Statistics#title
     - Getting started
-  API reference:
-    - stats#stats
-  Types:
-    - Related Types#related-types
+    - API Reference#api-reference
 ---
 
 The Ably service retains usage statistics per application and per account at 1 minute intervals. Your application statistics are available programmatically through our client libraries at 1 minute intervals, or aggregated up to the hour, day, or month.
@@ -87,46 +83,6 @@ try! realtime.stats(query) { results, error in
 
 <span lang="ruby">Note that all examples on this page assume you are running them within an EventMachine reactor. Find out more in our "Realtime usage documentation":/realtime/usage.</span>
 
-h1. Realtime API Reference
+h2(#api-reference). API Reference
 
-h6(#stats). stats
-
-bq(definition).
-  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
-  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
-  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
-  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
-
-This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
-
-<%= partial partial_version('realtime/_stats') %>
-
-h2(#related-types). Related types
-
-h3(#stats-type).
-  default: Stats object
-  objc,swift: ARTStats
-  java:    io.ably.lib.types.Stats
-  ruby:    Ably::Models::Stats
-  csharp:  IO.Ably.Stats
-
-<%= partial partial_version('types/_stats') %>
-
-h3(#stats-request-params).
-  csharp: IO.Ably.StatsRequestParams
-
-blang[csharp].
-  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
-
-h3(#stats-granularity).
-  objc,swift: ARTStatsGranularity
-  csharp: StatsIntervalGranularity
-
-<%= partial partial_version('types/_stats_granularity') %>
-
-h3(#param).
-  java:    io.ably.lib.types.Param
-
-blang[java].
-  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>
+View the "Realtime stats object":/api/realtime-sdk/stats for the associated Client Library SDK API reference.

--- a/content/realtime/versions/v0.8/statistics.textile
+++ b/content/realtime/versions/v0.8/statistics.textile
@@ -10,13 +10,11 @@ languages:
   - swift
   - objc
   - csharp
-api_separator:
 jump_to:
   Help with:
     - Statistics#title
     - Getting started
-  API reference:
-    - stats#stats
+    - API Reference#api-reference
 ---
 
 The Ably service retains usage statistics per application and per account at 1 minute intervals. Your application statistics are available programmatically through our client libraries at 1 minute intervals, or aggregated up to the hour, day, or month.
@@ -83,46 +81,6 @@ try! realtime.stats(query) { results, error in
 }
 ```
 
-h1. Realtime API Reference
+h2(#api-reference). API Reference
 
-h6(#stats). stats
-
-bq(definition).
-  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
-  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
-  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
-  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
-
-This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
-
-<%= partial partial_version('realtime/_stats') %>
-
-h2(#related-types). Related types
-
-h3(#stats-type).
-  default: Stats object
-  objc,swift: ARTStats
-  java:    io.ably.lib.types.Stats
-  ruby:    Ably::Models::Stats
-  csharp:  IO.Ably.Stats
-
-<%= partial partial_version('types/_stats') %>
-
-h3(#stats-request-params).
-  csharp: IO.Ably.StatsRequestParams
-
-blang[csharp].
-  <%= partial partial_version('types/_stats_request_params'), indent: 2, skip_first_indent: true %>
-
-h3(#stats-granularity).
-  objc,swift: ARTStatsGranularity
-  csharp: StatsIntervalGranularity
-
-<%= partial partial_version('types/_stats_granularity') %>
-
-h3(#param).
-  java:    io.ably.lib.types.Param
-
-blang[java].
-  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>
+View the "Realtime stats object":/api/realtime-sdk/stats for the associated Client Library SDK API reference.

--- a/content/realtime/versions/v1.0/statistics.textile
+++ b/content/realtime/versions/v1.0/statistics.textile
@@ -9,16 +9,12 @@ languages:
   - java
   - swift
   - objc
-  - csharp,0.8
-api_separator:
+  - csharp
 jump_to:
   Help with:
     - Statistics#title
     - Getting started
-  API reference:
-    - stats#stats
-  Types:
-    - Related Types#related-types
+    - API Reference#api-reference
 ---
 
 The Ably service retains usage statistics per application and per account at 1 minute intervals. Your application statistics are available programmatically through our client libraries at 1 minute intervals, or aggregated up to the hour, day, or month.
@@ -87,46 +83,6 @@ try! realtime.stats(query) { results, error in
 
 <span lang="ruby">Note that all examples on this page assume you are running them within an EventMachine reactor. Find out more in our "Realtime usage documentation":/realtime/usage.</span>
 
-h1. Realtime API Reference
+h2(#api-reference). API Reference
 
-h6(#stats). stats
-
-bq(definition).
-  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
-  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
-  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
-  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
-
-This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
-
-<%= partial partial_version('realtime/_stats') %>
-
-h2(#related-types). Related types
-
-h3(#stats-type).
-  default: Stats object
-  objc,swift: ARTStats
-  java:    io.ably.lib.types.Stats
-  ruby:    Ably::Models::Stats
-  csharp:  IO.Ably.Stats
-
-<%= partial partial_version('types/_stats') %>
-
-h3(#stats-request-params).
-  csharp: IO.Ably.StatsRequestParams
-
-blang[csharp].
-  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
-
-h3(#stats-granularity).
-  objc,swift: ARTStatsGranularity
-  csharp: StatsIntervalGranularity
-
-<%= partial partial_version('types/_stats_granularity') %>
-
-h3(#param).
-  java:    io.ably.lib.types.Param
-
-blang[java].
-  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>
+View the "Realtime stats object":/api/realtime-sdk/stats for the associated Client Library SDK API reference.

--- a/content/realtime/versions/v1.1/statistics.textile
+++ b/content/realtime/versions/v1.1/statistics.textile
@@ -10,15 +10,11 @@ languages:
   - swift
   - objc
   - csharp
-api_separator:
 jump_to:
   Help with:
     - Statistics#title
     - Getting started
-  API reference:
-    - stats#stats
-  Types:
-    - Related Types#related-types
+    - API Reference#api-reference
 ---
 
 The Ably service retains usage statistics per application and per account at 1 minute intervals. Your application statistics are available programmatically through our client libraries at 1 minute intervals, or aggregated up to the hour, day, or month.
@@ -87,46 +83,6 @@ try! realtime.stats(query) { results, error in
 
 <span lang="ruby">Note that all examples on this page assume you are running them within an EventMachine reactor. Find out more in our "Realtime usage documentation":/realtime/usage.</span>
 
-h1. Realtime API Reference
+h2(#api-reference). API Reference
 
-h6(#stats). stats
-
-bq(definition).
-  jsall:   stats(Object options, callback("ErrorInfo":/realtime/types#error-info err, "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats> results))
-  ruby:    "Deferrable":/realtime/types#deferrable stats(Hash options) -> yields "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats>
-  java:    "PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#stats-type> stats("Param":#param[] options)
-  swift,objc: stats(query: ARTStatsQuery?, callback: ("ARTPaginatedResult":/realtime/types#paginated-result<"ARTStats":/realtime/types#stats>?, ARTErrorInfo?) -> Void) throws
-  csharp:  Task<"PaginatedResult":/realtime/types#paginated-result<"Stats":/realtime/types#status>> StatsAsync("StatsRequestParams":#statsdatarequest query)
-
-This call queries the "REST @/stats@ API":/rest-api#stats-type and retrieves your application's usage statistics. A "PaginatedResult":/realtime/types#paginated-result is returned, containing an array of "Stats":/realtime/types#stats-type for the first page of results. "PaginatedResult":/realtime/types#paginated-result objects are iterable providing a means to page through historical statistics. "See an example set of raw stats returned via the REST API":/general/statistics.
-
-<%= partial partial_version('realtime/_stats') %>
-
-h2(#related-types). Related types
-
-h3(#stats-type).
-  default: Stats object
-  objc,swift: ARTStats
-  java:    io.ably.lib.types.Stats
-  ruby:    Ably::Models::Stats
-  csharp:  IO.Ably.Stats
-
-<%= partial partial_version('types/_stats') %>
-
-h3(#stats-request-params).
-  csharp: IO.Ably.StatsRequestParams
-
-blang[csharp].
-  <%= partial partial_version('types/_history_request_params'), indent: 2, skip_first_indent: true %>
-
-h3(#stats-granularity).
-  objc,swift: ARTStatsGranularity
-  csharp: StatsIntervalGranularity
-
-<%= partial partial_version('types/_stats_granularity') %>
-
-h3(#param).
-  java:    io.ably.lib.types.Param
-
-blang[java].
-  <%= partial partial_version('types/_param'), indent: 2, skip_first_indent: true %>
+View the "Realtime stats object":/api/realtime-sdk/stats for the associated Client Library SDK API reference.


### PR DESCRIPTION
## Description

This PR moves the realtime stats API reference to a new `/api` section for all versions.

See [EDX-86](https://ably.atlassian.net/browse/EDX-86) for further info.

## Review

View the stats API reference pages to review this PR.