### PR TITLE
[BUGFIX] - Fix on page nav detection

### DIFF
--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -7,8 +7,6 @@ import { HtmlComponentProps } from '../../html-component-props';
 
 import './styles.css';
 
-const onPageNav = /[#?]/;
-
 const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'>) => (
   <Link className="docs-link" to={to} {...props}>
     {children}
@@ -17,7 +15,7 @@ const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<Recor
 
 const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
   const rawHref = attribs?.href;
-  if (rawHref && /^(\/|#|https?:\/\/(?:www.)?ably.com\/docs).*/.test(rawHref) && !onPageNav.test(rawHref)) {
+  if (rawHref && /^(\/|https?:\/\/(?:www.)?ably.com\/docs).*/.test(rawHref)) {
     let href = rawHref;
     if (/^\/(?!docs\/).*/.test(rawHref)) {
       href = `/${DOCUMENTATION_NAME}${rawHref}`;


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

We shouldn't be detecting links that start with '#' and prefixing them with '/docs', and we shouldn't be preventing links that contain '#' from being prefixed with '/docs'.

e.g.
'/api/blah/blah#bleh' => '/docs/api/blah/blah#bleh'
'#bleh' => '#bleh'.
