### PR TITLE
[EDX-217]: Add meta_description to pages without it

### DIFF
--- a/content/code-index.textile
+++ b/content/code-index.textile
@@ -1,5 +1,6 @@
 ---
 title: Code Examples List
+meta_description: "A list of JSBin code examples used throughout the documentation."
 section: client-lib-development-guide
 index: 100
 hide_from_website: true

--- a/content/index.textile
+++ b/content/index.textile
@@ -1,5 +1,6 @@
 ---
 title: Ably API Documentation
+meta_description: "An introduction to the Ably documentation site."
 section: none
 hide_from_website: true
 ---

--- a/content/realtime/authentication.textile
+++ b/content/realtime/authentication.textile
@@ -1,5 +1,6 @@
 ---
 title: Authentication
+meta_description: "Authenticate with Ably using basic or token authentication."
 section: realtime
 index: 40
 languages:

--- a/content/realtime/channels.textile
+++ b/content/realtime/channels.textile
@@ -1,5 +1,6 @@
 ---
 title: Channels
+meta_description: "Channels are used to organize message traffic within Ably. The Realtime Client Library can subscribe and publish to channels."
 section: realtime
 index: 2
 languages:

--- a/content/realtime/channels/channel-parameters/deltas.textile
+++ b/content/realtime/channels/channel-parameters/deltas.textile
@@ -1,5 +1,6 @@
 ---
 title: Delta compression
+meta_description: "The delta feature enables clients to subscribe to a channel and only receive the difference between the current and previous message."
 section: realtime
 index: 6
 languages:

--- a/content/realtime/channels/channel-parameters/overview.textile
+++ b/content/realtime/channels/channel-parameters/overview.textile
@@ -1,5 +1,6 @@
 ---
 title: Channel Parameters
+meta_description: "Channel parameters enable channel functionality to be customized, using features such as rewind and deltas."
 section: realtime
 index: 4
 languages:

--- a/content/realtime/channels/channel-parameters/rewind.textile
+++ b/content/realtime/channels/channel-parameters/rewind.textile
@@ -1,5 +1,6 @@
 ---
 title: Rewind
+meta_description: "Rewind enables clients to attach to a channel and receive messages previously sent to that channel."
 section: realtime
 index: 5
 languages:

--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -1,5 +1,6 @@
 ---
 title: Connection
+meta_description: "Establish and maintain a persistent connection to Ably using the Realtime Client Library SDK."
 section: realtime
 index: 20
 languages:

--- a/content/realtime/encryption.textile
+++ b/content/realtime/encryption.textile
@@ -1,5 +1,6 @@
 ---
 title: Encryption
+meta_description: "Encrypt message payloads with the Realtime Client Library SDK."
 section: realtime
 index: 70
 languages:

--- a/content/realtime/history.textile
+++ b/content/realtime/history.textile
@@ -1,5 +1,6 @@
 ---
 title: History
+meta_description: "Retrieve previously sent messages with the Realtime Client Library SDK."
 section: realtime
 index: 50
 languages:

--- a/content/realtime/index.textile
+++ b/content/realtime/index.textile
@@ -1,5 +1,6 @@
 ---
 title: Realtime Client Library API
+meta_description: "The Realtime Client Library establishes and maintains a persistent connection to Ably. Clients can publish and subscribe to messages and be present on channels."
 section: realtime
 index: 0
 ---

--- a/content/realtime/messages.textile
+++ b/content/realtime/messages.textile
@@ -1,5 +1,6 @@
 ---
 title: Messages
+meta_description: "Messages contain data and are sent and received through channels. The Realtime Client Library SDK can publish and receive messages."
 section: realtime
 index: 31
 languages:

--- a/content/realtime/push.textile
+++ b/content/realtime/push.textile
@@ -1,5 +1,6 @@
 ---
 title: Push
+meta_description: "Send push notifications to channels or directly to devices with the Realtime Client Library SDK."
 section: realtime
 index: 55
 languages:

--- a/content/realtime/statistics.textile
+++ b/content/realtime/statistics.textile
@@ -1,5 +1,6 @@
 ---
 title: Statistics
+meta_description: "Retrieve application-level usage statistics using the Realtime Client Library SDK."
 section: realtime
 index: 100
 languages:

