### PR TITLE
[EDX-373] Width of main component and the right side nav don't match the specs on Figma for large screens

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -55,13 +55,13 @@ const Layout: FC<{ languages: Array<string>; versionData: VersionMenuProps }> = 
     <UserContext.Provider value={userState}>
       {hubspotTrackingId && <Script src={`//js.hs-scripts.com/${hubspotTrackingId}.js`} id="hs-script-loader" />}
       <Header />
-      <div className="grid grid-cols-5 2xl:grid-cols-7">
+      <div className="grid md:grid-cols-5 2xl:grid-cols-7">
         <LeftSideBar className="col-span-1 bg-extra-light-grey px-24" />
         <TopCodeMenu languages={languages} versionData={versionData} />
         <main
           className={`${
             languageAlternativesExist ? 'pt-128' : 'pt-96'
-          } ml-24 col-span-4 grid grid-cols-4 2xl:grid-cols-6 2xl:col-span-6`}
+          } md:ml-24 col-span-4 grid grid-cols-4 2xl:grid-cols-6 2xl:col-span-6`}
         >
           {children}
         </main>

--- a/src/components/Sidebar/SidebarHeading.test.tsx
+++ b/src/components/Sidebar/SidebarHeading.test.tsx
@@ -21,7 +21,7 @@ describe('<SidebarHeading />', () => {
 
   test('should render font in medium and cool-black when expanded', () => {
     render(
-      <SidebarHeading isExpanded as="button">
+      <SidebarHeading isExpandable as="button">
         Text
       </SidebarHeading>,
     );

--- a/src/components/Sidebar/SidebarHeading.tsx
+++ b/src/components/Sidebar/SidebarHeading.tsx
@@ -33,13 +33,8 @@ export const SidebarHeading = <C extends ElementType>({
       className={cn(
         sidebar,
         {
-<<<<<<< HEAD
           'font-light text-cool-black': !isActive && !href,
-          'font-medium': isActive || isExpanded || !!href,
-=======
-          'font-light text-cool-black': !isActive,
-          'font-medium': isActive || isExpandable,
->>>>>>> f9794898 (Add isExpandable prop instead of isExpanded)
+          'font-medium': isActive || isExpandable || !!href,
           'text-active-orange': isActive,
         },
         `ml-${indent}`,

--- a/src/components/Sidebar/SidebarHeading.tsx
+++ b/src/components/Sidebar/SidebarHeading.tsx
@@ -6,7 +6,7 @@ import { sidebar } from './SidebarHeading.module.css';
 export type SidebarHeadingProps<C extends ElementType> = {
   as?: C;
   indent?: number;
-  isExpanded?: boolean;
+  isExpandable?: boolean;
   isActive?: boolean;
   href?: string;
 };
@@ -18,7 +18,7 @@ type Props<C extends ElementType> = PropsWithChildren<SidebarHeadingProps<C>> &
 export const SidebarHeading = <C extends ElementType>({
   as,
   indent = 0,
-  isExpanded = false,
+  isExpandable = false,
   isActive = false,
   className = '',
   href,
@@ -33,8 +33,13 @@ export const SidebarHeading = <C extends ElementType>({
       className={cn(
         sidebar,
         {
+<<<<<<< HEAD
           'font-light text-cool-black': !isActive && !href,
           'font-medium': isActive || isExpanded || !!href,
+=======
+          'font-light text-cool-black': !isActive,
+          'font-medium': isActive || isExpandable,
+>>>>>>> f9794898 (Add isExpandable prop instead of isExpanded)
           'text-active-orange': isActive,
         },
         `ml-${indent}`,

--- a/src/components/Sidebar/SidebarLinkMenu.tsx
+++ b/src/components/Sidebar/SidebarLinkMenu.tsx
@@ -62,7 +62,13 @@ export const SidebarLinkMenu = ({
         const alwaysExpanded = isArray(content) && link !== '';
 
         const labelMaybeWithLink = expandable ? (
-          <SidebarHeading as={alwaysExpanded ? 'a' : 'span'} href={link} isActive={isActive} indent={indent}>
+          <SidebarHeading
+            as={alwaysExpanded ? 'a' : 'span'}
+            href={link}
+            isActive={isActive}
+            indent={indent}
+            isExpandable={expandable}
+          >
             {label}
           </SidebarHeading>
         ) : (


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

On mobile container used to have extra space on the left and right.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-373).

## Review

Container on mobile screen should be the right width
