### PR TITLE
[EDX-202] Render unwrapped root level text in p elements

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,9 @@
+# Git Hooks
+
+These are recommended git hooks for your project.
+
+You can activate them by running `npm run repo-githooks` and deactivate them by running `npm run no-githooks`.
+
+`npm run repo-githooks` will set your `core.hooksPath` to the correct folder, an example of running this without `npm` might be `git config core.hooksPath .githooks` - but as the specifics may change it might be more convenient to rely on `npm run repo-githooks`.
+
+`npm run no-githooks` can be substituted at any time for `git config --unset core.hooksPath`.

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm install

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm run lint-staged

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Place these in .env.development to run locally.
 
 ## Further Information
 
-Documentation is included throughout this repository in the form of README.md files at folder level. Thanks in part to support for this sort of setup from GitHub, these are intended to:
+Documentation is included throughout this repository in the form of README.md files at folder level. These are intended to:
 
 1. Aid navigation through the repository, so documentation contributors and developers can easily see if they are in the right place
 2. Support documentation contributors in understanding the expected results from their work

--- a/data/html-parser/index.ts
+++ b/data/html-parser/index.ts
@@ -1,6 +1,6 @@
 // Essentially jQuery for parsing the DOM
 import cheerio from 'cheerio';
-import { defaults, pickAll } from 'lodash/fp';
+import { defaults, isEmpty, pickAll } from 'lodash/fp';
 import DataTypes from '../types';
 import HtmlDataTypes from '../types/html';
 import { addAPIKeyInfoToCodeBlock } from './add-info-to-codeblocks/codeblock-api-key-info';

--- a/data/html-parser/index.ts
+++ b/data/html-parser/index.ts
@@ -1,6 +1,6 @@
 // Essentially jQuery for parsing the DOM
 import cheerio from 'cheerio';
-import { defaults, isEmpty, pickAll } from 'lodash/fp';
+import { defaults, pickAll } from 'lodash/fp';
 import DataTypes from '../types';
 import HtmlDataTypes from '../types/html';
 import { addAPIKeyInfoToCodeBlock } from './add-info-to-codeblocks/codeblock-api-key-info';

--- a/data/transform/post-parser/README.md
+++ b/data/transform/post-parser/README.md
@@ -17,6 +17,7 @@ It is a good place to put:
 * Operations that cannot take place before the parser runs, for example:
   * Operations that rely on text that would be interpreted by the parser as meaningful syntax
   * Operations that depend on the specific operations in the pre-parsing stage, such as regex operations on whitespace
+  * Operations that depend on some HTML to already be present, but cannot be processed through the htmlParser/Cheerio, such as operations on plain text that is not wrapped in HTML but contains some HTML markup.
 
 It is not the best place to put:
 * Operations that remove information for developers only - consider putting these in pre-parser, so there's less text to process later on, and parsing the more complex HTML structure is a little easier.

--- a/data/transform/post-parser/index.js
+++ b/data/transform/post-parser/index.js
@@ -1,5 +1,6 @@
 const { compose } = require('lodash/fp');
 const { convertBlangBlocksToHtml } = require('./blang');
