### PR TITLE
[EDX-119] Sync left menu with active content

### DIFF
--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -260,6 +260,9 @@ export type DirectoryCtimeArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Int']>;
+  host?: Maybe<Scalars['String']>;
+  assetPrefix?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   jsxRuntime?: Maybe<Scalars['String']>;
@@ -863,6 +866,9 @@ export type QueryAllDirectoryArgs = {
 export type QuerySiteArgs = {
   buildTime?: InputMaybe<DateQueryOperatorInput>;
   siteMetadata?: InputMaybe<SiteSiteMetadataFilterInput>;
+  port?: InputMaybe<IntQueryOperatorInput>;
+  host?: InputMaybe<StringQueryOperatorInput>;
+  assetPrefix?: InputMaybe<StringQueryOperatorInput>;
   polyfill?: InputMaybe<BooleanQueryOperatorInput>;
   pathPrefix?: InputMaybe<StringQueryOperatorInput>;
   jsxRuntime?: InputMaybe<StringQueryOperatorInput>;
@@ -2595,6 +2601,9 @@ export type SiteFieldsEnum =
   | 'siteMetadata___title'
   | 'siteMetadata___description'
   | 'siteMetadata___siteUrl'
+  | 'port'
+  | 'host'
+  | 'assetPrefix'
   | 'polyfill'
   | 'pathPrefix'
   | 'jsxRuntime'
@@ -2731,6 +2740,9 @@ export type SiteGroupConnectionGroupArgs = {
 export type SiteFilterInput = {
   buildTime?: InputMaybe<DateQueryOperatorInput>;
   siteMetadata?: InputMaybe<SiteSiteMetadataFilterInput>;
+  port?: InputMaybe<IntQueryOperatorInput>;
+  host?: InputMaybe<StringQueryOperatorInput>;
+  assetPrefix?: InputMaybe<StringQueryOperatorInput>;
   polyfill?: InputMaybe<BooleanQueryOperatorInput>;
   pathPrefix?: InputMaybe<StringQueryOperatorInput>;
   jsxRuntime?: InputMaybe<StringQueryOperatorInput>;

--- a/src/components/Sidebar/SidebarLinkMenu.js
+++ b/src/components/Sidebar/SidebarLinkMenu.js
@@ -7,6 +7,7 @@ import SidebarLabel from './SidebarLabel';
 import SidebarLink from './SidebarLink';
 import SidebarLinkItem from './SidebarLinkItem';
 import { EXPAND_MENU } from './expand-menu-enum';
+import { checkSectionMatch } from './check-section-match';
 
 const OrderedList = styled.ol`
   margin: 0;
@@ -31,6 +32,8 @@ const SidebarLinkMenu = ({ data, interactable = false, expandMenu = EXPAND_MENU.
         );
 
         if ([EXPAND_MENU.EXPANDED, EXPAND_MENU.COLLAPSE_NEXT].includes(expandMenu)) {
+          preExpanded.push(uuid);
+        } else if (EXPAND_MENU.SECTION_MATCH === expandMenu && checkSectionMatch('match')(data)) {
           preExpanded.push(uuid);
         }
         const nextExpandMenu = EXPAND_MENU.COLLAPSE_NEXT

--- a/src/components/Sidebar/SidebarLinkMenu.js
+++ b/src/components/Sidebar/SidebarLinkMenu.js
@@ -21,6 +21,26 @@ const SidebarLinkMenu = ({ data, interactable = false, expandMenu = EXPAND_MENU.
       data.map(({ label, link, level = ROOT_LEVEL, content = false }) => {
         const uuid = encodeURIComponent(`${label}${link}`);
 
+        if ([EXPAND_MENU.EXPANDED, EXPAND_MENU.COLLAPSE_NEXT].includes(expandMenu)) {
+          preExpanded.push(uuid);
+        } else if (
+          EXPAND_MENU.SECTION_MATCH === expandMenu &&
+          checkSectionMatch(window.location.pathname)({
+            label,
+            link,
+            level,
+            content,
+          })
+        ) {
+          preExpanded.push(uuid);
+        }
+        const nextExpandMenu =
+          expandMenu === EXPAND_MENU.COLLAPSE_NEXT
+            ? EXPAND_MENU.COLLAPSED
+            : expandMenu === EXPAND_MENU.EXPAND_NEXT
+            ? EXPAND_MENU.EXPANDED
+            : expandMenu;
+
         const labelMaybeWithLink = interactable ? (
           <SidebarLink $leaf={false} indent={indent} level={level} to={link}>
             {label}
@@ -31,16 +51,8 @@ const SidebarLinkMenu = ({ data, interactable = false, expandMenu = EXPAND_MENU.
           </SidebarLabel>
         );
 
-        if ([EXPAND_MENU.EXPANDED, EXPAND_MENU.COLLAPSE_NEXT].includes(expandMenu)) {
-          preExpanded.push(uuid);
-        } else if (EXPAND_MENU.SECTION_MATCH === expandMenu && checkSectionMatch('match')(data)) {
-          preExpanded.push(uuid);
-        }
-        const nextExpandMenu = EXPAND_MENU.COLLAPSE_NEXT
-          ? EXPAND_MENU.COLLAPSED
-          : EXPAND_MENU.EXPAND_NEXT
-          ? EXPAND_MENU.EXPANDED
-          : expandMenu;
+        const isActive = link === window.location.pathname;
+
         return content ? (
           <li key={`${label}-${link}-${level}`}>
             <SidebarLinkItem
@@ -56,7 +68,7 @@ const SidebarLinkMenu = ({ data, interactable = false, expandMenu = EXPAND_MENU.
           </li>
         ) : (
           <li key={`${label}-${link}-${level}`}>
-            <SidebarLink to={link} $leaf={indent > 0} indent={indent}>
+            <SidebarLink to={link} $leaf={indent > 0} active={isActive} indent={indent}>
               {label}
             </SidebarLink>
           </li>

--- a/src/components/Sidebar/SidebarLinkMenu.js
+++ b/src/components/Sidebar/SidebarLinkMenu.js
@@ -68,7 +68,7 @@ const SidebarLinkMenu = ({ data, interactable = false, expandMenu = EXPAND_MENU.
           </li>
         ) : (
           <li key={`${label}-${link}-${level}`}>
-            <SidebarLink to={link} $leaf={indent > 0} active={isActive} indent={indent}>
+            <SidebarLink to={link} $leaf={indent > 0} $active={isActive} indent={indent}>
               {label}
             </SidebarLink>
           </li>

--- a/src/components/Sidebar/check-section-match.test.ts
+++ b/src/components/Sidebar/check-section-match.test.ts
@@ -72,9 +72,9 @@ const sidebarDataArbitraryTreeWithMatchingLink = letrec((tie) => {
       link: string().filter((s) => s !== '/docs/match'),
       level: nat(),
       content: oneof(
-        { maxDepth: 5 },
-        array(sidebarDataArbitraryWithMatchingLink, { minLength: 1, maxLength: 5 }),
-        array(sidebarNode, { minLength: 1, maxLength: 5 }),
+        { depthIdentifier: 'node', maxDepth: 5 },
+        array(sidebarDataArbitraryWithMatchingLink, { minLength: 1, maxLength: 20, depthIdentifier: 'node' }),
+        array(sidebarNode, { minLength: 1, maxLength: 20, depthIdentifier: 'node' }),
       ),
     }),
   };

--- a/src/components/Sidebar/check-section-match.test.ts
+++ b/src/components/Sidebar/check-section-match.test.ts
@@ -1,0 +1,91 @@
+import { Arbitrary, array, assert, constant, letrec, nat, oneof, property, record, string } from 'fast-check';
+import { checkSectionMatch } from './check-section-match';
+import { SidebarData } from './sidebar-data';
+
+const simpleSectionMatch = checkSectionMatch('/docs/match');
+
+describe('Check Section Matches function', () => {
+  it('Matches on a simple slug', () =>
+    expect(
+      simpleSectionMatch({
+        label: 'Test Data',
+        link: '/docs/match',
+      }),
+    ).toBe(true));
+  it('Does not match on a simple absence of slug', () =>
+    expect(
+      simpleSectionMatch({
+        label: 'Test Data',
+      }),
+    ).toBe(false));
+  it('Does not match on a non-matching slug', () =>
+    expect(
+      simpleSectionMatch({
+        label: 'Test Data',
+        link: '/docs/match/overly-specific-page',
+      }),
+    ).toBe(false));
+
+  it('Matches on a nested slug', () =>
+    expect(
+      simpleSectionMatch({
+        label: 'Test Data',
+        link: '/docs',
+        content: [
+          {
+            label: 'Test Data Two',
+            link: '/docs/match',
+          },
+        ],
+      }),
+    ).toBe(true));
+  it('Does not match without a nested slug', () =>
+    expect(
+      simpleSectionMatch({
+        label: 'Test Data',
+        link: '/docs',
+        content: [
+          {
+            label: 'Test Data Two',
+            link: '/docs/no-match',
+          },
+          {
+            label: 'Test Data Two',
+          },
+        ],
+      }),
+    ).toBe(false));
+});
+
+const sidebarDataArbitraryWithMatchingLink: Arbitrary<SidebarData> = record({
+  label: string(),
+  link: constant('/docs/match'),
+  level: nat(),
+  content: constant(undefined),
+});
+
+const sidebarDataArbitraryTreeWithMatchingLink = letrec((tie) => ({
+  node: record({
+    label: string(),
+    link: string().filter((s) => s !== '/docs/match'),
+    level: nat(),
+    content: oneof(
+      { maxDepth: 5 },
+      array(sidebarDataArbitraryWithMatchingLink),
+      constant(undefined),
+      array(tie('node')),
+    ),
+  }),
+})).node;
+
+describe('Property test of Check Section Matches function', () => {
+  it('Matches when sidebar data contains a link', () => {
+    assert(
+      // @ts-ignore
+      property(sidebarDataArbitraryTreeWithMatchingLink, (sidebarData: SidebarData) =>
+        expect(simpleSectionMatch(sidebarData)).toBe(true),
+      ),
+    );
+  });
+  it('Does not match when sidebar data does not contain a link', () => {});
+});

--- a/src/components/Sidebar/check-section-match.test.ts
+++ b/src/components/Sidebar/check-section-match.test.ts
@@ -71,9 +71,8 @@ const sidebarDataArbitraryTreeWithMatchingLink = letrec((tie) => ({
     level: nat(),
     content: oneof(
       { maxDepth: 5 },
-      array(sidebarDataArbitraryWithMatchingLink),
-      constant(undefined),
-      array(tie('node')),
+      array(sidebarDataArbitraryWithMatchingLink, { minLength: 1, maxLength: 5 }),
+      array(tie('node'), { minLength: 1, maxLength: 5 }),
     ),
   }),
 })).node;

--- a/src/components/Sidebar/check-section-match.test.ts
+++ b/src/components/Sidebar/check-section-match.test.ts
@@ -1,4 +1,4 @@
-import { Arbitrary, array, assert, constant, letrec, nat, oneof, option, property, record, string } from 'fast-check';
+import { Arbitrary, array, assert, constant, letrec, nat, oneof, property, record, string } from 'fast-check';
 import { checkSectionMatch } from './check-section-match';
 import { SidebarData } from './sidebar-data';
 
@@ -64,36 +64,44 @@ const sidebarDataArbitraryWithMatchingLink: Arbitrary<SidebarData> = record({
   content: constant(undefined),
 });
 
-const sidebarDataArbitraryTreeWithMatchingLink = letrec((tie) => ({
-  node: record({
-    label: string(),
-    link: string().filter((s) => s !== '/docs/match'),
-    level: nat(),
-    content: oneof(
-      { maxDepth: 5 },
-      array(sidebarDataArbitraryWithMatchingLink, { minLength: 1, maxLength: 5 }),
-      array(tie('node'), { minLength: 1, maxLength: 5 }),
-    ),
-  }),
-})).node;
+const sidebarDataArbitraryTreeWithMatchingLink = letrec((tie) => {
+  const sidebarNode = <Arbitrary<SidebarData>>tie('node');
+  return {
+    node: record({
+      label: string(),
+      link: string().filter((s) => s !== '/docs/match'),
+      level: nat(),
+      content: oneof(
+        { maxDepth: 5 },
+        array(sidebarDataArbitraryWithMatchingLink, { minLength: 1, maxLength: 5 }),
+        array(sidebarNode, { minLength: 1, maxLength: 5 }),
+      ),
+    }),
+  };
+}).node;
 
-const sidebarDataArbitraryTreeWithoutMatchingLink = letrec((tie) => ({
-  node: record({
-    label: string(),
-    link: string().filter((s) => s !== '/docs/match'),
-    level: nat(),
-    content: oneof(
-      { depthIdentifier: 'node', maxDepth: 5 },
-      constant(undefined),
-      array(tie('node'), { minLength: 1, maxLength: 3, depthIdentifier: 'node' }),
-    ),
-  }),
-})).node;
+const sidebarDataArbitraryTreeWithoutMatchingLink = letrec<{
+  node: SidebarData;
+}>((tie) => {
+  const sidebarNode = <Arbitrary<SidebarData>>tie('node');
+
+  return {
+    node: record({
+      label: string(),
+      link: string().filter((s) => s !== '/docs/match'),
+      level: nat(),
+      content: oneof(
+        { depthIdentifier: 'node', maxDepth: 5 },
+        constant(undefined),
+        array(sidebarNode, { minLength: 1, maxLength: 3, depthIdentifier: 'node' }),
+      ),
+    }),
+  };
+}).node;
 
 describe('Property test of Check Section Matches function', () => {
   it('Matches when sidebar data contains a link', () => {
     assert(
-      // @ts-ignore
       property(sidebarDataArbitraryTreeWithMatchingLink, (sidebarData: SidebarData) =>
         expect(simpleSectionMatch(sidebarData)).toBe(true),
       ),
@@ -101,7 +109,6 @@ describe('Property test of Check Section Matches function', () => {
   });
   it('Does not match when sidebar data does not contain a link', () => {
     assert(
-      // @ts-ignore
       property(sidebarDataArbitraryTreeWithoutMatchingLink, (sidebarData: SidebarData) =>
         expect(simpleSectionMatch(sidebarData)).toBe(false),
       ),

--- a/src/components/Sidebar/check-section-match.ts
+++ b/src/components/Sidebar/check-section-match.ts
@@ -1,0 +1,18 @@
+import { isArray } from 'lodash';
+import { any } from 'lodash/fp';
+
+type SidebarData = {
+  label: string;
+  link?: string;
+  level?: number;
+  content?: null | string | SidebarData[];
+};
+export const checkSectionMatch =
+  (match: string) =>
+  (data: SidebarData): boolean => {
+    const content = data.content;
+    if (content && isArray(content)) {
+      return any(checkSectionMatch(match), content);
+    }
+    return !!data.link && match === data.link;
+  };

--- a/src/components/Sidebar/check-section-match.ts
+++ b/src/components/Sidebar/check-section-match.ts
@@ -11,8 +11,5 @@ export const checkSectionMatch =
   (match: string) =>
   (data: SidebarData): boolean => {
     const content = data.content;
-    if (content && isArray(content)) {
-      return any(checkSectionMatch(match), content);
-    }
-    return !!data.link && match === data.link;
+    return content && isArray(content) ? any(checkSectionMatch(match), content) : match === data.link;
   };

--- a/src/components/Sidebar/styles.js
+++ b/src/components/Sidebar/styles.js
@@ -11,9 +11,9 @@ const SidebarHeadingStyle = css`
   text-decoration: none;
   margin-left: ${({ $leaf, indent }) => `${($leaf ? 4 : 0) + (indent ?? 0)}px`};
 
-  color: ${({ active }) => (active ? colors.text.linkHoverAlternate : colors.text.link)};
-  border-left: ${({ active, $leaf }) =>
-    active
+  color: ${({ $active }) => ($active ? colors.text.linkHoverAlternate : colors.text.link)};
+  border-left: ${({ $active, $leaf }) =>
+    $active
       ? `${$leaf ? 1 : 2}px solid ${colors.text.linkHoverAlternateMuted}`
       : `${$leaf ? 1 : 2}px solid transparent`};
 

--- a/src/components/StaticQuerySidebar/left-sidebar.js
+++ b/src/components/StaticQuerySidebar/left-sidebar.js
@@ -50,7 +50,7 @@ const LeftSideBar = ({ className, languages }) => {
     sidebarData = sidebarDataFromDocumentPaths(data.allDocumentPath.edges);
   }
   return (
-    <Sidebar className={className} languages={languages} data={sidebarData} expandMenu={EXPAND_MENU.COLLAPSE_NEXT} />
+    <Sidebar className={className} languages={languages} data={sidebarData} expandMenu={EXPAND_MENU.SECTION_MATCH} />
   );
 };
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Expand the left side menu to the page that is currently active by default.

Also highlights the relevant page.

There is unusual but correct behaviour on visiting http://localhost:8000/docs/realtime/channels/channel-parameters/rewind (see Page to review).

* [Jira ticket](https://ably.atlassian.net/browse/EDX-119).

## Review

* [Check default behaviour here](http://localhost:8000/docs/rest/channels)

* [Check nested behaviour here](http://localhost:8000/docs/realtime/channels/channel-parameters/overview)

See unusual (but correct) behaviour here:

* [Unusual but correct behaviour](http://localhost:8000/docs/realtime/channels/channel-parameters/rewind)

Both`Rewind` & `Deltas` links are highlighted because both links match the page slug, due to an error in `sidebar.yml` (which will be rewritten anyway).
