### PR TITLE
[EDX-391] Never render the component label server side to avoid double renders

### DIFF
--- a/src/components/Menu/ReactSelectCustomComponents/Formatters/FormatOptionLabelWithLanguageLogo.tsx
+++ b/src/components/Menu/ReactSelectCustomComponents/Formatters/FormatOptionLabelWithLanguageLogo.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { ReactSelectOption } from 'src/components';
 import { imageMap, isInImageMap } from '../../LanguageDropdownSelector/image-map';
 
-const returnNullIfNoLanguageAvailable = (languageOption: ReactSelectOption) =>
-  isInImageMap(languageOption.value) ? imageMap[languageOption.value] : () => null;
+const returnNullIfNoLanguageAvailable = (languageOptionValue: string) =>
+  isInImageMap(languageOptionValue) && typeof window !== 'undefined' ? imageMap[languageOptionValue] : () => null;
 
 export const FormatOptionLabelWithLanguageLogo = (languageOption: ReactSelectOption) => {
-  const Component = returnNullIfNoLanguageAvailable(languageOption);
+  const Component = returnNullIfNoLanguageAvailable(languageOption.value);
   return (
     <div className="language-option items-center flex gap-8">
       <Component />


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Sometimes two logos render at once when you build the site (as opposed to running `gatsby develop`), for example here:

![9206ae6a-fc32-4d88-871d-0e0e5fa8632c](https://user-images.githubusercontent.com/32373140/198347594-f9702659-1397-470d-94a9-75e6006e87bf.png)

This happens because the component is loaded with no language selected (no query parameter) at build time, and then loaded again at run time.

This is the simplest possible guard to prevent the component from being loaded at build time.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-391).

## Review

Instructions on how to review the PR. 

* Run `gatsby clean` followed by `gatsby build --prefix-paths && gatsby serve --prefix-paths`
* [Check that there is only one logo displayed here](http://localhost:9000/docs/quick-start-guide)
* Select a language using the dropdown language selector
* [Check that there is only one logo displayed here](http://localhost:9000/docs/general/push/publish?lang=ruby)
