### PR TITLE
Fix incorrect link in Platform Customization page

### DIFF
--- a/content/root/platform-customization.textile
+++ b/content/root/platform-customization.textile
@@ -23,7 +23,7 @@ A custom environment provides you with your own endpoints to service Ably platfo
 
 If you are not currently an enterprise customer but are interested in finding out more, then please "get in touch":https://ably.com/contact.
 
-If you're ready to enable a custom environment to take advantage of these features, then please "see our guide":#custom-environment-setup. Otherwise, read on to find out more.
+If you're ready to enable a custom environment to take advantage of these features, then please "see our guide":#setting-up-a-custom-environment. Otherwise, read on to find out more.
 
 
 h2(#active-traffic-management). Active traffic management


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

The link on the [Platform Customization](https://ably.com/docs/platform-customization) page for "see our guide" links to the fragment "#custom-environment-setup", I think this is supposed to link to "#setting-up-a-custom-environment"

## Review

Check that the fragment on the "our guide" link now works correctly.

* Page to review: docs/platform-customization
