### PR TITLE
[EDU-1155] remove mentions of web push from the push notifications docs

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -103,7 +103,7 @@ bc[json]. {
       }
       apns: <optional, extends and overrides generic values when delivering via APNs>,
       fcm: <optional, extends and overrides generic values when delivering via FCM>,
-      web: <optional, extends and overrides generic values when delivering via web>
+      <!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.]web: <optional, extends and overrides generic values when delivering via web>-->
     }
   }
 }
@@ -323,11 +323,13 @@ bc[json]. {
   metadata: <optional, object, with flexible key/value string pairs>,
   push: {
     recipient: {
-      transportType: <string, one of fcm, apns or web>,
+      transportType: <string, one of fcm or apns>,
       <additional key/value string pairs for transport-specific recipient address>
     }
   }
 }
+
+<!--[!!Ed. note: removed "web" from "recipient:transportType:" as part of EDU-1155. Return if required in the future.]-->
 
 The recipient address attributes are necessary and vary by underlying transport service.
 
@@ -343,12 +345,7 @@ bc[json]. {
   registrationToken: <string>
 }
 
-For web:
-
-bc[json]. {
-  targetUrl: <string>
-  encryptionKey: <string>
-}
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.]For web:bc[json]. {  targetUrl: <string>  encryptionKey: <string>}-->
 
 Example request:
 
@@ -839,13 +836,7 @@ bc[json]. {
   registrationToken: <string>
 }
 
-For web:
-
-bc[json]. {
-  transportType: "web",
-  targetUrl: <string>,
-  encryptionKey: <string>
-}
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.]For web:bc[json]. {  transportType: "web",  targetUrl: <string>,  encryptionKey: <string>}-->
 
 The rest of the fields are "normal push-enabled Ably message's @push.extras@ object":#message-extras-push.
 

--- a/content/general/push.textile
+++ b/content/general/push.textile
@@ -24,9 +24,10 @@ The following Ably client library SDKs provide support for activating and receiv
 
 * "Android SDK":https://github.com/ably/ably-java
 * "iOS Objective-C and Swift SDK":https://github.com/ably/ably-cocoa
-* Experimental "W3C Push API":https://www.w3.org/TR/push-api/ push notification support for compatible browsers, in the "JavaScript SDK":https://github.com/ably/ably-js.
 
-**Note**: Our W3C Push API is still in development and should not be used in production applications. We welcome feedback and are particularly interested in which browsers you require support for. "Get in touch":https://ably.com/contact for access to this experimental feature.
+<!--*[!!Ed. note: removed as part of EDU-1155. Return if required in the future.] Experimental "W3C Push API":https://www.w3.org/TR/push-api/ push notification support for compatible browsers, in the "JavaScript SDK":https://github.com/ably/ably-js.-->
+
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.]**Note**: Our W3C Push API is still in development and should not be used in production applications. We welcome feedback and are particularly interested in which browsers you require support for. "Get in touch":https://ably.com/contact for access to this experimental feature.-->
 
 All Ably client library SDKs, that adhere to the "v1.1 specification support":/client-lib-development-guide/features/, support "push publishing":/general/push/publish and "push admin":/general/push/admin functionality.
 
@@ -34,9 +35,11 @@ All Ably client library SDKs, that adhere to the "v1.1 specification support":/c
 
 h3(#features). Key features
 
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.] * Browsers receive the notification in a Web Worker which is in turn responsible for presenting a visual notification to the user (this is an experimental feature). * Experimental support for Chrome, Firefox and Opera. Apple's Safari Notifications planned.-->
+
+
 * General Availability Support for Android and iOS
-* Experimental support for Chrome, Firefox and Opera. Apple's Safari Notifications planned.
-* Custom notification formats and badges for iOS and Android. Browsers receive the notification in a Web Worker which is in turn responsible for presenting a visual notification to the user (this is an experimental feature).
+* Custom notification formats and badges for iOS and Android. 
 * Both visual notifications and data payloads can be sent to mobile devices.
 * Any number of mobile and browser devices can be registered on pub/sub channels. Each time a message is published with a push notification payload, Ably will ensure that all registered devices receive the push notification in near realtime.
 * Scale to millions of devices simultaneously by leveraging Ably's global platform.