+const { rootLevelTextWrapper } = require('./root-level-text-wrapper');
 
 /**
  * Added by the pre-parser in order to survive textile parsing
@@ -11,7 +12,12 @@ const LINK_EXTERNAL_REGEX = /(<a[^>]*)class="external"([^>]*>)/m;
 const convertExternalLinksToBlankTarget = (content) =>
   content.replace(LINK_EXTERNAL_REGEX, '$1target="_blank" rel="noopener noreferrer"$2');
 
-const postParser = compose(convertExternalLinksToBlankTarget, convertBlangBlocksToHtml, addGithubLineBreaks);
+const postParser = compose(
+  convertExternalLinksToBlankTarget,
+  convertBlangBlocksToHtml,
+  addGithubLineBreaks,
+  rootLevelTextWrapper,
+);
 
 module.exports = {
   postParser,

--- a/data/transform/post-parser/root-level-text-wrapper.test.ts
+++ b/data/transform/post-parser/root-level-text-wrapper.test.ts
@@ -1,0 +1,33 @@
+import { rootLevelTextWrapper } from './root-level-text-wrapper';
+
+// If this is broken, the line beginning with 'Wherever possible..." will show up
+// as only the word 'HATEOS', with no surrounding elements when it is parsed by Cheerio.
+const sampleUnwrappedText = `<p>The properties of an Ably error are:</p>
+<dl>
+  <dt>code</dt>
+  <dd>A specific reason code as defined in the <a href="https://github.com/ably/ably-common/blob/main/protocol/errors.json">public errors definition</a>, where one is known</dd>
+  <dt>statusCode</dt>
+  <dd>Where a code is not available, the statusCode provides a generic indication of the nature of the failure and maps to <a href="https://en.wikipedia.org/wiki/List_of_HTTP_status_codes">standard <span class="caps">HTTP</span> statusCodes</a></dd>
+  <dt>message</dt>
+  <dd>The message string is an English language string that aims to provide useful information to the developer. It is not necessarily intended to be an informative string for the end user</dd>
+</dl>
+Wherever possible, success response bodies contain links, in <a href="https://en.wikipedia.org/wiki/HATEOAS"><span class="caps">HATEOS</span></a> style, to other resources relevant to the response; where these are present these are included as <code>href</code> attributes on the applicable part of the response object.
+<p><code>GET</code>, <code>PUT</code>, <code>POST</code> and <code>DELETE</code> are available in all contexts where they make sense. <code>GET</code> is always idempotent.</p>`;
+
+const textileTransformedUnwrappedTextSample = rootLevelTextWrapper(sampleUnwrappedText);
+
+describe('No section should be left unwrapped by an HTML element at the root level', () => {
+  it('Should successfully transform the content into HTML data', () => {
+    expect(textileTransformedUnwrappedTextSample).toBe(`<p>The properties of an Ably error are:</p>
+<dl>
+  <dt>code</dt>
+  <dd>A specific reason code as defined in the <a href="https://github.com/ably/ably-common/blob/main/protocol/errors.json">public errors definition</a>, where one is known</dd>
+  <dt>statusCode</dt>
+  <dd>Where a code is not available, the statusCode provides a generic indication of the nature of the failure and maps to <a href="https://en.wikipedia.org/wiki/List_of_HTTP_status_codes">standard <span class="caps">HTTP</span> statusCodes</a></dd>
+  <dt>message</dt>
+  <dd>The message string is an English language string that aims to provide useful information to the developer. It is not necessarily intended to be an informative string for the end user</dd>
+</dl>
+<p>Wherever possible, success response bodies contain links, in <a href="https://en.wikipedia.org/wiki/HATEOAS"><span class="caps">HATEOS</span></a> style, to other resources relevant to the response; where these are present these are included as <code>href</code> attributes on the applicable part of the response object.</p>
+<p><code>GET</code>, <code>PUT</code>, <code>POST</code> and <code>DELETE</code> are available in all contexts where they make sense. <code>GET</code> is always idempotent.</p>`);
+  });
+});

--- a/data/transform/post-parser/root-level-text-wrapper.test.ts
+++ b/data/transform/post-parser/root-level-text-wrapper.test.ts
@@ -16,9 +16,8 @@ Wherever possible, success response bodies contain links, in <a href="https://en
 
 const textileTransformedUnwrappedTextSample = rootLevelTextWrapper(sampleUnwrappedText);
 
-describe('No section should be left unwrapped by an HTML element at the root level', () => {
-  it('Should successfully transform the content into HTML data', () => {
-    expect(textileTransformedUnwrappedTextSample).toBe(`<p>The properties of an Ably error are:</p>
+it('No section should be left unwrapped by an HTML element at the root level', () => {
+  expect(textileTransformedUnwrappedTextSample).toBe(`<p>The properties of an Ably error are:</p>
 <dl>
   <dt>code</dt>
   <dd>A specific reason code as defined in the <a href="https://github.com/ably/ably-common/blob/main/protocol/errors.json">public errors definition</a>, where one is known</dd>
@@ -29,5 +28,4 @@ describe('No section should be left unwrapped by an HTML element at the root lev
 </dl>
 <p>Wherever possible, success response bodies contain links, in <a href="https://en.wikipedia.org/wiki/HATEOAS"><span class="caps">HATEOS</span></a> style, to other resources relevant to the response; where these are present these are included as <code>href</code> attributes on the applicable part of the response object.</p>
 <p><code>GET</code>, <code>PUT</code>, <code>POST</code> and <code>DELETE</code> are available in all contexts where they make sense. <code>GET</code> is always idempotent.</p>`);
-  });
 });

--- a/data/transform/post-parser/root-level-text-wrapper.ts
+++ b/data/transform/post-parser/root-level-text-wrapper.ts
@@ -1,1 +1,14 @@
-export const rootLevelTextWrapper = (content: string) => content.replace(/\n([A-Z].*)\n/g, '\n<p>$1</p>\n');
+/**
+ * This regex finds:
+ * (<\/[A-Za-z]+>)\n - closing HTML tag, followed by newline.
+ * ([A-Z].*)\n - a capital letter preceding any information, up to a newline.
+ *
+ * The overall effect is to find capitalised text that immediately follows on
+ * from a closing tag at the end of a line, which will always be plain text
+ * that is supposed to be wrapped in <p> elements but has been missed by the
+ * textile-js parser.
+ *
+ * Regex101: https://regex101.com/r/j4BLqX/1
+ */
+const rootLevelTextFinder = /(<\/[A-Za-z]+>)\n([A-Z].*)\n/g;
+export const rootLevelTextWrapper = (content: string) => content.replace(rootLevelTextFinder, '$1\n<p>$2</p>\n');

