### PR TITLE
[EDX-175] Document the stats types and add to the IDL

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -2050,6 +2050,59 @@ enum StatsIntervalGranularity:
   DAY
   MONTH
 
+class Stats.ConnectionTypes // TS4
+  tls: Stats.ResourceCount // TS4a
+  plain: Stats.ResourceCount // TS4b
+  all: Stats.ResourceCount // TS4c
+
+class Stats.MessageCount // TS5
+  count: Int // TS5a
+  data: Int // TS5b
+
+class Stats.MessageTypes // TS6
+  messages: Stats.MessageCount // TS6a
+  presence: Stats.MessageCount // TS6b
+  all: Stats.MessageCount // TS6c
+
+class Stats.MessageTraffic // TS7
+  realtime: Stats.MessageTypes // TS7a
+  rest: Stats.MessageTypes // TS7b
+  webhook: Stats.MessageTypes // TS7c
+  all: Stats.MessageTypes // TS7d
+
+class Stats.RequestCount // TS8
+  succeeded: Int // TS8a
+  failed: Int // TS8b
+  refused: Int // TS8c
+
+class Stats.ResourceCount // TS9
+  opened: Int // TS9a
+  peak: Int // TS9b
+  mean: Int // TS9c
+  min: Int // TS9d
+  refused: Int // TS9e
+
+class Stats.PushStats // TS10
+  messages: Int // TS10a
+  directPublishes: Int // TS10b
+  notifications: Stats.PushNotificationCount // TS10c
+
+class Stats.PushNotificationCount // TS13
+  invalid: Int // TS13a
+  attempted: Int // TS13b
+  successful: Int // TS13c
+  failed: Int // TS13d
+
+class Stats.XchgMessages // TS11
+  all: Stats.MessageTypes // TS11a
+  producerPaid: Stats.MessageDirections // TS11b
+  consumerPaid: Stats.MessageDirections // TS11c
+
+class Stats.MessageDirections // TS14
+  all: MessageTypes // TS14a
+  inbound: MessageTraffic // TS14b
+  outbound: MessageTraffic // TS14c
+
 class DeviceDetails:
   id: String
   clientId: String?

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1281,15 +1281,35 @@ h4. Stats
 
 * @(TS1)@ @Stats@ is a type encapsulating a statistics datapoint retrieved from the "REST stats endpoint":/rest-api/#stats.  See "example statistics in JSON format":/general/statistics/
 * @(TS2)@ All stats values default to zero when no underlying JSON value exists. We send sparse JSON to stats requests omitting fields where the value is zero to reduce bandwidth and optimize JSON parsing, however the API exposed to developers ensures that all properties of the @Stats@ object such as @stats.all.messages.count@ will always return an @Integer@ value i.e. all attributes are non-nullable
