### PR TITLE
[EDX-597] Add syntax highlighting for frameworks

### DIFF
--- a/content/realtime/usage.textile
+++ b/content/realtime/usage.textile
@@ -128,7 +128,7 @@ blang[csharp].
   ```[csharp]
   using IO.Ably;
 
-  ClientOptions clientOptions = new ClientOptions("<API Key>");
+  ClientOptions clientOptions = new ClientOptions(ApiKey);
   AblyRealtime realtime = new AblyRealtime(clientOptions);
   ```
 

--- a/content/rest/usage.textile
+++ b/content/rest/usage.textile
@@ -147,7 +147,7 @@ blang[csharp].
   ```[csharp]
   using IO.Ably;
 
-  ClientOptions clientOptions = new ClientOptions("<API Key>");
+  ClientOptions clientOptions = new ClientOptions(ApiKey);
   AblyRest rest = new AblyRest(clientOptions);
   ```
 

--- a/src/components/blocks/software/Code/index.tsx
+++ b/src/components/blocks/software/Code/index.tsx
@@ -29,6 +29,9 @@ export const multilineRegex = /\r|\n/gm;
 const alternativeLanguageRegistry: Record<string, string> = {
   objc: 'objectivec',
   nodejs: 'javascript',
+  dotnet: 'cs',
+  csharp: 'cs',
+  flutter: 'dart',
 };
 
 const retrieveFromAlternativeLanguageRegistry = (key?: string) =>


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Adds syntax highlighting for frameworks dotNet and Flutter, using the highlighting rules for C# and Dart respectively.

* [Jira ticket](https://ably.atlassian.net/browse/EDX-597).

## Review

There are a couple of examples of Flutter on this page:

[Flutter example](http://localhost:8000/docs/api/realtime-sdk/connection?lang=flutter)

The 'enums' are now highlighted, contrast with:

![Screenshot 2022-12-29 at 14 50 32](https://user-images.githubusercontent.com/32373140/209970059-f02e67e0-21a6-453e-9684-79789cdbe208.png)

There are more examples of DotNet/C# around, check this page:

[CSharp example](http://localhost:8000/docs/api/rest-sdk?lang=csharp#stats-granularity)

There is syntax highlighting on 'public' and 'enum' keywords, contrast with:

![Screenshot 2022-12-29 at 14 52 54](https://user-images.githubusercontent.com/32373140/209970359-d3a1a11b-f92a-48c7-906f-210b3b2dd0d0.png)
