### PR TITLE
[EDX-444] Incorrect try_files directive broke nginx

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -58,7 +58,7 @@ http {
     error_page 404 500 /404.html;
 
     location / {
-      try_files $uri.html $uri/ $uri;
+      try_files $uri.html $uri $uri/ @404;
     }
 
     location ~ \.html$ {


### PR DESCRIPTION
A last minute change in #1748 went undetected and unfortunately resulted in a broken nginx configuration. This fixes it by adding the missing `@404` fallback to a `try_files` directive.
