### PR TITLE
[EDX-115]: Make page titles consistent in new /api section

### DIFF
--- a/content/api/realtime-sdk.textile
+++ b/content/api/realtime-sdk.textile
@@ -1,5 +1,5 @@
 ---
-title: Constructor Object
+title: Constructor
 meta_description: "Realtime Client Library SDK API reference section for the constructor object."
 meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, constructor, instantiate"
 section: api

--- a/content/api/realtime-sdk/connection.textile
+++ b/content/api/realtime-sdk/connection.textile
@@ -1,5 +1,5 @@
 ---
-title: Connection Object
+title: Connection
 meta_description: "Realtime Client Library SDK API reference section for the connection object."
 meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, connect, connection"
 section: api

--- a/content/api/realtime-sdk/messages.textile
+++ b/content/api/realtime-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 meta_description: "Realtime Client Library SDK API reference section for the message object."
 meta_keywords: "Ably, Ably realtime, API Reference, Realtime SDK, message, messages"
 section: api

--- a/content/api/rest-sdk/messages.textile
+++ b/content/api/rest-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 meta_description: "Client Library SDK REST API Reference Message documentation."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Message"
 section: api

--- a/content/api/versions/v0.8/realtime-sdk.textile
+++ b/content/api/versions/v0.8/realtime-sdk.textile
@@ -1,5 +1,5 @@
 ---
-title: Constructor Object
+title: Constructor
 section: api
 index: 1
 languages:

--- a/content/api/versions/v0.8/realtime-sdk/connection.textile
+++ b/content/api/versions/v0.8/realtime-sdk/connection.textile
@@ -1,5 +1,5 @@
 ---
-title: Connection Object
+title: Connection
 section: api
 index: 5
 languages:

--- a/content/api/versions/v0.8/realtime-sdk/messages.textile
+++ b/content/api/versions/v0.8/realtime-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 section: api
 index: 10
 languages:

--- a/content/api/versions/v0.8/rest-sdk/messages.textile
+++ b/content/api/versions/v0.8/rest-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 meta_description: "Client Library SDK REST API Reference Message documentation."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Message"
 section: api

--- a/content/api/versions/v1.0/realtime-sdk.textile
+++ b/content/api/versions/v1.0/realtime-sdk.textile
@@ -1,5 +1,5 @@
 ---
-title: Constructor Object
+title: Constructor
 section: api
 index: 1
 languages:

--- a/content/api/versions/v1.0/realtime-sdk/connection.textile
+++ b/content/api/versions/v1.0/realtime-sdk/connection.textile
@@ -1,5 +1,5 @@
 ---
-title: Connection Object
+title: Connection
 section: api
 index: 5
 languages:

--- a/content/api/versions/v1.0/realtime-sdk/messages.textile
+++ b/content/api/versions/v1.0/realtime-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 section: api
 index: 10
 languages:

--- a/content/api/versions/v1.0/rest-sdk/messages.textile
+++ b/content/api/versions/v1.0/rest-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 meta_description: "Client Library SDK REST API Reference Message documentation."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Message"
 section: api

--- a/content/api/versions/v1.1/realtime-sdk.textile
+++ b/content/api/versions/v1.1/realtime-sdk.textile
@@ -1,5 +1,5 @@
 ---
-title: Constructor Object
+title: Constructor
 section: api
 index: 1
 languages:

--- a/content/api/versions/v1.1/realtime-sdk/connection.textile
+++ b/content/api/versions/v1.1/realtime-sdk/connection.textile
@@ -1,5 +1,5 @@
 ---
-title: Connection Object
+title: Connection
 section: api
 index: 5
 languages:

--- a/content/api/versions/v1.1/realtime-sdk/messages.textile
+++ b/content/api/versions/v1.1/realtime-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 section: api
 index: 10
 languages:

--- a/content/api/versions/v1.1/rest-sdk/messages.textile
+++ b/content/api/versions/v1.1/rest-sdk/messages.textile
@@ -1,5 +1,5 @@
 ---
-title: Message
+title: Messages
 meta_description: "Client Library SDK REST API Reference Message documentation."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Message"
 section: api


### PR DESCRIPTION
## Description

This PR moves makes sure all page titles are consistent in the new `/api` section. Page titles should match the existing equivalents in `/rest` and `/realtime` with a few exceptions.

See [EDX-115](https://ably.atlassian.net/browse/EDX-115) for further info.

## Review

Check that all page titles are consistent.