--- a/data/transform/post-parser/root-level-text-wrapper.ts
+++ b/data/transform/post-parser/root-level-text-wrapper.ts
@@ -1,0 +1,1 @@
+export const rootLevelTextWrapper = (content: string) => content.replace(/\n([A-Z].*)\n/g, '\n<p>$1</p>\n');

--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -648,6 +648,7 @@ export type FileHtmlMetaData = {
 export type FileHtml = Node & {
   contentOrderedList?: Maybe<Array<Maybe<FileHtmlContentOrderedListItem>>>;
   meta?: Maybe<FileHtmlMetaData>;
+  articleType?: Maybe<Scalars['String']>;
   slug?: Maybe<Scalars['String']>;
   parentSlug?: Maybe<Scalars['String']>;
   version?: Maybe<Scalars['String']>;
@@ -751,6 +752,7 @@ export type FileHtmlPartial = Node & {
   parent?: Maybe<Node>;
   children: Array<Node>;
   internal: Internal;
+  articleType?: Maybe<Scalars['String']>;
   contentOrderedList?: Maybe<Array<Maybe<FileHtmlPartialContentOrderedList>>>;
   relativePath?: Maybe<Scalars['String']>;
 };
@@ -1075,6 +1077,7 @@ export type QueryAllPageFurnitureYamlArgs = {
 export type QueryFileHtmlArgs = {
   contentOrderedList?: InputMaybe<FileHtmlContentOrderedListItemFilterListInput>;
   meta?: InputMaybe<FileHtmlMetaDataFilterInput>;
+  articleType?: InputMaybe<StringQueryOperatorInput>;
   slug?: InputMaybe<StringQueryOperatorInput>;
   parentSlug?: InputMaybe<StringQueryOperatorInput>;
   version?: InputMaybe<StringQueryOperatorInput>;
@@ -1173,6 +1176,7 @@ export type QueryFileHtmlPartialArgs = {
   parent?: InputMaybe<NodeFilterInput>;
   children?: InputMaybe<NodeFilterListInput>;
   internal?: InputMaybe<InternalFilterInput>;
+  articleType?: InputMaybe<StringQueryOperatorInput>;
   contentOrderedList?: InputMaybe<FileHtmlPartialContentOrderedListFilterListInput>;
   relativePath?: InputMaybe<StringQueryOperatorInput>;
 };
@@ -1365,6 +1369,7 @@ export type FileHtmlFilterListInput = {
 export type FileHtmlFilterInput = {
   contentOrderedList?: InputMaybe<FileHtmlContentOrderedListItemFilterListInput>;
   meta?: InputMaybe<FileHtmlMetaDataFilterInput>;
+  articleType?: InputMaybe<StringQueryOperatorInput>;
   slug?: InputMaybe<StringQueryOperatorInput>;
   parentSlug?: InputMaybe<StringQueryOperatorInput>;
   version?: InputMaybe<StringQueryOperatorInput>;
@@ -1514,6 +1519,7 @@ export type FileHtmlPartialFilterInput = {
   parent?: InputMaybe<NodeFilterInput>;
   children?: InputMaybe<NodeFilterListInput>;
   internal?: InputMaybe<InternalFilterInput>;
+  articleType?: InputMaybe<StringQueryOperatorInput>;
   contentOrderedList?: InputMaybe<FileHtmlPartialContentOrderedListFilterListInput>;
   relativePath?: InputMaybe<StringQueryOperatorInput>;
 };
@@ -1911,6 +1917,7 @@ export type FileFieldsEnum =
   | 'childrenFileHtml___meta___meta_description'
   | 'childrenFileHtml___meta___title'
   | 'childrenFileHtml___meta___redirect_from'
+  | 'childrenFileHtml___articleType'
   | 'childrenFileHtml___slug'
   | 'childrenFileHtml___parentSlug'
   | 'childrenFileHtml___version'
@@ -1994,6 +2001,7 @@ export type FileFieldsEnum =
   | 'childFileHtml___meta___meta_description'
   | 'childFileHtml___meta___title'
   | 'childFileHtml___meta___redirect_from'
+  | 'childFileHtml___articleType'
   | 'childFileHtml___slug'
   | 'childFileHtml___parentSlug'
   | 'childFileHtml___version'
@@ -2303,6 +2311,7 @@ export type FileFieldsEnum =
   | 'childrenFileHtmlPartial___internal___mediaType'
   | 'childrenFileHtmlPartial___internal___owner'
   | 'childrenFileHtmlPartial___internal___type'
+  | 'childrenFileHtmlPartial___articleType'
   | 'childrenFileHtmlPartial___contentOrderedList'
   | 'childrenFileHtmlPartial___contentOrderedList___data'
   | 'childrenFileHtmlPartial___contentOrderedList___type'
@@ -2345,6 +2354,7 @@ export type FileFieldsEnum =
   | 'childFileHtmlPartial___internal___mediaType'
   | 'childFileHtmlPartial___internal___owner'
   | 'childFileHtmlPartial___internal___type'
+  | 'childFileHtmlPartial___articleType'
   | 'childFileHtmlPartial___contentOrderedList'
   | 'childFileHtmlPartial___contentOrderedList___data'
   | 'childFileHtmlPartial___contentOrderedList___type'
@@ -4369,6 +4379,7 @@ export type FileHtmlFieldsEnum =
   | 'meta___meta_description'
   | 'meta___title'
   | 'meta___redirect_from'
+  | 'articleType'
   | 'slug'
   | 'parentSlug'
   | 'version'
@@ -5471,6 +5482,7 @@ export type FileHtmlPartialFieldsEnum =
   | 'internal___mediaType'
   | 'internal___owner'
   | 'internal___type'
+  | 'articleType'
   | 'contentOrderedList'
   | 'contentOrderedList___data'
   | 'contentOrderedList___type'

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "fast-check": "^2.21.0",
         "gatsby-plugin-postcss": "^5.4.0",
-        "husky": "^8.0.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "lint-staged": "^13.0.3",
@@ -15623,21 +15622,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -39103,12 +39087,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
-    },
-    "husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "fast-check": "^2.21.0",
         "gatsby-plugin-postcss": "^5.4.0",
-        "husky": "^4.3.8",
+        "husky": "^8.0.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "lint-staged": "^13.0.3",
@@ -8818,12 +8818,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
-    "node_modules/compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-      "dev": true
-    },
     "node_modules/comparejs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/comparejs/-/comparejs-1.0.0.tgz",
@@ -12085,21 +12079,6 @@
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
-      "dev": true,
-      "dependencies": {
-        "semver-regex": "^3.1.2"
       },
       "engines": {
         "node": ">=10"
@@ -15647,115 +15626,18 @@
       }
     },
     "node_modules/husky": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
-      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "ci-info": "^2.0.0",
-        "compare-versions": "^3.6.0",
-        "cosmiconfig": "^7.0.0",
-        "find-versions": "^4.0.0",
-        "opencollective-postinstall": "^2.0.2",
-        "pkg-dir": "^5.0.0",
-        "please-upgrade-node": "^3.2.0",
-        "slash": "^3.0.0",
-        "which-pm-runs": "^1.0.0"
-      },
       "bin": {
-        "husky-run": "bin/run.js",
-        "husky-upgrade": "lib/upgrader/bin.js"
+        "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/husky"
-      }
-    },
-    "node_modules/husky/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/husky/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/husky/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/husky/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/husky/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/husky/node_modules/pkg-dir": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/husky/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -20905,15 +20787,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/opencollective-postinstall": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "dev": true,
-      "bin": {
-        "opencollective-postinstall": "index.js"
-      }
-    },
     "node_modules/opentracing": {
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
@@ -21731,15 +21604,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
-    },
-    "node_modules/please-upgrade-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
-      "dependencies": {
-        "semver-compare": "^1.0.0"
-      }
     },
     "node_modules/pngjs": {
       "version": "3.4.0",
@@ -23988,12 +23852,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true
-    },
     "node_modules/semver-diff": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
