### PR TITLE
[FIX] Disable `port_in_redirect` in nginx config

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -40,6 +40,9 @@ http {
 
     add_header X-Frame-Options SAMEORIGIN always;
 
+    # Prevent nginx from adding the PORT to any redirects
+    port_in_redirect off;
+
     # Enforce HTTPS
     if ($http_x_forwarded_proto != "https") {
       return 301 https://$host$request_uri;


### PR DESCRIPTION
## Description

There seems to be an issue with Heroku lately where redirects on trailing slashes suddenly include the PORT number, making the redirects unreachable.

The review apps for #1658 & #1705 exhibited this issue:

~~~
$ curl -I https://ably-docs-edx-496-neste-pziq0w.herokuapp.com/rest
HTTP/1.1 301 Moved Permanently
Connection: keep-alive
Server: nginx
Date: Mon, 07 Nov 2022 10:05:15 GMT
Content-Type: text/html
Content-Length: 162
Location: http://ably-docs-edx-496-neste-pziq0w.herokuapp.com:51026/rest/   # <= THIS SHOULD NOT HAVE A PORT
X-Frame-Options: SAMEORIGIN
Via: 1.1 vegur
~~~

## Review

To review this PR you'd need access to Heroku to run the following test:

~~~
$ heroku ps:exec -a <any-docs-review-app>
~~~

Once you're in, you can run the following test:

~~~
$ curl -I -H "X-Forwarded-Proto: https" -H "X-Forwarded-Port: 443" http://localhost:21136/rest
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Mon, 07 Nov 2022 09:56:05 GMT
Content-Type: text/html
Content-Length: 162
Location: http://localhost/rest/         # <= THIS SHOULD NOT INCLUDE THE PORT NUMBER
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
~~~

On other recent review apps, like #1705, you'll see the following happen.

~~~
$ curl -I -H "X-Forwarded-Proto: https" -H "X-Forwarded-Port: 443" http://localhost:51026/rest
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Mon, 07 Nov 2022 10:03:06 GMT
Content-Type: text/html
Content-Length: 162
Location: http://localhost:51026/rest/    # <= THIS PORT SHOULD NOT BE HERE
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
~~~