### PR TITLE
EDX-60: Fix bc. blocks inside blang blocks not rendering correctly.

### DIFF
--- a/data/transform/post-parser/blang.js
+++ b/data/transform/post-parser/blang.js
@@ -15,7 +15,7 @@ const BLANG_REGEX_STRING = `${
 const BLANG_REGEX = new RegExp(BLANG_REGEX_STRING, 'gms');
 const convertBlangBlocksToHtml = (content) =>
   content.replace(BLANG_REGEX, (_match, p1, p2) => {
-    return `<div lang="${p1}"><!-- start ${p1} language block -->${p2.trim()}</div><!-- /end ${p1} language block -->`;
+    return `<div lang="${p1}"><!-- start ${p1} language block -->\n${p2.trim()}</div><!-- /end ${p1} language block -->`;
   });
 
 module.exports = {

--- a/data/transform/post-parser/blang.test.js
+++ b/data/transform/post-parser/blang.test.js
@@ -35,7 +35,8 @@ describe('Converts Blang strings to HTML', () => {
     });
     const result = convertBlangBlocksToHtml(blangBlock);
     expect(result).toBe(
-      `<div lang="javascript"><!-- start javascript language block --><div>Lorem ipsum adipiscitor</div></div><!-- /end javascript language block -->`,
+      `<div lang="javascript"><!-- start javascript language block -->
+<div>Lorem ipsum adipiscitor</div></div><!-- /end javascript language block -->`,
     );
   });
   it('Converts broken Blang block while keeping multiple languages separate', () => {
@@ -71,7 +72,8 @@ describe('Converts Blang strings to HTML', () => {
         });
         const result = convertBlangBlocksToHtml(blangBlock);
         expect(result).toBe(
-          `<div lang="${language}"><!-- start ${language} language block -->${content.trim()}</div><!-- /end ${language} language block -->`,
+          `<div lang="${language}"><!-- start ${language} language block -->
+${content.trim()}</div><!-- /end ${language} language block -->`,
         );
       }),
     );

--- a/data/transform/pre-parser/language/blang.raw.examples.js
+++ b/data/transform/pre-parser/language/blang.raw.examples.js
@@ -153,6 +153,7 @@ blang[flutter].
 
 const riskyBlangExpectedResult = `
 {{LANG_BLOCK[jsall]}}
+
 @ConnectionState@ is a String with a value matching any of the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[javascript]
@@ -171,6 +172,7 @@ const riskyBlangExpectedResult = `
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[java]}}
+
 @io.ably.lib.realtime.ConnectionState@ is an enum representing all the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[java]
@@ -189,6 +191,7 @@ const riskyBlangExpectedResult = `
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[csharp]}}
+
 @IO.Ably.Realtime.ConnectionState@ is an enum representing all the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[csharp]
@@ -208,6 +211,7 @@ const riskyBlangExpectedResult = `
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[ruby]}}
+
 @Ably::Realtime::Connection::STATE@ is an enum-like value representing all the "@Realtime Connection@ states":/realtime/connection#connection-states. @STATE@ can be represented interchangeably as either symbols or constants.
 
 h4. Symbol states
@@ -252,6 +256,7 @@ h4. Example usage
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[objc,swift]}}
+
 @ARTRealtimeConnectionState@ is an enum representing all the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[objc]
@@ -283,6 +288,7 @@ h4. Example usage
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[go]}}
+
 @ConnectionState@ is an enum representing all the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[go]
@@ -301,6 +307,7 @@ h4. Example usage
 {{/LANG_BLOCK}}
 
 {{LANG_BLOCK[flutter]}}
+
 @ably.ConnectionState@ is an enum representing all the "@Realtime Connection@ states":/realtime/connection#connection-states.
 
 \`\`\`[flutter]
@@ -365,6 +372,15 @@ h4.
       - <span lang="javascript,nodejs,java,swift,objc">params</span><span lang="csharp">Params</span> := Optional "parameters":/realtime/channels/channel-parameters/overview which specify behaviour of the channel.<br>__Type: <span lang='java'>@Map<String, String>@</span><span lang="javascript,nodejs,objc,csharp,swift">@JSON Object@</span>__
       - <span lang="javascript,nodejs,java,swift,objc">cipher</span><span lang="csharp">CipherParams</span> := Requests encryption for this channel when not null, and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See "an example":/realtime/encryption#getting-started<br>__Type: "@CipherParams@":/realtime/encryption#cipher-params<span lang="javascript,nodejs,java,ruby,php"> or <span lang="javascript,nodejs">an options object</span><span lang="java">a @Param[]@ list</span><span lang="ruby">an options hash</span><span lang="php">an Associative Array</span> containing at a minimum a @key@</span>__`;
 
