### PR TITLE
Remove mention of occupancy events on metachannels; add integrations to metadata page

### DIFF
--- a/content/realtime/channel-metadata.textile
+++ b/content/realtime/channel-metadata.textile
@@ -17,8 +17,9 @@ h2(#overview). Overview
 Channel Metadata provides information about channels, such as the current state changes of a channel, or the changes in its occupancy. There are several ways to obtain channel metadata:
 
 1. "Metachannels":/realtime/metachannels - Metachannels are special channels that carry metadata events about all activity associated with an Ably application, which includes metadata associated with channel and connection lifecycle.
-2. "Inband channel occupancy events":/realtime/inband-occupancy - Inband occupancy events are occupancy events relating to a channel that are delivered within the channel itself. 
+2. "Inband channel occupancy events":/realtime/inband-occupancy - Inband occupancy events are occupancy events relating to a channel that are delivered within the channel itself.
 3. "Channel Status API":/rest/channel-status - The Channel Status API is a REST API that allows users to query a channel to retrieve channel metadata. It also allows you to "enumerate":/rest/channel-status#enumeration-rest all the active channels in a particular app. The details of the Channel Status API are covered in the "Channel Status documentation":/rest/channel-status.
+4. "Integration rules":/general/events - Integration rules allow events within Ably to be pushed to targets such as AWS Lambda or Kinesis, webhook URLs, and so on. The "choice of event sources includes channel lifecycle and channel occupancy events.":/general/events#sources
 
 h2(#use-cases). Use cases
 
@@ -32,9 +33,9 @@ h2(#tutorials). Tutorials
 
 The tutorials provide step-by-step examples of how to obtain and use channel metadata:
 
-* "Channel Lifecycle Events":/tutorials/channel-lifecycle-events 
+* "Channel Lifecycle Events":/tutorials/channel-lifecycle-events
 * "Channel Enumeration":/tutorials/channel-enumeration-rest
-* "Inband occupancy events":/tutorials/channel-occupancy-events 
+* "Inband occupancy events":/tutorials/channel-occupancy-events
 
 h2(#api-reference). API Reference
 

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -546,7 +546,7 @@ Clients attach to a channel in order to participate on that channel in any way (
 
 h3(#channel-metadata). Channel metadata
 
-Ably provides a "REST API":/realtime/channel-metadata to query your app for metadata about channels, as well as a "realtime API":/realtime/channel-metadata to subscribe to channel lifecycle events. Using the "REST API":/rest-api, you can enumerate all active channels, or obtain the status of an individual channel. Using our Realtime API, you can subscribe to "channel lifecycle events":/realtime/metachannels#lifecycle-events (such as being created or closed etc), or subscribe to periodic "occupancy":/realtime/metachannels#occupancy-events updates for all active channels (such as how many people are subscribed to a channel).
+Ably provides various APIs for obtaining metadata (such as querying the current status of a channel, or subscribing to channel lifecycle or channel occupancy events), see "our Channel Metadata documentation.":/realtime/channel-metadata
 
 h3(#implicit-attach). Implicit attach
 

--- a/content/realtime/metachannels.textile
+++ b/content/realtime/metachannels.textile
@@ -9,7 +9,6 @@ jump_to:
     - Overview#overview
     - Permissions#permissions
     - Lifecycle events#lifecycle-events
-    - Channel occupancy#occupancy-events
     - App statistics#app-stats
     - Sampled connection and request events#sampled-events
 ---
@@ -93,7 +92,6 @@ The following events are published as messages on the @[meta]channel.lifecycle@ 
 - channel.closed := indicates that the channel has been deactivated globally.
 - channel.region.active := indicates that the channel has been activated in a specific region. The included @ChannelDetails.status@ includes "occupancy":#occupancy in that region.
 - channel.region.inactive := indicates that the channel has been deactivated in a specific region. The included @ChannelDetails.status@ includes "occupancy":#occupancy-events in that region.
-- channel.occupancy := indicates a change in global "occupancy":#occupancy-events on the channel. Not all "occupancy":#occupancy changes are sent; there is a minimum interval on a per-channel basis, so if the "occupancy":#occupancy-events is changing continuously, then only periodic snapshots of occupancy are sent. Further roll-up of events may occur depending on the capacity of the lifecycle channel. Any "occupancy":#occupancy changes in which any of the "occupancy":#occupancy-events categories changes from 0 to a non-zero count, or vice versa, are always included. This feature is only available on a per-app basis to Ably's "enterprise customers":https://www.ably.com/pricing. It is recommended that you use "inband channel occupancy":/realtime/inband-occupancy events instead.
 
 The following code snippet shows how to subscribe to @channel.closed@ channel lifecycle events:
 
@@ -114,15 +112,6 @@ channel.subscribe((msg) => {
     console.log('Event type: ' + msg.name, msg.data);
 });
 ```
-
-h2(#occupancy-events). channel.occupancy lifecycle events
-
-When @channel.occupancy@ "events are enabled":https://faqs.ably.com/how-can-i-enable-channel-lifecycles for your app, you can subscribe to channel occupancy events by attaching to the channel @[meta]channel.lifecycle@ using a realtime connection. However, please bear in mind that "realtime connections and channels have rate limits":/general/limits based on your package size. If the rate of channel lifecycle events exceeds this, a realtime connection is not going to be a reliable way to consume these events as you may get disconnected or lifecycle events may be discarded.
-
-While the channel lifecycle metachannel can provide occupancy metrics, there may be a performance impact, since this involves funnelling occupancy updates for every channel in the app to a single metachannel. This approach does not scale well as the number of channels grows, and so has limited use cases. There are two recommended alternatives:
-
-* "Inband channel occupancy events":/realtime/inband-occupancy - for use cases where the entity that needs to determine occupancy is attached to the channel.
-* Occupancy rules - for use cases where the entity needing to determine channel occupancy is not connected to the channel. A channel occupancy rule allows you to obtain occupancy updates from a set of channels in a centralized way, that doesn't involve attaching to all of them. Please "contact us":https://ably.com/contact for further information.
 
 h2(#app-stats). App statistics
 

--- a/content/tutorials/channel-enumeration-rest.textile
+++ b/content/tutorials/channel-enumeration-rest.textile
@@ -34,11 +34,13 @@ meta_keywords: "Ably realtime, channel metadata, REST API"
 
 "Ably's global platform":https://ably.com/platform organizes all message traffic within an application into named "channels":/core-features/channels. Clients attach to the channels they are interested in. They can then publish messages to those channels or subscribe to receive messages from them.
 
-Often, its useful for developers to be able to access channel metadata. Ably provides two APIs for this:
+Often, its useful for developers to be able to access channel metadata. Ably provides three APIs for this:
 
-* The "Channel Metadata API":/realtime/channel-metadata enables you to subscribe to "channel lifecycle events":/realtime/metachannels#lifecycle-events or to "channel occupancy events":/realtime/metachannels#occupancy-events.
+* The "Channel Metadata API":/realtime/channel-metadata enables you to subscribe to "channel lifecycle events":/realtime/metachannels#lifecycle-events or to "channel occupancy events":/realtime/inband-occupancy.
 
 * The "Channel Status API":/rest/channel-status enables you to query the status of a specific channel or perform "channel enumeration":/api/rest-api#enumeration-rest: that is, to list __all__ active channels within an application that are associated with a particular API key and optionally retrieve the status of each channel at the same time.
+
+* "Integration rules":/general/events#sources enable you to have channel lifecycle events or occupancy updates for channels you're interested in pushed to your server.
 
 In this tutorial, you will learn how to implement channel enumeration.
 

--- a/content/tutorials/channel-lifecycle-events.textile
+++ b/content/tutorials/channel-lifecycle-events.textile
@@ -26,7 +26,7 @@ meta_keywords: "Ably realtime, channel metadata"
 
 "Ably's global platform":https://ably.com/platform organizes all of the message traffic within its applications into named "channels":/core-features/channels. Channels are the “unit” of message distribution; clients attach to any number of channels to publish or subscribe to messages. Every message published to a channel is broadcasted to all subscribers.
 
-Many times, developers find it helpful to be aware of specific metadata related to their channels. This metadata can be accessed using our "Channel Metadata API":/realtime/channel-metadata. This API allows you to subscribe to the "channel lifecycle events":/realtime/metachannels#lifecycle-events and "channel occupancy events":/realtime/metachannels#occupancy-events or send one off REST requests to the "Channel Status API":/rest/channel-status to query "channel enumeration":/api/rest-api#enumeration-rest, i.e., listing all the active channels associated with a particular API key in an app or to query the status and occupancy data associated with the channel. In this tutorial, we'll see how to subscribe to the channel lifecycle events.
+Many times, developers find it helpful to be aware of specific metadata related to their channels. This metadata can be accessed using our "Channel Metadata API":/realtime/channel-metadata. This API allows you to do things such as subscribe to the "channel lifecycle events":/realtime/metachannels#lifecycle-events and "channel occupancy events.":/realtime/inband-occupancy In this tutorial, we'll see how to subscribe to the channel lifecycle events.
 
 <%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 


### PR DESCRIPTION
Remove all mention of channel.occupancy events on metachannels: these are long-deprecated in favour of inband occupancy events and occupancy rules, there's no circumstances in which we'd enable this for a customer now, so we shouldn't document it.

Also added integrations to the list of options for obtaining channel metadata and in a couple other places, not sure why were omitted