### PR TITLE
Remove min width from table component, prevent sidebar overlap

### DIFF
--- a/src/components/blocks/table/Table.module.css
+++ b/src/components/blocks/table/Table.module.css
@@ -1,6 +1,5 @@
 .table {
   line-height: 23px;
-  min-width: 754px;
 }
 
 .tableContainer {


### PR DESCRIPTION
Prevents table component overlapping right sidebar in some cases.

**Main**

![Screenshot 2022-12-07 at 17 27 24](https://user-images.githubusercontent.com/32373140/206248867-9e97bc92-99dc-43b4-8cc3-36410e2d217d.png)

[Example page](https://docs.ably.com/docs/asset-tracking?lang=kotlin)

**Branch**

![Screenshot 2022-12-07 at 17 28 56](https://user-images.githubusercontent.com/32373140/206249397-419f3f0b-5624-435b-8d18-12bd90872370.png)

[Example page](http://localhost:8000/docs/asset-tracking?lang=swift)
