### PR TITLE
[EDU-257] - Add notes on persist last message

### DIFF
--- a/content/adapters/pusher.md
+++ b/content/adapters/pusher.md
@@ -35,7 +35,7 @@ Please note:
 * For the Pusher key, use the part of the [Ably API key](https://faqs.ably.com/what-is-an-app-api-key) before the colon; for the secret, use the part after the colon.
 * You can add any other Pusher options you would normally use in the initializer.
 * In the Pusher client library terminology, the 'encrypted' option controls whether the the lib uses TLS, not end-to-end encryption. Setting the `encrypted` option to true is not mandatory, but strongly recommended to avoid sending private keys over plain text connections.
-* Pusher adapter clients are not "identified" in the Ably sense. Make sure you do not have 'require identification' channel rule on for any channels/namespaces you will be accessing with the adapter. See [this article](https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app) on how to change channel rules. If you get an "Ably error 40160", this is the reason why.
+* Pusher adapter clients are not "identified" in the Ably sense. Make sure you do not have 'require identification' channel rule on for any channels/namespaces you will be accessing with the adapter. See [this article](/general/channel-rules-namespaces) on how to change channel rules. If you get an "Ably error 40160", this is the reason why.
 * *The Pusher channel will have a different name from the corresponding Ably channel*. See the 'Channels' section below.
 
 ## Supported features

--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -193,7 +193,7 @@ h3(#message-history). Retrieve message history for a channel
 
 h6. GET rest.ably.io/channels/@<channelId>@/messages
 
-If a channel is "configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
+If a channel is "configured to persist messages":/general/channel-rules-namespaces, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
 
 Example request:
 

--- a/content/api/versions/v0.8/rest-api.textile
+++ b/content/api/versions/v0.8/rest-api.textile
@@ -70,7 +70,7 @@ h3(#message-history). Retrieve message history for a channel
 
 h6. GET rest.ably.io/channels/@<channelId>@/messages
 
-If a channel is "configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
+If a channel is "configured to persist messages":/general/channel-rules-namespaces, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
 
 Example request:
 

--- a/content/api/versions/v1.0/rest-api.textile
+++ b/content/api/versions/v1.0/rest-api.textile
@@ -144,7 +144,7 @@ h3(#message-history). Retrieve message history for a channel
 
 h6. GET rest.ably.io/channels/@<channelId>@/messages
 
-If a channel is "configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
+If a channel is "configured to persist messages":/general/channel-rules-namespaces, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
 
 Example request:
 

--- a/content/api/versions/v1.1/rest-api.textile
+++ b/content/api/versions/v1.1/rest-api.textile
@@ -187,7 +187,7 @@ h3(#message-history). Retrieve message history for a channel
 
 h6. GET rest.ably.io/channels/@<channelId>@/messages
 
-If a channel is "configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
+If a channel is "configured to persist messages":/general/channel-rules-namespaces, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
 
 Example request:
 

--- a/content/core-features/history.textile
+++ b/content/core-features/history.textile
@@ -18,7 +18,11 @@ h2(#persisted-history). Enabling persistent history
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quota. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a @persist all messages@ "channel rule":/general/channel-rules-namespaces in the settings of your Ably "dashboard":https://ably.com/dashboard.
+
+It is also possible to "persist last message":/general/channel-rules-namespaces on a channel, which preserves the last message published on the channel for one year. 
+
+This last message is retrievable using the "channel rewind":/realtime/channels/channel-parameters/rewind mechanism by attaching to the channel with @rewind=1@. Only messages are stored, not presence messages. This last message storage is not accessible using the normal "history API":/realtime/history, only through rewind.
 
 h2(#ordering). Ordering of historical messages
 

--- a/content/core-features/history.textile
+++ b/content/core-features/history.textile
@@ -20,9 +20,7 @@ Every message that is persisted to or retrieved from disk counts as an extra mes
 
 To enable history on a channel, it is necessary to add a @persist all messages@ "channel rule":/general/channel-rules-namespaces in the settings of your Ably "dashboard":https://ably.com/dashboard.
 
-It is also possible to "persist last message":/general/channel-rules-namespaces on a channel, which preserves the last message published on the channel for one year. 
-
-This last message is retrievable using the "channel rewind":/realtime/channels/channel-parameters/rewind mechanism by attaching to the channel with @rewind=1@. Only messages are stored, not presence messages. This last message storage is not accessible using the normal "history API":/realtime/history, only through rewind.
+It is also possible to "persist last message":/general/channel-rules-namespaces on a channel, which preserves the last message published on the channel for one year. This last message is retrievable using the "channel rewind":/realtime/channels/channel-parameters/rewind mechanism by attaching to the channel with @rewind=1@. Only messages are stored, not presence messages. This last message storage is not accessible using the normal "history API":/realtime/history, only through rewind.
 
 h2(#ordering). Ordering of historical messages
 

--- a/content/core-features/versions/v1.1/history.textile
+++ b/content/core-features/versions/v1.1/history.textile
@@ -16,4 +16,4 @@ h2(#persisted-history). Enabling persistent history
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quota. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.

--- a/content/general/push/activate-subscribe.textile
+++ b/content/general/push/activate-subscribe.textile
@@ -215,7 +215,7 @@ ably.push.activate()
 
 h2(#subscribing). Subscribe for push notifications
 
-Before you subscribe to a channel for push, make sure its "channel namespace is configured to explicitly enable push notifications":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. By default, push notifications on channels are disabled.
+Before you subscribe to a channel for push, make sure its "channel namespace is configured to explicitly enable push notifications":/general/channel-rules-namespaces. By default, push notifications on channels are disabled.
 
 There are two ways a device can be subscribed to a channel: directly "by its device ID":#subscribing-device-id, or indirectly "by its associated client ID":#subscribing-client-id.
 

--- a/content/general/push/publish.textile
+++ b/content/general/push/publish.textile
@@ -42,7 +42,7 @@ Therefore, the process for delivering push notifications to devices using channe
 Please note that a push notification published on a channel will only be delivered to a device if:
 
 * the *extra push notification* payload is included in the published message
-* a "channel rule":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app is configured explicitly enabling push notifications on that channel
+* a "channel rule":/general/channel-rules-namespaces is configured explicitly enabling push notifications on that channel
 * the device is subscribed to the channel
 * the push notification payload is compatible with the subscribed push notification device
 

--- a/content/general/versions/v1.1/push/activate-subscribe.textile
+++ b/content/general/versions/v1.1/push/activate-subscribe.textile
@@ -189,7 +189,7 @@ ably.push.activate()
 
 h2(#subscribing). Subscribe for push notifications
 
-Before you subscribe to a channel for push, make sure its "channel namespace is configured to explicitly enable push notifications":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. By default, push notifications on channels are disabled.
+Before you subscribe to a channel for push, make sure its "channel namespace is configured to explicitly enable push notifications":/general/channel-rules-namespaces. By default, push notifications on channels are disabled.
 
 There are two ways a device can be subscribed to a channel: directly "by its device ID":#subscribing-device-id, or indirectly "by its associated client ID":#subscribing-client-id.
 

--- a/content/general/versions/v1.1/push/publish.textile
+++ b/content/general/versions/v1.1/push/publish.textile
@@ -38,7 +38,7 @@ Therefore, the process for delivering push notifications to devices using channe
 Please note that a push notification published on a channel will only be delivered to a device if:
 
 * the *extra push notification* payload is included in the published message
-* a "channel rule":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app is configured explicitly enabling push notifications on that channel
+* a "channel rule":/general/channel-rules-namespaces is configured explicitly enabling push notifications on that channel
 * the device is subscribed to the channel
 * the push notification payload is compatible with the subscribed push notification device
 

--- a/content/partials/compare/intros/_security.textile
+++ b/content/partials/compare/intros/_security.textile
@@ -2,5 +2,5 @@ Security and encryption are front of mind and any realtime platform will have ro
 
 * TLS connection to ensure all "data in transit are encrypted":https://faqs.ably.com/are-messages-sent-to-and-received-from-ably-securely-using-tls
 * "Token-based authentication":/core-features/authentication?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages (including "JWT":https://jwt.io support), which ensures your private key is never shared and instead a short-lived token is used to authenticate
-* Configurable "private key permissions":https://faqs.ably.com/setting-up-and-managing-api-keys to restrict "channels/topics":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app or operations
+* Configurable "private key permissions":https://faqs.ably.com/setting-up-and-managing-api-keys to restrict "channels/topics":/general/channel-rules-namespaces or operations
 * "Encrypted message payloads":https://faqs.ably.com/cross-platform-symmetric-encryption-offered-by-the-libraries to enhance security and privacy of all messages

--- a/content/partials/versions/v0.8/shared/_channel_namespaces.textile
+++ b/content/partials/versions/v0.8/shared/_channel_namespaces.textile
@@ -2,7 +2,7 @@ One or more channel namespaces, or channel name prefixes, may be "configured for
 
 Namespace-prefixed channel names are delimited by a single colon @:@; the first component of the channel name (from the start up to and including the last character before the colon) is the namespace. A channel name may validly contain a colon even if the namespace component does not correspond to a namespace; also, a channel may contain multiple colons and only the component up to the first colon will be matched with a namespace. The only restriction on channel names is that a channel name may not start with a colon @:@, an open square bracket @[@ and it may not be empty.
 
-Namespaces are defined and configured via the "application dashboard settings":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. The namespace attributes that can be configured are:
+Namespaces are defined and configured via the "application dashboard settings":/general/channel-rules-namespaces. The namespace attributes that can be configured are:
 
 * **Persisted messages** - If enabled, all messages within this namespace will be stored according to the storage rules for your account. You can access stored messages via the "history API":/realtime/history
 * **Require identification** - if enabled, clients will not be permitted to subscribe to matching channels unless they are both authenticated and identified (they have an assigned client ID). Anonymous clients are not permitted to join these channels. Find out more about "authenticated and identified clients":https://faqs.ably.com/authenticated-and-identified-clients

--- a/content/partials/versions/v1.0/shared/_channel_namespaces.textile
+++ b/content/partials/versions/v1.0/shared/_channel_namespaces.textile
@@ -2,7 +2,7 @@ One or more channel namespaces, or channel name prefixes, may be "configured for
 
 Namespace-prefixed channel names are delimited by a single colon @:@; the first component of the channel name (from the start up to and including the last character before the colon) is the namespace. A channel name may validly contain a colon even if the namespace component does not correspond to a namespace; also, a channel may contain multiple colons and only the component up to the first colon will be matched with a namespace. The only restriction on channel names is that a channel name may not start with a colon @:@, an open square bracket @[@ and it may not be empty.
 
-Namespaces are defined and configured via the "application dashboard settings":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. The namespace attributes that can be configured are:
+Namespaces are defined and configured via the "application dashboard settings":/general/channel-rules-namespaces. The namespace attributes that can be configured are:
 
 * **Persisted messages** - If enabled, all messages within this namespace will be stored according to the storage rules for your account. You can access stored messages via the "history API":/realtime/history
 * **Require identification** - if enabled, clients will not be permitted to subscribe to matching channels unless they are both authenticated and identified (they have an assigned client ID). Anonymous clients are not permitted to join these channels. Find out more about "authenticated and identified clients":https://faqs.ably.com/authenticated-and-identified-clients

--- a/content/partials/versions/v1.1/shared/_channel_namespaces.textile
+++ b/content/partials/versions/v1.1/shared/_channel_namespaces.textile
@@ -2,7 +2,7 @@ One or more channel namespaces, or channel name prefixes, may be "configured for
 
 Namespace-prefixed channel names are delimited by a single colon @:@; the first component of the channel name (from the start up to and including the last character before the colon) is the namespace. A channel name may validly contain a colon even if the namespace component does not correspond to a namespace; also, a channel may contain multiple colons and only the component up to the first colon will be matched with a namespace. The only restriction on channel names is that a channel name may not start with a colon @:@, an open square bracket @[@ and it may not be empty.
 
-Namespaces are defined and configured via the "application dashboard settings":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. The namespace attributes that can be configured are:
+Namespaces are defined and configured via the "application dashboard settings":/general/channel-rules-namespaces. The namespace attributes that can be configured are:
 
 * **Persisted messages** - If enabled, all messages within this namespace will be stored according to the storage rules for your account. You can access stored messages via the "history API":/realtime/history
 * **Require identification** - if enabled, clients will not be permitted to subscribe to matching channels unless they are both authenticated and identified (they have an assigned client ID). Anonymous clients are not permitted to join these channels. Find out more about "authenticated and identified clients":https://faqs.ably.com/authenticated-and-identified-clients

--- a/content/realtime/channels/channel-parameters/rewind.textile
+++ b/content/realtime/channels/channel-parameters/rewind.textile
@@ -133,9 +133,9 @@ The channel position expressed by a @rewind@ parameter only has an effect on an 
 
 Any @rewind@ parameter value that cannot be parsed either as a number or a time specifier will cause the attachment request to fail and return an error.
 
-h3(#state-persistence). State persistence
+h3(#persist-last-message). Persist last message
 
-If you have enabled the "**State persistence** channel rule,":/general/channel-rules-namespaces/ on the channel in question, you can attach with @rewind=1@ to retrieve the last message. Note that only the last message can be stored long-term (up to a year), and persisting the last message does not work for presence messages.
+If you have enabled the @persist last message@ "channel rule":/general/channel-rules-namespaces/ on a channel, you can attach with @rewind=1@ to retrieve the last message. Note that only the last message can be stored long-term (up to a year), and persisting the last message does not work for presence messages.
 
 h2(#api-reference). API Reference
 

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -130,7 +130,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h3(#continuous-history). Continuous history
 

--- a/content/realtime/versions/v0.8/history.textile
+++ b/content/realtime/versions/v0.8/history.textile
@@ -126,7 +126,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h3(#continuous-history). Continuous history
 

--- a/content/realtime/versions/v1.0/history.textile
+++ b/content/realtime/versions/v1.0/history.textile
@@ -130,7 +130,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h3(#continuous-history). Continuous history
 

--- a/content/realtime/versions/v1.1/channel-params.textile
+++ b/content/realtime/versions/v1.1/channel-params.textile
@@ -89,7 +89,7 @@ At most 100 messages will be sent in a rewind request. If the number of messages
 
 By default, a maximum of two minutes of channel history is available when attaching. This means that a rewind time specifier of greater than two minutes will only be able to rewind by two minutes. If a channel has persistence enabled, then it is possible to rewind back in time by up to the persistence TTL on the channel.
 
-If you have enabled the "**State persistence** channel rule,":/general/channel-rules-namespaces/ on the channel in question, you can attach with @rewind=1@ to retrieve the last message. Note that only the last message can be stored long-term (up to a year), and persisting the last message does not work for presence messages.
+If you have enabled the @persist last message@ "channel rule":/general/channel-rules-namespaces/ on a channel, you can attach with @rewind=1@ to retrieve the last message. Note that only the last message can be stored long-term (up to a year), and persisting the last message does not work for presence messages.
 
 The channel position expressed by a @rewind@ parameter has an effect only on an initial channel attachment. Any subsequent reattachment of the same channel on the same connection, in order to resume the connection, will attempt to resume with continuity from the point at which the connection dropped. (There are a few exceptions to this: in particular, client libraries earlier than v1.2 that have been disconnected for over two minutes, and all clients when using "@recover@ mode":/realtime/connection#connection-state-recovery ; in both cases the previous attachment state is not preserved).
 

--- a/content/realtime/versions/v1.1/history.textile
+++ b/content/realtime/versions/v1.1/history.textile
@@ -130,7 +130,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h3(#continuous-history). Continuous history
 

--- a/content/rest/history.textile
+++ b/content/rest/history.textile
@@ -135,7 +135,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h2(#api-reference). API Reference
 

--- a/content/rest/versions/v0.8/history.textile
+++ b/content/rest/versions/v0.8/history.textile
@@ -114,7 +114,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h2(#api-reference). API Reference
 

--- a/content/rest/versions/v1.0/history.textile
+++ b/content/rest/versions/v1.0/history.textile
@@ -126,7 +126,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h2(#api-reference). API Reference
 

--- a/content/rest/versions/v1.1/history.textile
+++ b/content/rest/versions/v1.1/history.textile
@@ -135,7 +135,7 @@ By default, persisted history on channels is disabled and messages are only stor
 
 Every message that is persisted to or retrieved from disk counts as an extra message towards your monthly quote. For example, for a channel that has persistence enabled, if a message is published, two messages will be deducted from your monthly quota. If the message is later retrieved from history, another message will be deducted from your monthly quota.
 
-To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app for further information on what they are and how to configure them.
+To enable history on a channel, it is necessary to add a channel rule in the settings of your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard. See the "documentation on channel rules":/general/channel-rules-namespaces for further information on what they are and how to configure them.
 
 h2(#api-reference). API Reference
 

--- a/content/root/key-concepts.textile
+++ b/content/root/key-concepts.textile
@@ -45,7 +45,7 @@ h4. Message persistence
 All messages received by Ably are immediately stored in RAM in three separate physical locations for redundancy. They are then persisted as follows:
 
 * In server RAM for 2 minutes in every location that the channel is active
-* On disk in three locations for 24 - 72 hours if the "channel is configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app
+* On disk in three locations for 24 - 72 hours if the "channel is configured to persist messages":/general/channel-rules-namespaces
 
 Whilst Ably is used primarily by clients to receive messages in real time, Ably provides a "history API":/rest/history that allows clients to retrieve older messages from memory and/or disk.
 
@@ -55,7 +55,7 @@ Presence provides awareness of other clients that are connected to Ably and pres
 
 There are three presence operations, @enter@ for new members, @update@ allowing the payload data associated with a member to be updated and announced to everyone, and @leave@ for members that have requested to leave or who have left implicitly as a result of their connection being disconnected.
 
-The complete set of members present and their optional payload is stored by Ably in server RAM in at least three locations. Like messages, presence events such as @enter@ and @leave@ are persisted in RAM for 2 minutes, and optionally to disk in three locations for 24 - 72 hours if the "channel is configured to persist messages":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app
+The complete set of members present and their optional payload is stored by Ably in server RAM in at least three locations. Like messages, presence events such as @enter@ and @leave@ are persisted in RAM for 2 minutes, and optionally to disk in three locations for 24 - 72 hours if the "channel is configured to persist messages":/general/channel-rules-namespaces
 
 h3(#integrations). Integrations
 

--- a/content/tutorials/channel-rewind.textile
+++ b/content/tutorials/channel-rewind.textile
@@ -31,7 +31,7 @@ Usually in applications that implement the Pub/Sub messaging pattern, a client i
 
 However, in some applications it is useful to have access also to messages that occurred in the past. Ably supports a "History API":/core-features/history whereby, for channels that are persisted, it is possible to query explicitly for historical messages on a channel within any specified time bounds.
 
-bq. You can now persist the last realtime message on a channel for 365 days. *State Persistence* allows you to instantly retrieve realtime messages sent in the past, helping with long-term state synchronization. "Read how to enable State Persistence":/realtime/channels/channel-parameters/rewind#state-persistence.
+bq. You can now persist the last realtime message on a channel for 365 days. *Persist last message* allows you to instantly retrieve realtime messages sent in the past, helping with long-term state synchronization. Read how to enable "persist last message":/realtime/channels/channel-parameters/rewind#persist-last-message.
 
 For some applications, the requirement for historical access is simply to be able to obtain the most recent message(s) on a channel. This can apply, for example, in a data streaming scenario where a data provider continuously streams data in realtime as it is generated but a new consumer just tuning in to get that data may have to sit idle until the next available update arrives, unless they have access to the previously published message.
 

--- a/content/tutorials/history.textile
+++ b/content/tutorials/history.textile
@@ -41,11 +41,11 @@ meta_keywords: Ably, Ably realtime, History
 
 Ably's "history feature":/realtime/history enables you to store messages published on channels that can later be retrieved using the "channel history API":/api/realtime-sdk/history.
 
-By default, channels will only store messages in memory for up to two minutes. However, using "channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, you can configure messages published on matching channels to be persisted to disk for "typically 24 - 72 hours":https://faqs.ably.com/how-long-are-messages-stored-for. Those messages will then be immediately available for retrieval via our Realtime and REST API clients for as long as the message is stored on disk.
+By default, channels will only store messages in memory for up to two minutes. However, using "channel rules":/general/channel-rules-namespaces, you can configure messages published on matching channels to be persisted to disk for "typically 24 - 72 hours":https://faqs.ably.com/how-long-are-messages-stored-for. Those messages will then be immediately available for retrieval via our Realtime and REST API clients for as long as the message is stored on disk.
 
 Using our "history API":/realtime/history is trivial.  Let's get started.
 
-bq. You can now persist the last realtime message on a channel for 365 days. *State Persistence* allows you to instantly retrieve realtime messages sent in the past, helping with long-term state synchronization. "Read how to enable State Persistence":/realtime/channels/channel-parameters/rewind#state-persistence.
+bq. You can now persist the last realtime message on a channel for 365 days. *Persist last message* allows you to instantly retrieve realtime messages sent in the past, helping with long-term state synchronization. Read how to enable "persist last message":/realtime/channels/channel-parameters/rewind#persist-last-message.
 
 
 <%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>

--- a/content/tutorials/reactjs-realtime-commenting.textile
+++ b/content/tutorials/reactjs-realtime-commenting.textile
@@ -515,7 +515,7 @@ this.handleAddComment = this.handleAddComment.bind(this)
 
 h2. Step 15 - Configure channels to persist messages to disk
 
-You'll use Ably's "history feature":/realtime/history to persist all comment messages to disk for later retrieval by clients. This capability must be configured on channels using "channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app. In this tutorial you will create a channel rule for all channels in the @persisted@ "namespace":https://faqs.ably.com/what-is-a-channel-namespace-and-how-can-i-use-them.
+You'll use Ably's "history feature":/realtime/history to persist all comment messages to disk for later retrieval by clients. This capability must be configured on channels using "channel rules":/general/channel-rules-namespaces. In this tutorial you will create a channel rule for all channels in the @persisted@ "namespace":https://faqs.ably.com/what-is-a-channel-namespace-and-how-can-i-use-them.
 
 # Visit your "account dashboard":https://faqs.ably.com/how-do-i-access-my-account-dashboard and select the same app you chose in Step 1 when obtaining your API key
 # Click on the Settings tab and scroll down to the "Channel rules" section

--- a/content/tutorials/vue-tictactoe.textile
+++ b/content/tutorials/vue-tictactoe.textile
@@ -57,7 +57,7 @@ First, make sure you have your Ably account set up, with an application and API 
 # Follow "these instructions for setting up an API key":https://faqs.ably.com/setting-up-and-managing-api-keys if you haven't done so before.
 # In your "application dashboard":https://faqs.ably.com/how-do-i-access-my-app-dashboard, go to the &quot;Settings&quot; tab and scroll down to the &quot;Channel rules&quot; section.
 # Click the &quot;Add new rule&quot; button, and enter &quot;tictactoe&quot; in the &quot;Namespace or Channel ID&quot; field, then check the &quot;Persisted&quot; checkbox. This will enable history for any channel starting with @tictactoe:@.
-# Hit &quot;Save&quot; and you're done. Further details about setting up channel rules "can be found here":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app.
+# Hit &quot;Save&quot; and you're done. Further details about setting up channel rules "can be found here":/general/channel-rules-namespaces.
 
 Next, let's get the project environment and dependencies in place.
 


### PR DESCRIPTION
## Description

[Original ticket](https://ably.atlassian.net/browse/EDU-257) requested mention of `persist last message` on the history page. That has been done along with:

* Cleanup of naming in several locations. Persist last message was renamed to state persistence - however, it is referred to as `persist last message` in places such as Control API, Dashboard and in error messages etc. Casuing confusion. Rename to `persist last message` to be consistent with other parts of the product.
* Instead of pointing to FAQs, point to channel rules / namespaces docs in the main docs. 
* [EDU-257](https://ably.atlassian.net/browse/EDU-257).

## Review

History page now mentions `persist last message`:

* [History](https://ably-docs-edu-257-persi-dqfbow.herokuapp.com/core-features/history/)
