### PR TITLE
[EDX-183] Copy link title only on hover link

### DIFF
--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -260,6 +260,8 @@ export type DirectoryCtimeArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Int']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   jsxRuntime?: Maybe<Scalars['String']>;
@@ -863,6 +865,8 @@ export type QueryAllDirectoryArgs = {
 export type QuerySiteArgs = {
   buildTime?: InputMaybe<DateQueryOperatorInput>;
   siteMetadata?: InputMaybe<SiteSiteMetadataFilterInput>;
+  port?: InputMaybe<IntQueryOperatorInput>;
+  host?: InputMaybe<StringQueryOperatorInput>;
   polyfill?: InputMaybe<BooleanQueryOperatorInput>;
   pathPrefix?: InputMaybe<StringQueryOperatorInput>;
   jsxRuntime?: InputMaybe<StringQueryOperatorInput>;
@@ -2595,6 +2599,8 @@ export type SiteFieldsEnum =
   | 'siteMetadata___title'
   | 'siteMetadata___description'
   | 'siteMetadata___siteUrl'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'jsxRuntime'
@@ -2731,6 +2737,8 @@ export type SiteGroupConnectionGroupArgs = {
 export type SiteFilterInput = {
   buildTime?: InputMaybe<DateQueryOperatorInput>;
   siteMetadata?: InputMaybe<SiteSiteMetadataFilterInput>;
+  port?: InputMaybe<IntQueryOperatorInput>;
+  host?: InputMaybe<StringQueryOperatorInput>;
   polyfill?: InputMaybe<BooleanQueryOperatorInput>;
   pathPrefix?: InputMaybe<StringQueryOperatorInput>;
   jsxRuntime?: InputMaybe<StringQueryOperatorInput>;

--- a/src/components/blocks/wrappers/CopyLink.tsx
+++ b/src/components/blocks/wrappers/CopyLink.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ChildPropTypes } from '../../../react-utilities';
 import styled from 'styled-components';
@@ -15,7 +15,8 @@ const StyledLinkCopyButton = styled.button`
   }
 `;
 
-const successColor = ({ copySuccess }) => (copySuccess ? gui.success : copySuccess === null ? '#fff' : gui.error);
+const successColor = ({ copySuccess }: { copySuccess: boolean | null }) =>
+  copySuccess ? gui.success : copySuccess === null ? '#fff' : gui.error;
 
 const LinkHoverPopup = styled.div`
   display: inline-block;
@@ -49,10 +50,10 @@ const LinkHoverPopup = styled.div`
   }
 `;
 
-const LinkCopyButton = ({ id, parentHovered, ...props }) => {
+const LinkCopyButton = ({ id, ...props }: { id: string }) => {
   const [hover, setHover] = useState(false);
   const [content, setContent] = useState('Copy section link to clipboard');
-  const [copySuccess, setCopySuccess] = useState(null);
+  const [copySuccess, setCopySuccess] = useState<null | boolean>(null);
 
   const resetState = () => {
     setContent('Copy section link to clipboard');
@@ -79,7 +80,7 @@ const LinkCopyButton = ({ id, parentHovered, ...props }) => {
   }, [copySuccess]);
   return (
     <div className="relative pt-8" onKeyPress={(event) => event.key === 'Enter' && copyLink()}>
-      {(hover || parentHovered) && (
+      {hover && (
         <LinkHoverPopup id={'link-copy-tooltip'} role="tooltip" copySuccess={copySuccess}>
           {content}
         </LinkHoverPopup>
@@ -106,19 +107,22 @@ LinkCopyButton.propTypes = {
   parentHovered: PropTypes.bool,
 };
 
-const CopyLink = ({ attribs, marginBottom, children }) => {
-  const [hover, setHover] = useState(false);
+const CopyLink = ({
+  attribs,
+  marginBottom,
+  children,
+}: {
+  attribs: { id?: string };
+  marginBottom: string;
+  children: ReactNode;
+}) => {
   if (!attribs || !attribs.id) {
     return <>{children}</>;
   }
   return (
-    <div
-      className={`flex items-center ${marginBottom}`}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-    >
+    <div className={`flex items-center ${marginBottom}`}>
       {children}
-      <LinkCopyButton id={attribs.id} parentHovered={hover} />
+      <LinkCopyButton id={attribs.id} />
     </div>
   );
 };

--- a/src/components/blocks/wrappers/__snapshots__/CopyLink.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/CopyLink.test.js.snap
@@ -9,8 +9,6 @@ exports[`CopyLink displays statically as expected Snapshot of CopyLink is the sa
 exports[`CopyLink displays statically as expected Snapshot of CopyLink with ID is the same 1`] = `
 <div
   className="flex items-center undefined"
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   <h1
     attribs={


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Only show the copy link title when you hover the link rather than the full parent element.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-183).

## Review

Make sure the section link copying text only appears when you hover the 'link' button, not the full parent element.

* [Page to review](http://localhost:8000/docs/quick-start-guide)
