### PR TITLE
[CHORE] Add robots.txt to prevent direct indexing

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Description

We don't want docs.ably.com indexed, we expect most visitors to be accessing the docs through ably.com/docs

This PR introduces a `robots.txt` file that disallows all crawlers.

## Review

Ensure the review app has a `/robots.txt` file.
