### PR TITLE
[EDU-647] - Fix get device reg info

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -517,7 +517,7 @@ bc[json]. {
 
 or a 404 error if a device by that ID does not exist. 
 
-If Ably could not register the device on a behalf of the push notifications provider, then @push.error@ contains the relevant error information.
+If Ably could not register the device on behalf of the push notifications provider, then @push.error@ contains the relevant error information.
 
 h3(#list-device-registrations). List registered devices
 

--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -506,11 +506,18 @@ bc[json]. {
       transportType: <string>,
       <additional recipient address key/value pairs>
     },
-    state: <active or failed>
+    state: <active or failed>,
+    error: {
+      code: <string>,
+      statusCode: <string>,
+      message: <string>
+    }
   }
 }
 
-or a 404 error if a device by that ID does not exist.
+or a 404 error if a device by that ID does not exist. 
+
+If Ably could not register the device on a behalf of the push notifications provider, then @push.error@ contains the relevant error information.
 
 h3(#list-device-registrations). List registered devices
 


### PR DESCRIPTION
## Description

Fix the get device registration JSON block, and add info on `push.error`.

* [EDU-647](https://ably.atlassian.net/browse/EDU-647)

## Review

* [REST AI - get device reg](https://ably-docs-edu-647-error-lo5dqw.herokuapp.com/api/rest-api/#get-device-registration)
