### PR TITLE
[EDU-972] - Message interactions lang selection

### DIFF
--- a/content/realtime/messages.textile
+++ b/content/realtime/messages.textile
@@ -424,7 +424,8 @@ See the "history documentation":/api/realtime-sdk/history for further details of
 
 h2(#message-interactions). Message interactions
 
-Message interactions are currently only supported by the Ably JavaScript SDK. To read more about message interactions please refer to the "message interactions docs":/realtime/messages?lang=javascript#message-interactions.
+blang[java,ruby,objc,swift,csharp,flutter].
+  Message interactions are currently only supported by the Ably JavaScript SDK. To read more about message interactions please refer to the "message interactions docs":/realtime/messages?lang=javascript#message-interactions.
 
 blang[jsall].
   Message interactions allow you to interact with messages previously sent to a channel. Once a channel is enabled with message interactions, messages received by that channel will contain a unique @timeSerial@ that can be referenced by later messages.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Make sure language selector on message interactions displays signposting on all languages not JS or Node, and doesn't display for JS and Node.

* [Bugs](https://ably.atlassian.net/browse/EDU-608).
* [Message interactions docs links to itself when JavaScript selected](https://ably.atlassian.net/browse/EDU-972).

## Review

Check language selector on message interactions display signposting on all languages not JS or Node, and doesn't display for JS and Node.

* [Messages - Message Interactions](https://ably-docs-edu-972-messa-0yngmo.herokuapp.com/realtime/messages/#message-interactions)
