### PR TITLE
[EDU-970] - Standardize newly written tutorials

### DIFF
--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -15,7 +15,7 @@ excerpt: Learn how to issue Ably JWTs for your users, configure their capabiliti
 group: sdk
 index: 55
 date_published: '2018-04-25T16:49:28+02:00'
-last_updated: '2022-09-021T09:35:45+00:00'
+last_updated: '2022-09-21T09:35:45+00:00'
 languages:
 - javascript
 - nodejs

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -15,7 +15,7 @@ excerpt: Learn how to issue Ably JWTs for your users, configure their capabiliti
 group: sdk
 index: 55
 date_published: '2018-04-25T16:49:28+02:00'
-last_updated: '2022-08-10T09:35:45+00:00'
+last_updated: '2022-09-021T09:35:45+00:00'
 languages:
 - javascript
 - nodejs

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -90,7 +90,7 @@ The full code for this project can be found in its "Ably GitHub repository":http
 
 <%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
-h2(#step-2-creating-the-server). Step 2 - Creating the server
+h2(#step-2-creating-the-server). Step 2 - Create the server
 
 This step shows you how to create the server code from scratch. If you get stuck at any point, you can always refer to the "complete code":https://github.com/ably/tutorials/tree/jwt-authentication-nodejs.
 
@@ -212,7 +212,7 @@ app.listen(3000, function () {
 
 Complete code for this tutorial can be found in its "GitHub repository":https://github.com/ably/tutorials/tree/jwt-authentication-nodejs. The server code you have just created can be found in @server.js@.
 
-h2(#step-3-creating-the-client). Step 3 - Creating the client
+h2(#step-3-creating-the-client). Step 3 - Create the client
 
 You will now learn how to create a client with a simple login form. For the simplicity of this tutorial, your code will authenticate all users, irrespective of the data they enter in the username and the password fields. However, in a real deployment, your auth server would verify this data according to profile information stored in your user database and generate and return a JWT back to the client only if the verification was successful.
 
@@ -285,7 +285,7 @@ With the returned JWT, the client automatically attempts to connect to Ably usin
 
 Complete code for this tutorial can be found in its "GitHub repository":https://github.com/ably/tutorials/tree/jwt-authentication-nodejs
 
-h2(#step-4-checking-the-output). Step 4 - Checking the output
+h2(#step-4-checking-the-output). Step 4 - Check the output
 
 Now you are ready to test your application.
 

--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -58,7 +58,7 @@ In the following steps you will:
 
 So, let's get started and see a typical client-server architecture using JWT authentication.
 
-h2(#live-demo). Ably JWT auth example - Live Demo
+h2(#live-demo). Live Demo
 
 This section contains a live demo of the project you will create in this tutorial.
 
@@ -87,48 +87,6 @@ This section contains a live demo of the project you will create in this tutoria
 If the server returns a valid JWT the client is authenticated with Ably, and you see an alert box with the message: "Client successfully connected to Ably using JWT auth".
 
 The full code for this project can be found in its "Ably GitHub repository":https://github.com/ably/tutorials/tree/jwt-authentication-nodejs.
-
-h2(#running-locally). Running the project locally
-
-In this section you'll learn how to clone the project code and run it locally. Alternatively, you can work through creating the project "step-by-step":#setup-ably-account.
-
-The project can be run locally using the following steps:
-
-1. Make sure that you have a "free Ably account":https://ably.com/sign-up.
-
-2. Make sure you have "Node.js":https://nodejs.org/en/ and "npm":https://www.npmjs.com/ installed on your system.
-
-3. Clone the Ably tutorials repository:
-
-```[sh]
-git clone git@github.com:ably/tutorials.git
-```
-
-4. Change to the project branch @jwt-authentication-nodejs@ where the source code resides.
-
-```[sh]
-git checkout jwt-authentication-nodejs
-```
-
-5. Copy @env.example@ to @.env@.
-
-6. Edit @.env@ and replace the placeholder text with your "Ably API key":https://ably.com/dashboard.
-
-7. Enter @npm install@ on the command line to install the required packages.
-
-8. Enter @npm start@ on the command line to start the server.
-
-9. Navigate your browser to @http://localhost:3000@.
-
-You will see a dialog similar to the following displayed:
-
-<a href="/images/tutorials/jwt-auth/jwt-auth-output.png" target="_blank">
-    <img src="/images/tutorials/jwt-auth/jwt-auth-output.png" style="width: 80%" alt="JWT Auth Demo">
-</a>
-
-10. Enter any username and password and click **Login**.
-
-An alert box is displayed containing the message "Client successfully connected to Ably using JWT auth".
 
 <%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
@@ -352,6 +310,50 @@ In the browser you will see the login form.
 6. Enter any values into the @username@ and @password@ fields and click **login**.
 
 You will see an alert with the message "Client successfully connected to Ably using JWT auth".
+
+h2(#running-locally). Download tutorial source code
+
+In this section you'll learn how to download the tutorial solution code and run it locally. 
+
+Perform the following steps:
+
+1. Make sure that you have a "free Ably account":https://ably.com/sign-up.
+
+2. Make sure you have "Node.js":https://nodejs.org/en/ and "npm":https://www.npmjs.com/ installed on your system.
+
+3. Clone the Ably tutorials repository:
+
+```[sh]
+git clone git@github.com:ably/tutorials.git
+```
+
+4. Change to the project branch @jwt-authentication-nodejs@ where the source code resides.
+
+```[sh]
+git checkout jwt-authentication-nodejs
+```
+
+5. Copy @env.example@ to @.env@.
+
+6. Edit @.env@ and replace the placeholder text with your "Ably API key":https://ably.com/dashboard.
+
+7. Enter @npm install@ on the command line to install the required packages.
+
+8. Enter @npm start@ on the command line to start the server.
+
+9. Navigate your browser to @http://localhost:3000@.
+
+You will see a dialog similar to the following displayed:
+
+<a href="/images/tutorials/jwt-auth/jwt-auth-output.png" target="_blank">
+    <img src="/images/tutorials/jwt-auth/jwt-auth-output.png" style="width: 80%" alt="JWT Auth Demo">
+</a>
+
+10. Enter any username and password and click **Login**.
+
+An alert box is displayed containing the message "Client successfully connected to Ably using JWT auth".
+
+
 
 h2. Next steps
 

--- a/content/tutorials/presence.textile
+++ b/content/tutorials/presence.textile
@@ -18,7 +18,7 @@ languages:
 - javascript
 - ruby
 - nodejs
-last_updated: '2022-08-11T16:35:45+00:00'
+last_updated: '2022-09-21T16:35:45+00:00'
 level: medium
 platform: mixed
 reading_time: 15

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -812,7 +812,7 @@ blang[java].
 
   bc[sh]. git checkout publish-subscribe-java
 
-  Then you can run project inside your console. Be sure to switch into project's directory and then use these commands in your terminal:
+  Then you can run project inside your console. Be sure to switch into the project's directory and then use these commands in your terminal:
 
   bc[sh]. ./gradlew assemble
   ./gradlew run
@@ -920,7 +920,7 @@ blang[python].
 
   bc[sh]. pip install ably web.py
 
-  and run the web server @python server.py@.
+  And run the web server @python server.py@.
 
 blang[go].
   The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-go.

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -47,158 +47,6 @@ Messages published can contain string, JSON object, JSON array or binary data pa
 
 "Publishing and subscribing for messages on channels with our channel API":/realtime/channels is trivial. Let's get started.
 
-h2(#live-demo). Live demo
-
-This section contains a live demo of the project you will create in this tutorial.
-
-<a href="#" id="new-browser" target="_blank">Open this demo in a new browser window</a> to see publish and subscribe in action.
-
-<div>
-  <p>
-      Enter your message text: <input type="text" id="message-text" value="This is a message">
-  </p>
-  <p>
-      <button id="send-message">Click here to send your message</button>
-  </p>
-  <textarea id="result" rows="10" style="width: 60%; margin-top: 10px; font-family: courier, courier new; background-color: #333; color: orange" disabled></textarea>
-</div>
-
-
-h2(#download). Download tutorial source code
-
-blang[java].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-java.
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-java
-
-  Then you can run project inside your console. Be sure to switch into project's directory and then use these commands in your terminal:
-
-  bc[sh]. ./gradlew assemble
-  ./gradlew run
-
-  Don't forget to replace your @ExampleActivity#API_KEY@ field with "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys.
-
-blang[android].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-android.
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout history-android
-
-  And then run the demo on your Android device. Check "Android Developers website":https://developer.android.com/training/basics/firstapp/running-app.html if you are not familiar on how to run an Android Project. Don't forget to replace your @ExampleActivity#API_KEY@ field with "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys.
-
-blang[javascript].
-  The solution code for this tutorial is "available on Github":https://github.com/ably/js-publish-subscribe-tutorial.git.
-
-  To run the demo, perform the following tasks:
- 
-  1. Clone the repo locally:
-  
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  2. Add your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.html@ by replacing @YOUR_ABLY_API_KEY@ with your own API key.
-  3. In a new browser tab, open your browser's developer tools.
-  4. Open the @example.html@ file in the browser tab and inspect the console output.
-
-blang[nodejs].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-nodejs.
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-nodejs
-
-  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.js@ and running the demo @node example.js@
-
-blang[ruby].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-ruby
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-ruby
-
-  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.rb@ and running the demo @bundle exec ruby example.rb@
-
-blang[php].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-php
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-php
-
-  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @ably.php@, install composer dependencies with:
-
-  bc[sh]. composer install
-
-  and run the web server @php -S 0.0.0.0:8000@.
-
-blang[swift].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ShelinHime/tutorials/commits/publish-subscribe-swift
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-swift
-
-  In the project directory simply run:
-
-  bc[sh]. pod install
-
-  Open @example.xcworkspace@ and build the demo on your preferred iPhone simulator or device. Don't forget to replace your @ExampleViewController#API_KEY@ field by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @ExampleViewController.swift@.
-
-blang[python].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-python
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-python
-
-  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @server.py@, install the required libraries:
-
-  bc[sh]. pip install ably web.py
-
-  and run the web server @python server.py@.
-
-blang[go].
-  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-go.
-
-  We recommend that you clone the repo locally:
-
-  bc[sh]. git clone https://github.com/ably/tutorials.git
-
-  Checkout the tutorial branch:
-
-  bc[sh]. git checkout publish-subscribe-go
-
-  And then run the demo locally by adding your "Ably API key":https://support.ably.com/support/solutions/articles/3000030502 to @example.go@ and running the demo @go run example.go@
 
 <%= partial partial_version('tutorials/_step-1-create-app-and-api-key') %>
 
@@ -736,7 +584,7 @@ blang[go].
 
   "See this step in Github":https://github.com/ably/tutorials/commit/pubsub-go-step3
 
-h2(#step-4). Step 4 - Publishing a message
+h2(#step-4). Step 4 - Publish a message
 
 Publishing a message on a channel ensures that any number of subscribers on that channel receive the message in real time. To publish a message on the "sport" channel, call the @publish@ method on the channel, specify an optional message event name as the first argument, and provide the payload as the second argument.
 
@@ -951,6 +799,142 @@ blang[go].
 
 You have now learned how to instantiate the Ably client, subscribe to a channel, and publish messages on that channel.
 
+h2(#download). Download tutorial source code
+
+blang[java].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-java.
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-java
+
+  Then you can run project inside your console. Be sure to switch into project's directory and then use these commands in your terminal:
+
+  bc[sh]. ./gradlew assemble
+  ./gradlew run
+
+  Don't forget to replace your @ExampleActivity#API_KEY@ field with "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys.
+
+blang[android].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-android.
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout history-android
+
+  And then run the demo on your Android device. Check "Android Developers website":https://developer.android.com/training/basics/firstapp/running-app.html if you are not familiar on how to run an Android Project. Don't forget to replace your @ExampleActivity#API_KEY@ field with "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys.
+
+blang[javascript].
+  The solution code for this tutorial is "available on Github":https://github.com/ably/js-publish-subscribe-tutorial.git.
+
+  To run the demo, perform the following tasks:
+ 
+  1. Clone the repo locally:
+  
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  2. Add your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.html@ by replacing @YOUR_ABLY_API_KEY@ with your own API key.
+  3. In a new browser tab, open your browser's developer tools.
+  4. Open the @example.html@ file in the browser tab and inspect the console output.
+
+blang[nodejs].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-nodejs.
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-nodejs
+
+  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.js@ and running the demo @node example.js@
+
+blang[ruby].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-ruby
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-ruby
+
+  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @example.rb@ and running the demo @bundle exec ruby example.rb@
+
+blang[php].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-php
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-php
+
+  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @ably.php@, install composer dependencies with:
+
+  bc[sh]. composer install
+
+  and run the web server @php -S 0.0.0.0:8000@.
+
+blang[swift].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ShelinHime/tutorials/commits/publish-subscribe-swift
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-swift
+
+  In the project directory simply run:
+
+  bc[sh]. pod install
+
+  Open @example.xcworkspace@ and build the demo on your preferred iPhone simulator or device. Don't forget to replace your @ExampleViewController#API_KEY@ field by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @ExampleViewController.swift@.
+
+blang[python].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-python
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-python
+
+  And then run the demo locally by adding your "Ably API key":https://faqs.ably.com/setting-up-and-managing-api-keys to @server.py@, install the required libraries:
+
+  bc[sh]. pip install ably web.py
+
+  and run the web server @python server.py@.
+
+blang[go].
+  The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/publish-subscribe-go.
+
+  We recommend that you clone the repo locally:
+
+  bc[sh]. git clone https://github.com/ably/tutorials.git
+
+  Checkout the tutorial branch:
+
+  bc[sh]. git checkout publish-subscribe-go
+
+  And then run the demo locally by adding your "Ably API key":https://support.ably.com/support/solutions/articles/3000030502 to @example.go@ and running the demo @go run example.go@
+
 h2(#next-steps). Next steps
 
 1. If you would like to find out more about how channels, publishing and subscribing works, see the Realtime "channels":/realtime/channels and "messages":/realtime/messages documentation
@@ -958,43 +942,3 @@ h2(#next-steps). Next steps
 3. Gain a good technical "overview of how the Ably realtime platform works":https://ably.com/docs/key-concepts
 4. "Get in touch if you need help":https://ably.com/contact
 
-<script src="//cdn.ably.com/lib/ably.min-1.js" crossorigin="anonymous"></script>
-<script type="text/javascript">
-  window.addEventListener("load", function() {
-    var ably = new Ably.Realtime({ authUrl: 'https://ably.com/ably-auth/token/docs' }),
-        channelName = getQueryParam('channel') || getRandomChannelName(),
-        channel = ably.channels.get(channelName),
-        $result = $('#result');
-
-    ably.connection.on('connecting', function() {
-      log("[Connecting to Ably...]");
-    });
-
-    ably.connection.on('connected', function() {
-      log("[Connected to Ably] Waiting for messages...");
-    });
-
-    channel.subscribe(function(msg) {
-      log("[Received] " + msg.data);
-    });
-
-    $('button#send-message').on('click', function() {
-      var text = $('input#message-text').val();
-      log("[Publishing...] " + text);
-      channel.publish('msg', text);
-    });
-
-    /* Set up the link to open a new window with this random channel name */
-    var urlWithChannel = document.location.href.replace(/#.*$/, '');
-    if (urlWithChannel.indexOf('channel=') < 0) {
-      urlWithChannel += (urlWithChannel.indexOf('?') < 0 ? '?' : '&') + "channel=" + escape(channelName);
-    }
-    $('a#new-browser').attr('href', urlWithChannel + "#live-demo");
-
-    var started = new Date().getTime();
-    function log(msg) {
-      var timePassed = Math.round((new Date().getTime() - started) / 100) / 10;
-      $result.text(timePassed + "s - " + msg + "\n" + $result.text());
-    }
-  });
-</script>

--- a/content/tutorials/publish-subscribe.textile
+++ b/content/tutorials/publish-subscribe.textile
@@ -27,7 +27,7 @@ languages:
 - ruby
 - swift
 - go
-last_updated: '2022-07-22T14:06:46+00:00'
+last_updated: '2022-09-21T14:06:46+00:00'
 level: easy
 platform: mixed
 reading_time: 5 — 10


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This work is to update the newly-rewritten Publish/Subscribe Messaging App and JWT Authentication tutorials to use the same heading structure as used in the Tracking Connected Clients with Presence tutorial (defined in the [Tutorial Writing Guidelines](https://ably.atlassian.net/wiki/spaces/DEVX/pages/2261123086/Tutorial+Writing+Guidelines)).

Namely:

- Same order, casing, and imperative rather than gerund in the headings
- Remove live demo unless it exactly mirrors the tutorial project (which it does in the case of the JWT auth tutorial)

* [EDU-970](https://ably.atlassian.net/browse/EDU-970).

## Review

Instructions on how to review the PR. 

View the Publish/Subscribe Messaging App and JWT Authentication tutorials and ensure that they render correctly in web vide and that the headings match the structure of the Tracking Connected Clients with Presence tutorial.
