### PR TITLE
Hotfix api keys

### DIFF
--- a/src/components/blocks/software/Code/index.tsx
+++ b/src/components/blocks/software/Code/index.tsx
@@ -52,7 +52,7 @@ const Code = ({ data, attribs }: NestedHtmlComponentProps<'div'>) => {
   const contentWithRandomChannelName = useMemo(
     () =>
       dataContainsRandomChannelName ? content.replace(/{{RANDOM_CHANNEL_NAME}}/g, getRandomChannelName()) : content,
-    [content, dataContainsRandomChannelName],
+    [content, dataContainsRandomChannelName, attribs?.lang],
   );
 
   const hasMultilineText = isString && multilineRegex.test(content);

--- a/src/components/blocks/software/Code/index.tsx
+++ b/src/components/blocks/software/Code/index.tsx
@@ -52,7 +52,7 @@ const Code = ({ data, attribs }: NestedHtmlComponentProps<'div'>) => {
   const contentWithRandomChannelName = useMemo(
     () =>
       dataContainsRandomChannelName ? content.replace(/{{RANDOM_CHANNEL_NAME}}/g, getRandomChannelName()) : content,
-    [attribs?.lang],
+    [content, dataContainsRandomChannelName],
   );
 
   const hasMultilineText = isString && multilineRegex.test(content);
@@ -71,13 +71,13 @@ const Code = ({ data, attribs }: NestedHtmlComponentProps<'div'>) => {
           `${displayApiKey}${new Array(API_KEY_LENGTH + 1).join('*')}`,
         )
       : contentWithRandomChannelName;
-  }, [contentWithRandomChannelName, activeApiKey]);
+  }, [contentWithRandomChannelName, activeApiKey, dataContainsKey]);
   const contentWithKey = useMemo(
     () =>
       dataContainsKey
         ? contentWithRandomChannelName.replace(/{{API_KEY}}/g, activeApiKey.value)
         : contentWithRandomChannelName,
-    [contentWithRandomChannelName, activeApiKey],
+    [contentWithRandomChannelName, activeApiKey, dataContainsKey],
   );
 
   if (hasRenderableLanguages || hasMultilineText) {

--- a/src/redux/api-key/remote-api-key-data.ts
+++ b/src/redux/api-key/remote-api-key-data.ts
@@ -17,11 +17,7 @@ declare global {
 }
 
 const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>) => {
-  if (payload.error) {
-    console.error(`Error retrieving data from url, ${payload.error}`);
-    return { data: null };
-  }
-  if (!payload.data || !isArray(payload.data)) {
+  if (payload.error || !payload.data || !isArray(payload.data)) {
     console.warn('No data array on API Key payload object returned from endpoint');
     const tempApiKeyResponse = await fetch(WEB_API_TEMP_KEY_ENDPOINT, { cache: DEFAULT_CACHE_STRATEGY });
     const tempApiKey = await tempApiKeyResponse.text();


### PR DESCRIPTION
Temp API key loading doesn't work if the payload from /api/me has an error: it needs to account for that case when it loads, and provide a proper temporary API key.