### PR TITLE
chore: Pin node and npm versions necessary for the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "jest --findRelatedTests"
     ]
   },
+  "engines": {
+    "npm": ">=7.7.0",
+    "node": ">=15.14.0"
+  },
   "scripts": {
     "develop": "export EDITOR_WARNINGS_OFF='true' && gatsby clean && gatsby develop",
     "start": "npm run develop",


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

The project does not on node versions less than `15` because it uses `replace` function and with npm less than `7`, because it changes `package-lock.json`. To work with this project we need to have those pinned to avoid further confusion. 🙃 

* [Jira epic ticket](link) - if applicable.
* [Jira ticket](link).

## Review

Please, checkout the branch and make usre it runs fine on your machine locally. Suggest a different version/subversion if you think that it's also okay or better. :)

* [Page to review](link)
