### PR TITLE
remove reference to deprecated name property

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1349,7 +1349,7 @@ h4. ChannelProperties
 
 h4. ChannelDetails
 
-* @(CHD1)@ @ChannelDetails@ is a type that represents information for a channel including channelId, name, status and occupancy
+* @(CHD1)@ @ChannelDetails@ is a type that represents information for a channel including channelId, status and occupancy
 * @(CHD2)@ The attributes of @ChannelDetails@ consist of:
 ** @(CHD2a)@ @channelId@ string - the identifier of the channel
 ** @(CHD2b)@ @status@ @ChannelStatus@ - the status of the channel


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Spotted a small mistake where a deprecated property `name` (see https://github.com/ably/docs/pull/1428)  was mentioned in the description for ChannelDetails. This PR removes reference to `name`
