### PR TITLE
[EDX-298] Expand nested spans within types

### DIFF
--- a/content/api/rest-sdk/channels.textile
+++ b/content/api/rest-sdk/channels.textile
@@ -143,7 +143,8 @@ Publish several messages on this channel. <span lang="jsall,objc,swift">A callba
 
 h4. Parameters
 
-- name := event name for the published message<br><span lang="default">__Type: @String@__</span><span lang="python">__Type: @Unicode@ for Python 2, @String@ for Python 3__</span>
+- <div lang="default">name</div> := event name for the published message<br>__Type: @String@__
+- <div lang="python">name</div> := event name for the published message<br>__Type: @Unicode@ for Python 2, @String@ for Python 3__
 - <div lang="jsall">data</div> := data payload for the message. The supported payload types are Strings, objects or arrays capable of JSON representation, buffers containing arbitrary binary data, and null. (Note that if sending a binary, that binary should be the entire payload; an object with a binary field within it may not be correctly encoded)<br>__Type: @Object@__
 - <div lang="java">data</div> := data payload for the message. The supported payload types are Strings, JsonObject, binary data as byte arrays, and null.<br>__Type: @Object@__
 - <div lang="csharp">data</div> := data payload for the message. The supported payload types are strings, plain .NET objects, binary data as byte arrays, and null.<br>__Type: @Object@__

--- a/content/api/versions/v0.8/rest-sdk/channels.textile
+++ b/content/api/versions/v0.8/rest-sdk/channels.textile
@@ -77,7 +77,8 @@ Publish several messages on this channel. <span lang="jsall,objc,swift">A callba
 
 h4. Parameters
 
-- name := event name for the published message<br><span lang="default">__Type: @String@__</span><span lang="python">__Type: @Unicode@ for Python 2, @String@ for Python 3__</span>
+- <div lang="default">name</div> := event name for the published message<br>__Type: @String@__
+- <div lang="python">name</div> := event name for the published message<br>__Type: @Unicode@ for Python 2, @String@ for Python 3__
 - <div lang="jsall">data</div> := data payload for the message. The supported payload types are Strings, JSON objects and arrays, buffers containing arbitrary binary data, and null.<br>__Type: @Object@__
 - <div lang="java">data</div> := data payload for the message. The supported payload types are Strings, JsonObject, binary data as byte arrays, and null.<br>__Type: @Object@__
 - <div lang="csharp">data</div> := data payload for the message. The supported payload types are strings, plain .NET objects, binary data as byte arrays, and null.<br>__Type: @Object@__

--- a/content/api/versions/v0.8/rest-sdk/messages.textile
+++ b/content/api/versions/v0.8/rest-sdk/messages.textile
@@ -89,7 +89,8 @@ Publish several messages on this channel. <span lang="jsall,objc,swift">A callba
 
 h4. Parameters
 
-- name := event name for the published message<br><span lang="default">__Type: @String@__</span><span lang="python">__Type: @Unicode@ for Python 2, @String@ for Python 3__</span>
+- <div lang="default">name</div> := event name for the published message<br>__Type: @String@__
+- <div lang="python">name</div> := event name for the published message<br>__Type: @Unicode@ for Python 2, @String@ for Python 3__
 - <div lang="jsall">data</div> := data payload for the message. The supported payload types are Strings, JSON objects and arrays, buffers containing arbitrary binary data, and null.<br>__Type: @Object@__
 - <div lang="java">data</div> := data payload for the message. The supported payload types are Strings, JsonObject, binary data as byte arrays, and null.<br>__Type: @Object@__
 - <div lang="csharp">data</div> := data payload for the message. The supported payload types are strings, plain .NET objects, binary data as byte arrays, and null.<br>__Type: @Object@__

--- a/content/api/versions/v1.0/rest-sdk/channels.textile
+++ b/content/api/versions/v1.0/rest-sdk/channels.textile
@@ -89,7 +89,8 @@ Publish several messages on this channel. <span lang="jsall,objc,swift">A callba
 
 h4. Parameters
 
-- name := event name for the published message<br><span lang="default">__Type: @String@__</span><span lang="python">__Type: @Unicode@ for Python 2, @String@ for Python 3__</span>
+- <div lang="default">name</div> := event name for the published message<br>__Type: @String@__
+- <div lang="python">name</div> := event name for the published message<br>__Type: @Unicode@ for Python 2, @String@ for Python 3__
 - <div lang="jsall">data</div> := data payload for the message. The supported payload types are Strings, JSON objects and arrays, buffers containing arbitrary binary data, and null.<br>__Type: @Object@__
 - <div lang="java">data</div> := data payload for the message. The supported payload types are Strings, JsonObject, binary data as byte arrays, and null.<br>__Type: @Object@__
 - <div lang="csharp">data</div> := data payload for the message. The supported payload types are strings, plain .NET objects, binary data as byte arrays, and null.<br>__Type: @Object@__

--- a/content/api/versions/v1.1/rest-sdk/channels.textile
+++ b/content/api/versions/v1.1/rest-sdk/channels.textile
@@ -126,7 +126,8 @@ Publish several messages on this channel. <span lang="jsall,objc,swift">A callba
 
 h4. Parameters
 
