### PR TITLE
[EDU-513] - Add links to Control API reference guide

### DIFF
--- a/content/control-api/index.textile
+++ b/content/control-api/index.textile
@@ -15,7 +15,7 @@ jump_to:
     - See also#see-also
 ---
 
-Ably Control API is a REST API that enables you to manage your Ably account programmatically. The Control API also enables you to build web apps and command-line tools, to create and manage your Ably realtime infrastructure.
+"Ably Control API":/api/control-api is a REST API that enables you to manage your Ably account programmatically. The Control API also enables you to build web apps and command-line tools, to create and manage your Ably realtime infrastructure. Details of the API can be found in the "Control API Reference guide":/api/control-api.
 
 Using the Control API you can automate the provisioning, management, and testing of  your Ably realtime infrastructure. You can dynamically create Ably apps, configure them, and delete them if necessary. You can implement multi-tenancy solutions for your customers, and create configuration-driven environments that can easily be replicated under programmatic control. Once these environments are created you can also test them using Control API.
 

--- a/content/control-api/index.textile
+++ b/content/control-api/index.textile
@@ -15,7 +15,7 @@ jump_to:
     - See also#see-also
 ---
 
-"Ably Control API":/api/control-api is a REST API that enables you to manage your Ably account programmatically. The Control API also enables you to build web apps and command-line tools, to create and manage your Ably realtime infrastructure. Details of the API can be found in the "Control API Reference guide":/api/control-api.
+"Ably Control API":/api/control-api is a REST API that enables you to manage your Ably account programmatically. The Control API also enables you to build web apps and command-line tools, to create and manage your Ably realtime infrastructure. Details of the API can be found in the "Control API Reference":/api/control-api.
 
 Using the Control API you can automate the provisioning, management, and testing of  your Ably realtime infrastructure. You can dynamically create Ably apps, configure them, and delete them if necessary. You can implement multi-tenancy solutions for your customers, and create configuration-driven environments that can easily be replicated under programmatic control. Once these environments are created you can also test them using Control API.
 


### PR DESCRIPTION
## Description

Add a couple of links to Control API reference from intro para as per ticket (this was a request from Gino).

* [EDU-513](https://ably.atlassian.net/browse/EDU-513).

## Review

Check two links to API reference in the intro para.

* [Control API overview](https://ably-docs-edu-513-api-r-jovhvc.herokuapp.com/control-api/)
