### PR TITLE
edu-555 - clarify App ID

### DIFF
--- a/content/general/aws-authentication.textile
+++ b/content/general/aws-authentication.textile
@@ -218,7 +218,7 @@ Create an IAM role as follows:
 
 3. For Account ID specify 203461409171. This is the Ably AWS account.
 
-4. Click the "Require external ID checkbox" and then enter an external ID of @<Your_Ably_Account_ID>.<Your_Ably_app_ID>@. This is also displayed when you create an Ably Lambda, AWS Kinesis, or SQS integration rule and select the "ARN of an assumable role" radio button in the create rule dialog. Learn more about "finding your App ID here":https://faqs.ably.com/how-do-i-find-my-app-id.
+4. Click the "Require external ID checkbox" and then enter an external ID of @<Your_Ably_Account_ID>.<Your_Ably_app_ID>@. This is also displayed when you create an Ably AWS Lambda, AWS Kinesis, or AWS SQS integration rule and select the "ARN of an assumable role" radio button in the create rule dialog. Learn more about "finding your App ID here":https://faqs.ably.com/how-do-i-find-my-app-id.
 
 5. Click "Next: Permissions".
 

--- a/content/general/aws-authentication.textile
+++ b/content/general/aws-authentication.textile
@@ -218,7 +218,7 @@ Create an IAM role as follows:
 
 3. For Account ID specify 203461409171. This is the Ably AWS account.
 
-4. Click the "Require external ID checkbox" and then enter an external ID of @<Your_Ably_Account_ID>.<Your_Ably_app_ID>@. This is also displayed to you when you create an Ably Lambda rule and select the "ARN of an assumable role" radio button in the create rule dialog.
+4. Click the "Require external ID checkbox" and then enter an external ID of @<Your_Ably_Account_ID>.<Your_Ably_app_ID>@. This is also displayed when you create an Ably Lambda, AWS Kinesis, or SQS integration rule and select the "ARN of an assumable role" radio button in the create rule dialog. Learn more about "finding your App ID here":https://faqs.ably.com/how-do-i-find-my-app-id.
 
 5. Click "Next: Permissions".
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Add clarification to the AWS authentication docs on how to find API Key and App ID.

Added [new ticket](https://ably.atlassian.net/browse/EDU-987) to create a partial for API Key and App ID.

* [Bugs](https://ably.atlassian.net/browse/EDU-608)
* [EDU-555](https://ably.atlassian.net/browse/EDU-555).

## Review

Check content of 4th step under Create a Role on AWS Authentication page:

* [AWS Authentication - Create a Role](https://ably-docs-edu-555-api-k-ktexo1.herokuapp.com/general/aws-authentication/#create-role)
