### PR TITLE
[EDU-409] - Fix auth call and quick tidy

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -86,8 +86,8 @@ Using an Ably Client Library SDK, a @TokenRequest@ is "generated from your serve
 
 The following is an example of creating an Ably @TokenRequest@:
 
-bc[javascript](code-editor:authentication/create-token-request). var ably = new Ably.Rest({ key: '{{API_KEY}}' });
-ably.auth.createTokenRequest({ clientId: 'client@example.com' }, null, function(err, tokenRequest) {
+bc[javascript](code-editor:authentication/create-token-request). const ably = new Ably.Rest({ key: '{{API_KEY}}' });
+ably.auth.createTokenRequest({ clientId: 'client@example.com' }, null, (err, tokenRequest) => {
   /* tokenRequest => {
        "capability": "{\"*\":[\"*\"]}",
        "clientId": "client@example.com",
@@ -125,8 +125,8 @@ Using an Ably Client Library SDK, an "Ably Token is requested by your servers":/
 
 The following is an example of issuing an Ably Token:
 
-bc[javascript](code-editor:authentication/request-token). var ably = new Ably.Rest({ key: '{{API_KEY}}' });
-ably.requestToken({ clientId: 'client@example.com' }, function(err, token) {
+bc[javascript](code-editor:authentication/request-token). const ably = new Ably.Rest({ key: '{{API_KEY}}' });
+ably.auth.requestToken({ clientId: 'client@example.com' }, (err, token) => {
   /* token => {
        "token": "xVLyHw.Dtxd9tuz....EXAMPLE",
        "capability": "{\"*\":[\"*\"]}"
@@ -191,8 +191,8 @@ If a system has an existing "JWT":https://jwt.io/ scheme, it can be useful to em
 
 The following is an example of issuing an Ably-compatible token inside the of header of a JWT:
 
-bc[javascript]. var ably = new Ably.Rest({ key: '{{API_KEY}}' });
-ably.auth.requestToken({ clientId: 'client@example.com' }, function(err, tokenDetails) {
+bc[javascript]. const ably = new Ably.Rest({ key: '{{API_KEY}}' });
+ably.auth.requestToken({ clientId: 'client@example.com' }, (err, tokenDetails) => {
   var header = {
     "typ":"JWT",
     "alg":"HS256",
@@ -369,8 +369,8 @@ We encourage customers to always issue Ably-compatible tokens to clients so that
 The following JavaScript example demonstrates how to issue an "Ably Token":/api/realtime-sdk/authentication#token-details  with an explicit @client ID@ that, when used by a client, will then be considered an *identified client*.
 
 ```[javascript](code-editor:realtime/auth-client-id)
-  var realtime = new Ably.Rest({ key: '{{API_KEY}}' });
-  realtime.auth.createTokenRequest({ clientId: 'Bob' }, function(err, tokenRequest) {
+  const realtime = new Ably.Rest({ key: '{{API_KEY}}' });
+  realtime.auth.createTokenRequest({ clientId: 'Bob' }, (err, tokenRequest) => {
     /* ... issue the TokenRequest to a client ... */
   })
 ```


### PR DESCRIPTION
## Description

The main purpose of this PR is to fix the auth call which was `ably.requestToken` and should have been `ably.auth.requestToken`. 

I also did a little minor tidying of the code while I had the file open.

* [EDU-409](https://ably.atlassian.net/browse/EDU-409).

## Review

Check code samples on this page:

* [Auth](https://ably-docs-edu-409-bug-a-0mg4zh.herokuapp.com/core-features/authentication/)
