### PR TITLE
[DOC-741] Update Kafka Connector and remove preview status

### DIFF
--- a/content/general/kafka-connector.textile
+++ b/content/general/kafka-connector.textile
@@ -8,19 +8,15 @@ languages:
   - none
 jump_to:
   Help with:
-    - Development status#development-status
     - Install the connector#install
     - Configure the connector#configure
+    - Tutorials#tutorials
     - See also#see-also
 ---
 
-Use the Ably Kafka Connector to send data from one or more "Kafka topics":https://developer.confluent.io/learn-kafka/apache-kafka/topics/ into an Ably channel.
+Use the Ably Kafka Connector to send data from one or more "Kafka topics":https://developer.confluent.io/learn-kafka/apache-kafka/topics/ into Ably "channels":/realtime/channels.
 
 If you need to send data from Ably to Kafka instead, use a "Kafka rule":/general/firehose/kafka-rule.
-
-h2(#development-status). Development status
-
-This feature is currently in Preview.
 
 h2(#install). Install the connector
 
@@ -30,9 +26,13 @@ View detailed instructions for installation on "GitHub":https://github.com/ably/
 
 h2(#configure). Configure the connector
 
-Configure the connector to set "properties":https://github.com/ably/kafka-connect-ably#configure such as which Kafka topics to send data from, and which Ably channel should receive the data. 
+Configure the connector to set "properties":https://github.com/ably/kafka-connect-ably#configuration such as which Kafka topics to send data from, and which Ably channel should receive the data. 
 
 Note that the configuration method will differ depending on whether you are running a single or distributed set of "connect workers":https://docs.confluent.io/home/connect/self-managed/userguide.html#configuring-and-running-workers.
+
+h2(#tutorials). Tutorials
+
+View the "Ably Kafka Connector tutorial":/tutorials/ably-kafka-connector for an example of using the Ably Kafka Connector.
 
 h2(#see-also). See also
 


### PR DESCRIPTION
## Description

This PR removes the preview status from the Kafka Connector and adds links to the associated tutorial.

See [JIRA](https://ably.atlassian.net/browse/DOC-741) for further information.

## Review

View the [Kafka Connector](https://ably.com/docs/general/kafka-connector) page to review this PR.
