### PR TITLE
[EDX-445] broken image on page

### DIFF
--- a/data/transform/pre-parser/textile-js-workarounds/fix-html-tags-with-newlines.ts
+++ b/data/transform/pre-parser/textile-js-workarounds/fix-html-tags-with-newlines.ts
@@ -1,0 +1,3 @@
+// Restrict this for img tags for now; we do not know what the implications of a larger-scale replacement would be.
+export const fixImgTagsWithNewlines: StringTransformation = (content) =>
+  content.replace(/<img[^>]*\n+[^>]*>/g, (match) => match.replace(/\s{2,}/gm, ' '));

--- a/data/transform/pre-parser/textile-js-workarounds/index.ts
+++ b/data/transform/pre-parser/textile-js-workarounds/index.ts
@@ -6,6 +6,7 @@ import { addItalicisedText } from './add-italicised-text';
 import { fixLeadingHtmlTags } from './fix-leading-html-tags';
 import { addBoldText } from './add-bold-text';
 import { makeImplicitOrderedListExplicit } from './make-implicit-ordered-list-explicit';
+import { fixImgTagsWithNewlines } from './fix-html-tags-with-newlines';
 
 // textile-js, unlike RedCloth, cannot parse multiple new lines between list items
 // each list item will instead be wrapped in its own list collection
@@ -23,6 +24,7 @@ export const textileJSCompatibility = compose(
   compressMultipleNewlinesInLists,
   makeImplicitOrderedListExplicit,
   manuallyReplaceHTags,
+  fixImgTagsWithNewlines,
   fixDuplicateQuoteLinks,
   fixHtmlElementsInLinks,
   fixLinkElementsInBrackets,


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Removes extra spaces from img html elements, which allows them to display after textile parsing

* [Jira ticket](https://ably.atlassian.net/browse/EDX-445).

## Review

Make sure first image appears on this page:

* [Page to review](http://localhost:8000/docs/general/kafka-connector?lang=ruby)
