### PR TITLE
Make all TokenDetail fields apart from token optional

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1665,10 +1665,10 @@ class Auth:
 
 class TokenDetails:
   +fromJson(String | JsonObject) -> TokenDetails// TD7
-  capability: String // TD5
+  capability: String? // TD5
   clientId: String? // TD6
-  expires: Time // TD3
-  issued: Time // TD4
+  expires: Time? // TD3
+  issued: Time? // TD4
   token: String // TD2
 
 class TokenRequest:


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

RSA16b says:

If the library is provided with a token without the corresponding
TokenDetails, then this holds a TokenDetails instance in which only
the token attribute is populated with that token string
