### PR TITLE
Add protocol adapter overview

### DIFF
--- a/content/protocol-adapters/index.textile
+++ b/content/protocol-adapters/index.textile
@@ -10,24 +10,22 @@ jump_to:
     - SSE#sse
 ---
 
-While the recommended method for connecting to Ably is through the use of the Ably Client Library SDKs, there are certain situations where this is not possible, due to lack of platform support, or platform resource constraints. In this case, certain clients may be supported through the use of Ably protocol adapters. 
+Ably Client Library SDKs are the recommended method for connecting to Ably because they offer support for a comprehensive set of Ably features, such as automatic "connection management":/realtime/connection, "authentication token renewal":realtime/authentication#token-authentication and "presence":/realtime/presence.
 
-Ably Client Library SDKs are the recommended method for connecting to Ably, because they offer support for a comprehensive set of Ably features, such as automatic connection management, authentication token renewal via @authUrl@, and presence, whereas the protocol adapters may not support these features: for example MQTT protocol adapter does not have support for presence, and the SSE protocol adapter does not have support for automatic token renewal (this has to be handled manually in the client code). A full list of Ably Client Library SDKs can be found on the "SDK page":https://ably.com/download, and features supported by each SDK can be found in the "features matrix":https://ably.com/download/sdk-feature-support-matrix.
+Protocol adapters offer an alternative method for connecting to Ably. The advantage to protocol adapters is that they require fewer resources in terms of memory and network overhead such as in smaller footprint devices, or on a platform where an Ably Client Library SDK isn't available such as an Arduino-based IoT wearable. The potential drawback to consider when evaluating protocol adapters is that they do not support the full set of Ably features, for example the MQTT protocol adapter does not support presence, and the SSE protocol adapter does not support automatic token renewal.
 
-The advantage of protocol adapters, however, is that they require fewer resources in terms of memory, and network overhead, so can work in smaller footprint devices, or on a platform where an Ably Client Library SDK is not available, such as on a Arduino-based IoT wearable. In this latter case, for example, MQTT clients are readily available for Arduino-based devices, and these can be used to connect to Ably, via the Ably MQTT protocol adapter.
+A full list of Ably Client Library SDKs can be found on the "SDK page":https://ably.com/download, and features supported by each SDK can be found in the "features matrix":https://ably.com/download/sdk-feature-support-matrix.
 
-There are two protocol adapters covered in this section of the documentation:
+There are two available protocol adapters for use with Ably:
 