-- name := event name for the published message<br><span lang="default">__Type: @String@__</span><span lang="python">__Type: @Unicode@ for Python 2, @String@ for Python 3__</span>
+- <div lang="default">name</div> := event name for the published message<br>__Type: @String@__
+- <div lang="python">name</div> := event name for the published message<br>__Type: @Unicode@ for Python 2, @String@ for Python 3__
 - <div lang="jsall">data</div> := data payload for the message. The supported payload types are Strings, JSON objects and arrays, buffers containing arbitrary binary data, and null.<br>__Type: @Object@__
 - <div lang="java">data</div> := data payload for the message. The supported payload types are Strings, JsonObject, binary data as byte arrays, and null.<br>__Type: @Object@__
 - <div lang="csharp">data</div> := data payload for the message. The supported payload types are strings, plain .NET objects, binary data as byte arrays, and null.<br>__Type: @Object@__

--- a/content/partials/types/_http_paginated_response.textile
+++ b/content/partials/types/_http_paginated_response.textile
@@ -6,8 +6,9 @@ h4.
   ruby:    Attributes
   python:  Attributes
 
-
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <div lang="default">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="csharp,go">Items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="python">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @List<>@__
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
 - <span lang="default">success</span><span lang="csharp,go">Success</span> := whether the HTTP status code indicates success. This is equivalent to <span lang="default">@200 <= statusCode < 300@</span><span lang="ruby">@200 <= status_code < 300@</span><span lang="csharp,go">@200 <= StatusCode < 300@</span><br>__Type: @Boolean@__
 - <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the headers of the response<br>__Type: @Object@__

--- a/content/partials/types/_paginated_result.textile
+++ b/content/partials/types/_paginated_result.textile
@@ -5,7 +5,10 @@ h4.
   java:    Members
   ruby:    Attributes
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python,csharp">__Type: @List <Message, Presence, Stats>@__</span>
+- <div lang="default">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="csharp">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
+- <div lang="go">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="python">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
 
 h4. Methods
 

--- a/content/partials/versions/v0.8/types/_paginated_result.textile
+++ b/content/partials/versions/v0.8/types/_paginated_result.textile
@@ -6,7 +6,9 @@ h4.
   ruby:    Attributes
   python:  Attributes
 
-- <span lang="default">items</span><span lang="csharp">Items</span> := contains a page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python">__Type: @List <Message, Presence, Stats>@__</span>
+- <div lang="default">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="csharp">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
+- <div lang="python">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
 
 - <div lang="javascript,nodejs,java,swift,objc">isLast</div> := @true@ if this page is the last page<br>__Type: @Boolean@__
 - <div lang="ruby">last?</div> := @true@ if this page is the last page<br>__Type: @Boolean@__

--- a/content/partials/versions/v1.0/types/_http_paginated_response.textile
+++ b/content/partials/versions/v1.0/types/_http_paginated_response.textile
@@ -7,7 +7,9 @@ h4.
   python:  Attributes
 
 
-- <span lang="default">items</span><span lang="csharp">Items</span> := contains a page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request). <br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <div lang="default">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="csharp">Items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="python">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @List<>@__
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp">StatusCode</span> := the HTTP status code of the response<br>__Type: Number__
 - <span lang="default">success</span><span lang="csharp">Success</span> := whether that HTTP status code indicates success (equivalent to @200 <= statusCode < 300@)<br>__Type: Boolean__
 - <span lang="default">headers</span><span lang="csharp">Headers</span> := the response's headers<br>__Type: Object__

--- a/content/partials/versions/v1.0/types/_paginated_result.textile
+++ b/content/partials/versions/v1.0/types/_paginated_result.textile
@@ -5,7 +5,9 @@ h4.
   java:    Members
   ruby:    Attributes
 
-- <span lang="default">items</span><span lang="csharp">Items</span> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python,csharp">__Type: @List <Message, Presence, Stats>@__</span>
+- <div lang="default">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="csharp">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
+- <div lang="python">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
 
 h4. Methods
 

--- a/content/partials/versions/v1.1/types/_http_paginated_response.textile
+++ b/content/partials/versions/v1.1/types/_http_paginated_response.textile
@@ -7,7 +7,9 @@ h4.
   python:  Attributes
 
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains a page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request). <br><span lang="default">__Type: @Array<>@__</span><span lang="python">__Type: @List<>@__</span>
+- <div lang="default">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="csharp,go">Items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @Array<>@__
+- <div lang="python">items</div> := contains a page of results; for example, an array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request<br>__Type: @List<>@__
 - <span lang="default">statusCode</span><span lang="ruby">status_code</span><span lang="csharp,go">StatusCode</span> := the HTTP status code of the response<br>__Type: @Number@__
 - <span lang="default">success</span><span lang="csharp,go">Success</span> := whether that HTTP status code indicates success (equivalent to @200 <= statusCode < 300@)<br>__Type: @Boolean@__
 - <span lang="default">headers</span><span lang="csharp,go">Headers</span> := the response's headers<br>__Type: @Object@__

--- a/content/partials/versions/v1.1/types/_paginated_result.textile
+++ b/content/partials/versions/v1.1/types/_paginated_result.textile
@@ -5,7 +5,10 @@ h4.
   java:    Members
   ruby:    Attributes
 
-- <span lang="default">items</span><span lang="csharp,go">Items</span> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br><span lang="default">__Type: @Array <Message, Presence, Stats>@__</span><span lang="python,csharp">__Type: @List <Message, Presence, Stats>@__</span>
+- <div lang="default">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="csharp">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
+- <div lang="go">Items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @Array <Message, Presence, Stats>@__
+- <div lang="python">items</div> := contains the current page of results (for example an Array of "@Message@":#message or "@PresenceMessage@":#presence-message objects for a channel history request)<br>__Type: @List <Message, Presence, Stats>@__
 
 h4. Methods
 


### PR DESCRIPTION
## Description

This PR expands nested span tags found within `type` elements so that they can render correctly in the new toolchain.

## Review

Ensure that all types still display correctly in the current toolchain.
