### PR TITLE
Feature spec: remove ChannelDetails.name

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1352,7 +1352,6 @@ h4. ChannelDetails
 * @(CHD1)@ @ChannelDetails@ is a type that represents information for a channel including channelId, name, status and occupancy
 * @(CHD2)@ The attributes of @ChannelDetails@ consist of:
 ** @(CHD2a)@ @channelId@ string - the identifier of the channel
-** @(CHD2b)@ @name@ string - the name of the channel
 ** @(CHD2c)@ @status@ @ChannelStatus@ - the status of the channel
 
 h4. ChannelStatus
@@ -1803,7 +1802,6 @@ class ChannelOptions:
 
 class ChannelDetails:
   channelId: String // CHD2a
-  name: String // CHD2b
   status: ChannelStatus // CHD2c
 
 class ChannelStatus:


### PR DESCRIPTION
This property is deprecated in favour of `channelId`, see [internal slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1652783091921479).