### PR TITLE
Updated the example in local limits

### DIFF
--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -48,7 +48,7 @@ Instantaneous rate limits relate to the frequency of a given operation at a mome
 
 h4(#local-rates). Local instantaneous rate limits
 
-Local instantaneous rate limits reject operations in excess of their hard limit and return an error code. For example, the default limit on a PAYG package for the message publish rate on an individual channel is 2,400 messages per second (higher limits are available). Any message publish attempts in excess of the 2,400 messages per second will be rejected and an error code will be returned to the publisher.
+Local instantaneous rate limits reject operations in excess of their hard limit and return an error code. For example, the default limit for the message publish rate on an individual channel is 50 messages per second (higher limits are available). Any message publish attempts in excess of the 50 messages per second will be rejected and an error code will be returned to the publisher.
 
 h4(#global-rates). Global instantaneous rate limits
 


### PR DESCRIPTION
The local instantaneous limit example was incorrect. updated it to Channel Throughput rather.

> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

A PR description indicating the purpose of the PR.

* [Jira epic ticket](link) - if applicable.
* [Jira ticket](link).

## Review

Instructions on how to review the PR. 

* [Page to review](link)