-1. MQTT
-2. SSE
-
-Each of these will be described briefly in the following sections.
+1. "MQTT":#mqtt
+2. "SSE":#sse
 
 h2(#mqtt). MQTT
 
-"MQTT":https://mqtt.org/ is an OASIS standard messaging protocol for the Internet of Things (IoT). It is designed as an extremely lightweight publish/subscribe messaging transport that is ideal for connecting remote devices with a small code footprint and minimal network bandwidth.
+"MQTT":https://mqtt.org/ is an "OASIS":https://www.oasis-open.org/ standard messaging protocol for the Internet of Things (IoT). It is designed as an extremely lightweight publish/subscribe messaging transport that is ideal for connecting remote devices with a small code footprint and minimal network bandwidth.
 
-The Ably MQTT protocol adapter provides an interface between an MQTT client and Ably. Being a protocol designed for small systems and IoT devices, MQTT has a low overhead in terms of system resource requirements. MQTT libraries are widely available, and support a range of languages such as C/C++, Python, and Rust. Because of this, client platforms and programming languages where an Ably Client Library SDK is not available, can still access the Ably realtime network through the MQTT client and the Ably MQTT protocol adapter.
+The Ably MQTT protocol adapter provides an interface between an MQTT client and Ably. Being a protocol designed for small systems and IoT devices, MQTT has a low overhead in terms of system resource requirements. MQTT libraries are widely available, and support a range of languages such as C/C++, Python, and Rust. Because of this, client platforms and programming languages where an Ably Client Library SDK is not available, can still access the Ably platform through the MQTT client and the Ably MQTT protocol adapter.
 
 MQTT clients can subscribe and publish to Ably channels. Any client that supports MQTT can therefore leverage Ably's realtime network, with some constraints. 
 
@@ -35,10 +33,10 @@ For more information on Ably's MQTT protocol adapter see the "MQTT documentation
 
 h2(#sse). SSE
 
-Server-Sent Events (SSE) is a functionality built into more recent versions of browsers. Because "SSE support":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events is built-in, it does not require the loading of any additional libraries, such as is the case if you were to use the Ably JavaScript Client Library SDK. You will have to handle certain operations in your client, for example, token renewal will need to be managed by your client code.
+Server-Sent Events (SSE) is a functionality built into all modern browsers. Because "SSE support":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events is built-in, it does not require the loading of any additional libraries, such as is the case if you were to use the Ably "JavaScript Client Library SDK":https://github.com/ably/ably-js. The Ably SSE protocol adapter allows the browser to subscribe to a realtime stream of events from an Ably channel. 
 
-The Ably SSE protocol adapter allows the browser to subscribe to a realtime stream of events from an Ably channel. Publishing to a channel is not supported by SSE.
+In addition to the SSE endpoint, Ably also provides a raw HTTP streaming endpoint. This is similar to the SSE endpoint, but uses JSON envelopes instead of SSE events.
 
-In addition to the SSE endpoint, Ably also provides a raw HTTP streaming endpoint. 
+Note that SSE is for subscribing to events only and you cannot publish to a channel. You will have also to handle certain operations in your client code, such as token renewal.
 
 For more information on Ably's SSE protocol adapter see the "SSE documentation":/sse.

--- a/content/protocol-adapters/index.textile
+++ b/content/protocol-adapters/index.textile
@@ -1,0 +1,30 @@
+---
+title: Protocol Adapters
+meta_description: "Clients can use the Ably network using SSE and MQTT protocol adapters. This is especially useful where an Ably Client Library SDK is not available for your language of choice, or where platform resource constraints prohibit use of a Client Library SDK."
+meta_keywords: "SSE, MQTT, IoT, thin client, protocol adapter, lightweight clients"
+section: protocol-adapters
+index: 0
+jump_to:
+  Help with:
+    - MQTT#mqtt
+    - SSE#sse
+---
+
+While the recommended method for connecting to Ably is through the use of the Ably Client Library SDKs, there are certain situation where this is not possible, due to lack of platform support, or platform resource constraints. In this situation, certain clients may be supported though the use of Ably protocol adapters. There are two protocol adapters in this section of the documentation:
+
+1. MQTT
+2. SSE
+
+Each of these will be described in the following sections.
+
+h2(#mqtt). MQTT
+
+MQTT protocol adapter provides an interface between an MQTT client and Ably. MQTT clients can subscribe and publish to Ably channels. Any client that supports MQTT can therefore leverage Ably's realtime network, with some constraints. 
+
+For more information on Ably's MQTT protocol adapter see the "MQTT documentation":/mqtt.
+
+h2(#sse). SSE
+
+Server-Sent Events (SSE) is a functionality built into certain browsers. The Ably SSE protocol allows the browser to subscribe to a realtime stream of events from an Ably channel. In addition to the SSE endpoint, Ably also provides a raw HTTP streaming endpoint. 
+
+For more information on Ably's SSE protocol adapter see the "SSE documentation":/sse.

--- a/content/protocol-adapters/index.textile
+++ b/content/protocol-adapters/index.textile
@@ -27,7 +27,7 @@ h2(#mqtt). MQTT
 
 "MQTT":https://mqtt.org/ is an OASIS standard messaging protocol for the Internet of Things (IoT). It is designed as an extremely lightweight publish/subscribe messaging transport that is ideal for connecting remote devices with a small code footprint and minimal network bandwidth.
 
-The Ably MQTT protocol adapter provides an interface between an MQTT client and Ably. Being a protocol designed for small systems and IoT devices, MQTT has a low overhead in terms of system resource requirements. MQTT libraries are widely available, and support a range of languages such as C/C++, Python, and Rust.
+The Ably MQTT protocol adapter provides an interface between an MQTT client and Ably. Being a protocol designed for small systems and IoT devices, MQTT has a low overhead in terms of system resource requirements. MQTT libraries are widely available, and support a range of languages such as C/C++, Python, and Rust. Because of this, client platforms and programming languages where an Ably Client Library SDK is not available, can still access the Ably realtime network through the MQTT client and the Ably MQTT protocol adapter.
 
 MQTT clients can subscribe and publish to Ably channels. Any client that supports MQTT can therefore leverage Ably's realtime network, with some constraints. 
 

--- a/content/protocol-adapters/index.textile
+++ b/content/protocol-adapters/index.textile
@@ -1,7 +1,7 @@
 ---
 title: Protocol Adapters
 meta_description: "Clients can use the Ably network using SSE and MQTT protocol adapters. This is especially useful where an Ably Client Library SDK is not available for your language of choice, or where platform resource constraints prohibit use of a Client Library SDK."
-meta_keywords: "SSE, MQTT, IoT, thin client, protocol adapter, lightweight clients"
+meta_keywords: "SSE, MQTT, IoT, thin client, protocol adapter, lightweight clients, Arduino, Raspberry Pi, wearable"
 section: protocol-adapters
 index: 0
 jump_to:
@@ -10,21 +10,35 @@ jump_to:
     - SSE#sse
 ---
 
-While the recommended method for connecting to Ably is through the use of the Ably Client Library SDKs, there are certain situation where this is not possible, due to lack of platform support, or platform resource constraints. In this situation, certain clients may be supported though the use of Ably protocol adapters. There are two protocol adapters in this section of the documentation:
+While the recommended method for connecting to Ably is through the use of the Ably Client Library SDKs, there are certain situations where this is not possible, due to lack of platform support, or platform resource constraints. In this case, certain clients may be supported through the use of Ably protocol adapters. 
+
+Ably Client Library SDKs are the recommended method for connecting to Ably, because they offer support for a comprehensive set of Ably features, such as automatic connection management, authentication token renewal via @authUrl@, and presence, whereas the protocol adapters may not support these features: for example MQTT protocol adapter does not have support for presence, and the SSE protocol adapter does not have support for automatic token renewal (this has to be handled manually in the client code). A full list of Ably Client Library SDKs can be found on the "SDK page":https://ably.com/download, and features supported by each SDK can be found in the "features matrix":https://ably.com/download/sdk-feature-support-matrix.
+
+The advantage of protocol adapters, however, is that they require fewer resources in terms of memory, and network overhead, so can work in smaller footprint devices, or on a platform where an Ably Client Library SDK is not available, such as on a Arduino-based IoT wearable. In this latter case, for example, MQTT clients are readily available for Arduino-based devices, and these can be used to connect to Ably, via the Ably MQTT protocol adapter.
+
+There are two protocol adapters covered in this section of the documentation:
 
 1. MQTT
 2. SSE
 
-Each of these will be described in the following sections.
+Each of these will be described briefly in the following sections.
 
 h2(#mqtt). MQTT
 
-MQTT protocol adapter provides an interface between an MQTT client and Ably. MQTT clients can subscribe and publish to Ably channels. Any client that supports MQTT can therefore leverage Ably's realtime network, with some constraints. 
+"MQTT":https://mqtt.org/ is an OASIS standard messaging protocol for the Internet of Things (IoT). It is designed as an extremely lightweight publish/subscribe messaging transport that is ideal for connecting remote devices with a small code footprint and minimal network bandwidth.
+
+The Ably MQTT protocol adapter provides an interface between an MQTT client and Ably. Being a protocol designed for small systems and IoT devices, MQTT has a low overhead in terms of system resource requirements. MQTT libraries are widely available, and support a range of languages such as C/C++, Python, and Rust.
+
+MQTT clients can subscribe and publish to Ably channels. Any client that supports MQTT can therefore leverage Ably's realtime network, with some constraints. 
 
 For more information on Ably's MQTT protocol adapter see the "MQTT documentation":/mqtt.
 
 h2(#sse). SSE
 
-Server-Sent Events (SSE) is a functionality built into certain browsers. The Ably SSE protocol allows the browser to subscribe to a realtime stream of events from an Ably channel. In addition to the SSE endpoint, Ably also provides a raw HTTP streaming endpoint. 
+Server-Sent Events (SSE) is a functionality built into more recent versions of browsers. Because "SSE support":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events is built-in, it does not require the loading of any additional libraries, such as is the case if you were to use the Ably JavaScript Client Library SDK. You will have to handle certain operations in your client, for example, token renewal will need to be managed by your client code.
+
+The Ably SSE protocol adapter allows the browser to subscribe to a realtime stream of events from an Ably channel. Publishing to a channel is not supported by SSE.
+
+In addition to the SSE endpoint, Ably also provides a raw HTTP streaming endpoint. 
 
 For more information on Ably's SSE protocol adapter see the "SSE documentation":/sse.

--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -13,7 +13,7 @@ jump_to:
     - Plain event stream#event-stream
 ---
 
-The Ably SSE and raw HTTP streaming adapter provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably Realtime client library, or even an "MQTT":https://ably.com/topic/mqtt library, is impractical.
+The Ably SSE and raw HTTP streaming API provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably Realtime client library, or even an "MQTT":https://ably.com/topic/mqtt library, is impractical.
 
 HTTP streaming allows for a request from a client to be held by a server, allowing it to push data to the client without further requests. This, much like WebSockets, help avoid the overhead involved in normal HTTP requests. "Server-sent events":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events (SSE) provide a thin layer on top of HTTP streaming. A common use of SSE is through the use of "the EventSource API":https://developer.mozilla.org/en-US/docs/Web/API/EventSource in all modern web browsers.
 

--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -1,5 +1,5 @@
 ---
-title: SSE and Raw HTTP Streaming Adapter
+title: SSE and Raw HTTP Streaming API
 meta_description: "Ably provides support for Server-Sent Events (SSE). This is useful for where browser clients support SSE, and the use case does not require or support the resources used by the Ably client library SDK."
 meta_keywords: "Server-Sent Events, SSE, browser clients"
 section: sse

--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -1,5 +1,5 @@
 ---
-title: SSE and Raw HTTP Streaming API
+title: SSE and Raw HTTP Streaming Adapter
 meta_description: "Ably provides support for Server-Sent Events (SSE). This is useful for where browser clients support SSE, and the use case does not require or support the resources used by the Ably client library SDK."
 meta_keywords: "Server-Sent Events, SSE, browser clients"
 section: sse
@@ -13,7 +13,7 @@ jump_to:
     - Plain event stream#event-stream
 ---
 
-The Ably SSE and raw HTTP streaming API provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably Realtime client library, or even an "MQTT":https://ably.com/topic/mqtt library, is impractical.
+The Ably SSE and raw HTTP streaming adapter provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably Realtime client library, or even an "MQTT":https://ably.com/topic/mqtt library, is impractical.
 
 HTTP streaming allows for a request from a client to be held by a server, allowing it to push data to the client without further requests. This, much like WebSockets, help avoid the overhead involved in normal HTTP requests. "Server-sent events":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events (SSE) provide a thin layer on top of HTTP streaming. A common use of SSE is through the use of "the EventSource API":https://developer.mozilla.org/en-US/docs/Web/API/EventSource in all modern web browsers.
 

--- a/layouts/_nav.html.erb
+++ b/layouts/_nav.html.erb
@@ -13,6 +13,7 @@
     <%= nav_items 'core-features', :title => 'Core Features' %>
     <%= nav_items 'api-streamer', :title => 'API Streamer' %>
     <%= nav_items 'client-lib-development-guide', :title => 'Library Development' %>
+    <%= nav_items 'protocol-adapters', :title => 'Protocol Adapters' %>
   </nav>
   <a href="https://ably.com">Visit Ably.com</a>
 </div>


### PR DESCRIPTION
## Description

Adds a protocol adapter overview topic at `/protocol-adapters`.

* [EDX-122](https://ably.atlassian.net/browse/EDX-122).

## Review

If reviewing locally the overview can be found at:

http://localhost:4000/protocol-adapters/