### PR TITLE
[EDX-230] Replace nested codeblocks within blangs

### DIFF
--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -140,136 +140,127 @@ The @Connection@ object is an @EventEmitter@ and emits an event whose name is th
 
 The @Connection@ object can also emit an event that is not a state change: an @update@ event. This happens when there's a change to connection conditions for which the connection state doesn't change - that is, when the library remains connected, e.g. after a "reauth":/realtime/authentication#auth-url.
 
-blang[jsall].
-  ```[jsall]
-    realtime.connection.on('connected', function(stateChange) {
-      console.log('Ably is connected');
-    });
-  ```
+```[jsall]
+ realtime.connection.on('connected', function(stateChange) {
+     console.log('Ably is connected');
+ });
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[java]
+  realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is connected");
+    }
+  });
+```
 
-  ```[jsall]
-    realtime.connection.on(function(stateChange) {
-      console.log('New connection state is ' + stateChange.current);
-    });
-  ```
+```[csharp]
+  realtime.Connection.On(ConnectionState.Connected, args => {
+    Console.WriteLine("Connected, that was easy")
+  });
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[ruby]
+  realtime.connection.on(:connected) do
+    puts 'Ably is connected'
+  end
+```
 
-  ```[jsall]
-    /* remove a listener registered for a single event */
-    realtime.connection.off('connected', myListener);
-
-    /* remove a listener registered for all events */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[java].
-  ```[java]
-    realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is connected");
-      }
-    });
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[java]
-    realtime.connection.on(new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is " + change.current.name());
-      }
-    });
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[java]
-    /* remove a single listener */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[csharp].
-  ```[csharp]
-    realtime.Connection.On(ConnectionState.Connected, args => {
-      Console.WriteLine("Connected, that was easy")
-    });
-  ```
-
-  Alternatively a handler may be registered so that it receives all state change events.
-
-  ```[csharp]
-    realtime.Connection.On(args => {
-      Console.WriteLine("New state is " + args.Current)
-    });
-  ```
-
-  Previously registered handlers can be removed individually or all together.
-
-  ```[csharp]
-    /* remove a single handler */
-    realtime.Connection.Off(action);
-
-    /* remove all event handlers */
-    realtime.Connection.Off();
-  ```
-
-blang[ruby].
-  ```[ruby]
-    realtime.connection.on(:connected) do
-      puts 'Ably is connected'
-    end
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[ruby]
-    realtime.connection.on do |state_change|
-      puts "New connection state is #{state_change.current}"
-    end
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[ruby]
-    # remove a listener registered for a single even
-    realtime.connection.off :connected, &block
-
-    # remove a listener registered for all events
-    realtime.connection.off &block
-
-    # remove all event listeners
-    realtime.connection.off
-  ```
-
-blang[objc].
-  ```[objc]
+```[objc]
   ARTEventListener *listener = [realtime.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *change) {
-      NSLog(@"Ably is connected");
+    NSLog(@"Ably is connected");
   }];
-  ```
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[swift]
+  let listener = realtime.connection.on(.connected) { change in
+    print("Ably is connected")
+  }
+```
 
-  ```[objc]
+Alternatively a <span lang="default">listener</span><span lang="csharp">handler</span> may be registered so that it receives all state change events.
+
+```[jsall]
+  realtime.connection.on(function(stateChange) {
+    console.log('New connection state is ' + stateChange.current);
+  });
+```
+
+```[java]
+  realtime.connection.on(new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is " + change.current.name());
+    }
+  });
+```
+
+```[csharp]
+  realtime.Connection.On(args => {
+    Console.WriteLine("New state is " + args.Current)
+  });
+```
+
+```[ruby]
+  realtime.connection.on do |state_change|
+    puts "New connection state is #{state_change.current}"
+  end
+```
+
+```[objc]
   ARTEventListener *listener = [realtime.connection on:^(ARTConnectionStateChange *change) {
-      NSLog(@"New connection state is %lu", (unsigned long)change.current);
+    NSLog(@"New connection state is %lu", (unsigned long)change.current);
   }];
-  ```
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[swift]
+  let listener = realtime.connection.on { change in
+    print("New connection state is \(change!.current)")
+  }
+```
 
