### PR TITLE
[EDX-235] Tutorial page needs to be removed from the docs site

### DIFF
--- a/data/transform/index.js
+++ b/data/transform/index.js
@@ -142,6 +142,12 @@ const transformNanocTextiles =
       .replace(/(.*)\.[^.]+$/, '$1')
       .replace('root/', '')
       .replace(/index$/, '');
+
+    // NOTE: we need to exclude all the tutorials pages from the docs site
+    if (/^tutorials\/.*/.test(slug)) {
+      return;
+    }
+
     if (node.sourceInstanceName === 'textile-partials') {
       content = `${content}\n`;
     }


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Removing the tutorials pages from the docs site

* [Jira ticket](https://ably.atlassian.net/browse/EDX-235).

## Review

All the tutorials pages should be 404

* [Page to review](link)

`/tutorials/newsfeed-react.textile tutorials/newsfeed-react`
