### PR TITLE
[EDX-539] CSS alteration to prevent multiple definition list lines showing alongside each other

### DIFF
--- a/src/components/blocks/list/Dl/index.tsx
+++ b/src/components/blocks/list/Dl/index.tsx
@@ -20,6 +20,29 @@ const StyledDl = styled.dl`
   margin-bottom: 20px;
   font-size: 16px;
 
+  /**
+  * This :only-child directive is present to ensure that multiple lines are not shown in the situation
+  * where there is a <dl> inside a <div> that is selected based on language type in between two other divs, i.e.
+  * <dl>
+  *   <dt></dt>
+  *   <dd></dd>
+  * </dl>
+  * <div>
+  *   <dl>
+  *     <dt></dt>
+  *     <dd></dd>
+  *   </dl>
+  * </div>
+  * <dl>
+  *   <dt></dt>
+  *   <dd></dd>
+  * </dl>
+  */
+  :only-child {
+    margin-bottom: -1px;
+    margin-top: -21px;
+  }
+
   div {
     display: contents;
   }

--- a/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><dd> pair of children from alternatives for parsed definition lists ConditionalChildrenLanguageDisplay displays the expected results from HTML data 1`] = `
 <dl
-  className="sc-gsnTZi bhboXE"
+  className="sc-gsnTZi clNgQc"
 >
   
 	


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

* [Jira ticket](https://ably.atlassian.net/browse/EDX-539).

## Review

Check this page:

* [Page to review](https://ably-docs-next-staging.herokuapp.com/docs/api/rest-sdk?lang=php#client-options)

It looks like this live, note the gap between definition lists (may need to click to expand):

![Screenshot 2022-12-29 at 15 14 14](https://user-images.githubusercontent.com/32373140/209972961-99da4f9a-259d-4400-97c0-9dc3697e70c6.png)

Locally it should look like this:

![Screenshot 2022-12-29 at 15 15 28](https://user-images.githubusercontent.com/32373140/209973115-7c75c974-2d96-4228-a5df-442d194eddee.png)

See comments for how this fixes the issue and why.