--- a/content/general/push/publish.textile
+++ b/content/general/push/publish.textile
@@ -164,7 +164,9 @@ Ably provides an API that allows push notifications to be delivered directly to:
 
 * Devices identified by their unique device ID
 * Devices identified by their assigned "@clientId@":/realtime/authentication#identified-clients
-* Devices identified by their recipient attributes such as their unique @registrationToken@ in the case of FCM, @deviceToken@ in the case of APNs, or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*). This is particularly useful when migrating to Ably with existing push notification target devices.
+* Devices identified by their recipient attributes such as their unique @registrationToken@ in the case of FCM, or @deviceToken@ in the case of APNs.
+<!--[!!Ed. note: removed as this is experimental. Kept in case it is required in the future.] or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*). -->
+ This is particularly useful when migrating to Ably with existing push notification target devices.
 
 See the "push admin publish documentation":/api/realtime-sdk/push-admin#publish for the client library API details, and the "raw push publish REST API documentation":/rest-api#push-publish for information on the underlying direct publishing endpoint used by the client libraries.
 
@@ -490,13 +492,17 @@ A push notification payload has a generic structure as follows:
 
 Depending on the transport (APNs, FCM, etc.), the following transformations are made automatically by Ably to make each field compatible with the target push notification transport:
 
-|_=. Ably field |_=. FCM |_=. APNs |_=. Web (*experimental*) |
-| @notification.title@ | @notification.title@ | @aps.alert.title@ | @notification.title@ |
-| @notification.body@ | @notification.body@ | @aps.alert.body@ | @notification.body@ |
-| @notification.icon@ | @notification.icon@ | Discarded. | @notification.icon@ |
-| @notification.sound@ | @notification.sound@ | @aps.alert.sound@ | @notification.sound@ |
-| @notification.collapseKey@ | @collapse_key@ | @aps.thread-id@ | @notification.collapseKey@ |
-| @data@ | @data@ | Merged into root object. | @data@ |
+<!--[!!Ed. note: Removed experimental component column] _=. Web (*experimental*) | @notification.title@ | @notification.body@ |@notification.icon@ |@notification.sound@ |@notification.collapseKey@ |@data@ |-->
+
+|_=. Ably field |_=. FCM |_=. APNs |
+| @notification.title@ | @notification.title@ | @aps.alert.title@ |
+| @notification.body@ | @notification.body@ | @aps.alert.body@ |
+| @notification.icon@ | @notification.icon@ | Discarded. |
+| @notification.sound@ | @notification.sound@ | @aps.alert.sound@ |
+| @notification.collapseKey@ | @collapse_key@ | @aps.thread-id@ |
+| @data@ | @data@ | Merged into root object. |
+
+
 
 So for example, a push payload in a message published to Ably as follows:
 
