### PR TITLE
[EDU-989] - Make it clear async wrapper not provided in snippets

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -37,14 +37,14 @@ You'll learn how to:
 * Publish a message on a channel.
 * Close a connection to Ably.
 
-Ably Client Library SDKs are available in multiple programming languages. Some SDKs have a realtime and a REST interface, while others only have a REST interface. The "SDK downloads":https://ably.com/download page lists availability. For further information on when it's best to use the realtime or REST SDK, see "the best practice guide":https://ably.com/docs/best-practice-guide#choosing-between-realtime-rest-mqtt.
-
 p(tip#terms). The terms used in the guide such as 'connection', 'channel', 'message', 'publish' and 'subscribe' are described in the "glossary":/glossary.
+
+Ably Client Library SDKs are available in multiple programming languages. Some SDKs have a realtime and a REST interface, while others only have a REST interface. The "SDK downloads":https://ably.com/download page lists availability. For further information on when it's best to use the realtime or REST SDK, see "the best practice guide":https://ably.com/docs/best-practice-guide#choosing-between-realtime-rest-mqtt.
 
 You're currently viewing the guide in <span lang="javascript">JavaScript</span><span lang="nodejs">Node.js</span><span lang="java">Java</span><span lang="ruby">Ruby</span><span lang="objc">Objective-C</span><span lang="python">Python</span><span lang="php">PHP</span><span lang="swift">Swift</span><span lang="csharp">C# .NET</span><span lang="flutter">Flutter</span><span lang="go">Go</span>. If you would like to view it in another language, use the selector above to change it. 
 
 blang[jsall].
-  **Note:** The complete source code for JavaScript and Node.js versions of this guide can be found in the "Quickstart repo":https://github.com/ably/quickstart-js. Both callback and promises interface examples are provided.
+  bq. **Note:** The JavaScript and Node.js code snippets in this Quickstart guide do not show the main @async@ wrapper function. However, the complete source code for the JavaScript and Node.js code snippets can be found in the "Quickstart repo":https://github.com/ably/quickstart-js. Both callback and promises interface examples are provided.
 
 h2(#step-0). Create an Ably account
 
@@ -264,11 +264,13 @@ blang[python,php].
 
 *Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/core-features/authentication#token-authentication should be used instead.
 
-bc[javascript]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
+bc[javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js
+const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
 
-bc[nodejs]. const ably = new Ably.Realtime.Promise('{{API_KEY}}');
+bc[nodejs]. // For the full code sample see here: https://github.com/ably/quickstart-js
+const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
 


### PR DESCRIPTION
## Description

* [EDU-989](https://ably.atlassian.net/browse/EDU-989).

## Review

Review for both JavaScript and Node.js languages selected:

* [QSG](https://ably-docs-edu-989-updat-lcmgaz.herokuapp.com/quick-start-guide/)

It should be clear from the note and from the comment in the connect code that the `async` main wrapper is not shown to keep things simple, but they have full code on hand at the link provided.

![image](https://user-images.githubusercontent.com/25511700/187643599-346b2d88-9f50-46be-bb2a-5271a423abda.png)

![image](https://user-images.githubusercontent.com/25511700/187643778-9bd4657d-a995-42ee-baf4-1f9e89300f16.png)
