### PR TITLE
[EDX-295] Definition list indentation fix

### DIFF
--- a/content/tutorials/reactor-event-azure.textile
+++ b/content/tutorials/reactor-event-azure.textile
@@ -573,20 +573,8 @@ Congratulations, you're done!
 
 h2. Next Steps
 
-<<<<<<< HEAD
 1. Take a look at the "Webhooks documentation":/general/webhooks for further details about what was described in this tutorial.
 2. If you would like to find out more about Ably Integrations features and capabilities, see "Ably Integrations":/general/integrations.
-=======
-<<<<<<< HEAD
-1. Take a look at the "Webhooks documentation":https://ably.com/docs/general/events for further details about what was described in this tutorial.
-2. If you would like to find out more about Ably Integrations features and capabilities, see "Ably Integrations":https://ably.com/integrations.
->>>>>>> 77045f3e5 (Update references in docs also)
 3. Learn more about "Ably features":https://ably.com/platform by stepping through our other "Ably tutorials":https://ably.com/tutorials
 4. Gain a good technical "overview of how the Ably realtime platform works":https://ably.com/docs/key-concepts
-=======
-1. Take a look at the "Reactor Events documentation":https://ably.com/docs/general/events for further details about what was described in this tutorial.
-2. If you would like to find out more about Ably Reactor features and capabilities, see "Ably Integrations":https://ably.com/integrations.
-3. Learn more about "Ably features":https://ably.com/platform by stepping through our other "Ably tutorials":https://ably.com/tutorials
-4. Gain a good technical "overview of how the Ably realtime platform works":https://ably.com/docs/how-ably-works
->>>>>>> 3e2d494a2 (Update references in docs also)
 5. "Get in touch if you need help":https://ably.com/contact