-* @(TS3)@ See the "Ruby Stats type documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats for a list of attributes and their types for the @Stats@ object
-* @(TS4)@ @Stats.ConnectionTypes@ - see the "Ruby ConnectionTypes documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/ConnectionTypes
-* @(TS5)@ @Stats.MessageCount@ - see the "Ruby MessageCount documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/MessageCount
-* @(TS6)@ @Stats.MessageTypes@ - see the "Ruby MessageTypes documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/MessageTypes
-* @(TS7)@ @Stats.MessageTraffic@ - see the "Ruby MessageTraffic documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/MessageTraffic
-* @(TS8)@ @Stats.RequestCount@ - see the "Ruby RequestCount documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/RequestCount
-* @(TS9)@ @Stats.ResourceCount@ - see the "Ruby ResourceCount documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/ResourceCount
-* @(TS10)@ @Stats.PushStats@ - see the "Ruby PushStats documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/PushStats
-* @(TS11)@ @Stats.XchgMessages@ - see the "Ruby XchgMessages documentation":https://www.rubydoc.info/gems/ably/Ably/Models/Stats/PushStats
+* @(TS3)@ This clause has been deleted.
+* @(TS4)@ @Stats.ConnectionTypes@ - contains a breakdown of summary stats data for different (TLS vs non-TLS) connection types. Has the following attributes:
+** @(TS4a)@ @tls@ - a @ResourceCount@. The number of TLS connections.
+** @(TS4b)@ @plain@ - a @ResourceCount@. The number of non-TLS connections.
+** @(TS4c)@ @all@ - a @ResourceCount@. The number of all connections (both TLS & non-TLS).
+* @(TS5)@ @Stats.MessageCount@ - contains aggregate counts for messages and data transferred. Has the following attributes:
+** @(TS5a)@ @count@ - integer. The count of all messages.
+** @(TS5b)@ @data@ - integer. The total number of bytes transferred for all messages.
+* @(TS6)@ @Stats.MessageTypes@ - contains a breakdown of summary stats data for different (channel vs presence) message types. Has the following attributes:
+** @(TS6a)@ @messages@ - a @MessageCount@. The count of channel messages.
+** @(TS6b)@ @presence@ - a @MessageCount@. The count of presence messages.
+** @(TS6c)@ @all@ - a @MessageCount@. The count of all messages (channel & presence).
+* @(TS7)@ @Stats.MessageTraffic@ - contains a breakdown of summary stats data for traffic over various transport types. Has the following attributes:
+** @(TS7a)@ @realtime@ - a @MessageTypes@. The count of messages transferred over a realtime transport such as WebSocket.
+** @(TS7b)@ @rest@ - a @MessageTypes@. The count of messages transferred over a realtime transport such as WebSocket.
+** @(TS7c)@ @webhook@ - a @MessageTypes@. The count of messages delivered using webhooks.
+** @(TS7d)@ @all@ - a @MessageTypes@. The count of all messages (includes realtime, rest and webhook messages).
+* @(TS8)@ @Stats.RequestCount@ - contains aggregate counts for requests made. Has the following attributes:
+** @(TS8a)@ @succeeded@ - integer. The number of requests that succeeded.
+** @(TS8b)@ @failed@ - integer. The number of requests that failed.
+** @(TS8c)@ @refused@ - integer. The number of requests that were refused, typically as a result of permissions or a limit being exceeded.
+* @(TS9)@ @Stats.ResourceCount@ - contains aggregate data for usage of a resource in a specific scope. Has the following attributes:
+** @(TS9a)@ @opened@ - integer. The total number of resources opened of this type.
+** @(TS9b)@ @peak@ - integer. The peak number of resources of this type used for this period.
+** @(TS9c)@ @mean@ - integer. The average number of resources of this type used for this period.
+** @(TS9d)@ @min@ - integer. The minimum total resources of this type used for this period.
+** @(TS9e)@ @refused@ - integer. The number of resource requests refused within this period.
+* @(TS10)@ @Stats.PushStats@ - TODO find a source of documentation
+* @(TS11)@ @Stats.XchgMessages@ - TODO find a source of documentation
 * @(TS12)@ The attributes of a @Stats@ object consist of:
 ** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@
 ** @(TS12b)@ @intervalTime@ (optional) - a language-idiomatic @Time@ object, parsed from the @intervalId@

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1309,14 +1309,14 @@ h4. Stats
 ** @(TS9d)@ @min@ - integer. The minimum total resources of this type used for this period.
 ** @(TS9e)@ @refused@ - integer. The number of resource requests refused within this period.
 * @(TS10)@ @Stats.PushStats@ - detailed stats on push notifications. Has the following attributes:
-** @(TS10a)@ @messages@ - integer. TODO description
-** @(TS10b)@ @directPublishes@ - integer. TODO description
+** @(TS10a)@ @messages@ - integer. Total number of Push channel messages.
+** @(TS10b)@ @directPublishes@ - integer. Total number of direct publishes.
 ** @(TS10c)@ @notifications@ - a @PushNotificationCount@. TODO description
 * @(TS13)@ @Stats.PushNotificationCount@ - TODO description. Has the following attributes:
 ** @(TS13a)@ @invalid@ - integer. TODO description
 ** @(TS13b)@ @attempted@ - integer. TODO description
-** @(TS13c)@ @successful@ - integer. TODO description
-** @(TS13d)@ @failed@ - integer. TODO description
+** @(TS13c)@ @successful@ - integer. Total number of delivered Push notifications.
+** @(TS13d)@ @failed@ - integer. Total number of refused Push notifications.
 * @(TS11)@ @Stats.XchgMessages@ - TODO description. Has the following attributes:
 ** @(TS11a)@ @all@ - a @MessageTypes@. TODO description
 ** @(TS11b)@ @producerPaid@ - a @MessageDirections@. TODO description

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1309,14 +1309,14 @@ h4. Stats
 ** @(TS9d)@ @min@ - integer. The minimum total resources of this type used for this period.
 ** @(TS9e)@ @refused@ - integer. The number of resource requests refused within this period.
 * @(TS10)@ @Stats.PushStats@ - detailed stats on push notifications. Has the following attributes:
