### PR TITLE
Feature spec: move CHD2c to CHD2b

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1352,7 +1352,7 @@ h4. ChannelDetails
 * @(CHD1)@ @ChannelDetails@ is a type that represents information for a channel including channelId, name, status and occupancy
 * @(CHD2)@ The attributes of @ChannelDetails@ consist of:
 ** @(CHD2a)@ @channelId@ string - the identifier of the channel
-** @(CHD2c)@ @status@ @ChannelStatus@ - the status of the channel
+** @(CHD2b)@ @status@ @ChannelStatus@ - the status of the channel
 
 h4. ChannelStatus
 
@@ -1802,7 +1802,7 @@ class ChannelOptions:
 
 class ChannelDetails:
   channelId: String // CHD2a
-  status: ChannelStatus // CHD2c
+  status: ChannelStatus // CHD2b
 
 class ChannelStatus:
   isActive: Boolean // CHS2a


### PR DESCRIPTION
CHD2b was removed in #1428, this additional PR simply addresses the 'gap' in the spec IDs created by that PR.