### PR TITLE
[EDU-131] - Fix links to point at Push Admin API

### DIFF
--- a/content/general/push/admin.textile
+++ b/content/general/push/admin.textile
@@ -23,7 +23,7 @@ redirect_from:
   - /realtime/push/admin
 ---
 
-The client libraries provide a Push Admin API that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
+The client libraries provide a "Push Admin API":/api/realtime-sdk/push-admin that is intended to be used on a customer's servers to perform all the management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
 
 The push admin API is accessible via the @push@ attribute of the "realtime":/api/realtime-sdk/channels#properties or "rest":/api/rest-sdk/channels#properties client. For example to publish a push notification directly to a device, you would access the "@publish@":/api/realtime-sdk/push-admin#publish method as follows:
 
@@ -73,7 +73,7 @@ h2(#access-control). Push admin access control and device authentication
 
 Operations using the push admin API, as with all our other APIs, require specific permissions as part of the credentials of a client. The push admin API has two modes of authorization:
 
-* access using the "@push-admin@":/general/push/admin permission. A client whose credentials contain the @push-admin@ permission has full access to the push admin API, and can manage registrations and subscriptions for all devices;
+* access using the @push-admin@ permission. A client whose credentials contain the @push-admin@ permission has full access to the push admin API, and can manage registrations and subscriptions for all devices;
 
 * access using the @push-subscribe@ permission. A client with @push-subscribe@ is a push target device, and it can manage its registration and any subscription for itself; it is not able to manage push registrations or channel subscriptions for any other device. The credentials presented, as well as containing the @push-subscribe@ permission, must also authenticate the device itself.
 

--- a/content/partials/general/push/_push_intro.textile
+++ b/content/partials/general/push/_push_intro.textile
@@ -34,9 +34,9 @@ h2(#admin). Managing devices and subscriptions
 
 Whilst the realtime client libraries provide APIs for a device to activate itself (via "@client.push@":/general/push/activate-subscribe) and subscribe for push notifications (via "@channel.push@":/general/push/activate-subscribe), those APIs are intentionally limited to actions pertaining to the device it is run on.
 
-A separate and distinct push admin API is additionally provided in our client libraries specifically designed for use by your servers to facilitate managing and delivering push notifications across all of your registered devices. This API, amongst other things, includes features to manage registered devices, channel subscriptions and deliver push notifications directly. Currently the "push admin API":/general/push/admin is available in our JavaScript, Ruby, Java/Android, PHP, Python, and iOS libraries. It is also available in our other libraries through the use of the "request":/api/rest-sdk#request method, using the underlying "API":/rest-api directly.
+A separate and distinct push admin API is additionally provided in our client libraries specifically designed for use by your servers to facilitate managing and delivering push notifications across all of your registered devices. This API, amongst other things, includes features to manage registered devices, channel subscriptions and deliver push notifications directly. Currently the "push admin API":/api/realtime-sdk/push-admin is available in our JavaScript, Ruby, Java/Android, PHP, Python, and iOS libraries. It is also available in our other libraries through the use of the "request":/api/rest-sdk#request method, using the underlying "API":/rest-api directly.
 
-"Find out more about the push admin API":/general/push/admin.
+"Find out more about the push admin API":/api/realtime-sdk/push-admin.
 
 h2(#platform-support). Platform support
 

--- a/content/partials/versions/v1.1/general/push/_push_intro.textile
+++ b/content/partials/versions/v1.1/general/push/_push_intro.textile
@@ -36,9 +36,9 @@ h2(#admin). Managing devices and subscriptions
 
 Whilst the realtime client libraries provide APIs for a device to activate itself (via "@client.push@":/general/push/activate-subscribe) and subscribe for push notifications (via "@channel.push@":/general/push/activate-subscribe), those APIs are intentionally limited to actions pertaining to the device it is run on.
 
-A separate and distinct push admin API is additionally provided in our client libraries specifically designed for use by your servers to facilitate managing and delivering push notifications across all of your registered devices. This API, amongst other things, includes features to manage registered devices, channel subscriptions and deliver push notifications directly. Currently the "push admin API":/general/push/admin is available in our JavaScript, Ruby, Java/Android, PHP, Python, and iOS libraries. It is also available in our other libraries through the use of the "request":/api/rest-sdk#request method, using the underlying "API":/rest-api directly.
+A separate and distinct push admin API is additionally provided in our client libraries specifically designed for use by your servers to facilitate managing and delivering push notifications across all of your registered devices. This API, amongst other things, includes features to manage registered devices, channel subscriptions and deliver push notifications directly. Currently the "push admin API":/api/realtime-sdk/push-admin/ is available in our JavaScript, Ruby, Java/Android, PHP, Python, and iOS libraries. It is also available in our other libraries through the use of the "request":/api/rest-sdk#request method, using the underlying "API":/rest-api directly.
 
-"Find out more about the push admin API":/general/push/admin.
+"Find out more about the push admin API":/api/realtime-sdk/push-admin/.
 
 h2(#platform-support). Platform support
 


### PR DESCRIPTION
## Description

Links just self-reference their own page, instead of linking out to the API reference page.

* [EDU-131](https://ably.atlassian.net/browse/EDU-131).

## Review

In the admin section, links to push admin API should go to the API reference page, rather than to the top of the current page.

* [Admin section of admin page](http://ably-docs-edu-131-fix-p-qa79ye.herokuapp.com/general/push/admin/#admin)
