### PR TITLE
Fix for bad styling on paragraph children of blockquotes

### DIFF
--- a/src/components/blocks/typography/P/index.tsx
+++ b/src/components/blocks/typography/P/index.tsx
@@ -11,8 +11,8 @@ const Paragraph = ({ data, attribs = {} }: HtmlComponentProps<'p'>) => {
   }
   const paragraphClassName = 'text-p2 mb-24 leading-relaxed';
   const modifiedAttribs = { ...attribs, className: paragraphClassName };
-  if (modifiedAttribs.className.includes('definition')) {
-    modifiedAttribs.className = `${modifiedAttribs.className} font-mono font-semibold text-code leading-relaxed`;
+  if (attribs?.className?.includes('definition')) {
+    modifiedAttribs.className = `${attribs.className} font-mono font-semibold text-code leading-relaxed`;
   } else {
     modifiedAttribs.className = `${modifiedAttribs.className} ${paragraphClassName}`;
   }


### PR DESCRIPTION
Observe at:

**Main**

![Screenshot 2022-12-07 at 17 23 32](https://user-images.githubusercontent.com/32373140/206248067-818dcc3f-dcc9-4fd3-a93f-cf1fb138c82f.png)

[Example page](https://docs.ably.com/docs/api/realtime-sdk?lang=javascript)

**Branch**

![Screenshot 2022-12-07 at 17 25 05](https://user-images.githubusercontent.com/32373140/206248352-b95b4db6-2210-46f1-b4b0-15a7642f89d5.png)

[Example page](http://localhost:8000/docs/api/realtime-sdk?lang=javascript)