-  ```[objc]
+Previously registered <span lang="default">listeners</span><span lang="csharp">handlers</span> can be removed individually or all together.
+
+```[jsall]
+  /* remove a listener registered for a single event */
+  realtime.connection.off('connected', myListener);  
+
+  /* remove a listener registered for all events */
+  realtime.connection.off(myListener);  
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[java]
+  /* remove a single listener */
+  realtime.connection.off(myListener);
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[csharp]
+  /* remove a single handler */
+  realtime.Connection.Off(action);
+
+  /* remove all event handlers */
+  realtime.Connection.Off();
+```
+
+```[ruby]
+  # remove a listener registered for a single even
+  realtime.connection.off :connected, &block
+
+  # remove a listener registered for all events
+  realtime.connection.off &block
+
+  # remove all event listeners
+  realtime.connection.off
+```
+
+```[objc]
   // remove a listener registered for a single event
   [realtime.connection off:ARTRealtimeConnectionEventConnected listener:listener];
 
@@ -278,26 +269,9 @@ blang[objc].
 
   // remove all event listeners
   [realtime.connection off];
-  ```
+```
 
-blang[swift].
-  ```[swift]
-  let listener = realtime.connection.on(.connected) { change in
-      print("Ably is connected")
-  }
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[swift]
-  let listener = realtime.connection.on { change in
-      print("New connection state is \(change!.current)")
-  }
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[swift]
+```[swift]
   // remove a listener registered for a single event
   realtime.connection.off(.connected, listener: listener)
 
@@ -306,7 +280,7 @@ blang[swift].
 
   // remove all event listeners
   realtime.connection.off()
-  ```
+```
 
 h3(#handling-failures). Handling failures
 

--- a/content/realtime/versions/v0.8/connection.textile
+++ b/content/realtime/versions/v0.8/connection.textile
@@ -124,136 +124,127 @@ h4. Listening for state changes
 
 The @Connection@ object is an @EventEmitter@ and emits an event whose name is the new state whenever there is a connection state change. <span lang="default">An event listener function is passed a "ConnectionStateChange":/api/realtime-sdk/connection#connection-state-change object as the first argument for state change events.</span><span lang="csharp">An event listener function is passed a "ConnectionStateChange":/api/realtime-sdk/connection#connection-state-change object as the first argument for state change events.</span><span lang="ruby">The event block is passed the new state and an optional "@ErrorInfo@":/api/realtime-sdk/types#error-info object</span>
 
-blang[jsall].
-  ```[jsall]
-    realtime.connection.on('connected', function(stateChange) {
-      console.log('Ably is connected');
-    });
-  ```
+```[jsall]
+ realtime.connection.on('connected', function(stateChange) {
+     console.log('Ably is connected');
+ });
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[java]
+  realtime.connection.on(ConnectionState.connected, new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is connected");
+    }
+  });
+```
 
-  ```[jsall]
-    realtime.connection.on(function(stateChange) {
-      console.log('New connection state is ' + stateChange.current);
-    });
-  ```
+```[csharp]
+  realtime.Connection.On(ConnectionState.Connected, args => {
+    Console.WriteLine("Connected, that was easy")
+  });
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[ruby]
+  realtime.connection.on(:connected) do
+    puts 'Ably is connected'
+  end
+```
 
-  ```[jsall]
-    /* remove a listener registered for a single event */
-    realtime.connection.off('connected', myListener);
-
-    /* remove a listener registered for all events */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[java].
-  ```[java]
-    realtime.connection.on(ConnectionState.connected, new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is connected");
-      }
-    });
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[java]
-    realtime.connection.on(new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is " + change.current.name());
-      }
-    });
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[java]
-    /* remove a single listener */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[csharp].
-  ```[csharp]
-    realtime.Connection.On(ConnectionState.Connected, args => {
-      Console.WriteLine("Connected, that was easy");
-    });
-  ```
-
-  Alternatively a handler may be registered so that it receives all state change events.
-
-  ```[csharp]
-    realtime.Connection.On(args => {
-      Console.WriteLine("New state is " + args.Current);
-    });
-  ```
-
-  Previously registered handlers can be removed individually or all together.
-
-  ```[csharp]
-    /* remove a single handler */
-    realtime.Connection.Off(action);
-
-    /* remove all event handlers */
-    realtime.Connection.Off();
-  ```
-
-blang[ruby].
-  ```[ruby]
-    realtime.connection.on(:connected) do
-      puts 'Ably is connected'
-    end
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[ruby]
-    realtime.connection.on do |state_change|
-      puts "New connection state is #{state_change.current}"
-    end
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[ruby]
-    # remove a listener registered for a single even
-    realtime.connection.off :connected, &block
-
-    # remove a listener registered for all events
-    realtime.connection.off &block
-
-    # remove all event listeners
-    realtime.connection.off
-  ```
-
-blang[objc].
-  ```[objc]
+```[objc]
   ARTEventListener *listener = [realtime.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *change) {
-      NSLog(@"Ably is connected");
+    NSLog(@"Ably is connected");
   }];
