### PR TITLE
[EDX-576] Correct spacing and divs for /realtime-sdk/connections

### DIFF
--- a/content/api/realtime-sdk/connection.textile
+++ b/content/api/realtime-sdk/connection.textile
@@ -183,7 +183,8 @@ The Stream returned can be subscribed for with a listener.
 bq(definition). final streamSubscription = stream.listen(listener)
 
 </div>
-Register the given listener <span lang="ruby">block</span><span lang="swift,objc">function</span><span lang="csharp">action</span> for the specified "@ConnectionEvent@":#connection-event on the @Connection@. The listener is passed a "ConnectionStateChange":#connection-state-change object that contains the current state, previous state, and an optional reason for the event or state change.</span>
+
+Register the given listener <span lang="ruby">block</span><span lang="swift,objc">function</span><span lang="csharp">action</span> for the specified "@ConnectionEvent@":#connection-event on the @Connection@. The listener is passed a "ConnectionStateChange":#connection-state-change object that contains the current state, previous state, and an optional reason for the event or state change.
 
 <div lang="jsall">
 bq(definition). on(String[] events, listener("ConnectionStateChange":#connection-state-change stateChange))
@@ -205,7 +206,8 @@ The Stream returned can be subscribed for with a listener.
 bq(definition). final streamSubscription = stream.listen(listener)
 
 </div>
-Register the given listener <span lang="ruby">block</span><span lang="swift,objc">function</span><span lang="csharp">action</span> for all "ConnectionEvents":#connection-event on the @Connection@. The listener is passed a "ConnectionStateChange":#connection-state-change object that contains the current state, previous state, the event, and an optional reason for the event or state change. (For the @update@ event, the current and previous states will be the same).</span>
+
+Register the given listener <span lang="ruby">block</span><span lang="swift,objc">function</span><span lang="csharp">action</span> for all "ConnectionEvents":#connection-event on the @Connection@. The listener is passed a "ConnectionStateChange":#connection-state-change object that contains the current state, previous state, the event, and an optional reason for the event or state change. (For the @update@ event, the current and previous states will be the same).
 
 <div lang="jsall">
 If an exception is thrown in the listener and bubbles up to the event emitter, it will be caught and logged at @error@ level, so as not to affect other listeners for the same event
@@ -313,6 +315,8 @@ bq(definition). off()
 
 Removes all listeners (including both those registered against specific events and those registered without an event).
 
+</div>
+
 h4. Parameters
 
 - <div lang="jsall">event(s)</div> := the connection event(s) to unsubscribe from<br>__Type: @String@ or @String[]@__
@@ -326,9 +330,9 @@ h4. Parameters
 - <div lang="csharp">action</div> := action to be executed for matching event changes<br>__Type: "@ConnectioneventChangeEventArgs@":#connection-state-listener__
 - <div lang="ruby">&block</div> := is the listener block to be removed
 - <div lang="swift,objc">listener</div> := previous return value from a @on@ or @once@ call
-</div><div lang="flutter">
-@streamSubscription@ obtained from calling @on@ can be used to cancel a listener by calling @streamSubscription.cancel@.
 
+<div lang="flutter">
+@streamSubscription@ obtained from calling @on@ can be used to cancel a listener by calling @streamSubscription.cancel@.
 </div>
 
 h6(#ping).


### PR DESCRIPTION
## Description

This PR fixes some issues with `/api/realtime-sdk/connections` caused by incorrectly terminated divs and spacing of elements. It also removes additional closing span tags that weren't doing anything.

See [JIRA](https://ably.atlassian.net/browse/EDX-576) for further information.

