### PR TITLE
Made `ChannelDetails.status` and `ChannelStatus.occupancy` optional

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -1357,14 +1357,14 @@ h4. ChannelDetails
 * @(CHD1)@ @ChannelDetails@ is a type that represents information for a channel including channelId, status and occupancy
 * @(CHD2)@ The attributes of @ChannelDetails@ consist of:
 ** @(CHD2a)@ @channelId@ string - the identifier of the channel
-** @(CHD2b)@ @status@ @ChannelStatus@ - the status of the channel
+** @(CHD2b)@ @status@ @ChannelStatus@ (optional) - the status of the channel
 
 h4. ChannelStatus
 
 * @(CHS1)@ @ChannelStatus@ is a type that contains status and occupancy for a channel
 * @(CHS2)@ The attributes of @ChannelStatus@ consist of:
 ** @(CHS2a)@ @isActive@ boolean - represents if the channel is active
-** @(CHS2b)@ @occupancy@ @ChannelOccupancy@ - occupancy is an object containing the metrics for the channel
+** @(CHS2b)@ @occupancy@ @ChannelOccupancy@ (optional) - occupancy is an object containing the metrics for the channel
 
 h4. ChannelOccupancy
 
@@ -1808,11 +1808,11 @@ class ChannelOptions:
 
 class ChannelDetails:
   channelId: String // CHD2a
-  status: ChannelStatus // CHD2b
+  status: ChannelStatus? // CHD2b
 
 class ChannelStatus:
   isActive: Boolean // CHS2a
-  occupancy: ChannelOccupancy // CHS2b
+  occupancy: ChannelOccupancy? // CHS2b
 
 class ChannelOccupancy:
   metrics: ChannelMetrics // CHO2a


### PR DESCRIPTION
As mentioned by @lawrence-forooghian in [this](https://github.com/ably/ably-cocoa/pull/1420#discussion_r891168741) and [this](https://github.com/ably/ably-cocoa/pull/1420#discussion_r891172648) comments, both `ChannelDetails.status` and `ChannelStatus.occupancy` should be optional.