### PR TITLE
[EDU-113] - Fix dotnet function prototype

### DIFF
--- a/content/api/realtime-sdk/presence.textile
+++ b/content/api/realtime-sdk/presence.textile
@@ -500,7 +500,7 @@ bq(definition#enter-client-none).
   ruby:     "Deferrable":/api/realtime-sdk/types#deferrable enter_client(String client_id) -> yields
   java:     void enterClient(String clientId, "CompletionListener":#completion-listener listener)
   objc,swift: enterClient(clientId: String, data: nil, callback: ((ARTErrorInfo?) -> Void)?)
-  csharp:   Task EnterClientAsync(string clientId, object clientData)
+  csharp:   Task EnterClientAsync(string clientId)
 
 Enter a presence channel on behalf of the provided <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span><span lang="csharp">@ClientId@</span> without any data. If the channel is @initialized@ (i.e. no attempt to attach has yet been made for this channel), then calling @enter@ will implicitly attach the channel.
 

--- a/content/api/versions/v0.8/realtime-sdk/presence.textile
+++ b/content/api/versions/v0.8/realtime-sdk/presence.textile
@@ -473,7 +473,7 @@ bq(definition#enter-client-none).
   ruby:     "Deferrable":/api/realtime-sdk/types#deferrable enter_client(String client_id) -> yields
   java:     void enterClient(String clientId, "CompletionListener":#completion-listener listener)
   objc,swift: enterClient(clientId: String, data: nil, callback: ((ARTErrorInfo?) -> Void)?)
-  csharp:   Task EnterClientAsync(string clientId, object clientData)
+  csharp:   Task EnterClientAsync(string clientId)
 
 Enter a presence channel on behalf of the provided <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span><span lang="csharp">@ClientId@</span> without any data.
 

--- a/content/api/versions/v0.8/realtime-sdk/presence.textile
+++ b/content/api/versions/v0.8/realtime-sdk/presence.textile
@@ -482,7 +482,7 @@ bq(definition#enter-client-data).
   ruby:    "Deferrable":/api/realtime-sdk/types#deferrable enter_client(String client_id, Object data) -> yields
   java:    void enterClient(String clientId, Object data, "CompletionListener":#completion-listener listener)
   objc,swift: enterClient(clientId: String, data: AnyObject?, callback: ((ARTErrorInfo?) -> Void)?)
-  csharp:  Task EnterClientAsync(string clientId)
+  csharp:  Task EnterClientAsync(string clientId, object clientData)
 
 Enter a presence channel and provide data that is associated with the current present member.
 

--- a/content/api/versions/v1.0/realtime-sdk/presence.textile
+++ b/content/api/versions/v1.0/realtime-sdk/presence.textile
@@ -502,7 +502,7 @@ bq(definition#enter-client-none).
   ruby:     "Deferrable":/api/realtime-sdk/types#deferrable enter_client(String client_id) -> yields
   java:     void enterClient(String clientId, "CompletionListener":#completion-listener listener)
   objc,swift: enterClient(clientId: String, data: nil, callback: ((ARTErrorInfo?) -> Void)?)
-  csharp:   Task EnterClientAsync(string clientId, object clientData)
+  csharp:   Task EnterClientAsync(string clientId)
 
 Enter a presence channel on behalf of the provided <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span><span lang="csharp">@ClientId@</span> without any data. If the channel is @initialized@ (i.e. no attempt to attach has yet been made for this channel), then calling @enter@ will implicitly attach the channel.
 

--- a/content/api/versions/v1.1/realtime-sdk/presence.textile
+++ b/content/api/versions/v1.1/realtime-sdk/presence.textile
@@ -498,7 +498,7 @@ bq(definition#enter-client-none).
   ruby:     "Deferrable":/api/realtime-sdk/types#deferrable enter_client(String client_id) -> yields
   java:     void enterClient(String clientId, "CompletionListener":#completion-listener listener)
   objc,swift: enterClient(clientId: String, data: nil, callback: ((ARTErrorInfo?) -> Void)?)
-  csharp:   Task EnterClientAsync(string clientId, object clientData)
+  csharp:   Task EnterClientAsync(string clientId)
 
 Enter a presence channel on behalf of the provided <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span><span lang="csharp">@ClientId@</span> without any data. If the channel is @initialized@ (i.e. no attempt to attach has yet been made for this channel), then calling @enter@ will implicitly attach the channel.
 


### PR DESCRIPTION
## Description

Fixes the Csharp prototype (data parameter should not be provided on the first prototype version).

* [EDU-113](https://ably.atlassian.net/browse/EDU-113)

## Review

Select Csharp programming language:

* [Realtime API](https://ably-docs-edu-113-fix-d-wuhl20.herokuapp.com/api/realtime-sdk/presence/#enter-client)
