### PR TITLE
[EDX-614] Redirect tutorials and client lib development references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,15 @@ jobs:
             ./bin/assert-success.sh /docs/quick-start-guide
             ./bin/assert-redirect.sh /docs/quick-start-guide/ \
                                      https://localhost/docs/quick-start-guide
+      - run:
+          name: Test website redirects
+          command: |
+            ./bin/assert-redirect.sh /tutorials https://ably.com/tutorials
+      - run:
+          name: Test client library redirects
+          command: |
+            ./bin/assert-redirect.sh /client-lib-development-guide \
+                                     https://sdk.ably.com/builds/ably/specification/main/
 
 workflows:
   test_branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,20 +148,9 @@ jobs:
       - run:
           name: Smoke test quick start redirects
           command: |
-            status=$(curl --header "x-forwarded-proto: https" \
-                          --silent --output /dev/null -w "%{http_code}" \
-                          http://localhost:3001/docs/quick-start-guide)
-            if [ ${status} -ne 200 ]; then
-              echo "Expect a 200 status code, got ${status}"
-              exit 1
-            fi
-            status=$(curl --header "x-forwarded-proto: https" \
-                          --silent --output /dev/null -w "%{http_code}" \
-                          http://localhost:3001/docs/quick-start-guide/)
-            if [ ${status} -ne 301 ]; then
-              echo "Expect a 301 status code, got ${status}"
-              exit 1
-            fi
+            ./bin/assert-success.sh /docs/quick-start-guide
+            ./bin/assert-redirect.sh /docs/quick-start-guide/ \
+                                     https://localhost/docs/quick-start-guide
 
 workflows:
   test_branch:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ graphql-types.ts
 cli
 dist
 config/nginx-redirects.conf
+/config/nginx.conf
+/logs/

--- a/bin/assert-redirect.sh
+++ b/bin/assert-redirect.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# A utility script to assert redirects served up by nginx
+#
+# Usage: assert-redirects.sh PATH DESTINATION_URL
+#
+# - PATH - Local URL path, like /docs
+# - DESTINATION_URL - Destination URL the direct goes to
+
+FROM=${1}
+TO=${2}
+
+if [[ -z $FROM || -z $TO ]]; then
+  echo "Usage: assert-redirects.sh PATH DESTINATION_URL"
+  exit 1
+fi
+
+OUTPUT=$(curl --header "X-Forwarded-Proto: https" \
+              --silent --output /dev/null \
+              --write-out "%{http_code} %{redirect_url}" \
+              http://localhost:3001${FROM})
+
+CODE=$(echo $OUTPUT | cut -f 1 -d " ")
+URL=$(echo $OUTPUT | cut -f 2 -d " ")
+
+if [ ${CODE} -ne 301 ]; then
+  echo "Expect a 301 status code, got '${CODE}'"
+  exit 1
+fi
+
+if [ ${URL} != ${TO} ]; then
+  echo "Expected ${FROM} to redirect to ${TO}, got '${URL}' instead"
+  exit 1
+fi
+
+echo "OK: '${FROM}' redirects to '${TO}'"

--- a/bin/assert-success.sh
+++ b/bin/assert-success.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# A utility script to assert successful responses served up by nginx
+#
+# Usage: assert-success.sh PATH
+#
+# - PATH - Local URL path, like /docs
+
+URI_PATH=${1}
+
+if [[ -z $URI_PATH ]]; then
+  echo "Usage: assert-success.sh PATH"
+  exit 1
+fi
+
+CODE=$(curl --header "X-Forwarded-Proto: https" \
+              --silent --output /dev/null \
+              --write-out "%{http_code}" \
+              http://localhost:3001${URI_PATH})
+
+if [ ${CODE} -ne 200 ]; then
+  echo "Expect a 200 status code, got '${CODE}'"
+  exit 1
+fi
+
+echo "OK: '${URI_PATH}' returned a 200 status code"

--- a/config/client-lib-development-guide-redirects.conf
+++ b/config/client-lib-development-guide-redirects.conf
@@ -1,0 +1,13 @@
+# These pages for the client library development guides used to be accessible
+# on docs.ably.com, but have moved to sdk.ably.com and are no longer available
+# in the Gatsby toolchain.
+
+/client-lib-development-guide/comet https://sdk.ably.com/builds/ably/specification/main/comet/;
+/client-lib-development-guide/encryption https://sdk.ably.com/builds/ably/specification/main/encryption/;
+/client-lib-development-guide/feature-prioritisation https://sdk.ably.com/builds/ably/specification/main/feature-prioritisation/;
+/client-lib-development-guide/features https://sdk.ably.com/builds/ably/specification/main/features/;
+/client-lib-development-guide/protocol https://sdk.ably.com/builds/ably/specification/main/protocol/;
+/client-lib-development-guide/test-api https://sdk.ably.com/builds/ably/specification/main/test-api/;
+/client-lib-development-guide/versioning https://sdk.ably.com/builds/ably/specification/main/versioning/;
+/client-lib-development-guide/websocket https://sdk.ably.com/builds/ably/specification/main/websocket/;
+/client-lib-development-guide https://sdk.ably.com/builds/ably/specification/main/;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -51,6 +51,8 @@ http {
   # Creates a map of redirects for us
   map $uri $redirected_url {
     default "none";
+    include website-redirects.conf;
+    include client-lib-development-guide-redirects.conf;
     <% if File.exists?(File.dirname(__FILE__) + '/nginx-redirects.conf') %>
     include nginx-redirects.conf;
     <% end %>

--- a/config/website-redirects.conf
+++ b/config/website-redirects.conf
@@ -1,0 +1,4 @@
+# Redirect pages that used to be available in the nanoc toolchain, back
+# to the website where people should be accessing them
+
+~^/tutorials(.*)$ https://ably.com/tutorials$1;


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Now that the new toolchain is available on docs.ably.com as well, we have some old nanoc toolchain artefacts to deal with as well:

* Tutorials should be accessed from ably.com/tutorials
* Client library development guides have moved to sdk.ably.com in #1608

See EDX-614

This also addresses [these comments](https://github.com/ably/docs/pull/1608#issuecomment-1266837897) from @m-hulbert & @QuintinWillison in #1608 

>> Any objections if we get redirects set up with the web team in the future to remove these pages from docs entirely? Do we need to preserve the deep links of the features spec for anything?

> I would love for that to happen and I had presumed that this would be the next logical step, after this pull request has landed. My intention here was to get the 'soft redirects' in place. What I would want to see from future redirects, of course, is that they also carry over the HTML element id anchors too. Some of these documents are quite long and that was one of my goals, to keep that rich, deep linking carrying forwards.

## Review

Testing is quite simple on the review app

Visiting https://ably-docs-edx-614-redir-vohrir.herokuapp.com/tutorials should redirect to ably.com/tutorials
Visiting https://ably-docs-edx-614-redir-vohrir.herokuapp.com/client-lib-development-guide should redirect to sdk.ably.com (as per #1608)
