### PR TITLE
[EDU-781] - Update Quickstart code to use promises 

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -511,10 +511,10 @@ blang[default].
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
 
-bc[javascript]. ably.close(); // resolves synchronously
+bc[javascript]. ably.close(); // runs synchronously
 console.log('Closed the connection to Ably.');
 
-bc[nodejs]. ably.close(); // resolves synchronously
+bc[nodejs]. ably.close(); // runs synchronously
 console.log('Closed the connection to Ably.');
 
 bc[java]. ably.connection.close();

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -265,20 +265,12 @@ blang[python,php].
 *Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/core-features/authentication#token-authentication should be used instead.
 
 bc[javascript]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
-try {
-  await ably.connection.once('connected');
-  console.log('Connected to Ably!');
-} catch (error) {
-  console.error(error);
-}
+await ably.connection.once('connected');
+console.log('Connected to Ably!');
 
 bc[nodejs]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
-try {
-  await ably.connection.once('connected');
-  console.log('Connected to Ably!');
-} catch (error) {
-  console.error(error);
-}
+await ably.connection.once('connected');
+console.log('Connected to Ably!');
 
 bc[java]. ClientOptions options = new ClientOptions("{{API_KEY}}");
 AblyRealtime ably = new AblyRealtime(options);

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -43,6 +43,9 @@ p(tip#terms). The terms used in the guide such as 'connection', 'channel', 'mess
 
 You're currently viewing the guide in <span lang="javascript">JavaScript</span><span lang="nodejs">Node.js</span><span lang="java">Java</span><span lang="ruby">Ruby</span><span lang="objc">Objective-C</span><span lang="python">Python</span><span lang="php">PHP</span><span lang="swift">Swift</span><span lang="csharp">C# .NET</span><span lang="flutter">Flutter</span><span lang="go">Go</span>. If you would like to view it in another language, use the selector above to change it. 
 
+blang[jsall].
+  **Note:** The complete source code for JavaScript and Node.js versions of this guide can be found in the "Quickstart repo":https://github.com/ably/quickstart-js. Both callback and promises interface examples are provided.
+
 h2(#step-0). Create an Ably account
 
 "Sign up":https://ably.com/signup for a free account to get your own API key.
@@ -76,7 +79,7 @@ blang[nodejs].
   Include the SDK as a module in your @.js@ files:
 
   ```[nodejs]
-  const Ably = require('ably');
+  const Ably = require('ably/promises');
   ```
 
 blang[ruby].
@@ -261,15 +264,21 @@ blang[python,php].
 
 *Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/core-features/authentication#token-authentication should be used instead.
 
-bc[javascript](code-editor:quick-start-guide/connect). const ably = new Ably.Realtime('{{API_KEY}}');
-ably.connection.on('connected', () => {
-  alert('Connected to Ably!');
-});
+bc[javascript]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
+try {
+  await ably.connection.once('connected');
+  console.log('connected');
+} catch (error) {
+  console.error(error);
+}
 
-bc[nodejs](code-editor:quick-start-guide/connect). const ably = new Ably.Realtime('{{API_KEY}}');
-ably.connection.on('connected', () => {
-  console.log('Connected to Ably!');
-});
+bc[nodejs]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
+try {
+  await ably.connection.once('connected');
+  console.log('connected');
+} catch (error) {
+  console.error(error);
+}
 
 bc[java]. ClientOptions options = new ClientOptions("{{API_KEY}}");
 AblyRealtime ably = new AblyRealtime(options);
@@ -360,18 +369,28 @@ blang[default].
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to subscribe to a channel and receive messages. Use the language selector above to select a language with realtime support.
 
-```[javascript](code-editor:quick-start-guide/send-message)
-  const channel = ably.channels.get('quickstart');
-  channel.subscribe('greeting', (message) => {
-    alert(`Received a greeting message in realtime: ${message.data}`);
-  });
+```[javascript]
+// get the channel to subscribe to
+const channel = ably.channels.get('quickstart');
+
+// Subscribe to a channel
+// the promise resolves when the channel is attached (and resolves synchronously
+// if the channel is already attached)
+await channel.subscribe('greeting', (message) => {
+  console.log('Message is ==> ' + message.data)
+});
 ```
 
-```[nodejs](code-editor:quick-start-guide/send-message)
-  const channel = ably.channels.get('quickstart');
-  channel.subscribe('greeting', (message) => {
-    console.log(`Received a greeting message in realtime: ${message.data}`);
-  });
+```[nodejs]
+// get the channel to subscribe to
+const channel = ably.channels.get('quickstart');
+
+// Subscribe to a channel
+// the promise resolves when the channel is attached (and resolves synchronously
+// if the channel is already attached)
+await channel.subscribe('greeting', (message) => {
+  console.log('Message is ==> ' + message.data)
+});
 ```
 
 ```[ruby]
@@ -425,8 +444,7 @@ h2(#step-4). Publish a message
 
 The following example code publishes a message to the @quickstart@ channel with the name @greeting@ and the contents @hello!@.
 
-bc[jsall](code-editor:quick-start-guide/send-message). const channel = ably.channels.get('quickstart');
-channel.publish('greeting', 'hello!');
+bc[jsall]. await channel.publish('greeting', 'hello!');
 
 bc[java]. Channel channel = ably.channels.get("quickstart");
 channel.publish("greeting", "hello", new CompletionListener() {
@@ -489,15 +507,11 @@ blang[default].
 blang[python,php].
   The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
 
-bc[javascript](code-editor:quick-start-guide/close). ably.connection.close();
-ably.connection.on('closed', () => {
-  alert('Closed the connection to Ably.');
-});
+bc[javascript]. ably.close(); // resolves synchronously
+console.log('Closed the connection to Ably.');
 
-bc[nodejs](code-editor:quick-start-guide/close). ably.connection.close();
-ably.connection.on('closed', () => {
-  console.log('Closed the connection to Ably.');
-});
+bc[nodejs]. ably.close(); // resolves synchronously
+console.log('Closed the connection to Ably.');
 
 bc[java]. ably.connection.close();
 ably.connection.on(ConnectionState.closed, new ConnectionStateListener() {
@@ -578,23 +592,3 @@ This guide introduced the basic concepts of Ably and illustrated how easy it is 
 * Try out some "tutorials":/tutorials.
 * Provision Ably apps using the "Control API":/control-api.
 
-<script src="//cdn.ably.io/lib/ably.min-1.js" crossorigin="anonymous"></script>
-<script type="text/javascript">
-function subscribeToCurlRequest(key) {
-  var ably = new Ably.Realtime(key),
-      channelName = '{{RANDOM_CHANNEL_NAME}}';
-  if (channelName === '{{RANDOM_CHANNEL' + '_NAME}}') { channelName = window.randomChannelName; }
-  ably.channels.get(channelName).subscribe('greeting', function(message) {
-    alert('That was easy, a message was just received from the REST API on channel "' + channelName + '".\n\nGreeting => ' + message.data);
-  });
-}
-
-/* API_KEY variable is replaced inline on https://ably.com so
-  {{API_KEY}} will not equal '{{API_' + 'KEY}}'
-  On docs.ably.com, we rely on application.js to call the onApiKeyRetrieved method */
-if ('{{API_KEY}}' !== '{{API_' + 'KEY}}') {
-  subscribeToCurlRequest('{{API_KEY}}');
-} else {
-  window.onApiKeyRetrieved = subscribeToCurlRequest;
-}
-</script>

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -377,7 +377,7 @@ const channel = ably.channels.get('quickstart');
 // the promise resolves when the channel is attached (and resolves synchronously
 // if the channel is already attached)
 await channel.subscribe('greeting', (message) => {
-  console.log('Message is ==> ' + message.data)
+  console.log('Received a greeting message in realtime: ' + message.data)
 });
 ```
 
@@ -389,7 +389,7 @@ const channel = ably.channels.get('quickstart');
 // the promise resolves when the channel is attached (and resolves synchronously
 // if the channel is already attached)
 await channel.subscribe('greeting', (message) => {
-  console.log('Message is ==> ' + message.data)
+  console.log('Received a greeting message in realtime: ' + message.data)
 });
 ```
 

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -373,9 +373,11 @@ blang[python,php].
 // get the channel to subscribe to
 const channel = ably.channels.get('quickstart');
 
-// Subscribe to a channel
-// the promise resolves when the channel is attached (and resolves synchronously
-// if the channel is already attached)
+/* 
+  Subscribe to a channel. 
+  The promise resolves when the channel is attached 
+  (and resolves synchronously if the channel is already attached).
+*/
 await channel.subscribe('greeting', (message) => {
   console.log('Received a greeting message in realtime: ' + message.data)
 });
@@ -385,9 +387,11 @@ await channel.subscribe('greeting', (message) => {
 // get the channel to subscribe to
 const channel = ably.channels.get('quickstart');
 
-// Subscribe to a channel
-// the promise resolves when the channel is attached (and resolves synchronously
-// if the channel is already attached)
+/* 
+  Subscribe to a channel. 
+  The promise resolves when the channel is attached 
+  (and resolves synchronously if the channel is already attached).
+*/
 await channel.subscribe('greeting', (message) => {
   console.log('Received a greeting message in realtime: ' + message.data)
 });

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -267,7 +267,7 @@ blang[python,php].
 bc[javascript]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 try {
   await ably.connection.once('connected');
-  console.log('connected');
+  console.log('Connected to Ably!');
 } catch (error) {
   console.error(error);
 }
@@ -275,7 +275,7 @@ try {
 bc[nodejs]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 try {
   await ably.connection.once('connected');
-  console.log('connected');
+  console.log('Connected to Ably!');
 } catch (error) {
   console.error(error);
 }


### PR DESCRIPTION
## Description

The purpose of this PR is to update the Quickstart Guide for both JavaScript and Node.js language options, to use the promises interface. 

I have also created a [repo](https://github.com/ably/quickstart-js) to contain complete working source code, as an aid to developers. The repo is linked to from both the JavaScript and Node.js language versions.

Tickets:

* Epic: [EDU-779](https://ably.atlassian.net/browse/EDU-779)
* [EDU-781](https://ably.atlassian.net/browse/EDU-781)

## Review

Review (and test) the Quickstart guide for both JavaScript and Node.js language options:

* [Quickstart guide](https://ably-docs-edu-781-updat-ef7cyq.herokuapp.com/quick-start-guide/)
