### PR TITLE
[EDX-529] Remove HTML wrapping link

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -95,7 +95,7 @@ Specific request and response data types are documented in the context of each A
 
 A response status code of 20X (200, 201 or 204) indicates success. A successful result will typically provide a response body but certain operations (such as DELETE) may respond with a 204 response and no response body.
 
-<a name="error-response">All other "standard HTTP statusCodes":https://en.wikipedia.org/wiki/List_of_HTTP_status_codes signify an error. Errors from all APIs are returned as an object of the form:</a>
+All other "standard HTTP statusCodes":https://en.wikipedia.org/wiki/List_of_HTTP_status_codes signify an error. Errors from all APIs are returned as an object of the form:
 
 bc[json]. {
   error: {


### PR DESCRIPTION
## Description

This PR removes unnecessary `<a>` tags from around a link that was malformed in the new toolchain.

See [JIRA](https://ably.atlassian.net/browse/EDX-529) for further information.