### PR TITLE
Top nav menu add style for hover  and remove outline when focus

### DIFF
--- a/src/components/Header/TopMainNav/Dropdown/Button/DropdownButton.tsx
+++ b/src/components/Header/TopMainNav/Dropdown/Button/DropdownButton.tsx
@@ -36,7 +36,7 @@ export const DropdownButtonAndMenu = ({
       <button
         type="button"
         data-id="meganav-control"
-        className="hidden md:flex items-center h-full"
+        className="hidden md:flex items-center h-full focus:outline-none hover:text-gui-hover"
         aria-expanded={isOpen}
         aria-label={`Show ${dropdownDataID}`}
         onClick={() => onActivated(dropdownDataID)}

--- a/src/components/Header/TopMainNav/TopMainNavUser/TopMainNavLink.tsx
+++ b/src/components/Header/TopMainNav/TopMainNavUser/TopMainNavLink.tsx
@@ -9,7 +9,11 @@ export const TopMainNavLink = ({
   dataId: string;
   children: React.ReactNode;
 }) => (
-  <a href={href} className="hidden md:flex items-center h-full mr-24 py-24 font-medium" data-id={dataId}>
+  <a
+    href={href}
+    className="hidden md:flex items-center h-full mr-24 py-24 font-medium hover:text-gui-hover"
+    data-id={dataId}
+  >
     {children}
   </a>
 );


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Add hover text color and remove outine when focsused

Currently when clicked it looks like this:

<img width="224" alt="Screenshot 2022-11-24 at 10 19 16" src="https://user-images.githubusercontent.com/9053042/203759129-d005dcf2-50af-4841-84d2-8721703e08b1.png">

After fix
<img width="386" alt="Screenshot 2022-11-24 at 10 19 40" src="https://user-images.githubusercontent.com/9053042/203759201-3174b0ed-a94f-4ece-9ccc-af9753b80f02.png">

Add hover text color to the other non-dropdown links as well



## Review

Instructions on how to review the PR. 

* all pages with top navigation
* click the dropdown
* it should same as ably.com
