### PR TITLE
[Chore] - Fix active classname

### DIFF
--- a/src/components/Sidebar/SidebarHeading.tsx
+++ b/src/components/Sidebar/SidebarHeading.tsx
@@ -31,7 +31,7 @@ export const SidebarHeading = <C extends ElementType>({
     }
   };
   let maybeClassName = undefined;
-  if (!isString(as)) {
+  if (!isString(Component)) {
     maybeClassName = activeClassName;
   }
   return (

--- a/src/components/Sidebar/SidebarHeading.tsx
+++ b/src/components/Sidebar/SidebarHeading.tsx
@@ -30,19 +30,20 @@ export const SidebarHeading = <C extends ElementType>({
       node.scrollIntoView();
     }
   };
-  let maybeClassName = undefined;
+  const finalProps: Omit<Props<C>, 'as' | 'indent' | 'isActive' | 'className'> & {
+    ref: (node: HTMLElement) => void;
+    className: string;
+    activeClassName?: string;
+  } = {
+    ...props,
+    ref: scrollLinkIntoView,
+    className: cn(sidebar, `ml-${indent} break-words`, className, {
+      'font-light text-cool-black': !isActive,
+      [activeClassName]: isActive,
+    }),
+  };
   if (!isString(Component)) {
-    maybeClassName = activeClassName;
+    finalProps.activeClassName = activeClassName;
   }
-  return (
-    <Component
-      {...props}
-      ref={scrollLinkIntoView}
-      className={cn(sidebar, `ml-${indent} break-words`, className, {
-        'font-light text-cool-black': !isActive,
-        [activeClassName]: isActive,
-      })}
-      activeClassName={maybeClassName}
-    />
-  );
+  return <Component {...finalProps} />;
 };


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

Currently there are errors in React if you accidentally use a native HTML JSX element with the `activeClassName` prop. This fix expands an existing fix to make sure that the Component rendered is never a native HTML element.