### PR TITLE
Added TS linting rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,56 +1,47 @@
 {
-    "extends": [
-      "eslint:recommended",
-      "plugin:prettier/recommended",
-      "plugin:jest/recommended",
-      "plugin:jest/style"
-    ],
-    "plugins": [
-      "jest",
-      "prettier",
-      "react"
-    ],
-    "rules": {
-      "react/display-name": 0
+  "extends": ["eslint:recommended", "plugin:prettier/recommended", "plugin:jest/recommended", "plugin:jest/style"],
+  "plugins": ["jest", "prettier", "react"],
+  "rules": {
+    "react/display-name": 0
+  },
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest/globals": true,
+    "node": true
+  },
+  "globals": {
+    "mockMatchMedia": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "settings": {
+    "import/resolver": {
+      "alias": [["./src"]]
     },
-    "env": {
-      "browser": true,
-      "es6": true,
-      "jest/globals": true,
-      "node": true
-    },
-    "globals": {
-      "mockMatchMedia": true
-    },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaFeatures": {
-        "jsx": true
+    "react": {
+      "version": "detect"
+    }
+  },
+  "overrides": [
+    // Typescript
+    {
+      "files": ["*.ts", "*.tsx"],
+      "extends": [
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "plugins": ["@typescript-eslint"],
+      "rules": {
+        // disable the rule for all files
+        "@typescript-eslint/explicit-module-boundary-types": "off"
       }
-    },
-    "settings": {
-      "import/resolver": {
-        "alias": [
-          [
-            "./src"
-          ]
-        ]
-      },
-      "react": {
-        "version": "detect"
-      }
-    },
-    "overrides": [
-      // Typescript
-      {
-          "files": ["*.ts", "*.tsx"],
-          "extends": [
-            "plugin:react/recommended",
-            "plugin:react-hooks/recommended",
-            "plugin:@typescript-eslint/eslint-recommended",
-            "plugin:@typescript-eslint/recommended"
-          ],
-          "plugins": ["@typescript-eslint"]
-      }
+    }
   ]
 }


### PR DESCRIPTION
There is only one added rule here (everything else is prettifying). The added rule is:
      "rules": {
        // disable the rule for all files
        "@typescript-eslint/explicit-module-boundary-types": "off"
      }

And I've turned it off because I see implicit return types as a feature of TypeScript, not a negative. I get where they are coming from:
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
But in reality, most of your stuff returns HTML elements and you don't want to have to explicitly type that all the time.