@@ -24003,18 +23861,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/send": {
@@ -27289,15 +27135,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/which-typed-array": {
       "version": "1.1.8",
@@ -34169,12 +34006,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
-    "compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-      "dev": true
-    },
     "comparejs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/comparejs/-/comparejs-1.0.0.tgz",
@@ -36654,15 +36485,6 @@
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
-      }
-    },
-    "find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
-      "dev": true,
-      "requires": {
-        "semver-regex": "^3.1.2"
       }
     },
     "flaschenpost": {
@@ -39283,82 +39105,10 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "husky": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
-      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "ci-info": "^2.0.0",
-        "compare-versions": "^3.6.0",
-        "cosmiconfig": "^7.0.0",
-        "find-versions": "^4.0.0",
-        "opencollective-postinstall": "^2.0.2",
-        "pkg-dir": "^5.0.0",
-        "please-upgrade-node": "^3.2.0",
-        "slash": "^3.0.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-          "dev": true,
-          "requires": {
-            "find-up": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -43218,12 +42968,6 @@
         "is-wsl": "^2.1.1"
       }
     },
-    "opencollective-postinstall": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "dev": true
-    },
     "opentracing": {
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
@@ -43850,15 +43594,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
-    },
-    "please-upgrade-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
-      "requires": {
-        "semver-compare": "^1.0.0"
-      }
     },
     "pngjs": {
       "version": "3.4.0",
@@ -45437,12 +45172,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true
-    },
     "semver-diff": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
