### PR TITLE
[EDX-458] Add JavaScript links to API references

### DIFF
--- a/content/api/index.textile
+++ b/content/api/index.textile
@@ -39,6 +39,8 @@ The API references generated from source code are structured by classes. The com
 
 The SDKs that have API references generated from source code are:
 
+* "JavaScript (callbacks)":https://ably.com/docs/sdk/js/v1.2/callbacks
+* "JavaScript (promises)":https://ably.com/docs/sdk/js/v1.2/promises
 * "Objective-C":https://ably.com/docs/sdk/cocoa/v1.2/
 * "Ruby":https://ably.com/docs/sdk/ruby/v1.2/
 * "Swift":https://ably.com/docs/sdk/cocoa/v1.2/


### PR DESCRIPTION
## Description

This PR adds links to the auto-generated API references for JavaScript to the API reference overview.

