### PR TITLE
Redesign API Key indicator

### DIFF
--- a/src/components/HorizontalMenu/HorizontalMenu.test.tsx
+++ b/src/components/HorizontalMenu/HorizontalMenu.test.tsx
@@ -8,7 +8,7 @@ describe('<HorizontalMenu />', () => {
 
     expect(screen.getByRole('menu')).toMatchInlineSnapshot(`
       <menu
-        class="flex overflow-visible m-0 rounded-t border-b border-charcoal-grey relative p-0"
+        class="flex overflow-visible m-0 border-b border-charcoal-grey relative p-0"
         role="menu"
       >
         children go here

--- a/src/components/blocks/software/Code/ApiKeyIndicator.tsx
+++ b/src/components/blocks/software/Code/ApiKeyIndicator.tsx
@@ -1,12 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Icon from '@ably/ui/core/Icon';
 
-const tooltip =
-  'This code example uses a temporary key that is rate limited and expires in 4 hours. Sign in to Ably to use your API keys instead.';
-
-const APIKeyIndicator = () => (
-  <div className="docs-api-key-label" title={tooltip}>
-    Api Key: Demo Only
-  </div>
-);
+const APIKeyIndicator = ({ tooltip }: { tooltip: string }) => {
+  const [tooltipHover, setTooltipHover] = useState<boolean>(false);
+  return (
+    <div
+      className="flex flex-row w-full justify-start mt-2"
+      onMouseOver={() => setTooltipHover(true)}
+      onMouseOut={() => setTooltipHover(false)}
+    >
+      <div className="docs-api-key-label" title={tooltip}>
+        Demo Only
+      </div>
+      <Icon additionalCSS="ml-4 cursor-help" name="icon-gui-info" size="1rem" />
+      {tooltipHover ? (
+        <aside
+          className="w-240 max-w-240 absolute -mt-140 box-border
+          whitespace-pre-wrap bg-white shadow-tooltip rounded border border-light-grey
+          text-cool-black font-sans p-16 text-center text-p3 leading-5 cursor-default"
+        >
+          {tooltip}
+        </aside>
+      ) : null}
+    </div>
+  );
+};
 
 export default APIKeyIndicator;

--- a/src/components/blocks/software/Code/ApiKeyMenuSelector.tsx
+++ b/src/components/blocks/software/Code/ApiKeyMenuSelector.tsx
@@ -5,6 +5,9 @@ import APIKeyIndicator from './ApiKeyIndicator';
 import APIKeyMenu, { APIKeyMenuProps } from './ApiKeyMenu';
 import { SmallMenuLabel } from '../../../Menu/Label';
 
+const NO_API_KEY_TOOLTIP =
+  'This code example uses a temporary key that is rate limited and expires in 4 hours. Sign in to Ably to use your API keys instead.';
+
 type APIKeyMenuSelectorProps = APIKeyMenuProps & {
   dataContainsKey: boolean;
   signedIn: boolean;
@@ -33,7 +36,7 @@ const APIKeyMenuSelector = ({
       {signedIn && userApiKeys ? (
         <APIKeyMenu userApiKeys={userApiKeys} setActiveApiKey={setActiveApiKey} />
       ) : (
-        <APIKeyIndicator />
+        <APIKeyIndicator tooltip={NO_API_KEY_TOOLTIP} />
       )}
     </div>
   ) : null;

--- a/src/components/blocks/software/Code/__snapshots__/Code.test.tsx.snap
+++ b/src/components/blocks/software/Code/__snapshots__/Code.test.tsx.snap
@@ -216,8 +216,8 @@ exports[`<Code /> Updates the codeblock when language is switched 2`] = `
     class="p-32 language-plaintext"
     style="white-space: pre-wrap;"
   >
-    channel &lt;span class="token operator"&gt;=&lt;/span&gt; ably&lt;span class="token punctuation"&gt;.&lt;/span&gt;channels&lt;span class="token punctuation"&gt;.&lt;/span&gt;get&lt;span class="token punctuation"&gt;(&lt;/span&gt;&lt;span class="token string-literal"&gt;&lt;span class="token string"&gt;'quickstart'&lt;/span&gt;&lt;/span&gt;&lt;span class="token punctuation"&gt;)&lt;/span&gt;
-channel&lt;span class="token punctuation"&gt;.&lt;/span&gt;publish &lt;span class="token string-literal"&gt;&lt;span class="token string"&gt;'greeting'&lt;/span&gt;&lt;/span&gt;&lt;span class="token punctuation"&gt;,&lt;/span&gt; &lt;span class="token string-literal"&gt;&lt;span class="token string"&gt;'hello!'&lt;/span&gt;&lt;/span&gt;
+    channel = ably.channels.get('quickstart')
+channel.publish 'greeting', 'hello!'
   </code>
 </div>
 `;

--- a/src/components/blocks/software/styles.css
+++ b/src/components/blocks/software/styles.css
@@ -1,15 +1,16 @@
 @import '@ably/ui/core/styles.css';
 @layer components {
   .docs-label {
-    @apply absolute bg-charcoal-grey p-4 ui-text-menu3;
+    @apply bg-charcoal-grey p-4 ui-text-menu3;
     color: #d9d9da;
   }
 
   .docs-language-label {
-    @apply top-4 right-4 docs-label cursor-default;
+    @apply absolute top-4 right-4 docs-label cursor-default;
   }
 
   .docs-api-key-label {
-    @apply top-4 left-4 docs-label cursor-help;
+    @apply ui-text-menu3 cursor-help;
+    color: white;
   }
 }

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.js.snap
@@ -3,7 +3,7 @@
 exports[`LocalLanguageAlternatives displays statically as expected Snapshot of LocalLanguageAlternatives is the same 1`] = `
 Array [
   <menu
-    className="flex overflow-visible m-0 rounded-t border-b border-charcoal-grey relative p-0"
+    className="flex overflow-visible m-0 border-b border-charcoal-grey relative p-0 justify-end md:justify-start"
     role="menu"
   >
     <button
@@ -30,6 +30,84 @@ Array [
     >
       C#
     </button>
+    <div
+      className="drodownContainer flex justify-end md:hidden py-12 pl-16 pr-40"
+    >
+      <div
+        className=" css-fyq6mk-container"
+        onKeyDown={[Function]}
+      >
+        <span
+          className="css-1f43avz-a11yText-A11yText"
+          id="react-select-2-live-region"
+        />
+        <span
+          aria-atomic="false"
+          aria-live="polite"
+          aria-relevant="additions text"
+          className="css-1f43avz-a11yText-A11yText"
+        />
+        <div
+          className="ably-select__control css-kumdtp-control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="ably-select__value-container css-319lph-ValueContainer"
+          >
+            <div
+              className="ably-select__placeholder css-14el2xx-placeholder"
+              id="react-select-2-placeholder"
+            >
+              Select...
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-describedby="react-select-2-placeholder"
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-readonly={true}
+              className="css-mohuvp-dummyInput-DummyInput"
+              disabled={false}
+              id="react-select-2-input"
+              inputMode="none"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              role="combobox"
+              tabIndex={0}
+              value=""
+            />
+          </div>
+          <div
+            className="ably-select__indicators css-1hb7zxy-IndicatorsContainer"
+          >
+            <span
+              className="ably-select__indicator-separator css-1xjgjl1-IndicatorSeparator"
+            />
+            <div
+              aria-hidden="true"
+              className="ably-select__indicator ably-select__dropdown-indicator css-1324rh2-indicatorContainer"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+            >
+              <svg
+                aria-hidden="true"
+                className="css-tj5bde-Svg"
+                focusable="false"
+                height={20}
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </menu>,
   "This is default content.",
 ]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,6 +73,8 @@ module.exports = extendConfig((ablyUIConfig) => ({
       38: '2.375rem',
       78: '4.875rem',
       128: 'var(--spacing-128)',
+      140: '8.75rem',
+      240: '15rem',
       300: '18.75rem',
       320: '20rem',
       420: '26.25rem',


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Redesigning the API key indicator to show a custom designed tooltip on hover and display in the appropriate location.

## Review

Run docs locally and view any page.

Ask me if you have any issues!

Compare and contrast for example:

http://localhost:8000/docs/quick-start-guide?lang=flutter

https://ably-docs-next-staging.herokuapp.com/docs/quick-start-guide?lang=javascript

Paying attention to the API key indicator:

![Screenshot 2022-09-13 at 15 31 04](https://user-images.githubusercontent.com/32373140/189928858-36d32d84-0560-4841-8508-1f2ab79f2b65.png)

![Screenshot 2022-09-13 at 15 31 18](https://user-images.githubusercontent.com/32373140/189928883-bcb151da-1344-4363-8748-1c00dcd891fa.png)

