### PR TITLE
EDX-231: Create sitemaps for docs

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -9,12 +9,41 @@ export const plugins = [
   'gatsby-plugin-postcss',
   'gatsby-plugin-styled-components',
   'gatsby-plugin-image',
-  'gatsby-plugin-sitemap',
   'gatsby-plugin-sharp',
   'gatsby-transformer-yaml',
   'gatsby-transformer-sharp',
   'gatsby-plugin-react-helmet',
   'gatsby-plugin-ts',
+  {
+    resolve: 'gatsby-plugin-sitemap',
+    options: {
+      resolveSiteUrl: () => siteMetadata.siteUrl,
+      excludes: ['/_*'],
+      output: '/docs',
+      filterPages: ({ path }) => {
+        // NOTE: these didn't work in `exclude` field, so we had to use custom regex in filterPage function
+        if (
+          // Legacy versions of pages are excluded from the sitemap (anything with a URL containing .../versions/vx.x/where x is at least one digit, e.g. v1.1, v1.2
+          /\/\b(versions)\b\/(v)[0-9]./.test(path) ||
+          // Urls with /docs/code-
+          /\/\b(docs)\/\b(code-)/.test(path) ||
+          // anything with a URL beginning with /docs/tutorials
+          /\/\b(docs)\b\/(tutorials)\//.test(path) ||
+          // /documentation/
+          /\/\b(documentation)\/$/.test(path) ||
+          // Exclude root domain url
+          path === '/'
+        )
+          return true;
+
+        return false;
+      },
+      serialize: ({ path }) => ({
+        url: path,
+        changefreq: 'monthly',
+      }),
+    },
+  },
   // Images
   {
     resolve: 'gatsby-source-filesystem',

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -20,24 +20,18 @@ export const plugins = [
       resolveSiteUrl: () => siteMetadata.siteUrl,
       excludes: ['/_*'],
       output: '/docs',
-      filterPages: ({ path }) => {
-        // NOTE: these didn't work in `exclude` field, so we had to use custom regex in filterPage function
-        if (
-          // Legacy versions of pages are excluded from the sitemap (anything with a URL containing .../versions/vx.x/where x is at least one digit, e.g. v1.1, v1.2
-          /\/\b(versions)\b\/(v)[0-9]./.test(path) ||
-          // Urls with /docs/code-
-          /\/\b(docs)\/\b(code-)/.test(path) ||
-          // anything with a URL beginning with /docs/tutorials
-          /\/\b(docs)\b\/(tutorials)\//.test(path) ||
-          // /documentation/
-          /\/\b(documentation)\/$/.test(path) ||
-          // Exclude root domain url
-          path === '/'
-        )
-          return true;
-
-        return false;
-      },
+      // NOTE: these didn't work in `exclude` field, so we had to use custom regex in filterPage function
+      filterPages: ({ path }) =>
+        // Legacy versions of pages are excluded from the sitemap (anything with a URL containing .../versions/vx.x/where x is at least one digit, e.g. v1.1, v1.2
+        /\/\b(versions)\b\/(v)[0-9]./.test(path) ||
+        // Urls with /docs/code-
+        /\/\b(docs)\/\b(code-)/.test(path) ||
+        // anything with a URL beginning with /docs/tutorials
+        /\/\b(docs)\b\/(tutorials)\//.test(path) ||
+        // /documentation/
+        /\/\b(documentation)\/$/.test(path) ||
+        // Exclude root domain url
+        path === '/',
       serialize: ({ path }) => ({
         url: path,
         changefreq: 'monthly',

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -19,11 +19,3 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
   `;
   createTypes(typeDefs);
 };
-
-// Gatsby doesn't allow you to change sitemap filename, so we have to do it manually.
-// https://github.com/gatsbyjs/gatsby/issues/31515
-exports.onPostBuild = () => {
-  if (fs.existsSync('./public/docs/sitemap-index.xml')) {
-    fs.renameSync('./public/docs/sitemap-index.xml', './public/docs/sitemap.xml');
-  }
-};

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { GatsbyNode } from 'gatsby';
 export { createPages } from './data/createPages';
 export { onCreateNode } from './data/onCreateNode';
@@ -17,4 +18,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
     }
   `;
   createTypes(typeDefs);
+};
+
+// Gatsby doesn't allow you to change sitemap filename, so we have to do it manually.
+// https://github.com/gatsbyjs/gatsby/issues/31515
+exports.onPostBuild = () => {
+  if (fs.existsSync('./public/docs/sitemap-index.xml')) {
+    fs.renameSync('./public/docs/sitemap-index.xml', './public/docs/sitemap.xml');
+  }
 };

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { GatsbyNode } from 'gatsby';
 export { createPages } from './data/createPages';
 export { onCreateNode } from './data/onCreateNode';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "develop": "export EDITOR_WARNINGS_OFF='true' && gatsby clean && gatsby develop",
     "start": "npm run develop",
     "edit": "unset EDITOR_WARNINGS_OFF && gatsby clean && gatsby develop",
-    "build": "gatsby build --prefix-paths",
+    "build": "npm run clean && gatsby build --prefix-paths",
     "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean",
     "rebuild": "gatsby clean && gatsby build --prefix-paths && gatsby serve --prefix-paths",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "develop": "export EDITOR_WARNINGS_OFF='true' && gatsby clean && gatsby develop",
-    "start": "npm run develop",
+    "start": "npm run clean && npm run develop",
     "edit": "unset EDITOR_WARNINGS_OFF && gatsby clean && gatsby develop",
     "build": "npm run clean && gatsby build --prefix-paths",
     "serve": "gatsby serve --prefix-paths",


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Custom config of a gatsby sitemap plugin to include only relevant `docs` files/pages

* [Jira ticket](https://ably.atlassian.net/browse/EDX-231).

## Review

The main `sitemap.xml` file is generated inside the `public/docs` folder on a build that references the` sitemap-0.xml` file, which, in essence, is the actual sitemap.
