### PR TITLE
Add DEFAULT_LANGUAGE option for rendering languages correctly

### DIFF
--- a/src/components/blocks/list/Dl/DlWrapper.tsx
+++ b/src/components/blocks/list/Dl/DlWrapper.tsx
@@ -11,7 +11,8 @@ export const DlWrapper: FunctionComponent<any> = ({ children }) => {
     if (attribs?.lang) {
       if (
         (language === DEFAULT_LANGUAGE && attribs?.lang === DEFAULT_PREFERRED_LANGUAGE) ||
-        attribs?.lang === language
+        attribs?.lang === language ||
+        attribs?.lang === DEFAULT_LANGUAGE
       ) {
         return child;
       }


### PR DESCRIPTION
## Description

Adds `DEFAULT_LANGUAGE` to fix issues where default blocks don't always appear.