+const brokenCodeInsideBlangExample = `blang[jsall].
+  \`\`\`[jsall]
+    realtime.connection.on('connected', function(stateChange) {
+      console.log('Ably is connected');
+    });
+  \`\`\`
+
+`;
+
 module.exports = {
   riskyBlangExample,
   riskyBlangExpectedResult,
@@ -372,4 +388,5 @@ module.exports = {
   brokenBlangExpectedResult,
   brokenBlangTokenExpectedResult,
   brokenBlangTokenAfterJSConversionExpectedResult,
+  brokenCodeInsideBlangExample,
 };

--- a/data/transform/pre-parser/language/conversions.js
+++ b/data/transform/pre-parser/language/conversions.js
@@ -53,7 +53,7 @@ const convertJSAllToNodeAndJavaScript = (content) => {
 
 const BLANG_REGEX = /^blang\[([\w,]+)\]\.\s*$/m;
 
-const langBlockWrapper = (languages) => `\n{{LANG_BLOCK[${languages}]}}\n`;
+const langBlockWrapper = (languages) => `\n{{LANG_BLOCK[${languages}]}}\n\n`;
 const langBlockEnd = '{{/LANG_BLOCK}}\n';
 
 const convertBlangBlocksToTokens = (content) => {

--- a/data/transform/pre-parser/shared-utilities/extract-indented.js
+++ b/data/transform/pre-parser/shared-utilities/extract-indented.js
@@ -1,43 +1,45 @@
 const INDENTATION_REGEX = /^(\s+).*$/m;
 
-const extractIndented = (text, name='Indentable', allowEmptyLines=false) => {
-    /**
-     * Find some amount of indentation followed by some amount of content
-     */
-    const indentationResult = text.match(INDENTATION_REGEX);
-    if(!indentationResult || !indentationResult[1]) {
-        throw `${name} blocks must be followed by indentation. Offending block: '${text.slice(0,127)}'\n`;
-    }
-    
-    const indentation = indentationResult[1];
-    /**
-     * Find the same level of indentation we matched first in the text 
-     */
-    const indentationRegexString = `^${indentation}(.*)$`
-    const indentationRegex = new RegExp(indentationRegexString, 'gm');
-    /**
-     * Find the next instance that doesn't match the same level of indentation we matched in the text
-     * 
-     * If allowEmptyLines is truthy, find the next instance that doesn't match the same level of indentation
-     * we matched in the text AND isn't an empty line.
-     */
-    const negativeIndentationRegexString = allowEmptyLines ? `^(?!${indentation}.*\\n)(?!\\s*\\n)` : `^(?!${indentation}.*)$`
-    const negativeIndentationRegex = new RegExp(negativeIndentationRegexString, 'gm');
-    
-    const nonIndentedLineLocation = text.search(negativeIndentationRegex);
+const extractIndented = (text, name = 'Indentable', allowEmptyLines = false) => {
+  /**
+   * Find some amount of indentation followed by some amount of content
+   */
+  const indentationResult = text.match(INDENTATION_REGEX);
+  if (!indentationResult || !indentationResult[1]) {
+    throw `${name} blocks must be followed by indentation. Offending block: '${text.slice(0, 127)}'\n`;
+  }
 
-    /**
-     * If we can't find a non-indented line, that's likely an error in the regex; display this at build time
-     */
-    if(nonIndentedLineLocation === -1) {
-        throw `${name} block regex error, could not find ${negativeIndentationRegex.source} in ${text.slice(0,100)}`;
-    }
+  const indentation = indentationResult[1];
+  /**
+   * Find the same level of indentation we matched first in the text
+   */
+  const indentationRegexString = `^${indentation}(.*)$`;
+  const indentationRegex = new RegExp(indentationRegexString, 'gm');
+  /**
+   * Find the next instance that doesn't match the same level of indentation we matched in the text
+   *
+   * If allowEmptyLines is truthy, find the next instance that doesn't match the same level of indentation
+   * we matched in the text AND isn't an empty line.
+   */
+  const negativeIndentationRegexString = allowEmptyLines
+    ? `^(?!${indentation}.*\\n)(?!\\s*\\n)`
+    : `^(?!${indentation}.*)$`;
+  const negativeIndentationRegex = new RegExp(negativeIndentationRegexString, 'gm');
 
-    const onlyIndentedLines = text.slice(0,nonIndentedLineLocation).replace(indentationRegex, '$1');
+  const nonIndentedLineLocation = text.search(negativeIndentationRegex);
 
-    return { onlyIndentedLines, nonIndentedLineLocation };
-}
+  /**
+   * If we can't find a non-indented line, that's likely an error in the regex; display this at build time
+   */
+  if (nonIndentedLineLocation === -1) {
+    throw `${name} block regex error, could not find ${negativeIndentationRegex.source} in ${text.slice(0, 100)}`;
+  }
+
+  const onlyIndentedLines = text.slice(0, nonIndentedLineLocation).replace(indentationRegex, '$1');
+
+  return { onlyIndentedLines, nonIndentedLineLocation };
+};
 
 module.exports = {
-    extractIndented
-}
+  extractIndented,
+};


### PR DESCRIPTION
## Description

Fixes an issue with bc. blocks inside blang blocks not rendering correctly.

Achieves this by adding a newline to LANG_BLOCK token strings.

Also cleans up some linting issues in e.g. extract-indented.js.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-60).

## Review

Error was occurring on page:

* [Page to review](http://localhost:8000/docs/realtime/connection) - problem occurred on second set of code blocks.