-** @(TS10a)@ @messages@ - integer. Total number of Push channel messages.
+** @(TS10a)@ @messages@ - integer. Total number of push channel messages.
 ** @(TS10b)@ @directPublishes@ - integer. Total number of direct publishes.
 ** @(TS10c)@ @notifications@ - a @PushNotificationCount@. TODO description
 * @(TS13)@ @Stats.PushNotificationCount@ - TODO description. Has the following attributes:
 ** @(TS13a)@ @invalid@ - integer. TODO description
 ** @(TS13b)@ @attempted@ - integer. TODO description
-** @(TS13c)@ @successful@ - integer. Total number of delivered Push notifications.
-** @(TS13d)@ @failed@ - integer. Total number of refused Push notifications.
+** @(TS13c)@ @successful@ - integer. Total number of delivered push notifications.
+** @(TS13d)@ @failed@ - integer. Total number of refused push notifications.
 * @(TS11)@ @Stats.XchgMessages@ - contains data about usage of Ably API Streamer as a producer or consumer. Has the following attributes:
 ** @(TS11a)@ @all@ - a @MessageTypes@. Data about all Ably API Streamer usage.
 ** @(TS11b)@ @producerPaid@ - a @MessageDirections@. Data about Ably API Streamer usage which was charged to the producer.

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1305,7 +1305,7 @@ h4. Stats
 * @(TS9)@ @Stats.ResourceCount@ - contains aggregate data for usage of a resource in a specific scope. Has the following attributes:
 ** @(TS9a)@ @opened@ - integer. The total number of resources opened of this type.
 ** @(TS9b)@ @peak@ - integer. The peak number of resources of this type used for this period.
-** @(TS9c)@ @mean@ - integer. The average number of resources of this type used for this period.
+** @(TS9c)@ @mean@ - float. The average number of resources of this type used for this period.
 ** @(TS9d)@ @min@ - integer. The minimum total resources of this type used for this period.
 ** @(TS9e)@ @refused@ - integer. The number of resource requests refused within this period.
 * @(TS10)@ @Stats.PushStats@ - detailed stats on push notifications. Has the following attributes:
@@ -2078,7 +2078,7 @@ class Stats.RequestCount // TS8
 class Stats.ResourceCount // TS9
   opened: Int // TS9a
   peak: Int // TS9b
-  mean: Int // TS9c
+  mean: Float // TS9c
   min: Int // TS9d
   refused: Int // TS9e
 

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1308,7 +1308,15 @@ h4. Stats
 ** @(TS9c)@ @mean@ - integer. The average number of resources of this type used for this period.
 ** @(TS9d)@ @min@ - integer. The minimum total resources of this type used for this period.
 ** @(TS9e)@ @refused@ - integer. The number of resource requests refused within this period.
-* @(TS10)@ @Stats.PushStats@ - TODO find a source of documentation
+* @(TS10)@ @Stats.PushStats@ - detailed stats on push notifications. Has the following attributes:
+** @(TS10a)@ @messages@ - integer. TODO description
+** @(TS10b)@ @directPublishes@ - integer. TODO description
+** @(TS10c)@ @notifications@ - a @PushNotificationCount@. TODO description
+* @(TS13)@ @Stats.PushNotificationCount@ - TODO description. Has the following attributes:
+** @(TS13a)@ @invalid@ - integer. TODO description
+** @(TS13b)@ @attempted@ - integer. TODO description
+** @(TS13c)@ @successful@ - integer. TODO description
+** @(TS13d)@ @failed@ - integer. TODO description
 * @(TS11)@ @Stats.XchgMessages@ - TODO find a source of documentation
 * @(TS12)@ The attributes of a @Stats@ object consist of:
 ** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1317,7 +1317,14 @@ h4. Stats
 ** @(TS13b)@ @attempted@ - integer. TODO description
 ** @(TS13c)@ @successful@ - integer. TODO description
 ** @(TS13d)@ @failed@ - integer. TODO description
-* @(TS11)@ @Stats.XchgMessages@ - TODO find a source of documentation
+* @(TS11)@ @Stats.XchgMessages@ - TODO description. Has the following attributes:
+** @(TS11a)@ @all@ - a @MessageTypes@. TODO description
+** @(TS11b)@ @producerPaid@ - a @MessageDirections@. TODO description
+** @(TS11c)@ @consumerPaid@ - a @MessageDirections@. TODO description
+* @(TS14)@ @Stats.MessageDirections@ - TODO description. Has the following attributes:
+** @(TS14a)@ @all@ - a @MessageTypes@. TODO description
+** @(TS14b)@ @inbound@ - a @MessageTraffic@. TODO description
+** @(TS14c)@ @outbound@ - a @MessageTraffic@. TODO description
 * @(TS12)@ The attributes of a @Stats@ object consist of:
 ** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@
 ** @(TS12b)@ @intervalTime@ (optional) - a language-idiomatic @Time@ object, parsed from the @intervalId@

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1311,10 +1311,10 @@ h4. Stats
 * @(TS10)@ @Stats.PushStats@ - detailed stats on push notifications. Has the following attributes:
 ** @(TS10a)@ @messages@ - integer. Total number of push channel messages.
 ** @(TS10b)@ @directPublishes@ - integer. Total number of direct publishes.