-  ```
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[swift]
+  let listener = realtime.connection.on(.connected) { change in
+    print("Ably is connected")
+  }
+```
 
-  ```[objc]
+Alternatively a <span lang="default">listener</span><span lang="csharp">handler</span> may be registered so that it receives all state change events.
+
+```[jsall]
+  realtime.connection.on(function(stateChange) {
+    console.log('New connection state is ' + stateChange.current);
+  });
+```
+
+```[java]
+  realtime.connection.on(new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is " + change.current.name());
+    }
+  });
+```
+
+```[csharp]
+  realtime.Connection.On(args => {
+    Console.WriteLine("New state is " + args.Current)
+  });
+```
+
+```[ruby]
+  realtime.connection.on do |state_change|
+    puts "New connection state is #{state_change.current}"
+  end
+```
+
+```[objc]
   ARTEventListener *listener = [realtime.connection on:^(ARTConnectionStateChange *change) {
-      NSLog(@"New connection state is %lu", (unsigned long)change.current);
+    NSLog(@"New connection state is %lu", (unsigned long)change.current);
   }];
-  ```
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[swift]
+  let listener = realtime.connection.on { change in
+    print("New connection state is \(change!.current)")
+  }
+```
 
-  ```[objc]
+Previously registered <span lang="default">listeners</span><span lang="csharp">handlers</span> can be removed individually or all together.
+
+```[jsall]
+  /* remove a listener registered for a single event */
+  realtime.connection.off('connected', myListener);  
+
+  /* remove a listener registered for all events */
+  realtime.connection.off(myListener);  
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[java]
+  /* remove a single listener */
+  realtime.connection.off(myListener);
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[csharp]
+  /* remove a single handler */
+  realtime.Connection.Off(action);
+
+  /* remove all event handlers */
+  realtime.Connection.Off();
+```
+
+```[ruby]
+  # remove a listener registered for a single even
+  realtime.connection.off :connected, &block
+
+  # remove a listener registered for all events
+  realtime.connection.off &block
+
+  # remove all event listeners
+  realtime.connection.off
+```
+
+```[objc]
   // remove a listener registered for a single event
   [realtime.connection off:ARTRealtimeConnectionEventConnected listener:listener];
 
@@ -262,26 +253,9 @@ blang[objc].
 
   // remove all event listeners
   [realtime.connection off];
-  ```
+```
 
-blang[swift].
-  ```[swift]
-  let listener = realtime.connection.on(.connected) { change in
-      print("Ably is connected")
-  }
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[swift]
-  let listener = realtime.connection.on { change in
-      print("New connection state is \(change!.current)")
-  }
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[swift]
+```[swift]
   // remove a listener registered for a single event
   realtime.connection.off(.connected, listener: listener)
 
@@ -290,7 +264,7 @@ blang[swift].
 
   // remove all event listeners
   realtime.connection.off()
