### PR TITLE
[EDU-725] - correct sse consistency

### DIFF
--- a/content/api/sse.textile
+++ b/content/api/sse.textile
@@ -45,7 +45,7 @@ h5. Code example
 
 ```[javascript](code-editor:sse/sse)
 var apiKey = '{{API_KEY}}';
-var url = 'https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apikey;
+var url = 'https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
 var eventSource = new EventSource(url);
 
 eventSource.onmessage = function(event) {

--- a/content/sse/index.textile
+++ b/content/sse/index.textile
@@ -23,8 +23,8 @@ h2(#getting-started). Getting Started
 SSE is incredibly simple to get started with. The code sample below provides an example of how to use it with Ably.
 
 ```[javascript](code-editor:sse/sse)
-var key ='{{API_KEY}}';
-var url ='https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + key;
+var apiKey ='{{API_KEY}}';
+var url ='https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
 var eventSource = new EventSource(url);
 
 eventSource.onmessage = function(event) {


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Correct the example consistency for SSE, the variable defined and being referenced didn't match. Replicated changes to another example that worked, but were different, for consistency.

* [Jira epic ticket](https://ably.atlassian.net/browse/EDU-608).
* [Jira ticket](https://ably.atlassian.net/browse/EDU-725).

## Review

Check code examples are correct:

* [SSE](https://ably-docs-edu-725-sse-b-wutt7z.herokuapp.com/sse/)
* [API - SSE](https://ably-docs-edu-725-sse-b-wutt7z.herokuapp.com/api/sse/)
