### PR TITLE
[DOC-742] Add kafka group to tutorials

### DIFF
--- a/config/tutorials/tutorials.json
+++ b/config/tutorials/tutorials.json
@@ -43,6 +43,12 @@
       "name": "Using Ably Client Library SDKs",
       "desc": "A selection of tutorials demonstrating the use of Realtime and/or REST libraries within devices such as browsers, desktops, mobiles or servers."
     },
+    "kafka": {
+      "id": "kafka",
+      "tab": "Channels, Push, Reactor & API Hub",
+      "name": "With Using Ably with Kafka",
+      "desc": "Tutorials on using Kafka with Ably."
+    },
     "sse": {
       "id": "sse",
       "tab": "Channels, Push, Reactor & API Hub",

--- a/config/tutorials/tutorials.json
+++ b/config/tutorials/tutorials.json
@@ -27,7 +27,7 @@
     {
       "id": "reactor-integrations",
       "icon": "lightning",
-      "name": "Reactor Integrations",
+      "name": "Integrations",
       "desc": "Fun tutorials on how to make use of various libraries and JS frameworks with Ably."
     },
     {
@@ -41,25 +41,19 @@
     "sdk": {
       "id": "sdk",
       "name": "Using Ably Client Library SDKs",
-      "desc": "A selection of tutorials demonstrating the use of Realtime and/or REST libraries within devices such as browsers, desktops, mobiles or servers."
-    },
-    "kafka": {
-      "id": "kafka",
-      "tab": "Channels, Push, Reactor & API Hub",
-      "name": "With Using Ably with Kafka",
-      "desc": "Tutorials on using Kafka with Ably."
+      "desc": "A selection of tutorials demonstrating the use of the Ably Client library SDKs, or the Ably REST API, within devices such as browsers, desktops, mobiles or servers."
     },
     "sse": {
       "id": "sse",
       "tab": "Channels, Push, Reactor & API Hub",
       "name": "Using SSE",
-      "desc": "Simple walkthroughs demonstrating how to connect Ably with external services (Ably Reactor, non-Ably protocols and Push Notifications). Find out more about Ably Reactor service, protocol adapters and migrating to Ably, and Push Notification service."
+      "desc": "Tutorials on using Server-Sent Events with Ably."
     },
     "mqtt": {
       "id": "mqtt",
       "tab": "Channels, Push, Reactor & API Hub",
       "name": "Using MQTT",
-      "desc": "Fun tutorials on how to make use of various libraries and JS frameworks with Ably."
+      "desc": "Tutorials on using the MQTT protocol with Ably."
     }
   }
 }

--- a/config/tutorials/tutorials.json
+++ b/config/tutorials/tutorials.json
@@ -16,13 +16,13 @@
       "id": "channels",
       "icon": "arrows-horizontal",
       "name": "Channels",
-      "desc": "A selection of tutorials demonstrating the use of Realtime and/or REST libraries within devices such as browsers, desktops, mobiles or servers."
+      "desc": "A selection of tutorials demonstrating the use of the Ably Client library SDKs, or the Ably REST API, on devices such as browsers, desktops, mobiles or servers."
     },
     {
       "id": "push-notifications",
       "icon": "bell",
       "name": "Push Notifications",
-      "desc": "Simple walkthroughs demonstrating how to connect Ably with external services (Ably Reactor, non-Ably protocols and Push Notifications).<br/> Find out more about <a href='/reactor'>Ably Reactor</a> service, <a href='/adapters'>protocol adapters</a> and migrating to Ably, and <a href='/push-notifications'>Push Notification</a> service."
+      "desc": "Tutorials demonstrating how to connect Ably with external services (Ably Reactor, non-Ably protocols and Push Notifications).<br/> Find out more about <a href='/reactor'>Ably Reactor</a> service, <a href='/adapters'>protocol adapters</a> and migrating to Ably, and <a href='/push-notifications'>Push Notification</a> service."
     },
     {
       "id": "reactor-integrations",
@@ -41,7 +41,7 @@
     "sdk": {
       "id": "sdk",
       "name": "Using Ably Client Library SDKs",
-      "desc": "A selection of tutorials demonstrating the use of the Ably Client library SDKs, or the Ably REST API, within devices such as browsers, desktops, mobiles or servers."
+      "desc": "A selection of tutorials demonstrating the use of the Ably Client library SDKs, or the Ably REST API, on devices such as browsers, desktops, mobiles or servers."
     },
     "sse": {
       "id": "sse",

--- a/content/tutorials/ably-kafka-connector.textile
+++ b/content/tutorials/ably-kafka-connector.textile
@@ -10,7 +10,7 @@ category:
 - reactor-integrations
 date_published: '2022-04-08T12:19:21+00:00'
 excerpt: Learn how to use the Ably Kafka Connector
-group: kafka
+group: sdk
 index: 131
 languages:
 - javascript

--- a/content/tutorials/ably-kafka-connector.textile
+++ b/content/tutorials/ably-kafka-connector.textile
@@ -9,7 +9,7 @@ category:
 - channels
 - reactor-integrations
 date_published: '2022-04-08T12:19:21+00:00'
-excerpt: Learn how to use the Ably Kafka Connector
+excerpt: In this tutorial you will learn how to use the Ably Kafka Connector to map a Kafka topic to an Ably channel.
 group: sdk
 index: 131
 languages:
@@ -21,9 +21,11 @@ reading_time: 20
 section: tutorials
 tags:
 - Kafka
+- Integration
+- javascript
 title: Learn how to use the Ably Kafka Connector
-meta_description: "Learn how to use the Ably Kafka Connector"
-meta_keywords: "Learn how to use the Ably Kafka Connector"
+meta_description: "In this tutorial you will learn how to use the Ably Kafka Connector to map a Kafka topic to an Ably channel."
+meta_keywords: "Ably, Kafka, Connector, Integrations, Kafka topic, Ably Channel"
 ---
 
 "Kafka":https://en.wikipedia.org/wiki/Apache_Kafka is an incredibly powerful tool, allowing for distributed event streaming and stream processing. It excels when it comes to acting as a traditional backend data broker. Due to its impressive throughput, scalability, and reliability, Kafka is often used to engineer large-scale event-driven systems.

--- a/content/tutorials/ably-kafka-connector.textile
+++ b/content/tutorials/ably-kafka-connector.textile
@@ -7,6 +7,7 @@ authors:
   author_profile_url: https://github.com/tomczoink
 category:
 - channels
+- reactor-integrations
 date_published: '2022-04-08T12:19:21+00:00'
 excerpt: Learn how to use the Ably Kafka Connector
 group: kafka


### PR DESCRIPTION
## Description

* [DOC-742](https://ably.atlassian.net/browse/DOC-742).

Tutorial did not display on Tutorials homepage, although it does display if the URL is invoked directly. The reason is the tutorial is in the group `kafka`, but that group does not exist. This PR does two things:

1. Adds the kafka group in `tutorials.json`.
2. Also adds the tutorial to the Integrations tab (as well as the channels tab). 

The effect of this is the tutorial will be displayed as follows:

![image](https://user-images.githubusercontent.com/25511700/164461462-4afbee8d-2b12-408f-92b4-1109d9b9f4f1.png)


## Review

I've added multiple reviewers as I want to make sure this approach is acceptable. Thanks.

Currently, this can only be reviewed by running the webview locally.