--- a/data/transform/StringContentOrderedList.d.ts
+++ b/data/transform/StringContentOrderedList.d.ts
@@ -1,4 +1,6 @@
-export type StringContentOrderedList = {
+export type StringContent = {
   data: string;
   type: string;
 };
+
+export type StringContentList = StringContent[];

--- a/data/transform/StringContentOrderedList.d.ts
+++ b/data/transform/StringContentOrderedList.d.ts
@@ -1,0 +1,4 @@
+export type StringContentOrderedList = {
+  data: string;
+  type: string;
+};

--- a/data/transform/retrieve-partials/applyIndent.test.ts
+++ b/data/transform/retrieve-partials/applyIndent.test.ts
@@ -1,0 +1,61 @@
+import { applyIndent, skipAndApplyIndent } from './applyIndent';
+
+describe('Applying indentation to partials works as expected', () => {
+  it('Applies indents to an example from docs', () => {
+    const docsExample = {
+      data: `@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see "<span lang="default">@Channel#history@</span><span lang="csharp,go">@Channel#History@</span>":/api/realtime-sdk/history#channel-history.
+
+h4. Members
+
+- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
+- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
+- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
+- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
+- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
+`,
+      type: 'html',
+    };
+    const docsData = applyIndent(2)(docsExample).data;
+    expect(docsData).toMatchInlineSnapshot(`
+      "		@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see \\"<span lang=\\"default\\">@Channel#history@</span><span lang=\\"csharp,go\\">@Channel#History@</span>\\":/api/realtime-sdk/history#channel-history.
+
+      		h4. Members
+
+      		- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
+      		- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
+      		- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
+      		- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
+      		- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
+      "
+    `);
+  });
+
+  it('Applies indents with one skip to an example from docs', () => {
+    const docsExample = {
+      data: `@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see "<span lang="default">@Channel#history@</span><span lang="csharp,go">@Channel#History@</span>":/api/realtime-sdk/history#channel-history.
+
+h4. Members
+
+- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
+- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
+- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
+- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
+- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
+`,
+      type: 'html',
+    };
+    const docsData = skipAndApplyIndent(2)(docsExample, 0).data;
+    expect(docsData).toMatchInlineSnapshot(`
+      "@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see \\"<span lang=\\"default\\">@Channel#history@</span><span lang=\\"csharp,go\\">@Channel#History@</span>\\":/api/realtime-sdk/history#channel-history.
+
+      		h4. Members
+
+      		- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
+      		- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
+      		- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
+      		- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
+      		- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
+      "
+    `);
+  });
+});

--- a/data/transform/retrieve-partials/applyIndent.test.ts
+++ b/data/transform/retrieve-partials/applyIndent.test.ts
@@ -1,52 +1,24 @@
-import { applyIndent, skipAndApplyIndent } from './applyIndent';
+import { applyIndent } from './applyIndent';
+
+const docsExample = {
+  data: `@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see "<span lang="default">@Channel#history@</span><span lang="csharp,go">@Channel#History@</span>":/api/realtime-sdk/history#channel-history.
+
+h4. Members
+
+- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
+- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
+- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
+- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
+- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
+`,
+  type: 'html',
+};
 
 describe('Applying indentation to partials works as expected', () => {
   it('Applies indents to an example from docs', () => {
-    const docsExample = {
-      data: `@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see "<span lang="default">@Channel#history@</span><span lang="csharp,go">@Channel#History@</span>":/api/realtime-sdk/history#channel-history.
-
-h4. Members
-
-- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
-- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
-- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
-- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
-- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
-`,
-      type: 'html',
-    };
     const docsData = applyIndent(2)(docsExample).data;
     expect(docsData).toMatchInlineSnapshot(`
       "		@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see \\"<span lang=\\"default\\">@Channel#history@</span><span lang=\\"csharp,go\\">@Channel#History@</span>\\":/api/realtime-sdk/history#channel-history.
-
-      		h4. Members
-
-      		- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
-      		- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
-      		- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
-      		- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
-      		- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
-      "
-    `);
-  });
-
-  it('Applies indents with one skip to an example from docs', () => {
-    const docsExample = {
-      data: `@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see "<span lang="default">@Channel#history@</span><span lang="csharp,go">@Channel#History@</span>":/api/realtime-sdk/history#channel-history.
-
-h4. Members
-
-- Start := _null_ The start of the queried interval<br>__Type: @DateTimeOffset@__
-- End := _null_ The end of the queried interval<br>__Type: @DateTimeOffset@__
-- Limit := _null_ By default it is null. Limits the number of items returned by history or stats<br>__Type: @Integer@__
-- Direction := _Backwards_ Enum which is either @Forwards@ or @Backwards@<br>__Type: @Direction@ enum__
-- ExtraParameters := Optionally any extra query parameters that may be passed to the query. This is mainly used internally by the library to manage paging.<br>__Type: @Dictionary<string, string>@__
-`,
-      type: 'html',
-    };
-    const docsData = skipAndApplyIndent(2)(docsExample, 0).data;
-    expect(docsData).toMatchInlineSnapshot(`
-      "@HistoryRequestParams@ is a type that encapsulates the parameters for a history queries. For example usage see \\"<span lang=\\"default\\">@Channel#history@</span><span lang=\\"csharp,go\\">@Channel#History@</span>\\":/api/realtime-sdk/history#channel-history.
 
       		h4. Members
 

--- a/data/transform/retrieve-partials/applyIndent.ts
+++ b/data/transform/retrieve-partials/applyIndent.ts
@@ -1,0 +1,16 @@
+import { indent } from '../shared-utilities';
+import { StringContentOrderedList } from '../StringContentOrderedList';
+
+export const skipAndApplyIndent = (indentation: number) => (content: StringContentOrderedList, i: number) => {
+  if (i === 0) {
+    return {
+      ...content,
+      data: indent(content.data.substring(content.data.indexOf('\n') + 1), indentation),
+    };
+  }
+
+  return {
+    ...content,
+    data: indent(content.data, indentation),
+  };
+};

--- a/data/transform/retrieve-partials/applyIndent.ts
+++ b/data/transform/retrieve-partials/applyIndent.ts
@@ -5,22 +5,3 @@ export const applyIndent = (indentation: number) => (content: StringContent) => 
   ...content,
   data: indent(content.data, indentation),
 });
-
-export const skipAndApplyIndent = (indentation: number) => (content: StringContent, i: number) => {
-  if (i === 0) {
-    const lines = content.data.split('\n');
-    const data = `${lines[0]}\n${lines
-      .slice(1)
-      .map((line) => indent(line, indentation))
-      .join('\n')}`;
-    return {
-      ...content,
-      data,
-    };
-  }
-
-  return {
-    ...content,
-    data: indent(content.data, indentation),
-  };
-};

--- a/data/transform/retrieve-partials/applyIndent.ts
+++ b/data/transform/retrieve-partials/applyIndent.ts
@@ -1,11 +1,21 @@
 import { indent } from '../shared-utilities';
-import { StringContentOrderedList } from '../StringContentOrderedList';
+import { StringContent } from '../StringContentOrderedList';
 
-export const skipAndApplyIndent = (indentation: number) => (content: StringContentOrderedList, i: number) => {
+export const applyIndent = (indentation: number) => (content: StringContent) => ({
+  ...content,
+  data: indent(content.data, indentation),
+});
+
+export const skipAndApplyIndent = (indentation: number) => (content: StringContent, i: number) => {
   if (i === 0) {
+    const lines = content.data.split('\n');
+    const data = `${lines[0]}\n${lines
+      .slice(1)
+      .map((line) => indent(line, indentation))
+      .join('\n')}`;
     return {
       ...content,
-      data: indent(content.data.substring(content.data.indexOf('\n') + 1), indentation),
+      data,
     };
   }
 

--- a/data/transform/retrieve-partials/index.js
+++ b/data/transform/retrieve-partials/index.js
@@ -1,7 +1,6 @@
 const DataTypes = require('../../types');
 const { flattenContentOrderedList } = require('../shared-utilities');
 const { applyIndent } = require('./applyIndent');
-const { skipAndApplyIndent } = require('./applyIndent');
 
 const maybeRetrievePartial =
   (graphql) =>
@@ -49,11 +48,8 @@ const maybeRetrievePartial =
       // Finally, apply the indentation specified from the attributeObject and return the data
       const indentation = parseInt(attributeObject['indent']);
       const applyIndentation = applyIndent(indentation);
-      const skipAndApplyIndentation = skipAndApplyIndent(indentation);
       if (attributeObject['indent']) {
-        if (attributeObject['skip_first_indent']) {
-          contentOrderedList = contentOrderedList.map(skipAndApplyIndentation);
-        } else {
+        if (!attributeObject['skip_first_indent']) {
           contentOrderedList = contentOrderedList.map(applyIndentation);
         }
       }

--- a/data/transform/retrieve-partials/index.js
+++ b/data/transform/retrieve-partials/index.js
@@ -1,5 +1,6 @@
 const DataTypes = require('../../types');
 const { indent, flattenContentOrderedList } = require('../shared-utilities');
+const { skipAndApplyIndent } = require('./applyIndent');
 
 const maybeRetrievePartial =
   (graphql) =>
@@ -7,6 +8,7 @@ const maybeRetrievePartial =
     if (type !== DataTypes.Partial) {
       return { data, type };
     }
+    // Retrieving data about the partial
     // eslint-disable-next-line no-sparse-arrays
     const fileName = (data.match(/<%=\s+partial\s+partial_version\('([^')]*)'\)[^%>]*%>/) ?? [, ''])[1];
 
@@ -24,6 +26,7 @@ const maybeRetrievePartial =
       attributeObject = Object.fromEntries(attributePairs);
     }
 
+    // Retrieving the data contained in the partial based on the file name
     const result = await graphql(`
         query {
             fileHtmlPartial(relativePath: { eq:"${fileName}.textile"}) {
@@ -38,27 +41,16 @@ const maybeRetrievePartial =
     const retrievePartialFromGraphQL = maybeRetrievePartial(graphql);
     let contentOrderedList = partial && partial.contentOrderedList;
     if (partial) {
+      // Repeat this operation on any partials contained inside the partial
       contentOrderedList = await Promise.all(contentOrderedList.map(retrievePartialFromGraphQL));
       contentOrderedList = flattenContentOrderedList(contentOrderedList);
 
+      // Finally, apply the indentation specified from the attributeObject and return the data
+      const indentation = parseInt(attributeObject['indent']);
+      const skipAndApplyIndentation = skipAndApplyIndent(indentation);
       if (attributeObject['indent']) {
         if (attributeObject['skip_first_indent']) {
-          contentOrderedList = contentOrderedList.map((content, i) => {
-            if (i === 0) {
-              return {
-                ...content,
-                data: indent(
-                  content.data.substring(content.data.indexOf('\n') + 1),
-                  parseInt(attributeObject['indent']),
-                ),
-              };
-            }
-
-            return {
-              ...content,
-              data: indent(content.data, parseInt(attributeObject['indent'])),
-            };
-          });
+          contentOrderedList = contentOrderedList.map(skipAndApplyIndentation);
         } else {
           contentOrderedList = contentOrderedList.map((content) => ({
             ...content,

--- a/data/transform/retrieve-partials/index.js
+++ b/data/transform/retrieve-partials/index.js
@@ -1,5 +1,6 @@
 const DataTypes = require('../../types');
-const { indent, flattenContentOrderedList } = require('../shared-utilities');
+const { flattenContentOrderedList } = require('../shared-utilities');
+const { applyIndent } = require('./applyIndent');
 const { skipAndApplyIndent } = require('./applyIndent');
 
 const maybeRetrievePartial =
@@ -47,15 +48,13 @@ const maybeRetrievePartial =
 
       // Finally, apply the indentation specified from the attributeObject and return the data
       const indentation = parseInt(attributeObject['indent']);
+      const applyIndentation = applyIndent(indentation);
       const skipAndApplyIndentation = skipAndApplyIndent(indentation);
       if (attributeObject['indent']) {
         if (attributeObject['skip_first_indent']) {
           contentOrderedList = contentOrderedList.map(skipAndApplyIndentation);
         } else {
-          contentOrderedList = contentOrderedList.map((content) => ({
-            ...content,
-            data: indent(content.data, parseInt(attributeObject['indent'])),
-          }));
+          contentOrderedList = contentOrderedList.map(applyIndentation);
         }
       }
     }


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Remove bug that means that when a .textile file is used as a partial, definition lists are not parsed correctly by textile.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-295).

## Review

The bug mostly appeared on this page:

* [Page to review](http://localhost:8000/docs/api/realtime-sdk/channels?lang=java)

Here's a screenshot of the problem in the current toolchain, right at the bottom you can see:

    Members
    - key := The key valueType: String - value := The value associated with the keyType: String

It should be rendered as a definition list.

![Screenshot 2022-10-07 at 10 25 22](https://user-images.githubusercontent.com/32373140/194521201-b2cf5f63-2b8b-48c1-a29c-e804c2e74dad.png)