--- a/content/realtime/usage.textile
+++ b/content/realtime/usage.textile
@@ -1,5 +1,6 @@
 ---
 title: Using the Realtime library
+meta_description: "Instantiate the Ably Realtime Client Library SDK."
 section: realtime
 index: 10
 languages:

--- a/content/rest-api/token-request-spec.textile
+++ b/content/rest-api/token-request-spec.textile
@@ -1,5 +1,6 @@
 ---
 title: REST API Token Request Spec
+meta_description: "Ably raw REST API specification for TokenRequests."
 index: 10
 jump_to:
   Help with:

--- a/content/rest/authentication.textile
+++ b/content/rest/authentication.textile
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-meta_description: "Client Library SDK REST API Reference Authentication documentation."
+meta_description: "Authenticate with Ably using basic or token authentication."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Authentication"
 section: rest
 index: 48

--- a/content/rest/channel-status.textile
+++ b/content/rest/channel-status.textile
@@ -1,5 +1,6 @@
 ---
 title: Channel Status API
+meta_description: "The Channel Status API enables you to query the state and occupancy of one or more channels."
 section: rest
 index: 21
 jump_to:

--- a/content/rest/channels.textile
+++ b/content/rest/channels.textile
@@ -1,5 +1,6 @@
 ---
 title: Channels
+meta_description: "Channels are used to organize message traffic within Ably. The REST Client Library can publish to channels."
 section: rest
 index: 20
 languages:

--- a/content/rest/encryption.textile
+++ b/content/rest/encryption.textile
@@ -1,6 +1,6 @@
 ---
 title: Encryption
-meta_description: "Client Library SDK REST API Reference Crypto documentation."
+meta_description: "Encrypt message payloads with the REST Client Library SDK."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Encryption, Crypto"
 section: rest
 index: 70

--- a/content/rest/history.textile
+++ b/content/rest/history.textile
@@ -1,6 +1,6 @@
 ---
 title: History
-meta_description: "Client Library SDK REST API Reference History documentation."
+meta_description: "Retrieve previously sent messages using the REST Client Library SDK."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, History"
 section: rest
 index: 50

--- a/content/rest/index.textile
+++ b/content/rest/index.textile
@@ -1,5 +1,6 @@
 ---
 title: REST Client Library API
+meta_description: "The REST Client Library SDK provides a simple stateless API to interact with Ably's REST API."
 section: rest
 index: 0
 ---

--- a/content/rest/messages.textile
+++ b/content/rest/messages.textile
@@ -1,6 +1,6 @@
 ---
 title: Messages
-meta_description: "Client Library SDK REST API Reference Message documentation."
+meta_description: "Messages contain data and are sent and received through channels. The REST Client Library SDK can publish messages."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Message"
 section: rest
 index: 24

--- a/content/rest/push.textile
+++ b/content/rest/push.textile
@@ -1,6 +1,6 @@
 ---
 title: Push
-meta_description: "Client Library SDK REST API Reference Push documentation."
+meta_description: "Send push notifications to channels or directly to devices with the REST Client Library SDK."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Push"
 section: rest
 index: 55

--- a/content/rest/statistics.textile
+++ b/content/rest/statistics.textile
@@ -1,6 +1,6 @@
 ---
 title: Statistics
-meta_description: "Client Library SDK REST API Reference Statistics documentation."
+meta_description: "Retrieve application-level usage statistics using the REST Client Library SDK."
 meta_keywords: "Ably, Ably REST, API Reference, REST SDK, REST interface, REST API, Statistics"
 section: rest
 index: 100

--- a/content/rest/usage.textile
+++ b/content/rest/usage.textile
@@ -1,5 +1,6 @@
 ---
 title: Using the REST library
+meta_description: "Instantiate the Ably REST Client Library SDK."
 section: rest
 index: 10
 languages:


### PR DESCRIPTION
## Description

This PR adds a `meta_description` to pages that were previously missing it. It also updates the descriptions for some of the REST conceptual pages that haven't been updated since the API references were separated.

Sections that did not have `meta_description` added are:
* Client library development guide
* Comparison pages

See [JIRA](https://ably.atlassian.net/browse/EDX-217) for further information.

## Review

The simplest way to review this PR is using diffs and running the preview app to ensure the site builds.
