### PR TITLE
[EDX-84]: Migrate realtime push API reference

### DIFF
--- a/content/api/realtime-sdk.textile
+++ b/content/api/realtime-sdk.textile
@@ -124,7 +124,7 @@ A reference to the "@Push@":/realtime/push object in this client library.
 h6(#device).
   default: device
 
-A reference to the "<span lang="default">@LocalDevice@</span><span lang="objc,swift">@ARTLocalDevice@</span>":/general/push/activate-subscribe#local-device object.
+A reference to the "<span lang="default">@LocalDevice@</span><span lang="objc,swift">@ARTLocalDevice@</span>":/api/realtime-sdk/push#local-device object.
 </div>
 
 h6(#channels).

--- a/content/api/realtime-sdk/channels.textile
+++ b/content/api/realtime-sdk/channels.textile
@@ -139,7 +139,7 @@ Provides access to the "Presence":/realtime/presence object for this channel whi
 h6(#push).
   default: push
 
-Provides access to the "PushChannel":/general/push/activate-subscribe#push-channel object for this channel which can be used to access members present on the channel, or participate in presence.
+Provides access to the "PushChannel":/api/realtime-sdk/push#push-channel object for this channel which can be used to access members present on the channel, or participate in presence.
 
 h3. Methods
 

--- a/content/api/realtime-sdk/push-admin.textile
+++ b/content/api/realtime-sdk/push-admin.textile
@@ -1,0 +1,72 @@
+---
+title: Push Notifications - Admin
+meta_description: "Realtime Client Library SDK API reference section for push notifications admin."
+meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, push, push notification, notification, push notifications, notifications, admin, push admin"
+section: api
+index: 45
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - php
+  - python
+  - swift
+  - objc
+  - java
+  - android
+jump_to:
+  API reference:
+    - publish#publish
+    - DeviceRegistrations#device-registrations-object
+    - PushChannelSubscriptions#push-channel-subscriptions
+  Types:
+    - Related Types#related-types
+---
+
+inline-toc.
+  Methods:
+    - publish#publish
+  Properties:
+    - deviceRegistrations#device-registrations
+    - channelSubscriptions#channel-subscriptions
+  DeviceRegistrations:
+    - get#device-get-id
+    - list(params)#device-list
+    - save(DeviceDetails)#device-save
+    - remove#device-remove-id
+    - removeWhere(params)#device-remove-where
+  PushChannelSubscriptions:
+    - list(params)#push-channel-sub-list
+    - listChannels(params)#push-channel-sub-list-channels
+    - save(PushChannelSubscription)#push-channel-sub-save
+    - remove(PushChannelSubscription)#push-channel-sub-remove
+    - removeWhere(params)#push-channel-sub-remove-where
+  Related types:
+    - DeviceDetails#device-details
+    - PushChannelSubscription#push-channel-subscription
+    - PaginatedResult#paginated-result
+
+<%= partial partial_version('types/_push_admin') %>
+
+h2(#related-types). Related types
+
+h3(#device-details).
+  default: DeviceDetails
+  ruby:    Ably::Models::DeviceDetails
+
+<%= partial partial_version('types/_device_details') %>
+
+h3(#push-channel-subscription).
+  default: PushChannelSubscription
+  ruby:    Ably::Models::PushChannelSubscription
+
+<%= partial partial_version('types/_push_channel_subscription') %>
+
+h3(#paginated-result).
+  default: PaginatedResult
+  swift,objc: ARTPaginatedResult
+  ruby:    Ably::Models::PaginatedResult
+  java:    io.ably.lib.types.PaginatedResult
+  csharp:  IO.Ably.PaginatedResult
+
+<%= partial partial_version('types/_paginated_result') %>

--- a/content/api/realtime-sdk/push.textile
+++ b/content/api/realtime-sdk/push.textile
@@ -1,0 +1,68 @@
+---
+title: Push Notifications - Device Activation and Subscription
+meta_description: "Realtime Client Library SDK API reference section for push notification device subscription."
+meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, push, push notification, notification, push notifications, notifications, device subscription, activate device"
+section: api
+index: 40
+languages:
+  - android
+  - swift
+  - objc
+jump_to:
+  API reference:
+    - activate#activate
+    - deactivate#deactivate
+  Types:
+    - Related Types#related-types
+---
+
+inline-toc.
+  Methods:
+    - activate()#activate
+    - deactivate()#deactivate
+  Related types:
+    - DeviceDetails#device-details
+    - LocalDevice#localdevice
+    - PushChannel#push-channel
+    - PushChannelSubscription#push-channel-subscription
+    - PaginatedResult#paginated-result
+
+<%= partial partial_version('types/_push_device') %>
+
+h2(#related-types). Related types
+
+h3(#device-details).
+  default:    DeviceDetails
+  ruby:       Ably::Models::DeviceDetails
+  swift,objc: ARTDeviceDetails
+
+<%= partial partial_version('types/_device_details') %>
+
+h3(#local-device).
+  default: LocalDevice
+  ruby:    Ably::Models::LocalDevice
+
+<%= partial partial_version('types/_local_device') %>
+
+h3(#push-channel).
+    default: PushChannel
+    ruby:    Ably::Models::PushChannel
+
+<%= partial partial_version('types/_push_channel') %>
+
+h3(#push-channel-subscription).
+  default:      PushChannelSubscription
+  ruby:         Ably::Models::PushChannelSubscription
+  java,android: ChannelSubscription
+  swift,objc:   ArtPushChannelSubscription
+
+<%= partial partial_version('types/_push_channel_subscription') %>
+
+h3(#paginated-result).
+  default:      PaginatedResult
+  swift,objc:   ARTPaginatedResult
+  ruby:         Ably::Models::PaginatedResult
+  java,android: io.ably.lib.types.PaginatedResult
+  csharp:       IO.Ably.PaginatedResult
+
+<%= partial partial_version('types/_paginated_result') %>

--- a/content/api/versions/v1.1/realtime-sdk.textile
+++ b/content/api/versions/v1.1/realtime-sdk.textile
@@ -119,7 +119,7 @@ A reference to the "@Push@":/realtime/push object in this client library.
 h6(#device).
   default: device
 
-A reference to the "<span lang="default">@LocalDevice@</span><span lang="objc,swift">@ARTLocalDevice@</span>":/general/push/activate-subscribe#local-device object.
+A reference to the "<span lang="default">@LocalDevice@</span><span lang="objc,swift">@ARTLocalDevice@</span>":/api/realtime-sdk/push#local-device object.
 </div>
 
 h6(#channels).

--- a/content/api/versions/v1.1/realtime-sdk/channels.textile
+++ b/content/api/versions/v1.1/realtime-sdk/channels.textile
@@ -122,7 +122,7 @@ Provides access to the "Presence":/realtime/presence object for this channel whi
 h6(#push).
   default: push
 
-Provides access to the "PushChannel":/general/push/activate-subscribe#push-channel object for this channel which can be used to access members present on the channel, or participate in presence.
+Provides access to the "PushChannel":/api/realtime-sdk/push#push-channel object for this channel which can be used to access members present on the channel, or participate in presence.
 
 h3. Methods
 

--- a/content/api/versions/v1.1/realtime-sdk/push-admin.textile
+++ b/content/api/versions/v1.1/realtime-sdk/push-admin.textile
@@ -1,0 +1,70 @@
+---
+title: Push Notifications - Admin
+section: api
+index: 45
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - php
+  - python
+  - swift
+  - objc
+  - java
+  - android
+jump_to:
+  API reference:
+    - publish#publish
+    - DeviceRegistrations#device-registrations-object
+    - PushChannelSubscriptions#push-channel-subscriptions
+  Types:
+    - Related Types#related-types
+---
+
+inline-toc.
+  Methods:
+    - publish#publish
+  Properties:
+    - deviceRegistrations#device-registrations
+    - channelSubscriptions#channel-subscriptions
+  DeviceRegistrations:
+    - get#device-get-id
+    - list(params)#device-list
+    - save(DeviceDetails)#device-save
+    - remove#device-remove-id
+    - removeWhere(params)#device-remove-where
+  PushChannelSubscriptions:
+    - list(params)#push-channel-sub-list
+    - listChannels(params)#push-channel-sub-list-channels
+    - save(PushChannelSubscription)#push-channel-sub-save
+    - remove(PushChannelSubscription)#push-channel-sub-remove
+    - removeWhere(params)#push-channel-sub-remove-where
+  Related types:
+    - DeviceDetails#device-details
+    - PushChannelSubscription#push-channel-subscription
+    - PaginatedResult#paginated-result
+
+<%= partial partial_version('types/_push_admin') %>
+
+h2(#related-types). Related types
+
+h3(#device-details).
+  default: DeviceDetails
+  ruby:    Ably::Models::DeviceDetails
+
+<%= partial partial_version('types/_device_details') %>
+
+h3(#push-channel-subscription).
+  default: PushChannelSubscription
+  ruby:    Ably::Models::PushChannelSubscription
+
+<%= partial partial_version('types/_push_channel_subscription') %>
+
+h3(#paginated-result).
+  default: PaginatedResult
+  swift,objc: ARTPaginatedResult
+  ruby:    Ably::Models::PaginatedResult
+  java:    io.ably.lib.types.PaginatedResult
+  csharp:  IO.Ably.PaginatedResult
+
+<%= partial partial_version('types/_paginated_result') %>

--- a/content/api/versions/v1.1/realtime-sdk/push.textile
+++ b/content/api/versions/v1.1/realtime-sdk/push.textile
@@ -1,0 +1,66 @@
+---
+title: Push Notifications - Device Activation and Subscription
+section: api
+index: 40
+languages:
+  - android
+  - swift
+  - objc
+jump_to:
+  API reference:
+    - activate#activate
+    - deactivate#deactivate
+  Types:
+    - Related Types#related-types
+---
+
+inline-toc.
+  Methods:
+    - activate()#activate
+    - deactivate()#deactivate
+  Related types:
+    - DeviceDetails#device-details
+    - LocalDevice#localdevice
+    - PushChannel#push-channel
+    - PushChannelSubscription#push-channel-subscription
+    - PaginatedResult#paginated-result
+
+<%= partial partial_version('types/_push_device') %>
+
+h2(#related-types). Related types
+
+h3(#device-details).
+  default:    DeviceDetails
+  ruby:       Ably::Models::DeviceDetails
+  swift,objc: ARTDeviceDetails
+
+<%= partial partial_version('types/_device_details') %>
+
+h3(#local-device).
+  default: LocalDevice
+  ruby:    Ably::Models::LocalDevice
+
+<%= partial partial_version('types/_local_device') %>
+
+h3(#push-channel).
+    default: PushChannel
+    ruby:    Ably::Models::PushChannel
+
+<%= partial partial_version('types/_push_channel') %>
+
+h3(#push-channel-subscription).
+  default:      PushChannelSubscription
+  ruby:         Ably::Models::PushChannelSubscription
+  java,android: ChannelSubscription
+  swift,objc:   ArtPushChannelSubscription
+
+<%= partial partial_version('types/_push_channel_subscription') %>
+
+h3(#paginated-result).
+  default:      PaginatedResult
+  swift,objc:   ARTPaginatedResult
+  ruby:         Ably::Models::PaginatedResult
+  java,android: io.ably.lib.types.PaginatedResult
+  csharp:       IO.Ably.PaginatedResult
+
+<%= partial partial_version('types/_paginated_result') %>

--- a/content/general/push/activate-subscribe.textile
+++ b/content/general/push/activate-subscribe.textile
@@ -5,9 +5,6 @@ meta_keywords: "Push, push notifications, Apple Push Notification Service, Googl
 section: general
 index: 44
 hide_from_nav: true
-api_separator:
-  Tutorials:
-    - Push Tutorials:/tutorials#tut-push-notifications
 languages:
   - android
   - swift
@@ -18,6 +15,7 @@ jump_to:
     - Platform installation#platform-install
     - Activating push on your device#device-activation
     - Subscribing to push notifications#subscribing
+    - API Reference#api-reference
 redirect_from:
   - /realtime/push/activate-subscribe
 ---
@@ -126,15 +124,15 @@ In the following example, we will both activate the device with the underlying p
 
 h3. Activate the device for push with @push.activate@
 
-If you want to start receiving push notifications from Ably (e.g. from <span lang="android">your main activity</span><span lang="objc,swift">your @UIApplicationDelegate@</span>), you need to first call "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":#activate which will *register the device for push* by doing the following on your behalf:
+If you want to start receiving push notifications from Ably (e.g. from <span lang="android">your main activity</span><span lang="objc,swift">your @UIApplicationDelegate@</span>), you need to first call "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":/api/realtime-sdk/push#activate which will *register the device for push* by doing the following on your behalf:
 
 * Ensure the Ably client is authenticated
 * Generate a unique identifier for this device and store this in local storage
 * Activate the device for push notifications with the underlying OS or platform and obtain a unique identifier for the device as a push recipient. For example, in FCM this is described as a "@registration token@":https://firebase.google.com/docs/cloud-messaging/android/client#sample-register, and in APNs this is described as a "@device token@":https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
 * Register the local device with Ably using the device's unique identifier, platform-specific details such as form factor and OS, and the push recipient details to receive push notifications. This in turn ensures Ably can reach this device and deliver push notifications
-* Store the "@deviceIdentityToken@":#local-device from the response from Ably in local storage so that subsequent requests to Ably to update push recipient details are authenticated as being from the device in question.
+* Store the "@deviceIdentityToken@":/api/realtime-sdk/push#local-device from the response from Ably in local storage so that subsequent requests to Ably to update push recipient details are authenticated as being from the device in question.
 
-Please note that the effects of calling "@activate@":#activate outlives the current process. Once called, the device will stay registered even after the application is closed, and up until "@deactivate@":#deactivate is called. "@activate@":#activate is idempotent: calling it again when device is already activated has the sole effect of calling its callback.
+Please note that the effects of calling "@activate@":/api/realtime-sdk/push#activate outlives the current process. Once called, the device will stay registered even after the application is closed, and up until "@deactivate@":/api/realtime-sdk/push#deactivate is called. "@activate@":/api/realtime-sdk/push#activate is idempotent: calling it again when device is already activated has the sole effect of calling its callback.
 
 ```[android]
 AblyRealtime ably = getAblyRealtime();
@@ -154,7 +152,7 @@ Please bear in mind that in order for the client to register itself automaticall
 
 h3. Handle push notification lifecycle
 
-When "@activate@":#activate and "@deactivate@":#deactivate are called, the device registers with FCM/APNs, and activation with Ably begins. Additionally, when a push token (APNs device token or FCM registration token) is updated on the device, the Ably SDK attempts to update Ably's servers with the new token. The activation, deactivation and update process might fail, and therefore you should handle the result of these methods in the push notification lifecycle methods. 
+When "@activate@":/api/realtime-sdk/push#activate and "@deactivate@":/api/realtime-sdk/push#deactivate are called, the device registers with FCM/APNs, and activation with Ably begins. Additionally, when a push token (APNs device token or FCM registration token) is updated on the device, the Ably SDK attempts to update Ably's servers with the new token. The activation, deactivation and update process might fail, and therefore you should handle the result of these methods in the push notification lifecycle methods. 
 
 There are three events which correspond to the three <span lang="android">broadcast intents you should listen to</span><span lang="objc,swift">delegate methods you should implement</span>:
 - Push activation completion:= (Success or failure). <span lang="android">Listen for the @io.ably.broadcast.PUSH_ACTIVATE@ action in a broadcast intent</span><span lang="objc">Implement @- (void)didActivateAblyPush:(nullable ARTErrorInfo *)error;@</span><span lang="swift">@func didActivateAblyPush(_ error: ARTErrorInfo?)@</span>. Once the device has successfully been activated, you can subscribe to push notifications on channels to receive push notifications from Ably.
@@ -253,11 +251,11 @@ realtime.channels.get("pushenabled:foo").push.subscribeDeviceAsync(context, new 
 });
 ```
 
-If your client doesn't have the @push-subscribe@ permissions, you should communicate the device ID to your server so that it can subscribe on the device's behalf. You can find your unique device ID at "<span lang="objc,swift">@ARTRealtime.device.id@</span><span lang="android">@AblyRealtime.device().id@</span>":#device-details. The server must then "use the push admin API":/general/push/admin to subscribe the device.
+If your client doesn't have the @push-subscribe@ permissions, you should communicate the device ID to your server so that it can subscribe on the device's behalf. You can find your unique device ID at "<span lang="objc,swift">@ARTRealtime.device.id@</span><span lang="android">@AblyRealtime.device().id@</span>":/api/realtime-sdk/push#device-details. The server must then "use the push admin API":/general/push/admin to subscribe the device.
 
 h3(#subscribing-client-id). Subscribing by client ID
 
-When a device is registered, it can be associated with a "client ID":/realtime/authentication/#identified-clients. "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":#activate takes the client ID from the @AblyRealtime@ instance.
+When a device is registered, it can be associated with a "client ID":/realtime/authentication/#identified-clients. "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":/api/realtime-sdk/push#activate takes the client ID from the @AblyRealtime@ instance.
 
 You can subscribe all devices associated with a client ID to a channel in a single operation; that is, create a subscription by client ID. New device registrations associated to that client ID will also be subscribed to the channel, and if a device registration is no longer associated with that client ID, it will also stop being subscribed to the channel (unless it's also "subscribed directly by device ID":#subscribing-device-id).
 
@@ -362,7 +360,7 @@ blang[objc,swift].
 blang[android].
   For this, you need to communicate back and forth with the Ably library via the application's "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager.
 
-  First, make sure you pass @true@ as the @useCustomRegisterer@ parameter to "@activate@":#activate (and for "@deactivate@":#deactivate).
+  First, make sure you pass @true@ as the @useCustomRegisterer@ parameter to "@activate@":/api/realtime-sdk/push#activate (and for "@deactivate@":/api/realtime-sdk/push#deactivate).
 
   ```[android]
   ably.push.activate(context, true);
@@ -428,55 +426,6 @@ If you want to control all of your devices server side then registration via ser
 
 <%= partial partial_version('general/push/_push_intro') %>
 
-h1. Push Device API reference
+h2(#api-reference). API Reference
 
-inline-toc.
-  Methods:
-    - activate()#activate
-    - deactivate()#deactivate
-  Related types:
-    - DeviceDetails#device-details
-    - LocalDevice#localdevice
-    - PushChannel#push-channel
-    - PushChannelSubscription#push-channel-subscription
-    - PaginatedResult#paginated-result
-
-<%= partial partial_version('types/_push_device') %>
-
-h2(#related-types). Related types
-
-h3(#device-details).
-  default:    DeviceDetails
-  ruby:       Ably::Models::DeviceDetails
-  swift,objc: ARTDeviceDetails
-
-<%= partial partial_version('types/_device_details') %>
-
-h3(#local-device).
-  default: LocalDevice
-  ruby:    Ably::Models::LocalDevice
-
-<%= partial partial_version('types/_local_device') %>
-
-h3(#push-channel).
-    default: PushChannel
-    ruby:    Ably::Models::PushChannel
-
-<%= partial partial_version('types/_push_channel') %>
-
-h3(#push-channel-subscription).
-  default:      PushChannelSubscription
-  ruby:         Ably::Models::PushChannelSubscription
-  java,android: ChannelSubscription
-  swift,objc:   ArtPushChannelSubscription
-
-<%= partial partial_version('types/_push_channel_subscription') %>
-
-h3(#paginated-result).
-  default:      PaginatedResult
-  swift,objc:   ARTPaginatedResult
-  ruby:         Ably::Models::PaginatedResult
-  java,android: io.ably.lib.types.PaginatedResult
-  csharp:       IO.Ably.PaginatedResult
-
-<%= partial partial_version('types/_paginated_result') %>
+View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push for the associated Client Library SDK API reference.

--- a/content/general/push/admin.textile
+++ b/content/general/push/admin.textile
@@ -5,9 +5,6 @@ meta_keywords: "Push, push notifications, Apple Push Notification Service, Googl
 section: general
 index: 43
 hide_from_nav: true
-api_separator:
-  Tutorials:
-    - Push Tutorials:/tutorials#tut-push-notifications
 languages:
   - javascript
   - nodejs
@@ -21,19 +18,14 @@ languages:
 jump_to:
   Help with:
     - Push Admin API Overview
-  API reference:
-    - publish#publish
-    - DeviceRegistrations#device-registrations-object
-    - PushChannelSubscriptions#push-channel-subscriptions
-  Types:
-    - Related Types#related-types
+    - API Reference#api-reference
 redirect_from:
   - /realtime/push/admin
 ---
 
 The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
-The push admin API is accessible via the @push@ attribute of the "realtime":/api/realtime-sdk/channels#properties or "rest":/api/rest-sdk/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
+The push admin API is accessible via the @push@ attribute of the "realtime":/api/realtime-sdk/channels#properties or "rest":/api/rest-sdk/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":/api/realtime-sdk/push-admin#publish method as follows:
 
 ```[jsall]
 var rest = new Ably.Rest({ key: apiKey });
@@ -73,9 +65,9 @@ Rest.Request("POST", "/push/publish", null, body, null);
 
 The push admin API offers three key features:
 
-* "@publish@":#publish for "direct publishing to devices and groups of identified devices":/general/push/publish#direct-publishing
-* "@deviceRegistrations@":#device-registrations for registering, updating, listing and de-registering push devices
-* "@channelSubscriptions@":#channel-subscriptions for subscribing, listing and unsubscribing individual devices or groups of identified devices to push notifications published on channels
+* "@publish@":/api/realtime-sdk/push-admin#publish for "direct publishing to devices and groups of identified devices":/general/push/publish#direct-publishing
+* "@deviceRegistrations@":/api/realtime-sdk/push-admin#device-registrations for registering, updating, listing and de-registering push devices
+* "@channelSubscriptions@":/api/realtime-sdk/push-admin#channel-subscriptions for subscribing, listing and unsubscribing individual devices or groups of identified devices to push notifications published on channels
 
 h2(#access-control). Push admin access control and device authentication
 
@@ -95,52 +87,6 @@ Management of device credentials is performed by the client library, so unless t
 
 <%= partial partial_version('general/push/_push_intro') %>
 
-h1. API reference
+h2(#api-reference). API Reference
 
-inline-toc.
-  Methods:
-    - publish#publish
-  Properties:
-    - deviceRegistrations#device-registrations
-    - channelSubscriptions#channel-subscriptions
-  DeviceRegistrations:
-    - get#device-get-id
-    - list(params)#device-list
-    - save(DeviceDetails)#device-save
-    - remove#device-remove-id
-    - removeWhere(params)#device-remove-where
-  PushChannelSubscriptions:
-    - list(params)#push-channel-sub-list
-    - listChannels(params)#push-channel-sub-list-channels
-    - save(PushChannelSubscription)#push-channel-sub-save
-    - remove(PushChannelSubscription)#push-channel-sub-remove
-    - removeWhere(params)#push-channel-sub-remove-where
-  Related types:
-    - DeviceDetails#device-details
-    - PushChannelSubscription#push-channel-subscription
-    - PaginatedResult#paginated-result
-
-<%= partial partial_version('types/_push_admin') %>
-
-h2(#related-types). Related types
-
-h3(#device-details).
-  default: DeviceDetails
-  ruby:    Ably::Models::DeviceDetails
-
-<%= partial partial_version('types/_device_details') %>
-
-h3(#push-channel-subscription).
-  default: PushChannelSubscription
-  ruby:    Ably::Models::PushChannelSubscription
-
-<%= partial partial_version('types/_push_channel_subscription') %>
-
-h3(#paginated-result).
-  default: PaginatedResult
-  swift,objc: ARTPaginatedResult
-  ruby:    Ably::Models::PaginatedResult
-  java:    io.ably.lib.types.PaginatedResult
-  csharp:  IO.Ably.PaginatedResult
-
-<%= partial partial_version('types/_paginated_result') %>
+View "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API reference.

--- a/content/general/push/publish.textile
+++ b/content/general/push/publish.textile
@@ -166,7 +166,7 @@ Ably provides an API that allows push notifications to be delivered directly to:
 * Devices identified by their assigned "@clientId@":/realtime/authentication#identified-clients
 * Devices identified by their recipient attributes such as their unique @registrationToken@ in the case of FCM, @deviceToken@ in the case of APNs, or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*). This is particularly useful when migrating to Ably with existing push notification target devices.
 
-See the "push admin publish documentation":/general/push/admin#publish for the client library API details, and the "raw push publish REST API documentation":/rest-api#push-publish for information on the underlying direct publishing endpoint used by the client libraries.
+See the "push admin publish documentation":/api/realtime-sdk/push-admin#publish for the client library API details, and the "raw push publish REST API documentation":/rest-api#push-publish for information on the underlying direct publishing endpoint used by the client libraries.
 
 h3(#direct-publishing-device-id-example). Publish to a device ID example
 

--- a/content/general/versions/v1.1/push/activate-subscribe.textile
+++ b/content/general/versions/v1.1/push/activate-subscribe.textile
@@ -3,9 +3,6 @@ title: Push Notifications - Device activation and subscription
 section: general
 index: 44
 hide_from_nav: true
-api_separator:
-  Tutorials:
-    - Push Tutorials:/tutorials#tut-push-notifications
 languages:
   - android
   - swift
@@ -16,6 +13,7 @@ jump_to:
     - Platform installation#platform-install
     - Activating push on your device#device-activation
     - Subscribing to push notifications#subscribing
+    - API Reference#api-reference
 ---
 
 Every device that will receive push notifications must activate itself with the local operating system or framework, and hook into the push notification services that the underlying platform provides. This functionality is platform-specific and can also vary considerably across not just platforms, but also across the push services that operate on those platforms such as GCM and FCM, both of which are available on the Android platform.
@@ -115,15 +113,15 @@ In the following example, we will both activate the device with the underlying p
 
 h3. Activate the device for push with @push.activate@
 
-If you want to start receiving push notifications from Ably (e.g. from <span lang="android">your main activity</span><span lang="objc,swift">your @UIApplicationDelegate@</span>), you need to first call "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":#activate which will *register the device for push* by doing the following on your behalf:
+If you want to start receiving push notifications from Ably (e.g. from <span lang="android">your main activity</span><span lang="objc,swift">your @UIApplicationDelegate@</span>), you need to first call "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":/api/realtime-sdk/push#activate which will *register the device for push* by doing the following on your behalf:
 
 * Ensure the Ably client is authenticated
 * Generate a unique identifier for this device and store this in local storage
 * Activate the device for push notifications with the underlying OS or platform and obtain a unique identifier for the device as a push recipient. For example, in FCM this is described as a "@registration token@":https://firebase.google.com/docs/cloud-messaging/android/client#sample-register, and in APNs this is described as a "@device token@":https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
 * Register the local device with Ably using the device's unique identifier, platform-specific details such as form factor and OS, and the push recipient details to receive push notifications. This in turn ensures Ably can reach this device and deliver push notifications
-* Store the "@deviceIdentityToken@":#local-device from the response from Ably in local storage so that subsequent requests to Ably to update push recipient details are authenticated as being from the device in question.
+* Store the "@deviceIdentityToken@":/api/realtime-sdk/push#local-device from the response from Ably in local storage so that subsequent requests to Ably to update push recipient details are authenticated as being from the device in question.
 
-Please note that the effects of calling "@activate@":#activate outlives the current process. Once called, the device will stay registered even after the application is closed, and up until "@deactivate@":#deactivate is called. "@activate@":#activate is idempotent: calling it again when device is already activated has the sole effect of calling its callback.
+Please note that the effects of calling "@activate@":/api/realtime-sdk/push#activate outlives the current process. Once called, the device will stay registered even after the application is closed, and up until "@deactivate@":/api/realtime-sdk/push#deactivate is called. "@activate@":/api/realtime-sdk/push#activate is idempotent: calling it again when device is already activated has the sole effect of calling its callback.
 
 ```[android]
 AblyRealtime ably = getAblyRealtime();
@@ -143,7 +141,7 @@ Please bear in mind that in order for the client to register itself automaticall
 
 h3. Register for callback from @activate@
 
-Once "@activate@":#activate is called, the aforementioned activation and registration process kicks off in the background. Once completed, a callback will be invoked if registered. We recommend you set up this callback so that you will be notified when push activation has succeeded or failed. Once the device has successfully been activated, you can then start subscribing for push notifications on channels and receiving push notifications via Ably.
+Once "@activate@":/api/realtime-sdk/push#activate is called, the aforementioned activation and registration process kicks off in the background. Once completed, a callback will be invoked if registered. We recommend you set up this callback so that you will be notified when push activation has succeeded or failed. Once the device has successfully been activated, you can then start subscribing for push notifications on channels and receiving push notifications via Ably.
 
 When the activation process is completed, Ably will <span lang="android">send a broadcast through the application's "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager. You should listen for a broadcast with action @io.ably.broadcast.PUSH_ACTIVATE@</span><span lang="objc,swift">call your </span><span lang="objc">@(void)didActivateAblyPush:(nullable ARTErrorInfo *)error@</span><span lang="swift">@didActivateAblyPush(error: ARTErrorInfo?)@</span><span lang="objc,swift"> method from your @ARTPushRegistererDelegate@ implementation </span> as follows:
 
@@ -227,11 +225,11 @@ realtime.channels.get("pushenabled:foo").push.subscribeDeviceAsync(context, new 
 });
 ```
 
-If your client doesn't have the @push-subscribe@ permissions, you should communicate the device ID to your server so that it can subscribe on the device's behalf. You can find your unique device ID at "<span lang="objc,swift">@ARTRealtime.device.id@</span><span lang="android">@AblyRealtime.device().id@</span>":#device-details. The server must then "use the push admin API":/general/push/admin to subscribe the device.
+If your client doesn't have the @push-subscribe@ permissions, you should communicate the device ID to your server so that it can subscribe on the device's behalf. You can find your unique device ID at "<span lang="objc,swift">@ARTRealtime.device.id@</span><span lang="android">@AblyRealtime.device().id@</span>":/api/realtime-sdk/push#device-details. The server must then "use the push admin API":/general/push/admin to subscribe the device.
 
 h3(#subscribing-client-id). Subscribing by client ID
 
-When a device is registered, it can be associated with a "client ID":/realtime/authentication/#identified-clients. "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":#activate takes the client ID from the @AblyRealtime@ instance.
+When a device is registered, it can be associated with a "client ID":/realtime/authentication/#identified-clients. "<span lang="android">@AblyRealtime.push.activate@</span><span lang="objc,swift">@ARTRealtime.push.activate@</span>":/api/realtime-sdk/push#activate takes the client ID from the @AblyRealtime@ instance.
 
 You can subscribe all devices associated with a client ID to a channel in a single operation; that is, create a subscription by client ID. New device registrations associated to that client ID will also be subscribed to the channel, and if a device registration is no longer associated with that client ID, it will also stop being subscribed to the channel (unless it's also "subscribed directly by device ID":#subscribing-device-id).
 
@@ -336,7 +334,7 @@ blang[objc,swift].
 blang[android].
   For this, you need to communicate back and forth with the Ably library via the application's "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager.
 
-  First, make sure you pass @true@ as the @useCustomRegisterer@ parameter to "@activate@":#activate (and for "@deactivate@":#deactivate).
+  First, make sure you pass @true@ as the @useCustomRegisterer@ parameter to "@activate@":/api/realtime-sdk/push#activate (and for "@deactivate@":/api/realtime-sdk/push#deactivate).
 
   ```[android]
   ably.push.activate(context, true);
@@ -402,55 +400,6 @@ If you want to control all of your devices server side then registration via ser
 
 <%= partial partial_version('general/push/_push_intro') %>
 
-h1. Push Device API reference
+h2(#api-reference). API Reference
 
-inline-toc.
-  Methods:
-    - activate()#activate
-    - deactivate()#deactivate
-  Related types:
-    - DeviceDetails#device-details
-    - LocalDevice#localdevice
-    - PushChannel#push-channel
-    - PushChannelSubscription#push-channel-subscription
-    - PaginatedResult#paginated-result
-
-<%= partial partial_version('types/_push_device') %>
-
-h2(#related-types). Related types
-
-h3(#device-details).
-  default:    DeviceDetails
-  ruby:       Ably::Models::DeviceDetails
-  swift,objc: ARTDeviceDetails
-
-<%= partial partial_version('types/_device_details') %>
-
-h3(#local-device).
-  default: LocalDevice
-  ruby:    Ably::Models::LocalDevice
-
-<%= partial partial_version('types/_local_device') %>
-
-h3(#push-channel).
-    default: PushChannel
-    ruby:    Ably::Models::PushChannel
-
-<%= partial partial_version('types/_push_channel') %>
-
-h3(#push-channel-subscription).
-  default:      PushChannelSubscription
-  ruby:         Ably::Models::PushChannelSubscription
-  java,android: ChannelSubscription
-  swift,objc:   ArtPushChannelSubscription
-
-<%= partial partial_version('types/_push_channel_subscription') %>
-
-h3(#paginated-result).
-  default:      PaginatedResult
-  swift,objc:   ARTPaginatedResult
-  ruby:         Ably::Models::PaginatedResult
-  java,android: io.ably.lib.types.PaginatedResult
-  csharp:       IO.Ably.PaginatedResult
-
-<%= partial partial_version('types/_paginated_result') %>
+View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push for the associated Client Library SDK API reference.

--- a/content/general/versions/v1.1/push/admin.textile
+++ b/content/general/versions/v1.1/push/admin.textile
@@ -3,9 +3,6 @@ title: Push Notifications - Admin
 section: general
 index: 43
 hide_from_nav: true
-api_separator:
-  Tutorials:
-    - Push Tutorials:/tutorials#tut-push-notifications
 languages:
   - javascript
   - nodejs
@@ -19,17 +16,12 @@ languages:
 jump_to:
   Help with:
     - Push Admin API Overview
-  API reference:
-    - publish#publish
-    - DeviceRegistrations#device-registrations-object
-    - PushChannelSubscriptions#push-channel-subscriptions
-  Types:
-    - Related Types#related-types
+    - API Reference#api-reference
 ---
 
 The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
-The push admin API is accessible via the @push@ attribute of the realtime client. For example to publish a push notification directly to a device, you would access the "@publish@":#publish method as follows:
+The push admin API is accessible via the @push@ attribute of the realtime client. For example to publish a push notification directly to a device, you would access the "@publish@":/api/realtime-sdk/push-admin#publish method as follows:
 
 ```[jsall]
 var rest = new Ably.Rest({ key: apiKey });
@@ -69,9 +61,9 @@ Rest.Request("POST", "/push/publish", null, body, null);
 
 The push admin API offers three key features:
 
-* "@publish@":#publish for "direct publishing to devices and groups of identified devices":/general/push/publish#direct-publishing
-* "@deviceRegistrations@":#device-registrations for registering, updating, listing and de-registering push devices
-* "@channelSubscriptions@":#channel-subscriptions for subscribing, listing and unsubscribing individual devices or groups of identified devices to push notifications published on channels
+* "@publish@":/api/realtime-sdk/push-admin#publish for "direct publishing to devices and groups of identified devices":/general/push/publish#direct-publishing
+* "@deviceRegistrations@":/api/realtime-sdk/push-admin#device-registrations for registering, updating, listing and de-registering push devices
+* "@channelSubscriptions@":/api/realtime-sdk/push-admin#channel-subscriptions for subscribing, listing and unsubscribing individual devices or groups of identified devices to push notifications published on channels
 
 h2(#access-control). Push admin access control and device authentication
 
@@ -91,52 +83,6 @@ Management of device credentials is performed by the client library, so unless t
 
 <%= partial partial_version('general/push/_push_intro') %>
 
-h1. API reference
+h2(#api-reference). API Reference
 
-inline-toc.
-  Methods:
-    - publish#publish
-  Properties:
-    - deviceRegistrations#device-registrations
-    - channelSubscriptions#channel-subscriptions
-  DeviceRegistrations:
-    - get#device-get-id
-    - list(params)#device-list
-    - save(DeviceDetails)#device-save
-    - remove#device-remove-id
-    - removeWhere(params)#device-remove-where
-  PushChannelSubscriptions:
-    - list(params)#push-channel-sub-list
-    - listChannels(params)#push-channel-sub-list-channels
-    - save(PushChannelSubscription)#push-channel-sub-save
-    - remove(PushChannelSubscription)#push-channel-sub-remove
-    - removeWhere(params)#push-channel-sub-remove-where
-  Related types:
-    - DeviceDetails#device-details
-    - PushChannelSubscription#push-channel-subscription
-    - PaginatedResult#paginated-result
-
-<%= partial partial_version('types/_push_admin') %>
-
-h2(#related-types). Related types
-
-h3(#device-details).
-  default: DeviceDetails
-  ruby:    Ably::Models::DeviceDetails
-
-<%= partial partial_version('types/_device_details') %>
-
-h3(#push-channel-subscription).
-  default: PushChannelSubscription
-  ruby:    Ably::Models::PushChannelSubscription
-
-<%= partial partial_version('types/_push_channel_subscription') %>
-
-h3(#paginated-result).
-  default: PaginatedResult
-  swift,objc: ARTPaginatedResult
-  ruby:    Ably::Models::PaginatedResult
-  java:    io.ably.lib.types.PaginatedResult
-  csharp:  IO.Ably.PaginatedResult
-
-<%= partial partial_version('types/_paginated_result') %>
+View "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API reference.

--- a/content/general/versions/v1.1/push/publish.textile
+++ b/content/general/versions/v1.1/push/publish.textile
@@ -162,7 +162,7 @@ Ably provides an API that allows push notifications to be delivered directly to:
 * Devices identified by their assigned "@clientId@":/realtime/authentication#identified-clients
 * Devices identified by their recipient attributes such as their unique @registrationToken@ in the case of GCM, @deviceToken@ in the case of APNS, or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*). This is particularly useful when migrating to Ably with existing push notification target devices.
 
-See the "push admin publish documentation":/general/push/admin#publish for the client library API details, and the "raw push publish REST API documentation":/rest-api#push-publish for information on the underlying direct publishing endpoint used by the client libraries.
+See the "push admin publish documentation":/api/realtime-sdk/push-admin#publish for the client library API details, and the "raw push publish REST API documentation":/rest-api#push-publish for information on the underlying direct publishing endpoint used by the client libraries.
 
 h3(#direct-publishing-device-id-example). Publish to a device ID example
 

--- a/content/partials/types/_push_channel.textile
+++ b/content/partials/types/_push_channel.textile
@@ -53,12 +53,12 @@ h4. Parameters
 
 - <div lang="default">deviceClientId</div> := a client ID associated with a device to filter by<br>__Type: @String@__
 
-- <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"PushChannelSubscription":/general/push/admin#push-channel-subscription> object or an error
+- <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"PushChannelSubscription":/api/realtime-sdk/push-admin#push-channel-subscription> object or an error
 
 blang[objc,swift].
   h4. Callback result
 
-  On success, @resultPage@ contains a "@PaginatedResult@":#paginated-result encapsulating an array of "PushChannelSubscription":/general/push/admin#push-channel-subscription objects corresponding to the current page of results. "@PaginatedResult@":#paginated-result supports pagination using "@next()@":#paginated-result and "@first()@":#paginated-result methods.
+  On success, @resultPage@ contains a "@PaginatedResult@":#paginated-result encapsulating an array of "PushChannelSubscription":/api/realtime-sdk/push-admin#push-channel-subscription objects corresponding to the current page of results. "@PaginatedResult@":#paginated-result supports pagination using "@next()@":#paginated-result and "@first()@":#paginated-result methods.
 
   On failure to retrieve message history, @err@ contains an "@ErrorInfo@":#error-info object with the failure reason.
 

--- a/content/partials/types/_push_device.textile
+++ b/content/partials/types/_push_device.textile
@@ -11,7 +11,7 @@ bq(definition).
   android:    void activate()
   objc,swift: activate(callback: ("ARTErrorInfo":/realtime/types#error-info?, DeviceDetails?) -> Void)
 
-Register the device for push. When the "activation process":#device-activation is completed, Ably will <span lang="android">send a broadcast through the application's "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager. Success or failure will be broadcast through @io.ably.broadcast.PUSH_ACTIVATE@</span><span lang="objc,swift">call the </span><span lang="objc">@(void)didActivateAblyPush:(nullable ARTErrorInfo *)error@</span><span lang="swift">@didActivateAblyPush(error: ARTErrorInfo?)@</span><span lang="objc,swift"> method from the @ARTPushRegistererDelegate@</span>.
+Register the device for push. When the "activation process":/general/push/activate-subscribe#device-activation is completed, Ably will <span lang="android">send a broadcast through the application's "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager. Success or failure will be broadcast through @io.ably.broadcast.PUSH_ACTIVATE@</span><span lang="objc,swift">call the </span><span lang="objc">@(void)didActivateAblyPush:(nullable ARTErrorInfo *)error@</span><span lang="swift">@didActivateAblyPush(error: ARTErrorInfo?)@</span><span lang="objc,swift"> method from the @ARTPushRegistererDelegate@</span>.
 
 h6(#deactivate).
   default: deactivate

--- a/content/partials/versions/v1.1/types/_push_channel.textile
+++ b/content/partials/versions/v1.1/types/_push_channel.textile
@@ -53,12 +53,12 @@ h4. Parameters
 
 - <div lang="default">deviceClientId</div> := a client ID associated with a device to filter by<br>__Type: @String@__
 
-- <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"PushChannelSubscription":/general/push/admin#push-channel-subscription> object or an error
+- <div lang="swift,objc">callback</div> := called with a "ARTPaginatedResult":#paginated-result<"PushChannelSubscription":/api/realtime-sdk/push-admin#push-channel-subscription> object or an error
 
 blang[objc,swift].
   h4. Callback result
 
-  On success, @resultPage@ contains a "@PaginatedResult@":#paginated-result encapsulating an array of "PushChannelSubscription":/general/push/admin#push-channel-subscription objects corresponding to the current page of results. "@PaginatedResult@":#paginated-result supports pagination using "@next()@":#paginated-result and "@first()@":#paginated-result methods.
+  On success, @resultPage@ contains a "@PaginatedResult@":#paginated-result encapsulating an array of "PushChannelSubscription":/api/realtime-sdk/push-admin#push-channel-subscription objects corresponding to the current page of results. "@PaginatedResult@":#paginated-result supports pagination using "@next()@":#paginated-result and "@first()@":#paginated-result methods.
 
   On failure to retrieve message history, @err@ contains an "@ErrorInfo@":#error-info object with the failure reason.
 

--- a/content/realtime/push.textile
+++ b/content/realtime/push.textile
@@ -10,91 +10,17 @@ languages:
   - nodejs
   - swift
   - objc
-api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver
     - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
+    - API Reference#api-reference
 ---
 
 <%= partial partial_version('general/push/_push_intro') %>
 
-h1. Push API reference
+h2(#api-reference). API Reference
 
-inline-toc.
-  Push Admin:
-    - Methods:
-      - publish#publish
-    - Properties:
-      - deviceRegistrations#device-registrations
-      - channelSubscriptions#channel-subscriptions
-    - DeviceRegistrations:
-      - get#device-get-id
-      - list(params)#device-list
-      - save(DeviceDetails)#device-save
-      - remove#device-remove-id
-      - removeWhere(params)#device-remove-where
-    - PushChannelSubscriptions:
-      - list(params)#push-channel-sub-list
-      - listChannels(params)#push-channel-sub-list-channels
-      - save(PushChannelSubscription)#push-channel-sub-save
-      - remove(PushChannelSubscription)#push-channel-sub-remove
-      - removeWhere(params)#push-channel-sub-remove-where
-  Push Device:
-    - Methods:
-      - activate()#activate
-      - deactivate()#deactivate
-  Related types:
-    - DeviceDetails#device-details
-    - PushChannelSubscription#push-channel-subscription
-    - LocalDevice#local-device
-    - PushChannel#push-channel
-    - PaginatedResult#paginated-result
-
-<%= partial partial_version('types/_push_admin') %>
-
-<div lang="android,swift,objc">
-
-<%= partial partial_version('types/_push_device') %>
-
-</div>
-
-h2(#related-types). Related types
-
-h3(#device-details).
-  default:      DeviceDetails
-  ruby:         Ably::Models::DeviceDetails
-  swift,objc:   ARTDeviceDetails
-
-<%= partial partial_version('types/_device_details') %>
-
-h3(#push-channel-subscription).
-  default:      PushChannelSubscription
-  ruby:         Ably::Models::PushChannelSubscription
-  java,android: ChannelSubscription
-  swift,objc:   ArtPushChannelSubscription
-
-<%= partial partial_version('types/_push_channel_subscription') %>
-
-h3(#local-device).
-  default: LocalDevice
-  ruby:    Ably::Models::LocalDevice
-
-<%= partial partial_version('types/_local_device') %>
-
-h3(#push-channel).
-    default: PushChannel
-    ruby:    Ably::Models::PushChannel
-
-<%= partial partial_version('types/_push_channel') %>
-
-h3(#paginated-result).
-  default:      PaginatedResult
-  swift,objc:   ARTPaginatedResult
-  ruby:         Ably::Models::PaginatedResult
-  java,android: io.ably.lib.types.PaginatedResult
-  csharp:       IO.Ably.PaginatedResult
-
-<%= partial partial_version('types/_paginated_result') %>
+View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API references.

--- a/content/realtime/push.textile
+++ b/content/realtime/push.textile
@@ -23,4 +23,4 @@ jump_to:
 
 h2(#api-reference). API Reference
 
-View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API references.
+View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push and "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API references.

--- a/content/realtime/versions/v1.1/push.textile
+++ b/content/realtime/versions/v1.1/push.textile
@@ -10,13 +10,13 @@ languages:
   - nodejs
   - swift
   - objc
-api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver
     - Activating and subscribing a device#activate-device
     - Managing devices and subscriptions#admin
     - Platform support#platform-support
+    - API Reference#api-reference
 ---
 
 <%= partial partial_version('general/push/_push_intro') %>
@@ -98,3 +98,7 @@ h3(#paginated-result).
   csharp:       IO.Ably.PaginatedResult
 
 <%= partial partial_version('types/_paginated_result') %>
+
+h2(#api-reference). API Reference
+
+View "Realtime push notifications - device activation and subscription":/api/realtime-sdk/push and "Realtime push notifications - admin":/api/realtime-sdk/push-admin for the associated Client Library SDK API references.

--- a/content/tutorials/android-push-notifications.textile
+++ b/content/tutorials/android-push-notifications.textile
@@ -349,7 +349,7 @@ Then, replace the @activatePush@ and @deactivatePush@ functions with the followi
     }
 ```
 
-In the above function, we've used the "@activate@":/general/push/activate-subscribe#activate method to register the device with FCM via Ably. We've also included the "@deactivate@":/general/push/activate-subscribe#deactivate method so you can easily de-register from Push notifications. These will be called from their respective buttons in the UI.
+In the above function, we've used the "@activate@":/api/realtime-sdk/push#activate method to register the device with FCM via Ably. We've also included the "@deactivate@":/api/realtime-sdk/push#deactivate method so you can easily de-register from Push notifications. These will be called from their respective buttons in the UI.
 
 Next, add a @BroadcastReceiver@, which we'll use to handle broadcasts from our @AblyPushMessagingService@:
 


### PR DESCRIPTION
## Description

This PR moves the realtime push API reference to a new `/api` section for all versions. 

It is also consolidates the API references between `/realtime/push`, `/general/push/admin` and `/general/push/activate-subscribe`, splitting them into two separate references.

See [EDX-84](https://ably.atlassian.net/browse/EDX-84) for further info.

## Review

View the push and push-admin API reference pages to review this PR.