### PR TITLE
[CHORE]: Remove need for importing React in every .tsx or .jsx file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
       "plugins": ["@typescript-eslint"],
       "rules": {
         // disable the rule for all files
+        "react/react-in-jsx-scope": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "curly": ["error"],
         "@typescript-eslint/ban-ts-comment": "warn",

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,32 +1,11 @@
 module.exports = {
-  presets: ['babel-preset-gatsby', '@babel/preset-typescript'],
-  plugins: [
+  presets: [
+    'babel-preset-gatsby',
+    '@babel/preset-typescript',
     [
-      'prismjs',
+      '@babel/preset-react',
       {
-        languages: [
-          'bash',
-          'c',
-          'clike',
-          'csharp',
-          'css',
-          'dart',
-          'go',
-          'java',
-          'javascript',
-          'kotlin',
-          'jsx',
-          'objectivec',
-          'php',
-          'python',
-          'ruby',
-          'swift',
-          'tsx',
-          'typescript',
-          'yaml',
-        ],
-        theme: 'tomorrow',
-        css: true,
+        runtime: 'automatic',
       },
     ],
   ],

--- a/content/root/tools.textile
+++ b/content/root/tools.textile
@@ -45,7 +45,7 @@ A GitHub Action to use the "Ably Control API":https://ably.com/docs/control-api.
 
 h2(#developer-console). Developer console
 
-The "Ably dashboard":ably.com/dashboard contains a developer console. In the developer console you can view connection events. The following screenshot illustrates an example connection:
+The "Ably dashboard":https://ably.com/dashboard contains a developer console. In the developer console you can view connection events. The following screenshot illustrates an example connection:
 
 <a href="/images/screenshots/developer-console.png" target="_blank">
   <img src="/images/screenshots/developer-console.png" style="width: 100%" alt="Developer Console">
@@ -65,7 +65,7 @@ The developer console provides you with some REST API Curl command snippets that
 
 Note, for convenience, the Curl commands have your Ably credentials already added.
 
-"Find it here.":ably.com/dashboard
+"Find it here.":https://ably.com/dashboard
 
 h2(#react-hooks). React hooks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "lodash.throttle": "^4.1.1",
         "markdown-to-jsx": "^7.1.7",
         "posthog-js": "^1.32.4",
-        "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-accessible-accordion": "^5.0.0",
         "react-dom": "^18.2.0",
@@ -67,7 +66,6 @@
         "@types/js-cookie": "^3.0.2",
         "@types/lodash.debounce": "^4.0.7",
         "@types/lodash.throttle": "^4.1.7",
-        "@types/prismjs": "^1.26.0",
         "@types/react-helmet": "^6.1.6",
         "@types/react-test-renderer": "^18.0.0",
         "@types/styled-components": "^5.1.26",
@@ -76,7 +74,6 @@
         "autoprefixer": "^10.4.13",
         "babel-jest": "^29.3.1",
         "babel-plugin-module-resolver": "^4.1.0",
-        "babel-plugin-prismjs": "^2.1.0",
         "babel-preset-gatsby": "^3.3.0",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
@@ -5358,12 +5355,6 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
-    "node_modules/@types/prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
-      "dev": true
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -7042,15 +7033,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/babel-plugin-prismjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-prismjs/-/babel-plugin-prismjs-2.1.0.tgz",
-      "integrity": "sha512-ehzSKYfeAz4U78zi/sfwsjDPlq0LvDKxNefcZTJ/iKBu+plsHsLqZhUeGf1+82LAcA35UZGbU6ksEx2Utphc/g==",
-      "dev": true,
-      "peerDependencies": {
-        "prismjs": "^1.18.0"
       }
     },
     "node_modules/babel-plugin-remove-graphql-queries": {
@@ -21174,14 +21156,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/probe-image-size": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
@@ -29127,12 +29101,6 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
-    "@types/prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
-      "dev": true
-    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -30407,13 +30375,6 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.2"
       }
-    },
-    "babel-plugin-prismjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-prismjs/-/babel-plugin-prismjs-2.1.0.tgz",
-      "integrity": "sha512-ehzSKYfeAz4U78zi/sfwsjDPlq0LvDKxNefcZTJ/iKBu+plsHsLqZhUeGf1+82LAcA35UZGbU6ksEx2Utphc/g==",
-      "dev": true,
-      "requires": {}
     },
     "babel-plugin-remove-graphql-queries": {
       "version": "5.3.1",
@@ -40695,11 +40656,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
-    },
-    "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "probe-image-size": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Ably"
   ],
   "lint-staged": {
-    "**/*.+(js|ts|jsx|tsx|json)": [
+    "**/*.+(js|ts|jsx|tsx)": [
       "jest --findRelatedTests",
       "npm run lint"
     ]
@@ -66,7 +66,6 @@
     "lodash.throttle": "^4.1.1",
     "markdown-to-jsx": "^7.1.7",
     "posthog-js": "^1.32.4",
-    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-accessible-accordion": "^5.0.0",
     "react-dom": "^18.2.0",
@@ -97,7 +96,6 @@
     "@types/js-cookie": "^3.0.2",
     "@types/lodash.debounce": "^4.0.7",
     "@types/lodash.throttle": "^4.1.7",
-    "@types/prismjs": "^1.26.0",
     "@types/react-helmet": "^6.1.6",
     "@types/react-test-renderer": "^18.0.0",
     "@types/styled-components": "^5.1.26",
@@ -106,7 +104,6 @@
     "autoprefixer": "^10.4.13",
     "babel-jest": "^29.3.1",
     "babel-plugin-module-resolver": "^4.1.0",
-    "babel-plugin-prismjs": "^2.1.0",
     "babel-preset-gatsby": "^3.3.0",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent as FC } from 'react';
+import { FunctionComponent as FC } from 'react';
 
 const PageTitle: FC = ({ children }) => (
   <h1 id="title" className="ui-text-h1 my-40 col-span-2 whitespace-nowrap overflow-x-scroll">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,
     "strict": true /* Enable all strict type-checking options. */,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,


### PR DESCRIPTION
## Description

Since we are using React 18, there is no longer a need to `import React from "react";` at the start of every .jsx/.tsx file. This change is to the configuration to allow babel and typescript to compile correctly without `import React from "react";`.

There is also:
* a minor typo/link correction in `tools.textile`.
* PrismJS (a code highlighting tool that we no longer use) has been uninstalled.

## Review

Ensure that docs still builds, make sure PageTitle component isn't broken.
