### PR TITLE
[EDU-35] - Add missing fields to http_paginated_response

### DIFF
--- a/content/api/realtime-sdk/types.textile
+++ b/content/api/realtime-sdk/types.textile
@@ -13,6 +13,7 @@ languages:
   - objc
   - csharp
   - flutter
+  - go
 redirect_from:
   - /realtime/types
 ---

--- a/content/partials/types/_http_paginated_response.textile
+++ b/content/partials/types/_http_paginated_response.textile
@@ -7,9 +7,9 @@ h4.
   python:  Attributes
 
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
-- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to @200 <= statusCode < 300@)<br>__Type: @Boolean@__
+- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to @200 <= statusCode < 300@<br>__Type: @Boolean@__
 - <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the headers of the response<br>__Type: @Object@__
 - <span lang="default">errorCode</span><span lang="ruby">error_code</span><span lang="csharp,go">ErrorCode</span> := the error code if the @X-Ably-Errorcode@ HTTP header is sent in the response<br>__Type: @Int@__
 - <span lang="default">errorMessage</span><span lang="ruby">error_message</span><span lang="csharp,go">ErrorMessage</span> := the error message if the @X-Ably-Errormessage@ HTTP header is sent in the response<br>__Type: @String@__

--- a/content/partials/types/_http_paginated_response.textile
+++ b/content/partials/types/_http_paginated_response.textile
@@ -9,7 +9,7 @@ h4.
 
 - <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
-- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to @200 <= statusCode < 300@<br>__Type: @Boolean@__
+- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to <span lang="default">@200 <= statusCode < 300@</span><span lang="ruby">@200 <= status_code < 300@</span><span lang="csharp,go">@200 <= StatusCode < 300@</span><br>__Type: @Boolean@__
 - <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the headers of the response<br>__Type: @Object@__
 - <span lang="default">errorCode</span><span lang="ruby">error_code</span><span lang="csharp,go">ErrorCode</span> := the error code if the @X-Ably-Errorcode@ HTTP header is sent in the response<br>__Type: @Int@__
 - <span lang="default">errorMessage</span><span lang="ruby">error_message</span><span lang="csharp,go">ErrorMessage</span> := the error message if the @X-Ably-Errormessage@ HTTP header is sent in the response<br>__Type: @String@__

--- a/content/partials/types/_http_paginated_response.textile
+++ b/content/partials/types/_http_paginated_response.textile
@@ -7,12 +7,12 @@ h4.
   python:  Attributes
 
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request). <br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
 - <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to @200 <= statusCode < 300@)<br>__Type: @Boolean@__
 - <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the headers of the response<br>__Type: @Object@__
-- <span lang="default">errorCode</span><span lang="ruby">error_code</span><span lang="csharp,go">ErrorCode</span> := the error code if the @X-Ably-Errorcode@ HTTP header is sent in the response.<br>__Type: @Int@__
-- <span lang="default">errorMessage</span><span lang="ruby">error_message</span><span lang="csharp,go">ErrorMessage</span> := the error message if the @X-Ably-Errormessage@ HTTP header is sent in the response..<br>__Type: @String@__
+- <span lang="default">errorCode</span><span lang="ruby">error_code</span><span lang="csharp,go">ErrorCode</span> := the error code if the @X-Ably-Errorcode@ HTTP header is sent in the response<br>__Type: @Int@__
+- <span lang="default">errorMessage</span><span lang="ruby">error_message</span><span lang="csharp,go">ErrorMessage</span> := the error message if the @X-Ably-Errormessage@ HTTP header is sent in the response<br>__Type: @String@__
 
 
 h4. Methods

--- a/content/partials/types/_http_paginated_response.textile
+++ b/content/partials/types/_http_paginated_response.textile
@@ -7,10 +7,13 @@ h4.
   python:  Attributes
 
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request). <br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request). <br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
-- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether that HTTP status code indicates success (equivalent to @200 <= statusCode < 300@)<br>__Type: @Boolean@__
-- <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the response's headers<br>__Type: @Object@__
+- <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to @200 <= statusCode < 300@)<br>__Type: @Boolean@__
+- <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the headers of the response<br>__Type: @Object@__
+- <span lang="default">errorCode</span><span lang="ruby">error_code</span><span lang="csharp,go">ErrorCode</span> := the error code if the @X-Ably-Errorcode@ HTTP header is sent in the response.<br>__Type: @Int@__
+- <span lang="default">errorMessage</span><span lang="ruby">error_message</span><span lang="csharp,go">ErrorMessage</span> := the error message if the @X-Ably-Errormessage@ HTTP header is sent in the response..<br>__Type: @String@__
+
 
 h4. Methods
 


### PR DESCRIPTION
## Description

Add missing fields to `HttpPaginatedResponse`. This topic is a partial so updating the type page updates both Realtime and Rest API refs. 

Also fixes: go lang selector was missing from realtime API ref types page.

* [EDU-35](https://ably.atlassian.net/browse/EDU-35).

## Review

Check information is present for all languages on this page:

* [HttpPaginatedResponse page](https://ably-docs-edu-35-httppa-gbi6io.herokuapp.com/api/realtime-sdk/types/#http-paginated-response)
