### PR TITLE
[EDX-21] Avoid building the site if we are missing meta descriptions

### DIFF
--- a/data/createPages/index.js
+++ b/data/createPages/index.js
@@ -14,6 +14,11 @@ const createPages = async ({ graphql, actions: { createPage } }) => {
   const documentTemplate = path.resolve(`src/templates/document.js`);
   const result = await graphql(`
     query {
+      allError {
+        nodes {
+          message
+        }
+      }
       allFileHtml {
         edges {
           node {
@@ -29,6 +34,9 @@ const createPages = async ({ graphql, actions: { createPage } }) => {
       }
     }
   `);
+  if (result.data.allError.nodes && result.data.allError.nodes.length > 0) {
+    process.exit(1);
+  }
   const retrievePartialFromGraphQL = maybeRetrievePartial(graphql);
   await Promise.all(
     result.data.allFileHtml.edges.map(async (edge) => {

--- a/data/onCreateNode/index.js
+++ b/data/onCreateNode/index.js
@@ -14,12 +14,24 @@ const onCreateNode = async ({
 
   if (node.extension === 'textile') {
     const content = await loadNodeContent(node);
-
-    transformNanocTextiles(node, content, createNodeId(`${node.id} >>> HTML`), makeTypeFromParentType('Html')(node), {
-      createContentDigest,
-      createNodesFromPath: createNodesFromPath('DocumentPath', { createNode, createNodeId, createContentDigest }),
-      createNodeId,
-    })(createChildNode);
+    try {
+      transformNanocTextiles(node, content, createNodeId(`${node.id} >>> HTML`), makeTypeFromParentType('Html')(node), {
+        createContentDigest,
+        createNodesFromPath: createNodesFromPath('DocumentPath', { createNode, createNodeId, createContentDigest }),
+        createNodeId,
+      })(createChildNode);
+    } catch (error) {
+      const ErrorNode = {
+        id: createNodeId(`${error.message} >>> Error`),
+        message: error.message,
+        internal: {
+          contentDigest: createContentDigest(error.message),
+          type: 'Error',
+        },
+      };
+      createNode(ErrorNode);
+      console.error(error.message);
+    }
   }
 };
 

--- a/data/transform/index.js
+++ b/data/transform/index.js
@@ -166,7 +166,7 @@ const transformNanocTextiles =
         process.env.EDITOR_WARNINGS_OFF !== 'true' &&
         !newNodeData.meta.meta_description
       ) {
-        console.warn(
+        throw new Error(
           `No meta_description for file: ${node.relativePath}\n\nPlease add a custom meta_description to the frontmatter YAML at the top of the file.\n\n`,
         );
       }

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -15,6 +15,9 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       text: String
       items: [PageFurnitureYaml!]
     }
+    type Error implements Node {
+      message: String
+    }
   `;
   createTypes(typeDefs);
 };

--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -629,6 +629,14 @@ export type PageFurnitureYaml = Node & {
   internal: Internal;
 };
 
+export type Error = Node & {
+  message?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  parent?: Maybe<Node>;
+  children: Array<Node>;
+  internal: Internal;
+};
+
 export type FileInlineToc = Node & {
   id: Scalars['ID'];
   parent?: Maybe<Node>;
@@ -743,6 +751,8 @@ export type Query = {
   allImageSharp: ImageSharpConnection;
   pageFurnitureYaml?: Maybe<PageFurnitureYaml>;
   allPageFurnitureYaml: PageFurnitureYamlConnection;
+  error?: Maybe<Error>;
+  allError: ErrorConnection;
   fileInlineToc?: Maybe<FileInlineToc>;
   allFileInlineToc: FileInlineTocConnection;
   fileHtmlVersion?: Maybe<FileHtmlVersion>;
@@ -1015,6 +1025,23 @@ export type QueryPageFurnitureYamlArgs = {
 export type QueryAllPageFurnitureYamlArgs = {
   filter?: InputMaybe<PageFurnitureYamlFilterInput>;
   sort?: InputMaybe<PageFurnitureYamlSortInput>;
+  skip?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type QueryErrorArgs = {
+  message?: InputMaybe<StringQueryOperatorInput>;
+  id?: InputMaybe<StringQueryOperatorInput>;
+  parent?: InputMaybe<NodeFilterInput>;
+  children?: InputMaybe<NodeFilterListInput>;
+  internal?: InputMaybe<InternalFilterInput>;
+};
+
+
+export type QueryAllErrorArgs = {
+  filter?: InputMaybe<ErrorFilterInput>;
+  sort?: InputMaybe<ErrorSortInput>;
   skip?: InputMaybe<Scalars['Int']>;
   limit?: InputMaybe<Scalars['Int']>;
 };
@@ -4066,6 +4093,194 @@ export type PageFurnitureYamlGroupConnectionGroupArgs = {
 
 export type PageFurnitureYamlSortInput = {
   fields?: InputMaybe<Array<InputMaybe<PageFurnitureYamlFieldsEnum>>>;
+  order?: InputMaybe<Array<InputMaybe<SortOrderEnum>>>;
+};
+
+export type ErrorConnection = {
+  totalCount: Scalars['Int'];
+  edges: Array<ErrorEdge>;
+  nodes: Array<Error>;
+  pageInfo: PageInfo;
+  distinct: Array<Scalars['String']>;
+  max?: Maybe<Scalars['Float']>;
+  min?: Maybe<Scalars['Float']>;
+  sum?: Maybe<Scalars['Float']>;
+  group: Array<ErrorGroupConnection>;
+};
+
+
+export type ErrorConnectionDistinctArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorConnectionMaxArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorConnectionMinArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorConnectionSumArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorConnectionGroupArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  field: ErrorFieldsEnum;
+};
+
+export type ErrorEdge = {
+  next?: Maybe<Error>;
+  node: Error;
+  previous?: Maybe<Error>;
+};
+
+export type ErrorFieldsEnum =
+  | 'message'
+  | 'id'
+  | 'parent___id'
+  | 'parent___parent___id'
+  | 'parent___parent___parent___id'
+  | 'parent___parent___parent___children'
+  | 'parent___parent___children'
+  | 'parent___parent___children___id'
+  | 'parent___parent___children___children'
+  | 'parent___parent___internal___content'
+  | 'parent___parent___internal___contentDigest'
+  | 'parent___parent___internal___description'
+  | 'parent___parent___internal___fieldOwners'
+  | 'parent___parent___internal___ignoreType'
+  | 'parent___parent___internal___mediaType'
+  | 'parent___parent___internal___owner'
+  | 'parent___parent___internal___type'
+  | 'parent___children'
+  | 'parent___children___id'
+  | 'parent___children___parent___id'
+  | 'parent___children___parent___children'
+  | 'parent___children___children'
+  | 'parent___children___children___id'
+  | 'parent___children___children___children'
+  | 'parent___children___internal___content'
+  | 'parent___children___internal___contentDigest'
+  | 'parent___children___internal___description'
+  | 'parent___children___internal___fieldOwners'
+  | 'parent___children___internal___ignoreType'
+  | 'parent___children___internal___mediaType'
+  | 'parent___children___internal___owner'
+  | 'parent___children___internal___type'
+  | 'parent___internal___content'
+  | 'parent___internal___contentDigest'
+  | 'parent___internal___description'
+  | 'parent___internal___fieldOwners'
+  | 'parent___internal___ignoreType'
+  | 'parent___internal___mediaType'
+  | 'parent___internal___owner'
+  | 'parent___internal___type'
+  | 'children'
+  | 'children___id'
+  | 'children___parent___id'
+  | 'children___parent___parent___id'
+  | 'children___parent___parent___children'
+  | 'children___parent___children'
+  | 'children___parent___children___id'
+  | 'children___parent___children___children'
+  | 'children___parent___internal___content'
+  | 'children___parent___internal___contentDigest'
+  | 'children___parent___internal___description'
+  | 'children___parent___internal___fieldOwners'
+  | 'children___parent___internal___ignoreType'
+  | 'children___parent___internal___mediaType'
+  | 'children___parent___internal___owner'
+  | 'children___parent___internal___type'
+  | 'children___children'
+  | 'children___children___id'
+  | 'children___children___parent___id'
+  | 'children___children___parent___children'
+  | 'children___children___children'
+  | 'children___children___children___id'
+  | 'children___children___children___children'
+  | 'children___children___internal___content'
+  | 'children___children___internal___contentDigest'
+  | 'children___children___internal___description'
+  | 'children___children___internal___fieldOwners'
+  | 'children___children___internal___ignoreType'
+  | 'children___children___internal___mediaType'
+  | 'children___children___internal___owner'
+  | 'children___children___internal___type'
+  | 'children___internal___content'
+  | 'children___internal___contentDigest'
+  | 'children___internal___description'
+  | 'children___internal___fieldOwners'
+  | 'children___internal___ignoreType'
+  | 'children___internal___mediaType'
+  | 'children___internal___owner'
+  | 'children___internal___type'
+  | 'internal___content'
+  | 'internal___contentDigest'
+  | 'internal___description'
+  | 'internal___fieldOwners'
+  | 'internal___ignoreType'
+  | 'internal___mediaType'
+  | 'internal___owner'
+  | 'internal___type';
+
+export type ErrorGroupConnection = {
+  totalCount: Scalars['Int'];
+  edges: Array<ErrorEdge>;
+  nodes: Array<Error>;
+  pageInfo: PageInfo;
+  distinct: Array<Scalars['String']>;
+  max?: Maybe<Scalars['Float']>;
+  min?: Maybe<Scalars['Float']>;
+  sum?: Maybe<Scalars['Float']>;
+  group: Array<ErrorGroupConnection>;
+  field: Scalars['String'];
+  fieldValue?: Maybe<Scalars['String']>;
+};
+
+
+export type ErrorGroupConnectionDistinctArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorGroupConnectionMaxArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorGroupConnectionMinArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorGroupConnectionSumArgs = {
+  field: ErrorFieldsEnum;
+};
+
+
+export type ErrorGroupConnectionGroupArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  field: ErrorFieldsEnum;
+};
+
+export type ErrorFilterInput = {
+  message?: InputMaybe<StringQueryOperatorInput>;
+  id?: InputMaybe<StringQueryOperatorInput>;
+  parent?: InputMaybe<NodeFilterInput>;
+  children?: InputMaybe<NodeFilterListInput>;
+  internal?: InputMaybe<InternalFilterInput>;
+};
+
+export type ErrorSortInput = {
+  fields?: InputMaybe<Array<InputMaybe<ErrorFieldsEnum>>>;
   order?: InputMaybe<Array<InputMaybe<SortOrderEnum>>>;
 };
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

* [Jira ticket](https://ably.atlassian.net/browse/EDX-21).

## Review

1. When the following conditions are met on a .textile file to be processed, an error will be thrown: `        !isVersion &&
        process.env.NODE_ENV === 'development' &&
        process.env.EDITOR_WARNINGS_OFF !== 'true' &&
        !newNodeData.meta.meta_description`
2. When this happens, an error should be logged, and a new Error node should be created in GraphQL
3. During the onCreatePage lifecycle, allError nodes should be queried. If any errors exist, we quietly exit the project.

The reason we do this is because if we exit the process during the onCreateNode section of the lifecycle, each onCreateNode async function runs independently and will error and exit in a very messy and uncontrolled fashion.
There is no way to cleanly control these exits, so we must save the error data in GraphQL and exit as soon as we can, which is during the very start of the onCreatePages section of the lifecycle.

Run `gatsby clean && gatsby develop`

Optionally, visit the [GraphiQL](http://localhost:8000/___graphql) page to verify that the allError nodes are populating correctly.