### PR TITLE
[EDX-491]:  API Ref definition lists should appear in separate lines

### DIFF
--- a/src/components/blocks/list/Dl/index.tsx
+++ b/src/components/blocks/list/Dl/index.tsx
@@ -32,6 +32,10 @@ const StyledDl = styled.dl`
     background: #e1e1e1;
     border-radius: 5px;
     padding: 2px 5px;
+    display: block;
+    width: fit-content;
+    block-size: fit-content;
+    margin-bottom: 7px;
     ::before {
       content: '(default: ';
     }

--- a/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><dd> pair of children from alternatives for parsed definition lists ConditionalChildrenLanguageDisplay displays the expected results from HTML data 1`] = `
 <dl
-  className="sc-gsnTZi cpSoUI"
+  className="sc-gsnTZi dOcohb"
 >
   
 	


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

A PR description indicating the purpose of the PR.

* [EDX-491](https://ably.atlassian.net/browse/EDX-491?atlOrigin=eyJpIjoiNWJkMmY5ODgxMDA3NGNkYWFiNmJjZTQwNDMwMjRmODQiLCJwIjoiaiJ9)

## Review

Instructions on how to review the PR. 

* /docs/api/realtime-sdk?lang=csharp