-  ```
+```
 
 h3(#handling-failures). Handling failures
 

--- a/content/realtime/versions/v1.0/connection.textile
+++ b/content/realtime/versions/v1.0/connection.textile
@@ -128,136 +128,127 @@ The @Connection@ object is an @EventEmitter@ and emits an event whose name is th
 
 The @Connection@ object can also emit an event that is not a state change: an @update@ event. This happens when there's a change to connection conditions for which the connection state doesn't change - that is, when the library remains connected, e.g. after a "reauth":/realtime/authentication#token-authentication.
 
-blang[jsall].
-  ```[jsall]
-    realtime.connection.on('connected', function(stateChange) {
-      console.log('Ably is connected');
-    });
-  ```
+```[jsall]
+ realtime.connection.on('connected', function(stateChange) {
+     console.log('Ably is connected');
+ });
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[java]
+  realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is connected");
+    }
+  });
+```
 
-  ```[jsall]
-    realtime.connection.on(function(stateChange) {
-      console.log('New connection state is ' + stateChange.current);
-    });
-  ```
+```[csharp]
+  realtime.Connection.On(ConnectionState.Connected, args => {
+    Console.WriteLine("Connected, that was easy")
+  });
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[ruby]
+  realtime.connection.on(:connected) do
+    puts 'Ably is connected'
+  end
+```
 
-  ```[jsall]
-    /* remove a listener registered for a single event */
-    realtime.connection.off('connected', myListener);
-
-    /* remove a listener registered for all events */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[java].
-  ```[java]
-    realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is connected");
-      }
-    });
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[java]
-    realtime.connection.on(new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is " + change.current.name());
-      }
-    });
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[java]
-    /* remove a single listener */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[csharp].
-  ```[csharp]
-    realtime.Connection.On(ConnectionState.Connected, args => {
-      Console.WriteLine("Connected, that was easy")
-    });
-  ```
-
-  Alternatively a handler may be registered so that it receives all state change events.
-
-  ```[csharp]
-    realtime.Connection.On(args => {
-      Console.WriteLine("New state is " + args.Current)
-    });
-  ```
-
-  Previously registered handlers can be removed individually or all together.
-
-  ```[csharp]
-    /* remove a single handler */
-    realtime.Connection.Off(action);
-
-    /* remove all event handlers */
-    realtime.Connection.Off();
-  ```
-
-blang[ruby].
-  ```[ruby]
-    realtime.connection.on(:connected) do
-      puts 'Ably is connected'
-    end
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[ruby]
-    realtime.connection.on do |state_change|
-      puts "New connection state is #{state_change.current}"
-    end
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[ruby]
-    # remove a listener registered for a single even
-    realtime.connection.off :connected, &block
-
-    # remove a listener registered for all events
-    realtime.connection.off &block
-
-    # remove all event listeners
-    realtime.connection.off
-  ```
-
-blang[objc].
-  ```[objc]
+```[objc]
   ARTEventListener *listener = [realtime.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *change) {
-      NSLog(@"Ably is connected");
+    NSLog(@"Ably is connected");
   }];
-  ```
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[swift]
+  let listener = realtime.connection.on(.connected) { change in
+    print("Ably is connected")
+  }
+```
 
-  ```[objc]
+Alternatively a <span lang="default">listener</span><span lang="csharp">handler</span> may be registered so that it receives all state change events.
+
+```[jsall]
+  realtime.connection.on(function(stateChange) {
+    console.log('New connection state is ' + stateChange.current);
+  });
+```
+
+```[java]
+  realtime.connection.on(new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is " + change.current.name());
+    }
+  });
+```
+
+```[csharp]
+  realtime.Connection.On(args => {
+    Console.WriteLine("New state is " + args.Current)
+  });
+```
+
+```[ruby]
+  realtime.connection.on do |state_change|
+    puts "New connection state is #{state_change.current}"
+  end
+```
+
+```[objc]
   ARTEventListener *listener = [realtime.connection on:^(ARTConnectionStateChange *change) {
-      NSLog(@"New connection state is %lu", (unsigned long)change.current);
+    NSLog(@"New connection state is %lu", (unsigned long)change.current);
   }];
-  ```
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[swift]
+  let listener = realtime.connection.on { change in
+    print("New connection state is \(change!.current)")
+  }
+```
 
