### PR TITLE
[EDX-384] Update syntax for nested spans

### DIFF
--- a/content/api/realtime-sdk/presence.textile
+++ b/content/api/realtime-sdk/presence.textile
@@ -77,8 +77,7 @@ h6(#enter).
 
 In order to enter and be present on a channel, the client must "be identified by having a client ID":https://faqs.ably.com/authenticated-and-identified-clients, "have permission to be present":https://faqs.ably.com/using-capabilities-to-manage-client-access-privileges-on-channels, and be attached to the channel. For simplicity, the library will implicitly attach to a channel when entering. Entering when already entered is treated as an "update":#update.
 
-There are two overloaded versions of this method. <span lang="csharp"></span><span lang="default">
-  With both versions, a <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span> can optionally be passed in to be notified of success or failure to enter.
+There are two overloaded versions of this method. <span lang="csharp"></span><span lang="default">With both versions, a <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark> can optionally be passed in to be notified of success or failure to enter.
 </span>
 
 bq(definition#enter-none).
@@ -141,7 +140,7 @@ h6(#leave).
 In order to leave the presence set of a channel, the client must have already "entered and been present":#enter.
 
 There are two overloaded versions of this method. <span lang="csharp"></span><span lang="default">
-  With both versions, a <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span> can optionally be passed in to be notified of success or failure to leave.
+  With both versions, a <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark> can optionally be passed in to be notified of success or failure to leave.
 </span>
 
 bq(definition#leave-none).
@@ -204,7 +203,7 @@ h6(#update).
 Clients can update their member data on the channel which will trigger a broadcast of this update to all presence subscribers. The "pre-requisites for <span lang="default">@update@</span><span lang="csharp">@Update@</span>":#update are the same as for "<span lang="default">@enter@</span><span lang="csharp">@Enter@</span>":#enter. If an attempt to <span lang="default">@update@</span><span lang="csharp">@Update@</span> is made before the client has entered the channel, the update is treated as an <span lang="default">@enter@</span><span lang="csharp">@Enter@</span>.
 
 <span lang="csharp"></span><span lang="default">
-  A <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span> can optionally be passed in to be notified of success or failure to update the member data.
+  A <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark> can optionally be passed in to be notified of success or failure to update the member data.
 </span>
 
 bq(definition#update-data).
@@ -492,7 +491,7 @@ Enter this presence channel for the given <span lang="default">@clientId@</span>
 
 There are two overloaded versions of this method.
 <span lang="csharp"></span><span lang="default">
-  With both versions, a <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span> can optionally be passed in to be notified of success or failure to enter.
+  With both versions, a <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark> can optionally be passed in to be notified of success or failure to enter.
 </span>
 
 bq(definition#enter-client-none).
@@ -557,7 +556,7 @@ Leave this presence channel for the given <span lang="default">@clientId@</span>
 
 There are two overloaded versions of this method.
 <span lang="csharp"></span><span lang="default">
-  With both versions, a <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span><span lang="csharp">handler</span> can optionally be passed in to be notified of success or failure to leave.
+  With both versions, a <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark><mark lang="csharp">handler</mark> can optionally be passed in to be notified of success or failure to leave.
 </span>
 
 bq(definition#leave-client-none).
@@ -621,7 +620,7 @@ h6(#update-client).
 Clients can update the member data on behalf of the given <span lang="default">@clientId@</span><span lang="ruby">@client_id@</span><span lang="csharp">@ClientId@</span> which will trigger a broadcast of this update to all presence subscribers. This method is provided to support typically server instances that act on behalf of multiple client IDs. See "Managing multiple client IDs":/realtime/presence#presence-multiple-client-id for more info. If an attempt to update is made before the member has entered the channel, the update is treated as an enter.
 
 <span lang="csharp"></span><span lang="default">
-  A <span lang="default">callback</span><span lang="ruby">block</span><span lang="java">completion listener</span> can optionally be passed in to be notified of success or failure to update the member data.
+  A <mark lang="default">callback</mark><mark lang="ruby">block</mark><mark lang="java">completion listener</mark> can optionally be passed in to be notified of success or failure to update the member data.
 </span>
 
 bq(definition#update-client-data).


### PR DESCRIPTION
## Description

This PR uses the `<mark>` syntax to ensure nested spans display correctly in the new toolchain.

See [JIRA](https://ably.atlassian.net/browse/EDX-384) for further information.

## Review

Ensure the spans still display correctly in the current toolchain.
