### PR TITLE
[EDU-1004] - Remove api_separator

### DIFF
--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -4,7 +4,6 @@ meta_description: "Ably can deliver push notifications to devices using, amongst
 meta_keywords: "Push, push notifications, Apple Push Notification Service, Google Firebase Cloud Messaging Service"
 section: general
 index: 55
-api_separator:
 jump_to:
   Help with:
     - Delivering push notifications#deliver

--- a/content/general/versions/v1.0/push.textile
+++ b/content/general/versions/v1.0/push.textile
@@ -2,7 +2,6 @@
 title: Push Notifications
 section: general
 index: 55
-api_separator:
 jump_to:
   Help with:
     - Delivery push notifications#deliver

--- a/content/general/versions/v1.1/push.textile
+++ b/content/general/versions/v1.1/push.textile
@@ -2,7 +2,6 @@
 title: Push Notifications
 section: general
 index: 55
-api_separator:
 jump_to:
   Help with:
     - Delivering push notifications#deliver

--- a/content/rest-api/versions/v1.1/beta.textile
+++ b/content/rest-api/versions/v1.1/beta.textile
@@ -1,7 +1,6 @@
 ---
 title: REST API Beta Features
 index: 501
-api_separator:
 jump_to:
   Help with:
     - Overview#overview

--- a/content/rest/batch.textile
+++ b/content/rest/batch.textile
@@ -4,7 +4,6 @@ section: rest
 index: 110
 meta_description: "Batch operations enable you to bulk publish messages and query the presence state for multiple channels."
 meta_keywords: "Ably, batch, bulk, batch publish, bulk publish, batch presence, bulk presence"
-api_separator:
 jump_to:
   Help with:
     - Batch operations#batch-operations

--- a/content/rest/versions/v0.8/usage.textile
+++ b/content/rest/versions/v0.8/usage.textile
@@ -2,7 +2,6 @@
 title: Using the REST library
 section: rest
 index: 10
-api_separator:
 jump_to:
   Help with:
     - Usage#title

--- a/content/rest/versions/v1.0/usage.textile
+++ b/content/rest/versions/v1.0/usage.textile
@@ -12,7 +12,6 @@ languages:
   - swift
   - objc
   - csharp,0.8
-api_separator:
 jump_to:
   Help with:
     - Usage#title


### PR DESCRIPTION
## Description

Removes the `api_separator`. See:

* [EDU-1004](https://ably.atlassian.net/browse/EDU-1004)

## Review

Easiest to check the diff.