-  ```[objc]
+Previously registered <span lang="default">listeners</span><span lang="csharp">handlers</span> can be removed individually or all together.
+
+```[jsall]
+  /* remove a listener registered for a single event */
+  realtime.connection.off('connected', myListener);  
+
+  /* remove a listener registered for all events */
+  realtime.connection.off(myListener);  
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[java]
+  /* remove a single listener */
+  realtime.connection.off(myListener);
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[csharp]
+  /* remove a single handler */
+  realtime.Connection.Off(action);
+
+  /* remove all event handlers */
+  realtime.Connection.Off();
+```
+
+```[ruby]
+  # remove a listener registered for a single even
+  realtime.connection.off :connected, &block
+
+  # remove a listener registered for all events
+  realtime.connection.off &block
+
+  # remove all event listeners
+  realtime.connection.off
+```
+
+```[objc]
   // remove a listener registered for a single event
   [realtime.connection off:ARTRealtimeConnectionEventConnected listener:listener];
 
@@ -266,26 +257,9 @@ blang[objc].
 
   // remove all event listeners
   [realtime.connection off];
-  ```
+```
 
-blang[swift].
-  ```[swift]
-  let listener = realtime.connection.on(.connected) { change in
-      print("Ably is connected")
-  }
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[swift]
-  let listener = realtime.connection.on { change in
-      print("New connection state is \(change!.current)")
-  }
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[swift]
+```[swift]
   // remove a listener registered for a single event
   realtime.connection.off(.connected, listener: listener)
 
@@ -294,7 +268,7 @@ blang[swift].
 
   // remove all event listeners
   realtime.connection.off()
