### PR TITLE
Update authentication.textile

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -215,7 +215,7 @@ h4(#jwt-claims). Using JWT for authenticated user claims
 
 It is possible for JWTs to contain authenticated claims for users that can be used to allow or disallow certain interactions in your channels.
 
-Messages can be annotated with trusted metadata copied from the client's authentication token by Ably servers. Clients are unable to directly publish messages with user claim metadata, and claims contained within the authentication token are signed to prevent tampering. Claims can be scoped to individual channels or to namespaces of channels, see our "namespaces documentation":/general/channel-rules-namespaces/ for more information. The most specific user claim will be added to the message as part of the `extras` object.
+Messages can be annotated with trusted metadata copied from the client's authentication token by Ably servers. Clients are unable to directly publish messages with user claim metadata, and claims contained within the authentication token are signed to prevent tampering. Claims can be scoped to individual channels or to namespaces of channels, see our "namespaces documentation":/general/channel-rules-namespaces/ for more information. The most specific user claim will be added to the message as part of the @extras@ object.
 
 *Note:* This does not apply to presence or metadata messages.
 


### PR DESCRIPTION
## Description

Minor formatting issue. Replace backticks with Textile `@` to correct formatting:

![image](https://user-images.githubusercontent.com/25511700/189158338-86d7f39c-544f-47ec-a586-5f3aff8bdb58.png)
