### PR TITLE
[EDX-369] Force consecutive blang to terminate properly 

### DIFF
--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -264,7 +264,7 @@ blang[go].
 
 h2(#step-2). Connect to Ably
 
-blang[default].
+blang[default,javascript].
   Clients need to authenticate with Ably to establish a realtime connection, typically over "WebSockets":https://ably.com/topic/websockets. The following code sample prints the message @Connected to Ably!@ when you've successfully connected.
 
 blang[python,php].
@@ -363,7 +363,7 @@ client.Connect()
 
 h2(#step-3). Subscribe to a channel
 
-blang[default].
+blang[default,javascript].
   Messages are broadcast on channels. The following example code subscribes the client to a channel called @quickstart@ and sets a filter so that the client only receives messages with the name @greeting@. When a message is received, its contents will be printed after the text @Received a greeting message in realtime:@.
 
   *Note*: The channel is created in the Ably service when the client subscribes to it.
@@ -508,7 +508,7 @@ bc[sh]. curl https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/publish \
 
 h2(#step-5). Close a connection to Ably
 
-blang[default].
+blang[default,javascript].
   A connection to Ably can be closed once it is no longer needed.
 
   The following code sample explicitly closes the connection to Ably and prints the message @Closed the connection to Ably.@.


### PR DESCRIPTION
## Description

The new toolchain handles simultaneous language blocks slightly differently. This caused a single instance of blangs using default to not render correctly in the quickstart guide. This PR forces the language grouping to "reset" by explicitly calling out javascript in the default block. 

See [JIRA](https://ably.atlassian.net/browse/EDX-369) for further information.

## Review

Ensure that the quickstart guide still renders correctly in the current toolchain.
