### PR TITLE
Fix incorrect key in JWT authentication example (user claims)

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -227,7 +227,7 @@ To set the trusted fields you need to include @ably.channel.*@ in your JWT authe
 const claims = {
   "sub": "1234567890",
   "name": "John Doe",
-  "x-ably-capabilities": <...>,
+  "x-ably-capability": <...>,
   "x-ably-clientId": <...>,
   "ably.channel.chat1": "admin", // the user is an admin for the chat1 channel
   "ably.channel.chat:*": "moderator", // the user is a moderator in channels within the chat namespace


### PR DESCRIPTION
I noticed this in passing, when I was reading this documentation and cross-verifying with the Realtime implementation (internal codebase).

The correct key is used elsewhere in the docs, so this was the only location that I could find this incorrect (pluralised) key being used in this codebase.