### PR TITLE
[EDX-300] Preferred language not set correctly

### DIFF
--- a/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
+++ b/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
@@ -65,7 +65,7 @@ export const LanguageDropdownSelector = ({
         if (isPageLanguageDefault) {
           safeWindow.localStorage.clear();
         } else {
-          safeWindow.localStorage.setItem(PREFERRED_LANGUAGE_KEY, language);
+          safeWindow.localStorage.setItem(PREFERRED_LANGUAGE_KEY, newLanguage);
         }
         navigate(href);
       }}

--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -31,14 +31,6 @@ const Template = ({
 }: AblyTemplateData) => {
   const params = new URLSearchParams(search);
   const language = params.get('lang') ?? DEFAULT_LANGUAGE;
-  useEffect(() => {
-    const preferredLanguage = safeWindow.localStorage.getItem(PREFERRED_LANGUAGE_KEY);
-    if (preferredLanguage && language !== preferredLanguage) {
-      const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(preferredLanguage, language);
-      const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, preferredLanguage);
-      navigate(href);
-    }
-  }, []);
 
   const title = getMetaDataDetails(document, 'title') as string;
   const description = getMetaDataDetails(document, 'meta_description', META_DESCRIPTION_FALLBACK) as string;
@@ -70,6 +62,19 @@ const Template = ({
       ),
     [contentOrderedList, language],
   );
+
+  useEffect(() => {
+    if (language === DEFAULT_LANGUAGE || !filteredLanguages.includes(language)) {
+      const preferredLanguage = safeWindow.localStorage.getItem(PREFERRED_LANGUAGE_KEY);
+      if (preferredLanguage) {
+        const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(preferredLanguage, language);
+        const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, preferredLanguage);
+        navigate(href);
+      }
+    } else {
+      safeWindow.localStorage.setItem(PREFERRED_LANGUAGE_KEY, language);
+    }
+  }, []);
 
   return (
     <PageLanguageContext.Provider value={language}>


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Acceptance Criteria:

- When I deliberately visit a query-string based language page variant (e.g. `http://localhost:8000/docs/realtime/usage?lang=javascript`, `http://localhost:8000/docs/realtime/usage?lang=nodejs`), I always land on that page, even if I have a preferredLanguage set.
- When I deliberately visit a query-string based language page variant as above, my preferredLanguage is set to the language of that page variant.
- When I visit a page with no language set (e.g. `http://localhost:8000/docs/realtime/usage`), if my preferredLanguage is set I am redirected to that page.

I've made the following additional change:
- If I visit a page with a made up language variant that is not one of the recognised languages on the page (e.g. `http://localhost:8000/docs/realtime/usage?lang=fsjgklsjlgk`), I am redirected as though it had no language set

* [Jira ticket](https://ably.atlassian.net/browse/EDX-300).

## Review

Check to make sure that visiting pages allows you to change the language of the page, check to make sure that visiting the page without a language redirects you to the last-selected language of the page, check that you can't just visit 'made-up' languages (languages that don't appear in the dropdown selector).

* [Page to review](http://localhost:8000/docs/realtime/usage?lang=javascript)
