### PR TITLE
Edx 164 gatsby yaml errors

### DIFF
--- a/data/transform/index.js
+++ b/data/transform/index.js
@@ -4,7 +4,7 @@ const { tryRetrieveMetaData, filterAllowedMetaFields, NO_MATCH } = require('./fr
 const DataTypes = require('../types');
 const { ROOT_LEVEL, MAX_LEVEL } = require('../../src/components/Sidebar/consts');
 const { preParser } = require('./pre-parser');
-const { enhancedParse } = require('./parser-enhancements');
+const { processAfterFrontmatterExtracted } = require('./parser-enhancements');
 const { maybeRetrievePartial } = require('./retrieve-partials');
 const { flattenContentOrderedList } = require('./shared-utilities');
 
@@ -85,7 +85,7 @@ const createNodesFromPath =
 const constructDataObjectsFromStrings = (contentStrings, frontmatterMeta) => {
   contentStrings =
     frontmatterMeta !== NO_MATCH && frontmatterMeta.attributes
-      ? contentStrings.map((content) => enhancedParse(content, frontmatterMeta.attributes))
+      ? contentStrings.map((content) => processAfterFrontmatterExtracted(content, frontmatterMeta.attributes))
       : contentStrings;
   const dataObjects = contentStrings.map((data, i) =>
     i % 2 === 0 ? { data: data, type: DataTypes.Html } : { data: data, type: DataTypes.Partial },

--- a/data/transform/parser-enhancements/index.js
+++ b/data/transform/parser-enhancements/index.js
@@ -2,7 +2,7 @@ const { addHyphenListSupport } = require('../pre-parser/textile-js-workarounds/a
 const { addDates } = require('./add-dates');
 const { addSpecAnchorLinks } = require('./spec-anchor-links');
 
-const enhancedParse = (content, attributes = {}, path = null) => {
+const processAfterFrontmatterExtracted = (content, attributes = {}, path = null) => {
   let result = addSpecAnchorLinks(content, attributes);
   result = addDates(result, attributes);
   result = addHyphenListSupport(result);
@@ -10,5 +10,5 @@ const enhancedParse = (content, attributes = {}, path = null) => {
 };
 
 module.exports = {
-  enhancedParse,
+  processAfterFrontmatterExtracted,
 };

--- a/data/transform/parser-enhancements/index.js
+++ b/data/transform/parser-enhancements/index.js
@@ -1,9 +1,11 @@
+const { addHyphenListSupport } = require('../pre-parser/textile-js-workarounds/add-hyphen-list-support');
 const { addDates } = require('./add-dates');
 const { addSpecAnchorLinks } = require('./spec-anchor-links');
 
 const enhancedParse = (content, attributes = {}, path = null) => {
   let result = addSpecAnchorLinks(content, attributes);
   result = addDates(result, attributes);
+  result = addHyphenListSupport(result);
   return result;
 };
 

--- a/data/transform/pre-parser/textile-js-workarounds/index.js
+++ b/data/transform/pre-parser/textile-js-workarounds/index.js
@@ -5,7 +5,6 @@ const { fixTextileDefinitionLists } = require('./fix-textile-definition-lists');
 const { addItalicisedText } = require('./add-italicised-text');
 const { fixLeadingHtmlTags } = require('./fix-leading-html-tags');
 const { addBoldText } = require('./add-bold-text');
-const { addHyphenListSupport } = require('./add-hyphen-list-support');
 const { makeImplicitOrderedListExplicit } = require('./make-implicit-ordered-list-explicit');
 
 // textile-js, unlike RedCloth, cannot parse multiple new lines between list items
@@ -24,7 +23,6 @@ const textileJSCompatibility = compose(
   manuallyReplaceHTags,
   fixDuplicateQuoteLinks,
   fixHtmlElementsInLinks,
-  addHyphenListSupport,
   addItalicisedText,
   addBoldText,
 );


### PR DESCRIPTION
## Description

Fixes Gatsby YAML errors (introduced by processing hyphen-led bullet point lists)
Renames 'enhancedParse' function to be more reflective of what it actually does/is for ('processAfterFrontmatterExtracted')

* [Jira ticket](https://ably.atlassian.net/browse/EDX-164).

## Review

Check that this page still has a bullet point list with the text:

- For a message event it will be a [Message](http://localhost:8000/api/realtime-sdk/types#message) object
- For a presence event it will be a [PresenceMessage](http://localhost:8000/api/realtime-sdk/types#presence-message) object
- For an error event it will be an [ErrorInfo](http://localhost:8000/api/realtime-sdk/types#error-info) object

* [Page to review](http://localhost:8000/docs/api/sse)
Make sure no errors appear after running.
