### PR TITLE
Update quickstart for python

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -108,6 +108,14 @@ blang[python].
 
   bc[python]. from ably import AblyRest
 
+  You will also need to install the @asyncio@ module:
+
+  bc[sh]. pip install asyncio
+  
+  Import the @asyncio@ module with:
+
+  bc[python]. import asyncio
+
 blang[php].
   The Ably Client Library SDK is available as a composer package on "packagist":https://packagist.org/packages/ably/ably-php. Note that the PHP SDK only implements the REST interface.
 
@@ -459,9 +467,12 @@ channel.publish("greeting", "hello", new CompletionListener() {
 bc[csharp]. var channel = ably.Channels.Get("quickstart");
 channel.Publish("greeting", "hello!");
 
-bc[python]. client = AblyRest('{{API_KEY}}')
-channel = client.channels.get('quickstart')
-channel.publish(u'greeting', u'hello!')
+bc[python]. async def main():
+  ably = AblyRest('{{API_KEY}}')
+  channel = ably.channels.get('quickstart')
+  await channel.publish(u'greeting', u'hello!')
+  # other code such as publish, close
+asyncio.run(main())
 
 bc[ruby]. channel = ably.channels.get('quickstart')
 channel.publish 'greeting', 'hello!'
@@ -500,10 +511,10 @@ h2(#step-5). Close a connection to Ably
 blang[default].
   A connection to Ably can be closed once it is no longer needed.
 
-  The following code sample explicitly closes the realtime connection to Ably and prints the message @Closed the connection to Ably.@.
+  The following code sample explicitly closes the connection to Ably and prints the message @Closed the connection to Ably.@.
 
-blang[python,php].
-  The <span lang="python">Python</span><span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
+blang[php].
+  The <span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
 
 bc[javascript]. ably.close(); // runs synchronously
 console.log('Closed the connection to Ably.');
@@ -529,6 +540,9 @@ ably.connection.on(ConnectionState.closed, new ConnectionStateListener() {
     }
   }
 });
+
+bc[python]. await ably.close()
+print('Closed the connection to Ably.')
 
 bc[ruby]. ably.connection.close
 ably.connection.on(:closed) do


### PR DESCRIPTION
## Description

Update quickstart guide for version 1.2.0 of the Python SDK.

* [EDU-971](https://ably.atlassian.net/browse/EDU-971).

## Review

Select the `Python` language from the language selector, and review the guide:

* [Page to review](http://ably-docs-edu-971-fix-p-lgdeyr.herokuapp.com/quick-start-guide)