-** @(TS10c)@ @notifications@ - a @PushNotificationCount@. TODO description
-* @(TS13)@ @Stats.PushNotificationCount@ - TODO description. Has the following attributes:
-** @(TS13a)@ @invalid@ - integer. TODO description
-** @(TS13b)@ @attempted@ - integer. TODO description
+** @(TS10c)@ @notifications@ - a @PushNotificationCount@. The count of push notifications.
+* @(TS13)@ @Stats.PushNotificationCount@ - Contains a count of push notifications published broken down by outcome. Has the following attributes:
+** @(TS13a)@ @invalid@ - integer. Total number of attempted push notifications which were rejected due to invalid request data.
+** @(TS13b)@ @attempted@ - integer. Total number of attempted push notifications including notifications which were rejected as invalid or failed to publish.
 ** @(TS13c)@ @successful@ - integer. Total number of delivered push notifications.
 ** @(TS13d)@ @failed@ - integer. Total number of refused push notifications.
 * @(TS11)@ @Stats.XchgMessages@ - contains data about usage of Ably API Streamer as a producer or consumer. Has the following attributes:

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1317,14 +1317,14 @@ h4. Stats
 ** @(TS13b)@ @attempted@ - integer. TODO description
 ** @(TS13c)@ @successful@ - integer. Total number of delivered Push notifications.
 ** @(TS13d)@ @failed@ - integer. Total number of refused Push notifications.
-* @(TS11)@ @Stats.XchgMessages@ - TODO description. Has the following attributes:
-** @(TS11a)@ @all@ - a @MessageTypes@. TODO description
-** @(TS11b)@ @producerPaid@ - a @MessageDirections@. TODO description
-** @(TS11c)@ @consumerPaid@ - a @MessageDirections@. TODO description
-* @(TS14)@ @Stats.MessageDirections@ - TODO description. Has the following attributes:
-** @(TS14a)@ @all@ - a @MessageTypes@. TODO description
-** @(TS14b)@ @inbound@ - a @MessageTraffic@. TODO description
-** @(TS14c)@ @outbound@ - a @MessageTraffic@. TODO description
+* @(TS11)@ @Stats.XchgMessages@ - contains data about usage of Ably API Streamer as a producer or consumer. Has the following attributes:
+** @(TS11a)@ @all@ - a @MessageTypes@. Data about all Ably API Streamer usage.
+** @(TS11b)@ @producerPaid@ - a @MessageDirections@. Data about Ably API Streamer usage which was charged to the producer.
+** @(TS11c)@ @consumerPaid@ - a @MessageDirections@. Data about Ably API Streamer usage which was charged to the consumer.
+* @(TS14)@ @Stats.MessageDirections@ - contains data about published and received messages. Has the following attributes:
+** @(TS14a)@ @all@ - a @MessageTypes@. Data about both received and published messages.
+** @(TS14b)@ @inbound@ - a @MessageTraffic@. Data about received messages.
+** @(TS14c)@ @outbound@ - a @MessageTraffic@. Data about published messages.
 * @(TS12)@ The attributes of a @Stats@ object consist of:
 ** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@
 ** @(TS12b)@ @intervalTime@ (optional) - a language-idiomatic @Time@ object, parsed from the @intervalId@

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1282,6 +1282,22 @@ h4. Stats
 * @(TS1)@ @Stats@ is a type encapsulating a statistics datapoint retrieved from the "REST stats endpoint":/rest-api/#stats.  See "example statistics in JSON format":/general/statistics/
 * @(TS2)@ All stats values default to zero when no underlying JSON value exists. We send sparse JSON to stats requests omitting fields where the value is zero to reduce bandwidth and optimize JSON parsing, however the API exposed to developers ensures that all properties of the @Stats@ object such as @stats.all.messages.count@ will always return an @Integer@ value i.e. all attributes are non-nullable
 * @(TS3)@ This clause has been deleted.
