### PR TITLE
Rename client classes

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -503,7 +503,7 @@ h3(#realtime-connection). Connection
 
 h3(#realtime-channels). Channels
 
-* @(RTS1)@ @Channels@ is a collection of @Channel@ objects accessible through @Realtime#channels@
+* @(RTS1)@ @Channels@ is a collection of @Channel@ objects accessible through @RealtimeClient#channels@
 * @(RTS2)@ Methods should exist to check if a channel exists or iterate through the existing channels
 * @(RTS3)@ @Channels#get@ function:
 ** @(RTS3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
@@ -598,7 +598,7 @@ h3(#realtime-channel). Channel
 ** @(RTL7c)@ Implicitly attaches the @Channel@ if the channel is in the @INITIALIZED@ state. The optional callback, if provided, is called according to "@RTL4d@":#RTL4d based on the implicit attach operation. The listener will always be registered regardless of the implicit attach result
 ** @(RTL7d)@ Messages delivered are automatically decoded based on the @encoding@ attribute; see REST @Channel@ encoding features. Tests should exist to publish and subscribe to encoded messages using the "AES 128":https://github.com/ably/ably-common/blob/main/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/main/test-resources/crypto-data-256.json fixture test data
 ** @(RTL7e)@ If a message cannot be decoded or decrypted successfully, it should be delivered to the listener with the @encoding@ attribute set indicating the residual encoding state, and an error should be logged
-** @(RTL7f)@ A test should exist ensuring published messages are not echoed back to the subscriber when @echoMessages@ is set to false in the @Realtime@ library constructor
+** @(RTL7f)@ A test should exist ensuring published messages are not echoed back to the subscriber when @echoMessages@ is set to false in the @RealtimeClient@ library constructor
 * @(RTL8)@ @Channel#unsubscribe@ function:
 ** @(RTL8a)@ Unsubscribe with no arguments unsubscribes the provided listener to all messages if subscribed
 ** @(RTL8b)@ Unsubscribe with a single name argument unsubscribes the provided listener if previously subscribed with a name-specific subscription
@@ -716,7 +716,7 @@ h3(#realtime-presence). Presence
 ** @(RTP14d)@ A test should exist that registers a number of members each with a different @clientId@ on a presence channel, and then a @Presence#get@ should be used to verify that all members are present as expected
 * @(RTP15)@ @Presence#enterClient@ @Presence#updateClient@ and @Presence#leaveClient@ function:
 ** @(RTP15a)@ Performs an enter, update or leave for given @clientId@. These methods apply if the Realtime library was not initialized with a specific @clientId@. This allows a single client with suitable permissions to update presence on behalf of any number of clients using a single connection. Otherwise these are functionality equivalent to the corresponding @enter@, @update@ and @leave@ methods, and equivalent test coverage should be provided
-** @(RTP15b)@ Tests should use @enterClient@, @updateClient@ and @leaveClient@ for many members from one @Realtime@ client and check that the operations are reflected in the presence map and the expected events are emitted on a separate client
+** @(RTP15b)@ Tests should use @enterClient@, @updateClient@ and @leaveClient@ for many members from one @RealtimeClient@ instance and check that the operations are reflected in the presence map and the expected events are emitted on a separate client
 ** @(RTP15c)@ Tests should also ensure that using these methods has no side effects on a client that has entered normally using @Presence#enter@
 ** @(RTP15d)@ A callback can be provided that will be called upon success or failure
 ** @(RTP15e)@ Implicitly attaches the @Channel@ if the channel is in the @INITIALIZED@ state. However, if the channel is in or enters the @DETACHED@ or @FAILED@ state before the operation succeeds, it will result in an error
@@ -1147,8 +1147,8 @@ h3(#push-channels). Push channels
 
 h3(#local-device). LocalDevice
 
-* @(RSH8)@ In platforms that support receiving push notifications, the @device@ method on the @RestClient@ or @Realtime@ interfaces returns an instance of @LocalDevice@ that represents the current state of the device in respect of it being a target for push notifications.
-** @(RSH8a)@ The @LocalDevice@ is initialised when first required, either as a result of a call to @RestClient#device@ or @Realtime#device@, or as a result of an operation involving the Activation State Machine. The @LocalDevice@ @id@, @clientId@, @deviceSecret@ and @deviceIdentityToken@ attributes are populated, together with any @recipient@-related attributes, to the extent that they exist, from the persisted state.
+* @(RSH8)@ In platforms that support receiving push notifications, the @device@ method on the @RestClient@ or @RealtimeClient@ interfaces returns an instance of @LocalDevice@ that represents the current state of the device in respect of it being a target for push notifications.
+** @(RSH8a)@ The @LocalDevice@ is initialised when first required, either as a result of a call to @RestClient#device@ or @RealtimeClient#device@, or as a result of an operation involving the Activation State Machine. The @LocalDevice@ @id@, @clientId@, @deviceSecret@ and @deviceIdentityToken@ attributes are populated, together with any @recipient@-related attributes, to the extent that they exist, from the persisted state.
 ** @(RSH8b)@ The @LocalDevice@ @id@ and @deviceSecret@ attributes are generated, and persisted as part of the @LocalDevice@ state, when required by step "@(RSH3a2b)@":#RSH3a2b in the Activation State Machine. At that time, the @clientId@ attribute is also initialised, if the client is identified according to "@(RSA7)@":#RSA7.
 ** @(RSH8c)@ Following successful registration of a @LocalDevice@, following the procedure in "@(RSH3c2a)@":#RSH3c2a, the now known @deviceIdentityToken@ is set and persisted.
 ** @(RSH8d)@ If the @LocalDevice* is created by an unidentified client (see "@(RSA7)@":#RSA7 ) and therefore has no @clientId@ set, but the client subsequently becomes identified (as a result of "@(RSA7b2)@":#RSA7b2 or "@(RSA7b3)@":#RSA7b3 ), then the @LocalDevice@ @clientId@ is set and persisted.
@@ -1585,7 +1585,7 @@ class RestClient:
   ) => io PaginatedResult<Stats> // RSC6a
   time() => io Time // RSC16
 
-class Realtime:
+class RealtimeClient:
   constructor(keyStr: String) // RSC1
   constructor(tokenStr: String) // RSC1
   constructor(ClientOptions) // RSC1

--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -236,7 +236,7 @@ h3(#rest-auth). Auth
 
 h3(#rest-channels). Channels
 
-* @(RSN1)@ @Channels@ is a collection of @Channel@ objects accessible through @Rest#channels@
+* @(RSN1)@ @Channels@ is a collection of @Channel@ objects accessible through @RestClient#channels@
 * @(RSN2)@ Methods should exist to check if a channel exists or iterate through the existing channels
 * @(RSN3)@ @Channels#get@ function:
 ** @(RSN3a)@ Creates a new @Channel@ object for the specified channel if none exists, or returns the existing channel. @ChannelOptions@ can be provided in an optional second argument
@@ -1036,7 +1036,7 @@ h2(#push-notifications). Push notifications
 
 h3(#activation-state-machine). Activation State Machine
 
-* @(RSH3)@ In platforms that support receiving push notifications, in order to connect the device's push features with Ably's, the library must perform the process described in the following abstract state machine. While this process should be implemented in whatever way better fits the concrete platform, it should be taken into account that its lifetime is that of the _app_ that runs it, which outlives that of the @Rest@ instance or (typically) the process running the app. This typically forces some kind of on-disk storage to which the state machine's state must be persisted, so that it can be recovered later by new instances and processes running the app triggered by external events.
+* @(RSH3)@ In platforms that support receiving push notifications, in order to connect the device's push features with Ably's, the library must perform the process described in the following abstract state machine. While this process should be implemented in whatever way better fits the concrete platform, it should be taken into account that its lifetime is that of the _app_ that runs it, which outlives that of the @RestClient@ instance or (typically) the process running the app. This typically forces some kind of on-disk storage to which the state machine's state must be persisted, so that it can be recovered later by new instances and processes running the app triggered by external events.
 ** @(RSH3a)@ State @NotActivated@ (the initial one).
 *** @(RSH3a1)@ On event @CalledDeactivate@:
 **** @(RSH3a1a)@ Makes @Push#deactivate@ return or call its callback with no error.
@@ -1147,8 +1147,8 @@ h3(#push-channels). Push channels
 
 h3(#local-device). LocalDevice
 
-* @(RSH8)@ In platforms that support receiving push notifications, the @device@ method on the @Rest@ or @Realtime@ interfaces returns an instance of @LocalDevice@ that represents the current state of the device in respect of it being a target for push notifications.
-** @(RSH8a)@ The @LocalDevice@ is initialised when first required, either as a result of a call to @Rest#device@ or @Realtime#device@, or as a result of an operation involving the Activation State Machine. The @LocalDevice@ @id@, @clientId@, @deviceSecret@ and @deviceIdentityToken@ attributes are populated, together with any @recipient@-related attributes, to the extent that they exist, from the persisted state.
+* @(RSH8)@ In platforms that support receiving push notifications, the @device@ method on the @RestClient@ or @Realtime@ interfaces returns an instance of @LocalDevice@ that represents the current state of the device in respect of it being a target for push notifications.
+** @(RSH8a)@ The @LocalDevice@ is initialised when first required, either as a result of a call to @RestClient#device@ or @Realtime#device@, or as a result of an operation involving the Activation State Machine. The @LocalDevice@ @id@, @clientId@, @deviceSecret@ and @deviceIdentityToken@ attributes are populated, together with any @recipient@-related attributes, to the extent that they exist, from the persisted state.
 ** @(RSH8b)@ The @LocalDevice@ @id@ and @deviceSecret@ attributes are generated, and persisted as part of the @LocalDevice@ state, when required by step "@(RSH3a2b)@":#RSH3a2b in the Activation State Machine. At that time, the @clientId@ attribute is also initialised, if the client is identified according to "@(RSA7)@":#RSA7.
 ** @(RSH8c)@ Following successful registration of a @LocalDevice@, following the procedure in "@(RSH3c2a)@":#RSH3c2a, the now known @deviceIdentityToken@ is set and persisted.
 ** @(RSH8d)@ If the @LocalDevice* is created by an unidentified client (see "@(RSA7)@":#RSA7 ) and therefore has no @clientId@ set, but the client subsequently becomes identified (as a result of "@(RSA7b2)@":#RSA7b2 or "@(RSA7b3)@":#RSA7b3 ), then the @LocalDevice@ @clientId@ is set and persisted.
@@ -1462,7 +1462,7 @@ h4. ClientOptions
 **** @(TO3l8c)@ The size of a @binary@ @data@ property is its size in bytes (of the actual binary, not the base64 representation, regardless of whether the binary protocol is in use)
 **** @(TO3l8d)@ The size of the @extras@ property is the string length of its JSON representation
 **** @(TO3l8e)@ The size of a @null@ or omitted property is zero
-*** @(TO3l9)@ @maxFrameSize@ integer - default 524288 (512KiB). The maximum size of a single POST body or "WebSocket":https://ably.com/topic/websockets frame. This is mostly only relevant for `Rest#request` (e.g. for batch publishes), since publishes will hit the @maxMessageSize@ limit before this
+*** @(TO3l9)@ @maxFrameSize@ integer - default 524288 (512KiB). The maximum size of a single POST body or "WebSocket":https://ably.com/topic/websockets frame. This is mostly only relevant for `RestClient#request` (e.g. for batch publishes), since publishes will hit the @maxMessageSize@ limit before this
 *** @(TO3l10)@ @fallbackRetryTimeout@ integer - default 600000 (10 minutes). (After a failed request to the default endpoint, followed by a successful request to a fallback endpoint), the period in milliseconds before HTTP requests are retried  against the default endpoint
 ** @(TO3o)@ @plugins@ @Dict<PluginType:Plugin>@ A map between a @PluginType@ and a @Plugin@ object. The client library might downcast a @Plugin@ to particular plugin type.
 ** @(TO3p)@ @addRequestIds@ boolean - defaults to false. If true, @RSC7c@ applies
@@ -1560,7 +1560,7 @@ Please note the following conventions:
 * @JSONObject@ and @JSONArray@ denote any type or interface in the target language that represents an "RFC4627":https://www.ietf.org/rfc/rfc4627.txt @object@ or @array@ value respectively. Such types serialize to, and may be deserialized from, the corresponding JSON text. In the specification text above, values of these types are collectively referred to as "JSON-encodable".
 
 ```
-class Rest:
+class RestClient:
   constructor(keyStr: String) // RSC1
   constructor(tokenStr: String) // RSC1
   constructor(ClientOptions) // RSC1
@@ -1603,7 +1603,7 @@ class Realtime:
     JsonObject | JsonArray body?,
     Dict<String, String> headers?
   ) => io HttpPaginatedResponse // RTC9
-  stats: // Same as Rest.stats, RTC5a
+  stats: // Same as RestClient.stats, RTC5a
   close() // proxy for RTN12
   connect() // proxy for RTN11
   time() => io Time // RTC6a


### PR DESCRIPTION
## Description

Renames the `Rest` and `Realtime` classes to `RestClient` and `RealtimeClient` for consistency throughout the spec (where this terminology was already being used in some places) and to match the IDL.