### PR TITLE
Fix broken link to client options section of API docs

### DIFF
--- a/content/rest/usage.textile
+++ b/content/rest/usage.textile
@@ -188,7 +188,7 @@ blang[flutter].
 
 "View our client library SDKs feature support matrix":https://ably.com/download/sdk-feature-support-matrix to see the list of all the available features.
 
-The supported "client options are described below":#client-options.
+The supported "client options are described below":/api/rest-sdk/types#client-options.
 
 h2(#tutorials). Tutorials
 

--- a/content/rest/usage.textile
+++ b/content/rest/usage.textile
@@ -188,7 +188,7 @@ blang[flutter].
 
 "View our client library SDKs feature support matrix":https://ably.com/download/sdk-feature-support-matrix to see the list of all the available features.
 
-The supported "client options are described below":/api/rest-sdk/types#client-options.
+The supported client options are described in the "API reference documentation":/api/rest-sdk/types#client-options.
 
 h2(#tutorials). Tutorials
 

--- a/content/rest/versions/v0.8/usage.textile
+++ b/content/rest/versions/v0.8/usage.textile
@@ -143,7 +143,7 @@ blang[objc,swift].
   let rest = ARTRest(key: apiKey)
   ```
 
-The supported "client options are described below":#client-options.
+The supported client options are described in the "API reference documentation":/api/rest-sdk/types#client-options.
 
 h2(#api-reference). API Reference
 

--- a/content/rest/versions/v1.0/usage.textile
+++ b/content/rest/versions/v1.0/usage.textile
@@ -168,7 +168,7 @@ blang[objc,swift].
   let rest = ARTRest(key: apiKey)
   ```
 
-The supported "client options are described below":#client-options.
+The supported client options are described in the "API reference documentation":/api/rest-sdk/types#client-options.
 
 h2(#tutorials). Tutorials
 

--- a/content/rest/versions/v1.1/usage.textile
+++ b/content/rest/versions/v1.1/usage.textile
@@ -175,7 +175,7 @@ blang[go].
 
 "View our client library SDKs feature support matrix":https://ably.com/download/sdk-feature-support-matrix to see the list of all the available features.
 
-The supported "client options are described below":#client-options.
+The supported client options are described in the "API reference documentation":/api/rest-sdk/types#client-options.
 
 h2(#tutorials). Tutorials
 


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

* [Jira epic ticket](https://ably.atlassian.net/browse/EDU-608) - if applicable.
* [Jira ticket](https://ably.atlassian.net/browse/EDU-868).

## Review

Replaced broken link with new link into API docs

* [Page to review](https://ably-docs-edu-868-fix-b-zdojju.herokuapp.com/rest/usage/)