@@ -45450,12 +45179,6 @@
       "requires": {
         "semver": "^6.3.0"
       }
-    },
-    "semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
-      "dev": true
     },
     "send": {
       "version": "0.18.0",
@@ -47991,12 +47714,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
-    },
-    "which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "dev": true
     },
     "which-typed-array": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "post-checkout": "npm install"
     }
   },
   "lint-staged": {
@@ -20,6 +21,7 @@
     "node": ">=16.14.2"
   },
   "scripts": {
+    "prepare": "npx husky install --save-dev",
     "develop": "export EDITOR_WARNINGS_OFF='true' && gatsby clean && gatsby develop",
     "start": "npm run clean && npm run develop",
     "edit": "unset EDITOR_WARNINGS_OFF && gatsby clean && gatsby develop",
@@ -98,7 +100,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "fast-check": "^2.21.0",
     "gatsby-plugin-postcss": "^5.4.0",
-    "husky": "^4.3.8",
+    "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
     "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "keywords": [
     "Ably"
   ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "post-checkout": "npm install"
-    }
-  },
   "lint-staged": {
     "**/*.+(js|ts|jsx|tsx|json|css)": [
       "jest --findRelatedTests"
@@ -21,7 +15,6 @@
     "node": ">=16.14.2"
   },
   "scripts": {
-    "prepare": "npx husky install --save-dev",
     "develop": "export EDITOR_WARNINGS_OFF='true' && gatsby clean && gatsby develop",
     "start": "npm run clean && npm run develop",
     "edit": "unset EDITOR_WARNINGS_OFF && gatsby clean && gatsby develop",
@@ -34,7 +27,10 @@
     "test:data": "npm run test:ETL",
     "test:app": "jest --testPathPattern=\"$PWD/src/*\"",
     "lint": "eslint \"src/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\" ./gatsby-config.ts ./gatsby-node.ts",
-    "lint:fix": "eslint --fix \"src/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\" ./gatsby-config.ts ./gatsby-node.ts"
+    "lint:fix": "eslint --fix \"src/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\" ./gatsby-config.ts ./gatsby-node.ts",
+    "lint-staged": "lint-staged",
+    "repo-githooks": "git config core.hooksPath .githooks",
+    "no-githooks": "git config --unset core.hooksPath"
   },
   "dependencies": {
     "@ably/ui": "7.8.2",
@@ -100,7 +96,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "fast-check": "^2.21.0",
     "gatsby-plugin-postcss": "^5.4.0",
-    "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
     "lint-staged": "^13.0.3",


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Wraps root level text elements in `<p>` elements. A simple change, tracking down the best place and way to do this without affecting anything else was what took most time so I've added a line to the postParser folder.

**Unrelated Changes:**
- Removes `husky` githooks package from the repository, as it did not work particularly well.
- Adds optional new .githooks folder that you can activate or deactivate using scripts.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-202).

## Review

Run the branch locally, check:

* [Page to review](http://localhost:8000/docs/rest-api?lang=python)

F3 or Cmd+F to find 'HATEOS':

![Screenshot 2022-09-01 at 16 49 14](https://user-images.githubusercontent.com/32373140/187957756-ad3f366f-45d7-49d1-bfb3-1b3644ed3179.png)

Check that nothing's wrong, see how it doesn't display currently on the [staging site](https://ably-docs-next-staging.herokuapp.com/docs/rest-api?lang=csharp)
