### PR TITLE
[EDX 512] - API H5 should be linkable like old site and Format Envelope should be visible

### DIFF
--- a/content/api/sse.textile
+++ b/content/api/sse.textile
@@ -119,7 +119,6 @@ h5. Request parameters
 - enveloped := **optional**. Default is @true@. If @true@, the @data@ from each event envelope for a @message@ event will be a "Message":/api/realtime-sdk/types#message object. If @false@, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
 - heartbeats := **optional**. Default is @false@. If @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
 
-
 h5(#envelope-format). Envelope format
 
 Once a streaming response is established, every line (other than empty lines sent as keepalive packets) will be a simple JSON object of the following form:

--- a/content/api/sse.textile
+++ b/content/api/sse.textile
@@ -119,6 +119,7 @@ h5. Request parameters
 - enveloped := **optional**. Default is @true@. If @true@, the @data@ from each event envelope for a @message@ event will be a "Message":/api/realtime-sdk/types#message object. If @false@, it will be the payload from the message directly. See "Envelope format":#envelope-format below.
 - heartbeats := **optional**. Default is @false@. If @true@ will use an explicit heartbeat event rather than a newline as a keepalive packet.
 
+
 h5(#envelope-format). Envelope format
 
 Once a streaming response is established, every line (other than empty lines sent as keepalive packets) will be a simple JSON object of the following form:

--- a/src/components/blocks/api-reference/headings/ApiReferenceH5.tsx
+++ b/src/components/blocks/api-reference/headings/ApiReferenceH5.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+import LinkableHtmlBlock from 'src/components/blocks/Html/LinkableHtmlBlock';
+import { HtmlAttributes } from 'src/components/html-component-props';
+
+const StyledApiReferenceH5: FC<HtmlAttributes<'h5'>> = ({ children, ...attribs }) => (
+  <h5 {...attribs} className="ui-text-h5 font-sans my-16 font-bold leading-normal">
+    {children}
+  </h5>
+);
+
+export const ApiReferenceH5 = LinkableHtmlBlock(StyledApiReferenceH5, 'mb-24');

--- a/src/components/blocks/block-component-maps/component-map.js
+++ b/src/components/blocks/block-component-maps/component-map.js
@@ -17,6 +17,7 @@ import { Code, Kbd, Output, Pre, Samp, Var } from '../software';
 import { Em, Small, Strong, Sub, Sup } from '../styles';
 import { Caption, Col, Colgroup, Table, Tbody, Td, Tfoot, Th, Thead, Tr } from '../table';
 import { Paragraph } from '../typography';
+import { ApiReferenceH5 } from '../api-reference/headings/ApiReferenceH5';
 
 export const IS_TEXT = null;
 
@@ -102,6 +103,7 @@ const ApiReferenceHtmlTypeComponentMap = Object.freeze({
   // external references
   [HtmlDataTypes.blockquote]: ApiReferenceBlockquote,
   // headings
+  [HtmlDataTypes.h5]: ApiReferenceH5,
   [HtmlDataTypes.h6]: ApiReferenceH6,
   // lists
   [HtmlDataTypes.dd]: ApiReferenceDd,


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

* [EDX-512](https://ably.atlassian.net/browse/EDX-512?atlOrigin=eyJpIjoiN2JlMTVjMGI4YTI3NGI5ODlmN2NhOGFhNDJmNDQyMzMiLCJwIjoiaiJ9)
* the textfile needs new line so the Header "Format Envelope" will be displayed [EDX-571](https://ably.atlassian.net/browse/EDX-571?atlOrigin=eyJpIjoiMzYxNmYxODY0YjdhNGFiMmFlZDNiMDk2MzJiNTdhNWMiLCJwIjoiaiJ9)


## Review

Instructions on how to review the PR. 

* [[Page to review](link)](https://ably.com/docs/api/sse?lang=python#envelope-format)