-  ```
+```
 
 h3(#handling-failures). Handling failures
 

--- a/content/realtime/versions/v1.1/connection.textile
+++ b/content/realtime/versions/v1.1/connection.textile
@@ -128,136 +128,127 @@ The @Connection@ object is an @EventEmitter@ and emits an event whose name is th
 
 The @Connection@ object can also emit an event that is not a state change: an @update@ event. This happens when there's a change to connection conditions for which the connection state doesn't change - that is, when the library remains connected, e.g. after a "reauth":/realtime/authentication#token-authentication.
 
-blang[jsall].
-  ```[jsall]
-    realtime.connection.on('connected', function(stateChange) {
-      console.log('Ably is connected');
-    });
-  ```
+```[jsall]
+ realtime.connection.on('connected', function(stateChange) {
+     console.log('Ably is connected');
+ });
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[java]
+  realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is connected");
+    }
+  });
+```
 
-  ```[jsall]
-    realtime.connection.on(function(stateChange) {
-      console.log('New connection state is ' + stateChange.current);
-    });
-  ```
+```[csharp]
+  realtime.Connection.On(ConnectionState.Connected, args => {
+    Console.WriteLine("Connected, that was easy")
+  });
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[ruby]
+  realtime.connection.on(:connected) do
+    puts 'Ably is connected'
+  end
+```
 
-  ```[jsall]
-    /* remove a listener registered for a single event */
-    realtime.connection.off('connected', myListener);
-
-    /* remove a listener registered for all events */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[java].
-  ```[java]
-    realtime.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is connected");
-      }
-    });
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[java]
-    realtime.connection.on(new ConnectionStateListener() {
-      @Override
-      public void onConnectionStateChanged(ConnectionStateChange change) {
-        System.out.println("New state is " + change.current.name());
-      }
-    });
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[java]
-    /* remove a single listener */
-    realtime.connection.off(myListener);
-
-    /* remove all event listeners */
-    realtime.connection.off();
-  ```
-
-blang[csharp].
-  ```[csharp]
-    realtime.Connection.On(ConnectionState.Connected, args => {
-      Console.WriteLine("Connected, that was easy")
-    });
-  ```
-
-  Alternatively a handler may be registered so that it receives all state change events.
-
-  ```[csharp]
-    realtime.Connection.On(args => {
-      Console.WriteLine("New state is " + args.Current)
-    });
-  ```
-
-  Previously registered handlers can be removed individually or all together.
-
-  ```[csharp]
-    /* remove a single handler */
-    realtime.Connection.Off(action);
-
-    /* remove all event handlers */
-    realtime.Connection.Off();
-  ```
-
-blang[ruby].
-  ```[ruby]
-    realtime.connection.on(:connected) do
-      puts 'Ably is connected'
-    end
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[ruby]
-    realtime.connection.on do |state_change|
-      puts "New connection state is #{state_change.current}"
-    end
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[ruby]
-    # remove a listener registered for a single even
-    realtime.connection.off :connected, &block
-
-    # remove a listener registered for all events
-    realtime.connection.off &block
-
-    # remove all event listeners
-    realtime.connection.off
-  ```
-
-blang[objc].
-  ```[objc]
+```[objc]
   ARTEventListener *listener = [realtime.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *change) {
-      NSLog(@"Ably is connected");
+    NSLog(@"Ably is connected");
   }];
-  ```
+```
 
-  Alternatively a listener may be registered so that it receives all state change events.
+```[swift]
+  let listener = realtime.connection.on(.connected) { change in
+    print("Ably is connected")
+  }
+```
 
-  ```[objc]
+Alternatively a <span lang="default">listener</span><span lang="csharp">handler</span> may be registered so that it receives all state change events.
+
+```[jsall]
+  realtime.connection.on(function(stateChange) {
+    console.log('New connection state is ' + stateChange.current);
+  });
+```
+
+```[java]
+  realtime.connection.on(new ConnectionStateListener() {
+    @Override
+    public void onConnectionStateChanged(ConnectionStateChange change) {
+      System.out.println("New state is " + change.current.name());
+    }
+  });
+```
+
+```[csharp]
+  realtime.Connection.On(args => {
+    Console.WriteLine("New state is " + args.Current)
+  });
+```
+
+```[ruby]
+  realtime.connection.on do |state_change|
+    puts "New connection state is #{state_change.current}"
+  end
+```
+
+```[objc]
   ARTEventListener *listener = [realtime.connection on:^(ARTConnectionStateChange *change) {
-      NSLog(@"New connection state is %lu", (unsigned long)change.current);
+    NSLog(@"New connection state is %lu", (unsigned long)change.current);
   }];
-  ```
+```
 
-  Previously registered listeners can be removed individually or all together.
+```[swift]
+  let listener = realtime.connection.on { change in
+    print("New connection state is \(change!.current)")
+  }
+```
 
-  ```[objc]
+Previously registered <span lang="default">listeners</span><span lang="csharp">handlers</span> can be removed individually or all together.
+
+```[jsall]
+  /* remove a listener registered for a single event */
+  realtime.connection.off('connected', myListener);  
+
+  /* remove a listener registered for all events */
+  realtime.connection.off(myListener);  
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[java]
+  /* remove a single listener */
+  realtime.connection.off(myListener);
+
+  /* remove all event listeners */
+  realtime.connection.off();
+```
+
+```[csharp]
+  /* remove a single handler */
+  realtime.Connection.Off(action);
+
+  /* remove all event handlers */
+  realtime.Connection.Off();
+```
+
+```[ruby]
+  # remove a listener registered for a single even
+  realtime.connection.off :connected, &block
+
+  # remove a listener registered for all events
+  realtime.connection.off &block
+
+  # remove all event listeners
+  realtime.connection.off
+```
+
+```[objc]
   // remove a listener registered for a single event
   [realtime.connection off:ARTRealtimeConnectionEventConnected listener:listener];
 
@@ -266,26 +257,9 @@ blang[objc].
 
   // remove all event listeners
   [realtime.connection off];
-  ```
+```
 
-blang[swift].
-  ```[swift]
-  let listener = realtime.connection.on(.connected) { change in
-      print("Ably is connected")
-  }
-  ```
-
-  Alternatively a listener may be registered so that it receives all state change events.
-
-  ```[swift]
-  let listener = realtime.connection.on { change in
-      print("New connection state is \(change!.current)")
-  }
-  ```
-
-  Previously registered listeners can be removed individually or all together.
-
-  ```[swift]
+```[swift]
   // remove a listener registered for a single event
   realtime.connection.off(.connected, listener: listener)
 
@@ -294,7 +268,7 @@ blang[swift].
 
   // remove all event listeners
   realtime.connection.off()
-  ```
+```
 
 h3(#handling-failures). Handling failures
 


### PR DESCRIPTION
## Description

This PR updates the `/realtime/connection` page (for all versions) to replace occurrences of codeblocks that are nested within `blang` elements. This is to make these easier to handle in a future toolchain.

See [JIRA](https://ably.atlassian.net/browse/EDX-230) for further information.

## Review

To review, visit the [realtime/connection](https://ably-docs-edx-230-neste-b4mjmt.herokuapp.com/realtime/connection) page.
