### PR TITLE
[EDX-156] Add `realtimeRequestTimeout` to `ClientOptions`

### DIFF
--- a/content/client-lib-development-guide/features.textile
+++ b/content/client-lib-development-guide/features.textile
@@ -157,7 +157,7 @@ h3(#rest-auth). Auth
 *** @(RSA4a2)@ if the server responds with a token error (401 HTTP status code and an Ably error value @40140 <= code < 40150@), then the client library should indicate an error with error code @40171@, not retry the request and, in the case of the realtime library, transition the connection to the @FAILED@ state
 ** @(RSA4b)@ When the client does have a means to renew the token automatically, and the server has responded with a token error (@statusCode@ value of 401 and error @code@ value in the range @40140 <= code < 40150@) or the client library has optionally detected the current token has expired (see "RSA4b1":#RSA4b1), then the client should automatically make a single attempt to reissue the token and resend the request using the new token. If the token creation failed or the subsequent request with the new token failed due to a token error, then the request should result in an error (in the case of a realtime library, follow @RSA4c@)
 *** @(RSA4b1)@ Client libraries can optionally save a round-trip request to the Ably service for expired tokens by detecting when a token has expired when all of the following applies: the current token is a @TokenDetails@ object with an @expires@ attribute; the library has previously queried the time from the Ably service and persisted the local clock offset according to "RSA10k":#RSA10k; the @expires@ time has passed based on the Ably service time and not the local clock (which is not guaranteed to be accurate)
-** @(RSA4c)@ If an attempt by the realtime client library to authenticate is made using the @authUrl@ or @authCallback@, and the request to @authUrl@ fails (unless @RSA4d@ applies), the callback @authCallback@ results in an error (unless "RSA4d":#RSA4d applies), an attempt to exchange a @TokenRequest@ for a @TokenDetails@ results in an error (unless "RSA4d":#RSA4d applies), the provided token is in an invalid format (as defined in "RSA4e":#RSA4e), or the attempt times out after "@realtimeRequestTimeout@":#DF1b, then:
+** @(RSA4c)@ If an attempt by the realtime client library to authenticate is made using the @authUrl@ or @authCallback@, and the request to @authUrl@ fails (unless @RSA4d@ applies), the callback @authCallback@ results in an error (unless "RSA4d":#RSA4d applies), an attempt to exchange a @TokenRequest@ for a @TokenDetails@ results in an error (unless "RSA4d":#RSA4d applies), the provided token is in an invalid format (as defined in "RSA4e":#RSA4e), or the attempt times out after "@realtimeRequestTimeout@":#TO3l11, then:
 *** @(RSA4c1)@An @ErrorInfo@ with @code@ @80019@, @statusCode@ 401, and @cause@ set to the underlying cause should be emitted with the state change if there is one (per @RSA4c2/3@) and set as the connection @errorReason@
 *** @(RSA4c2)@If the connection is @CONNECTING@, then the connection attempt should be treated as unsuccessful, and as such the connection should transition to the @DISCONNECTED@ or @SUSPENDED@ state as defined in "RTN14":#RTN14 and "RTN15":#RTN15
 *** @(RSA4c3)@If the connection is @CONNECTED@, then the connection should remain @CONNECTED@
@@ -1454,6 +1454,7 @@ h4. ClientOptions
 *** @(TO3l7)@ @channelRetryTimeout@ integer - default 15,000 (15s). When a channel becomes @SUSPENDED@ following a server initiated @DETACHED@, after this delay in milliseconds, if the channel is still @SUSPENDED@ and the connection is @CONNECTED@, the client library will attempt to re-attach the channel automatically
 *** @(TO3l3)@ @httpOpenTimeout@ integer - default 4,000 (4s). Timeout for opening the connection, available in the client library if supported by the transport
 *** @(TO3l4)@ @httpRequestTimeout@ integer - default 10,000 (10s). Timeout for any single HTTP request and response
+*** @(TO3l11)@ @realtimeRequestTimeout@ integer - default 10,000 (10s). When a realtime client library is establishing a connection with Ably, or sending a @HEARTBEAT@, @CONNECT@, @ATTACH@, @DETACH@ or @CLOSE@ @ProtocolMessage@ to Ably, this is the amount of time that the client library will wait before considering that request as failed and triggering a suitable failure condition
 *** @(TO3l5)@ @httpMaxRetryCount@ integer - default 3. Max number of fallback hosts to use as a fallback when an HTTP request to the primary host is unreachable or indicates that it is unserviceable
 *** @(TO3l6)@ @httpMaxRetryDuration@ integer - default 15,000 (15s). Max elapsed time in which fallback host retries for HTTP requests will be attempted i.e. if the first default host attempt takes 7s, and then the subsequent fallback retry attempt takes 10s, no further fallback host attempts will be made as the total elapsed time of 17s exceeds the default 15s limit
 *** @(TO3l8)@ @maxMessageSize@ integer - default 65536 (64KiB). The maximum size of messages that can be published in one go. That is, the size of the @ProtocolMessage.messages@ or @ProtocolMessage.presence@ array for a realtime publish or presence action, or the message or array of messages being published for a REST publish. For realtime publishes, the default will be overridden by the @maxMessageSize@ in the @connectionDetails@, see "CD2c":#CD2c
@@ -1535,7 +1536,7 @@ The following default values are configured for the client library:
 
 * @(DF1)@ Realtime defaults:
 ** @(DF1a)@ @connectionStateTtl@ integer - default 120s. The duration that Ably will persist the connection state when a Realtime client is abruptly disconnected. When the client is in the @DISCONNECTED@ state, once this TTL has passed, the client should transition the state to the @SUSPENDED@ state signifying that the state is now lost i.e. channels need to be re-attached manually. Note that this default is overriden by @connectionStateTtl@, if specified in the @ConnectionDetails@ of the @CONNECTED@ @ProtocolMessage@
-** @(DF1b)@ @realtimeRequestTimeout@ - default 10s. When a realtime client library is establishing a connection with Ably, or sending a @HEARTBEAT@, @CONNECT@, @ATTACH@, @DETACH@ or @CLOSE@ @ProtocolMessage@ to Ably, this is the amount of time that the client library will wait before considering that request as failed and triggering a suitable failure condition
+** @(DF1b)@ This clause has been replaced by "TO3l11":#TO3l11.
 
 h2(#idl). Interface Definition
 
@@ -1635,6 +1636,7 @@ class ClientOptions:
   channelRetryTimeout: Duration default 15s // RTL13b, TO3l7
   httpOpenTimeout: Duration default 4s // TO3l3
   httpRequestTimeout: Duration default 10s // TO3l4
+  realtimeRequestTimeout: Duration default 10s // TO3l11
   httpMaxRetryCount: Int default 3 // TO3l5
   httpMaxRetryDuration: Duration default 15s // TO3l6
   maxMessageSize: Int default 65536 // TO3l8


### PR DESCRIPTION
This already exists as a user-configurable `ClientOptions` property in several of our SDKs:

- ably-java@`7fc1939`
- ably-js@`48a66d6` (been configurable there since `1b355bf` in 2015)
- ably-ruby@`f5eac15`
- ably-go@`32ed667`
- ably-flutter@`2fe0059`

Furthermore, it seems consistent to allow this timeout to be configured, the same way as the others can be.