### PR TITLE
Slashless canonicals even for index files please

### DIFF
--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -44,7 +44,7 @@ const Template = ({
   const title = getMetaDataDetails(document, 'title') as string;
   const description = getMetaDataDetails(document, 'meta_description', META_DESCRIPTION_FALLBACK) as string;
   const menuLanguages = getMetaDataDetails(document, 'languages', languages) as string[];
-  const canonical = `${CANONICAL_ROOT}${slug}`;
+  const canonical = `${CANONICAL_ROOT}${slug}`.replace(/\/+$/, '');
 
   const contentMenuFromLanguage = contentMenu[language] ?? [[]];
 


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

When a file is index.textile, the slug ends with a slash

Canonicals should never end with a slash, so we have to address this.
