### PR TITLE
Edx 57 textile js ordered list workaround

### DIFF
--- a/data/transform/pre-parser/textile-js-workarounds/index.js
+++ b/data/transform/pre-parser/textile-js-workarounds/index.js
@@ -6,6 +6,7 @@ const { addItalicisedText } = require('./add-italicised-text');
 const { fixLeadingHtmlTags } = require('./fix-leading-html-tags');
 const { addBoldText } = require('./add-bold-text');
 const { addHyphenListSupport } = require('./add-hyphen-list-support');
+const { makeImplicitOrderedListExplicit } = require('./make-implicit-ordered-list-explicit');
 
 // textile-js, unlike RedCloth, cannot parse multiple new lines between list items
 // each list item will instead be wrapped in its own list collection
@@ -19,6 +20,7 @@ const textileJSCompatibility = compose(
   fixTextileDefinitionLists,
   fixInlineCode,
   compressMultipleNewlinesInLists,
+  makeImplicitOrderedListExplicit,
   manuallyReplaceHTags,
   fixDuplicateQuoteLinks,
   fixHtmlElementsInLinks,

--- a/data/transform/pre-parser/textile-js-workarounds/make-implicit-ordered-list-explicit.js
+++ b/data/transform/pre-parser/textile-js-workarounds/make-implicit-ordered-list-explicit.js
@@ -1,0 +1,7 @@
+// Not supporting implicit OLs at different indentation levels because the
+// chance of causing unexpected behaviour is too high.
+const makeImplicitOrderedListExplicit = (content) => content.replace(/^\d+\.(.+)$/gm, '# $1');
+
+module.exports = {
+  makeImplicitOrderedListExplicit,
+};

--- a/data/transform/pre-parser/textile-js-workarounds/make-implicit-ordered-list-explicit.test.js
+++ b/data/transform/pre-parser/textile-js-workarounds/make-implicit-ordered-list-explicit.test.js
@@ -1,0 +1,40 @@
+const textile = require('textile-js');
+const { preParser } = require('..');
+const { postParser } = require('../../post-parser');
+const { makeImplicitOrderedListExplicit } = require('./make-implicit-ordered-list-explicit');
+
+describe('Ensure that implicit ordered lists (decimal-led lines) are converted to explicit Textile ordered lists', () => {
+  it('Interprets ordered lists correctly', () => {
+    expect(
+      makeImplicitOrderedListExplicit(`
+
+Ably supports two methods of authentication:
+
+1. "Basic authentication":/core-features/authentication#basic-authentication
+2. "Token authentication":/core-features/authentication#token-authentication`),
+    ).toBe(`
+
+Ably supports two methods of authentication:
+
+#  "Basic authentication":/core-features/authentication#basic-authentication
+#  "Token authentication":/core-features/authentication#token-authentication`);
+  });
+  it('Preserves ordered lists throughout the parsing process', () => {
+    expect(
+      postParser(
+        textile(
+          preParser(`
+
+Ably supports two methods of authentication:
+
+1. "Basic authentication":/core-features/authentication#basic-authentication
+2. "Token authentication":/core-features/authentication#token-authentication`),
+        ),
+      ),
+    ).toBe(`<p>Ably supports two methods of authentication:</p>
+<ol>
+	<li><a href="/core-features/authentication#basic-authentication">Basic authentication</a></li>
+	<li><a href="/core-features/authentication#token-authentication">Token authentication</a></li>
+</ol>`);
+  });
+});

--- a/src/components/blocks/list/Ol.js
+++ b/src/components/blocks/list/Ol.js
@@ -1,5 +1,12 @@
+import styled from 'styled-components';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
+import { resetStyles } from './reset-styles';
 
-const Ol = GenericHtmlBlock('ol');
+const StyledOl = styled.ol`
+  list-style: decimal;
+  ${resetStyles}
+`;
+
+const Ol = GenericHtmlBlock(StyledOl);
 
 export default Ol;

--- a/src/components/blocks/list/Ul.js
+++ b/src/components/blocks/list/Ul.js
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
+import { resetStyles } from './reset-styles';
 
 // Unset these values inherited from AblyUI/reset.css
 const StyledUl = styled.ul`
   list-style: unset;
-  margin: unset;
-  padding: unset;
-  padding-left: 1em;
+  ${resetStyles}
 `;
 
 const Ul = GenericHtmlBlock(StyledUl);

--- a/src/components/blocks/list/reset-styles.js
+++ b/src/components/blocks/list/reset-styles.js
@@ -1,0 +1,10 @@
+const { css } = require('styled-components');
+
+// Unset these values inherited from AblyUI/reset.css
+const resetStyles = css`
+  margin: unset;
+  padding: unset;
+  padding-left: 1em;
+`;
+
+export { resetStyles };

--- a/src/components/blocks/list/reset-styles.js
+++ b/src/components/blocks/list/reset-styles.js
@@ -5,6 +5,7 @@ const resetStyles = css`
   margin: unset;
   padding: unset;
   padding-left: 1em;
+  padding-bottom: 1em;
 `;
 
 export { resetStyles };

--- a/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><dd> pair of children from alternatives for parsed definition lists ConditionalChildrenLanguageDisplay displays the expected results from HTML data 1`] = `
 <dl
-  className="sc-hKMtZM kHEDQX"
+  className="sc-eCYdqJ fwQCuu"
 >
   
 	
@@ -10,7 +10,7 @@ exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><
     lang="nodejs"
   >
     <dt
-      className="sc-eCYdqJ kFdOlo"
+      className="sc-jSMfEi gcMQlA"
     >
       <div>
         callback


### PR DESCRIPTION
## Description

Implicit ordered lists (e.g.
1. Item one
2. Item two
3. Item three)

Are not recognised as such by textile-js. To look nice they should be:

# Item one
# Item two
# Item three

* [Jira ticket](https://ably.atlassian.net/browse/EDX-57).

## Review

Ensure ordered lists are displayed prominently on these pages:

* [Page to review](http://localhost:8000/docs/best-practice-guide#auth)
* [Page to review](http://localhost:8000/docs/asset-tracking/example-apps?lang=swift) - note there is an issue with the h2s immediately in the blangs there, this is fixed separately by branch edx-60-some-bc-langs-not-rendering-correctly
