### PR TITLE
Fix misnamed indent_size property

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,5 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent-size = 2
+indent_size = 2
 charset = utf-8


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

As per the [.editorconfig spec](https://editorconfig-specification.readthedocs.io/#supported-pairs) the Indent Size property is indent_size, not indent-size. 

## Review

Check that your editor still parses .editorconfig correctly