+* @(TS12)@ The attributes of a @Stats@ object consist of:
+** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@
+** @(TS12b)@ @intervalTime@ (optional) - a language-idiomatic @Time@ object, parsed from the @intervalId@
+** @(TS12c)@ @unit@ (property present in the JSON) - a @String@ or (if idiomatic) an enumerable supporting the types @minute@, @hour@, @day@, and @month@. This must be from the @unit@ property of the JSON, not calculated from the @intervalId@
+** @(TS12d)@ @intervalGranularity@ (deprecated) - an alias for @unit@, only for 1.x versions of client libraries that had such a property in a previous 1.x version, to avoid breaking compatibility. As above, this must be from the @unit@ property of the JSON, not calculated from the @intervalId@
+** @(TS12e)@ @all@ (property present in the JSON) - a @MessageTypes@ object
+** @(TS12f)@ @inbound@ (property present in the JSON) - a @MessageTraffic@ object
+** @(TS12g)@ @outbound@ (property present in the JSON) - a @MessageTraffic@ object
+** @(TS12h)@ @persisted@ (property present in the JSON) - a @MessageTypes@ object
+** @(TS12i)@ @connections@ (property present in the JSON) - a @ConnectionTypes@ object
+** @(TS12j)@ @channels@ (property present in the JSON) - a @ResourceCount@ object
+** @(TS12k)@ @apiRequests@ (property present in the JSON) - a @RequestCount@ object
+** @(TS12l)@ @tokenRequests@ (property present in the JSON) - a @RequestCount@ object
+** @(TS12m)@ @push@ (property present in the JSON) - a @PushStats@ object
+** @(TS12n)@ @xchgProducer@ (property present in the JSON) - an @XchgMessages@ object
+** @(TS12o)@ @xchgConsumer@ (property present in the JSON) - an @XchgMessages@ object
 * @(TS4)@ @Stats.ConnectionTypes@ - contains a breakdown of summary stats data for different (TLS vs non-TLS) connection types. Has the following attributes:
 ** @(TS4a)@ @tls@ - a @ResourceCount@. The number of TLS connections.
 ** @(TS4b)@ @plain@ - a @ResourceCount@. The number of non-TLS connections.
@@ -1325,22 +1341,6 @@ h4. Stats
 ** @(TS14a)@ @all@ - a @MessageTypes@. Data about both received and published messages.
 ** @(TS14b)@ @inbound@ - a @MessageTraffic@. Data about received messages.
 ** @(TS14c)@ @outbound@ - a @MessageTraffic@. Data about published messages.
-* @(TS12)@ The attributes of a @Stats@ object consist of:
-** @(TS12a)@ @intervalId@ (property present in the JSON) - a @String@
-** @(TS12b)@ @intervalTime@ (optional) - a language-idiomatic @Time@ object, parsed from the @intervalId@
-** @(TS12c)@ @unit@ (property present in the JSON) - a @String@ or (if idiomatic) an enumerable supporting the types @minute@, @hour@, @day@, and @month@. This must be from the @unit@ property of the JSON, not calculated from the @intervalId@
-** @(TS12d)@ @intervalGranularity@ (deprecated) - an alias for @unit@, only for 1.x versions of client libraries that had such a property in a previous 1.x version, to avoid breaking compatibility. As above, this must be from the @unit@ property of the JSON, not calculated from the @intervalId@
-** @(TS12e)@ @all@ (property present in the JSON) - a @MessageTypes@ object
-** @(TS12f)@ @inbound@ (property present in the JSON) - a @MessageTraffic@ object
-** @(TS12g)@ @outbound@ (property present in the JSON) - a @MessageTraffic@ object
-** @(TS12h)@ @persisted@ (property present in the JSON) - a @MessageTypes@ object
-** @(TS12i)@ @connections@ (property present in the JSON) - a @ConnectionTypes@ object
-** @(TS12j)@ @channels@ (property present in the JSON) - a @ResourceCount@ object
-** @(TS12k)@ @apiRequests@ (property present in the JSON) - a @RequestCount@ object
-** @(TS12l)@ @tokenRequests@ (property present in the JSON) - a @RequestCount@ object
-** @(TS12m)@ @push@ (property present in the JSON) - a @PushStats@ object
-** @(TS12n)@ @xchgProducer@ (property present in the JSON) - an @XchgMessages@ object
-** @(TS12o)@ @xchgConsumer@ (property present in the JSON) - an @XchgMessages@ object
 
 h4. ErrorInfo
 


### PR DESCRIPTION
## Description

This adds documentation for all the stats-related types, instead of relying on links to the Ruby documentation.

## Review

Please review commit-by-commit and see commit messages for motivation and approach.

## Outstanding

If anybody would like to suggest descriptions for the things that say `TODO description`, I'd be very grateful. Else I'll leave the TODOs as is to be addressed some other time and will make an issue for it.