@@ -523,16 +529,7 @@ and would be delivered in raw format to APNs as:
   "aps.thread-id": "chat"
 }
 ```
-
-and would be delivered in raw format to a web push target (*experimental*) as:
-
-```[json]
-{
-  "notification": {
-    "collapseKey": "chat"
-  }
-}
-```
+<!--[!!Ed. note: reformat code if this is to be returned to production docs.] and would be delivered in raw format to a web push target (*experimental*) as: ```[json]{  "notification": {    "collapseKey": "chat"  }}```-->
 
 Additionally, you can set transport-specific attributes which will get merged into the root object resulting from generic mapping explained above only when pushing to the selected transport. This way, you can:
 
@@ -543,7 +540,8 @@ To do this, alongside @notification@ and @data@, add an object whose field is on
 
 * @fcm@, for "FCM":https://firebase.google.com/docs/cloud-messaging/concept-options.
 * @apns@, for "APNs":https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1.
-* @web@, for Web Notifications (*experimental*).
+
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.] * @web@, for Web Notifications (*experimental*).-->
 
 Here's an example of a push payload that overrides the default title for APNs iOS and sets the FCM Android-specific @color@ field:
 

--- a/content/partials/general/push/_push_intro.textile
+++ b/content/partials/general/push/_push_intro.textile
@@ -10,11 +10,13 @@ As shown above, Ably provides two models for delivering push notifications to de
 
 h3(#direct-publishing). Direct publishing
 
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.] * or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*)-->
+
 Ably provides a REST API that allows push notifications to be delivered directly to:
 
 * Devices identified by their unique device ID
 * Devices identified by their assigned "@clientId@":/realtime/authentication#identified-clients
-* Devices identified by the recipient details of the push transport such as their unique @registrationToken@ in the case of FCM, @deviceToken@ in the case of APNS, or @targetUrl@ and @encryptionKey@ in the case of a Web device (*experimental*). This means is particularly useful when migrating to Ably with existing push notification target devices.
+* Devices identified by the recipient details of the push transport such as their unique @registrationToken@ in the case of FCM or @deviceToken@ in the case of APNS. This means is particularly useful when migrating to Ably with existing push notification target devices.
 
 "Find out more about direct push notification publishing":/general/push/publish#direct-publishing
 
@@ -44,4 +46,6 @@ Ably currently offers support for push notifications on the following platforms:
 
 - "Apple Push Notifications":https://developer.apple.com/notifications/ := supported on all mobile devices running iOS and desktop devices running macOS
 - "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging/ := supported on all Android and iOS devices, although we use FCM exclusively for Android message delivery
-- Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). You must request access to use this API.
+
+
+<!--[!!Ed. note: removed as part of EDU-1155. Return if required in the future.] Experimental "W3C Push API":https://www.w3.org/TR/push-api/ := experimental support for "modern W3C compliant browsers":https://caniuse.com/#feat=push-api (this does not include Apple's Safari browser). You must request access to use this API.-->

--- a/writing-style-guide.md
+++ b/writing-style-guide.md
@@ -10,7 +10,7 @@ Some of the benefits of using this style guide are:
 * More professional feel to documentation.
 * Documentation is easier to translate to multiple languages.
 
-Technical accuracy is paramount. This overrides all else. In writing developer documentation technical writers and contributors should strive for:
+Paramount is technical accuracy, which overrides all else. In writing developer documentation technical writers and contributors should strive for:
 
 * Technical accuracy
 * Clarity

--- a/writing-style-guide.md
+++ b/writing-style-guide.md
@@ -10,7 +10,7 @@ Some of the benefits of using this style guide are:
 * More professional feel to documentation.
 * Documentation is easier to translate to multiple languages.
 
-Paramount is technical accuracy, which overrides all else. In writing developer documentation technical writers and contributors should strive for:
+Technical accuracy is paramount. This overrides all else. In writing developer documentation technical writers and contributors should strive for:
 
 * Technical accuracy
 * Clarity


### PR DESCRIPTION
## Description

There are several references to web Push Notifications in the docs and that it’s currently experimental. 
These should be removed for now. 
See discussion in Slack for more info: https://ably-real-time.slack.com/archives/CURL4U2FP/p1666172752980979

* [EDU-609](https://ably.atlassian.net/browse/EDU-609)
* [EDU-1155](https://ably.atlassian.net/browse/EDU-1155)

## Review

I have removed the required information by commenting the lines out so that they can be easily returned once the feature reaches production.

Verify that web push notification references and set-up information is not present at the following locations:
Main docs:
* [Push Notifications - Overview](https://ably.com/docs/general/push#direct-publishing)
* [Push Notifications - Overview](https://ably.com/docs/general/push#platform-support)
* [Push Notifications - Publishing Notifications](https://ably.com/docs/general/push/publish#payload-structure)
* [REST API Specification - Push](https://ably.com/docs/api/rest-api#post-device-registration)
Review docs:
*[]()
*[REST API Specification - Push](https://ably-docs-2-edu-1155-re-qs18uu.herokuapp.com/api/rest-api/)
Please also verify that too much information has not been removed.