### PR TITLE
[EDU-1053] - correct rendering

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -453,13 +453,16 @@ h4(#target-specifiers). Target specifiers
 
 A revocation request must include one or more target specifiers which define the token(s) that are affected by the request. Where multiple target specifiers are included, this is equivalent to making multiple independent revocation requests, each for a single target. The tokens affected by a request are those that match at least one of the target specifiers included in the request.
 
+All target specifiers are formatted as: @key:<string>@. 
+
 By default, supported target specifiers are:
 
-- clientId := For a string @clientId@, matches tokens that have a non-empty @clientId@ equal to that given, for example: <code>targets: ["clientId:client1@example.com" ]</code>
-- revocationKey := Matches tokens that have a @revocationKey@ claim that matches the given @revocationKey@, for example: <code>targets: ["revocationKey:users.group1@example.com"]</code>
+- clientId := Key that takes a string value, matches tokens that have a non-empty @clientId@ equal to that given, for example: <code>targets: ["clientId:client1@example.com" ]</code>
+- revocationKey := Key that takes a string value, matches tokens that have a @revocationKey@ claim that matches the given @revocationKey@, for example: <code>targets: ["revocationKey:users.group1@example.com"]</code>
+
 The following target specifier can also be enabled for you by Ably, should your use case require it:
 
-- resourceName := For a @resourceName@ that exactly matches one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
+- channel := Key that takes a string value that exactly matches one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
 
 h4. API endpoint
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -455,12 +455,11 @@ A revocation request must include one or more target specifiers which define the
 
 By default, supported target specifiers are:
 
-- clientId:<clientId> := For a string @clientId@, matches tokens that have a non-empty @clientId@ equal to that given.
-- revocationKey:<revocationKey> := Matches tokens that have a @revocationKey@ claim that matches the given @revocationKey@.
-
+- clientId := For a string @clientId@, matches tokens that have a non-empty @clientId@ equal to that given, for example: <code>targets: ["clientId:client1@example.com" ]</code>
+- revocationKey := Matches tokens that have a @revocationKey@ claim that matches the given @revocationKey@, for example: <code>targets: ["revocationKey:users.group1@example.com"]</code>
 The following target specifier can also be enabled for you by Ably, should your use case require it:
 
-- channel:<resourceName> := For a @resourceName@ that exactly matches one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
+- resourceName := For a @resourceName@ that exactly matches one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
 
 h4. API endpoint
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -457,12 +457,12 @@ All target specifiers are formatted as: @key:<string>@.
 
 By default, supported target specifiers are:
 
-- clientId := Key that takes a string value, matches tokens that have a non-empty @clientId@ equal to that given, for example: <code>targets: ["clientId:client1@example.com" ]</code>
-- revocationKey := Key that takes a string value, matches tokens that have a @revocationKey@ claim that matches the given @revocationKey@, for example: <code>targets: ["revocationKey:users.group1@example.com"]</code>
+- clientId := This target specifier will match tokens that have the specified @clientId@. For example, <code>targets: ["clientId:client1@example.com"]</code> matches tokens containing the @clientId@ of <code>client1@example.com</code>.
+- revocationKey := This target specifier will match tokens that have the specified @revocationKey@. For example: <code>targets: ["revocationKey:users.group1@example.com"]</code> matches tokens containing the @revocationKey@ of <code>users.group1@example.com</code>.
 
 The following target specifier can also be enabled for you by Ably, should your use case require it:
 
-- channel := Key that takes a string value that exactly matches one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
+- channel := This target specifier will match tokens that exactly match one of the "resource names":/core-features/authentication#wildcards present in the token capabilities. Note that this is not the same thing as revoking all tokens that have access to the channel. For example, a token with a capability of @{"foo:*": ["*"]}@ will be revoked by a target of @channel:foo:*@, but a revocation to @channel:*:*@ will have no effect (even though that is a superset of the capabilities of @foo:*@), and nor will @channel:foo:bar@ (even for connections using the token to attach to that particular channel). It must be the exact string used in the token capabilities (which may be inherited from key capabilities).  
 
 h4. API endpoint
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Rendering error with the table correction. Changed the formatting to show correctly then added example for clarification, example in code tags as it contained an @ symbol.

* [Bugs](https://ably.atlassian.net/browse/EDU-608).
* [Token revocation rendering error](https://ably.atlassian.net/browse/EDU-1053).

## Review

Check the rendering of the table for token revocation:

* [Auth and security](https://ably-docs-edu-1053-toke-4tj5lf.herokuapp.com/core-features/authentication/#token-revocation)
