### PR TITLE
[EDX-565] Fix language menu  being too wide on small screen

### DIFF
--- a/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
+++ b/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Select from 'react-select';
 import { noIndicatorSeparator } from '../ReactSelectCustomComponents/no-indicator-separator';
 import { FormatOptionLabelWithLanguageLogo } from '../ReactSelectCustomComponents/Formatters/FormatOptionLabelWithLanguageLogo';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactSelect, { Props, OptionProps } from 'react-select';
 import Icon from '@ably/ui/core/Icon';
 import { selectMenuStyles } from './styles';
@@ -21,6 +20,9 @@ const Select = ({ ...props }: Props<ReactSelectOption, false>) => {
   return (
     <ReactSelect
       {...props}
+      classNames={{
+        menu: () => `max-w-128 xs:max-w-256`,
+      }}
       components={{ Option: CustomOption }}
       styles={selectMenuStyles}
       classNamePrefix="ably-select"


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

EDX-565 - language menu on code elements is too wide on a small screen.

Before:
![Screenshot 2023-01-04 at 18 31 05](https://user-images.githubusercontent.com/32373140/210624830-5ece9b2f-6428-473e-9a60-3e131e36d345.png)

After:

![Screenshot 2023-01-04 at 18 30 27](https://user-images.githubusercontent.com/32373140/210624724-bcb1f044-8948-45d2-9203-9cd8e89a11f9.png)


[EDX-565]: https://ably.atlassian.net/browse/EDX-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