### PR TITLE
DRAFT: Markdown support demo

### DIFF
--- a/content/adapters/markdown-demo.md
+++ b/content/adapters/markdown-demo.md
@@ -93,11 +93,13 @@ Does [this](#definition-lists) link to definition lists?
 
 ### Complex
 
-|_=. Limit |_=. Free |_=. PAYG |_=. Committed Use |
-| "Number of apps":#apps (per account) |\4=. 100 |
-| "Number of API keys":#api-keys (per account) |\4=. 100 |
-| "Number of rules":#rules (per account) |\4=. 100 |
-| "Number of namespaces":#namespaces (per account) |\4=. 100 |
+| Limit | Free | PAYG | Committed Use |
+| ----- | :----: | ---- | -------------: |
+| [Number of apps](#apps) (per account) |  100  |||
+| [Number of API keys](#api-keys) (per account) |  100  |||
+| [Number of rules](#rules) (per account) |  100  |||
+| [Number of namespaces](#namespaces) (per account) |  100  |||
+| Centering etc. will take some more work ||||
 
 ## Lists
 

--- a/content/adapters/markdown-demo.md
+++ b/content/adapters/markdown-demo.md
@@ -123,6 +123,11 @@ A new connection attempt can be triggered by an explicit call to <span lang="def
 
 ## Definition lists
 
-- initialized := A `Connection` object having this state has been initialized but no connection has yet been attempted.
-- connecting := A connection attempt has been initiated. The connecting state is entered as soon as the library has completed initialization, and is reentered each time connection is re-attempted following disconnection.
-- connected := A connection exists and is active.
+initialized
+: A `Connection` object having this state has been initialized but no connection has yet been attempted.
+
+connecting
+: A connection attempt has been initiated. The connecting state is entered as soon as the library has completed initialization, and is reentered each time connection is re-attempted following disconnection.
+
+connected
+: A connection exists and is active.

--- a/content/adapters/markdown-demo.md
+++ b/content/adapters/markdown-demo.md
@@ -1,0 +1,126 @@
+---
+title: Markdown testing
+meta_description: "Test Markdown elements"
+languages:
+  - javascript
+  - nodejs
+  - ruby
+  - java
+  - swift
+  - objc
+  - csharp
+  - flutter
+---
+
+## Code snippets
+
+Example consecutive code snippets:
+
+```javascript
+const ably = new Ably.Realtime({ '{{API_KEY}}' });
+ably.connection.on('connected', () => {
+  console.log('Connected to Ably!');
+});
+```
+
+```nodejs
+const Ably = require('ably');
+const ably = new Ably.Realtime({ '{{API_KEY}}' });  
+ably.connection.on('connected', () => {
+  console.log('Connected to Ably!');
+});
+```
+
+```ruby
+ably = Ably::Realtime.new('{{API_KEY}}')
+ably.connection.on(:connected) do
+  puts "Connected to Ably!"
+end
+```
+
+```java
+AblyRealtime ably = new AblyRealtime("{{API_KEY}}");
+ably.connection.on('connected', new ConnectionStateListener() {
+  @Override
+  public void onConnectionStateChanged(ConnectionStateChange change) {
+    System.out.println("Connected to Ably!");
+  }
+});
+```
+
+```csharp
+AblyRealtime ably = new AblyRealtime("{{API_KEY}}");
+ably.Connection.On(ConnectionEvent.Connected, args => {
+  Console.WriteLine("Connected to Ably!");
+});
+```
+
+```objc
+ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+[ably.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *change) {
+    NSLog(@"Connected to Ably!");
+}];
+```
+
+```swift
+let realtime = ARTRealtime(key: "{{API_KEY}}")
+realtime.connection.on(.connected) { change in
+    print("Connected to Ably!")
+}
+```
+
+```flutter
+final realtime = ably.Realtime(key: '{{API_KEY}}');
+final channel = realtime
+  .on(ably.ConnectionStateChange.connected)
+  .subscribe((ably.ConnectionStateChange stateChange) {
+    print('Connected to Ably!');
+  }
+);
+```
+
+## Links
+
+Does [this](#definition-lists) link to definition lists?
+
+## Tables
+
+### Simple
+
+| Property | Description | Default |
+| -------- | ----------- | ------- |
+| `Test` | The test property sees if this table displays correctly | True |
+
+### Complex
+
+|_=. Limit |_=. Free |_=. PAYG |_=. Committed Use |
+| "Number of apps":#apps (per account) |\4=. 100 |
+| "Number of API keys":#api-keys (per account) |\4=. 100 |
+| "Number of rules":#rules (per account) |\4=. 100 |
+| "Number of namespaces":#namespaces (per account) |\4=. 100 |
+
+## Lists
+
+### Ordered
+
+1. Open this page.
+2. See if the numbering works.
+    * It either will,
+    * Or it won't.
+3. Test other pages.
+
+### Unordered
+
+* This one should
+    * Check the level of nesting
+        * We can handle.
+
+## Spans
+
+A new connection attempt can be triggered by an explicit call to <span lang="default">`connect()`</span><span lang="ruby">`connect`</span><span lang="csharp">`Connect()`</span> on the `Connection` object.
+
+## Definition lists
+
+- initialized := A `Connection` object having this state has been initialized but no connection has yet been attempted.
+- connecting := A connection attempt has been initiated. The connecting state is entered as soon as the library has completed initialization, and is reentered each time connection is re-attempted following disconnection.
+- connected := A connection exists and is active.

--- a/data/createPages/index.js
+++ b/data/createPages/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const textile = require('textile-js');
 const MarkdownIt = require('markdown-it');
+const MarkdownTablePlugin = require('markdown-it-multimd-table');
 const { simpleSitemapAndIndex } = require('sitemap');
 const { identity } = require('lodash');
 const { safeFileExists } = require('./safeFileExists');
@@ -131,6 +132,7 @@ const createPages = async ({ graphql, actions: { createPage, createRedirect } })
   const markdownToHtml = new MarkdownIt({
     html: true, // Enable HTML tags in source
   });
+  markdownToHtml.use(MarkdownTablePlugin);
 
   const markdownDocumentCreator = (documentTemplate) => async (edge) => {
     const content = flattenContentOrderedList(edge.node.contentOrderedList)

--- a/data/createPages/index.js
+++ b/data/createPages/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const textile = require('textile-js');
 const MarkdownIt = require('markdown-it');
 const MarkdownTablePlugin = require('markdown-it-multimd-table');
+const MarkdownDefinitionListPlugin = require('markdown-it-deflist');
 const { simpleSitemapAndIndex } = require('sitemap');
 const { identity } = require('lodash');
 const { safeFileExists } = require('./safeFileExists');
@@ -132,7 +133,7 @@ const createPages = async ({ graphql, actions: { createPage, createRedirect } })
   const markdownToHtml = new MarkdownIt({
     html: true, // Enable HTML tags in source
   });
-  markdownToHtml.use(MarkdownTablePlugin);
+  markdownToHtml.use(MarkdownTablePlugin).use(MarkdownDefinitionListPlugin);
 
   const markdownDocumentCreator = (documentTemplate) => async (edge) => {
     const content = flattenContentOrderedList(edge.node.contentOrderedList)

--- a/data/onCreateNode/index.js
+++ b/data/onCreateNode/index.js
@@ -41,7 +41,7 @@ const onCreateNode = async ({
   } else if (node.extension === 'md') {
     const content = await loadNodeContent(node);
     try {
-      transformMarkdown(node, content, createNodeId(`${node.id} >>> HTML`), makeTypeFromParentType('Html')(node), {
+      transformMarkdown(node, content, createNodeId(`${node.id} >>> HTML`), {
         createContentDigest,
         createNodesFromPath: createNodesFromPath('DocumentPath', { createNode, createNodeId, createContentDigest }),
         createNodeId,
@@ -56,7 +56,7 @@ const onCreateNode = async ({
         },
       };
       createNode(ErrorNode);
-      console.error('Error at relative path:\n', node.relativePath ? `${node.relativePath}\n` : '\n', error.message);
+      console.error('Error at relative path:\n', node.relativePath ? `${node.relativePath}\n` : '\n', error.stack);
     }
   }
 };

--- a/data/onCreateNode/index.js
+++ b/data/onCreateNode/index.js
@@ -1,4 +1,4 @@
-const { transformMarkdown } = require('data/transform/markdown/transform-markdown');
+const { transformMarkdown } = require('../transform/markdown/transform-markdown');
 const { transformNanocTextiles, makeTypeFromParentType, createNodesFromPath } = require('../transform');
 const { createSchemaCustomization } = require('./create-graphql-schema-customization');
 
@@ -34,9 +34,7 @@ const onCreateNode = async ({
       createNode(ErrorNode);
       console.error('Error at relative path:\n', node.relativePath ? `${node.relativePath}\n` : '\n', error.message);
     }
-  }
-
-  if (node.extension === 'md') {
+  } else if (node.extension === 'md') {
     const content = await loadNodeContent(node);
     try {
       transformMarkdown(node, content, createNodeId(`${node.id} >>> HTML`), makeTypeFromParentType('Html')(node), {

--- a/data/onCreateNode/index.js
+++ b/data/onCreateNode/index.js
@@ -1,5 +1,9 @@
-const { transformMarkdown } = require('../transform/markdown/transform-markdown');
-const { transformNanocTextiles, makeTypeFromParentType, createNodesFromPath } = require('../transform');
+const {
+  transformNanocTextiles,
+  transformMarkdown,
+  makeTypeFromParentType,
+  createNodesFromPath,
+} = require('../transform');
 const { createSchemaCustomization } = require('./create-graphql-schema-customization');
 
 const onCreateNode = async ({

--- a/data/transform/front-matter.ts
+++ b/data/transform/front-matter.ts
@@ -1,4 +1,4 @@
-import fm from 'front-matter';
+import fm, { FrontMatterResult } from 'front-matter';
 import { assign, isArray, isEmpty, pick } from 'lodash';
 
 export const NO_MATCH = false;
@@ -7,9 +7,9 @@ const ALLOWED_META_FIELDS = ['title', 'meta_description', 'languages', 'redirect
 const maybeStringToStringSingletonArray = (maybeString?: string | string[]) =>
   isEmpty(maybeString) ? undefined : isArray(maybeString) ? maybeString : [maybeString];
 
-export const tryRetrieveMetaData = (metaDataString: string) => {
+export const tryRetrieveMetaData = (metaDataString: string): false | FrontMatterResult<Record<string, string>> => {
   const frontMatter = fm(metaDataString);
-  return isEmpty(frontMatter.attributes) ? NO_MATCH : frontMatter;
+  return isEmpty(frontMatter.attributes) ? NO_MATCH : (frontMatter as FrontMatterResult<Record<string, string>>);
 };
 
 export const filterAllowedMetaFields = (metaObject: Record<string, string | string[]>) =>

--- a/data/transform/index.js
+++ b/data/transform/index.js
@@ -7,6 +7,7 @@ const { maybeRetrievePartial } = require('./retrieve-partials');
 const { flattenContentOrderedList } = require('./shared-utilities');
 const { ARTICLE_TYPES } = require('./constants');
 const { retrieveAndReplaceInlineTOC, splitDataAndMetaData } = require('./meta-data/utilities');
+const { transformMarkdown } = require('./markdown/transform-markdown');
 
 const processTOCItems = (tocItem) => {
   if (isEmpty(tocItem)) {
@@ -205,6 +206,7 @@ const transformNanocTextiles =
 module.exports = {
   createNodesFromPath,
   transformNanocTextiles,
+  transformMarkdown,
   makeTypeFromParentType,
   maybeRetrievePartial,
   flattenContentOrderedList,

--- a/data/transform/markdown/transform-markdown.ts
+++ b/data/transform/markdown/transform-markdown.ts
@@ -1,0 +1,102 @@
+import { NodeInput } from 'gatsby';
+import { makeTypeFromParentType } from '..';
+import { ARTICLE_TYPES } from '../constants';
+import { filterAllowedMetaFields, NO_MATCH, prepareAllowedMetaFields } from '../front-matter';
+import { splitDataAndMetaData } from '../meta-data/utilities';
+
+export const transformMarkdown =
+  (node, content, id, { createNodesFromPath, createContentDigest, createNodeId }) =>
+  (updateWithTransform) => {
+    const slug = node.relativePath
+      .replace(/(.*)\.[^.]+$/, '$1')
+      .replace('root/', '')
+      .replace(/index$/, '');
+
+    const { data, frontmatterMeta } = splitDataAndMetaData(content);
+
+    let articleType: keyof typeof ARTICLE_TYPES = ARTICLE_TYPES.document;
+    if (/^api\/.*/.test(slug)) {
+      articleType = ARTICLE_TYPES.apiReference;
+    }
+
+    const newNodeData: {
+      articleType: string;
+      contentOrderedList: { data: string; type: string }[];
+      id: string;
+      children: [];
+      parent: string;
+      meta?: Record<string, string | string[] | undefined>;
+      parentSlug?: string;
+      version?: string;
+    } = {
+      articleType,
+      contentOrderedList: data,
+      id,
+      children: [],
+      parent: node.id,
+    };
+
+    const isVersion = /\/versions\/v[\d.]+/.test(slug);
+    const isCompare = /^compare\/.*/.test(slug);
+    const isClientLibDevelopmentGuide = /^client-lib-development-guide\/.*/.test(slug);
+
+    const doesNotNeedMeta = isVersion || isCompare || isClientLibDevelopmentGuide;
+
+    if (frontmatterMeta !== NO_MATCH) {
+      newNodeData.meta = prepareAllowedMetaFields(filterAllowedMetaFields(frontmatterMeta.attributes));
+      if (
+        !doesNotNeedMeta &&
+        process.env.NODE_ENV === 'development' &&
+        process.env.EDITOR_WARNINGS_OFF !== 'true' &&
+        !newNodeData.meta.meta_description
+      ) {
+        throw new Error(
+          `No meta_description for file: ${node.relativePath}\n\nPlease add a custom meta_description to the frontmatter YAML at the top of the file.\n\n`,
+        );
+      }
+    }
+
+    const contentDigest = createContentDigest(data);
+
+    const newNodeInternals: NodeInput['internal'] & { htmlId?: string } = {
+      contentDigest,
+      type: 'Markdown',
+      mediaType: 'text',
+    };
+
+    const markdownNode = {
+      ...newNodeData,
+      internal: newNodeInternals,
+    };
+    if (content.id) {
+      markdownNode.internal.htmlId = content.id;
+    }
+
+    // Add completely separate nodes to keep track of relevant versions
+    if (isVersion) {
+      const parentSlug = slug.replace(/\/versions\/v[\d.]+/, '');
+      markdownNode.parentSlug = parentSlug;
+      const version = slug.match(/\/versions\/v([\d.]+)/)[1];
+      markdownNode.version = version;
+      const versionNodeInternals = {
+        contentDigest,
+        type: makeTypeFromParentType('Version')(markdownNode),
+        mediaType: 'text/html',
+      };
+      const versionNodeData = {
+        parent: id,
+        id: createNodeId(`${id} >>> Version`),
+        children: [],
+        parentSlug,
+        slug,
+        version,
+      };
+      const versionNode = {
+        ...versionNodeData,
+        internal: versionNodeInternals,
+      };
+      updateWithTransform({ parent: markdownNode, child: versionNode });
+    }
+
+    updateWithTransform({ parent: node, child: markdownNode });
+  };

--- a/data/transform/meta-data/utilities.ts
+++ b/data/transform/meta-data/utilities.ts
@@ -1,0 +1,55 @@
+import DataTypes from 'data/types';
+import { FrontMatterResult } from 'front-matter';
+import { NO_MATCH, tryRetrieveMetaData } from '../front-matter';
+import { processAfterFrontmatterExtracted } from '../parser-enhancements';
+
+const INLINE_TOC_REGEX = /^inline-toc\.[\r\n\s]*^([\s\S]*?)^\s*$/m;
+
+const tryRetrieveInlineTOC = (contentString: string) => contentString.match(INLINE_TOC_REGEX);
+const removeInlineTOC = (contentString: string) => contentString.replace(INLINE_TOC_REGEX, '');
+
+export const retrieveAndReplaceInlineTOC = (contentString: string) => ({
+  noInlineTOC: removeInlineTOC(contentString),
+  // eslint-disable-next-line no-sparse-arrays
+  inlineTOCOnly: (tryRetrieveInlineTOC(contentString) ?? [, null])[1],
+});
+
+// Just the partial name: /<%=\s+partial\s+partial_version\('([^')]*)'\)[^%>]*%>/
+const parseNanocPartials = (contentString: string) =>
+  contentString.split(/(<%=\s+partial\s+partial_version\('[^')]*'\)[^%>]*%>)/);
+
+const removeFalsy = (dataArray: string[]) => dataArray.filter((x) => !!x);
+
+const removeFalseFromPartials = (text: string) => {
+  const withPartials = parseNanocPartials(text);
+  const withoutFalsyValues = removeFalsy(withPartials);
+  return withoutFalsyValues;
+};
+
+const constructDataObjectsFromStrings = (
+  contentStrings: string[],
+  frontmatterMeta: FrontMatterResult<Record<string, string>> | false,
+) => {
+  contentStrings =
+    frontmatterMeta !== NO_MATCH && frontmatterMeta.attributes
+      ? contentStrings.map((content) => processAfterFrontmatterExtracted(content, frontmatterMeta.attributes))
+      : contentStrings;
+  const dataObjects = contentStrings.map((data, i) =>
+    i % 2 === 0 ? { data: data, type: DataTypes.Html } : { data: data, type: DataTypes.Partial },
+  );
+  return dataObjects;
+};
+
+export const splitDataAndMetaData = (text: string) => {
+  const withoutFalsyValues = removeFalseFromPartials(text);
+  const frontmatterMeta = tryRetrieveMetaData(withoutFalsyValues[0]);
+  if (frontmatterMeta !== NO_MATCH) {
+    withoutFalsyValues[0] = frontmatterMeta.body;
+  }
+
+  const asDataObjects = constructDataObjectsFromStrings(withoutFalsyValues, frontmatterMeta);
+  return {
+    data: asDataObjects,
+    frontmatterMeta,
+  };
+};

--- a/data/transform/meta-data/utilities.ts
+++ b/data/transform/meta-data/utilities.ts
@@ -1,4 +1,4 @@
-import DataTypes from 'data/types';
+import DataTypes from '../../../data/types';
 import { FrontMatterResult } from 'front-matter';
 import { NO_MATCH, tryRetrieveMetaData } from '../front-matter';
 import { processAfterFrontmatterExtracted } from '../parser-enhancements';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "lodash": "^4.17.21",
         "lodash.throttle": "^4.1.1",
         "markdown-it": "^13.0.1",
+        "markdown-it-multimd-table": "^4.2.0",
         "markdown-to-jsx": "^7.1.7",
         "posthog-js": "^1.32.4",
         "react": "^18.2.0",
@@ -18254,6 +18255,11 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
+    },
+    "node_modules/markdown-it-multimd-table": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-multimd-table/-/markdown-it-multimd-table-4.2.0.tgz",
+      "integrity": "sha512-wFpb8TSQ9josQrAlOg1toEAHHSGYQZ4krBKfpejPQ+lq3oudnxCNW4S6gYMcRbkrtrfX/ND2njr4belnKt3fBg=="
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "3.0.1",
@@ -38683,6 +38689,11 @@
           "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
+    },
+    "markdown-it-multimd-table": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-multimd-table/-/markdown-it-multimd-table-4.2.0.tgz",
+      "integrity": "sha512-wFpb8TSQ9josQrAlOg1toEAHHSGYQZ4krBKfpejPQ+lq3oudnxCNW4S6gYMcRbkrtrfX/ND2njr4belnKt3fBg=="
     },
     "markdown-to-jsx": {
       "version": "7.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "lodash.throttle": "^4.1.1",
+        "markdown-it": "^13.0.1",
         "markdown-to-jsx": "^7.1.7",
         "posthog-js": "^1.32.4",
         "react": "^18.2.0",
@@ -17449,6 +17450,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
@@ -18231,6 +18240,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-to-jsx": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
@@ -18257,6 +18292,11 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/meant": {
       "version": "1.0.3",
@@ -24245,6 +24285,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -38034,6 +38079,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "lint-staged": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
@@ -38612,6 +38665,25 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg=="
     },
+    "markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        }
+      }
+    },
     "markdown-to-jsx": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
@@ -38627,6 +38699,11 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "meant": {
       "version": "1.0.3",
@@ -42993,6 +43070,11 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
       "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "lodash": "^4.17.21",
         "lodash.throttle": "^4.1.1",
         "markdown-it": "^13.0.1",
+        "markdown-it-deflist": "^2.1.0",
         "markdown-it-multimd-table": "^4.2.0",
         "markdown-to-jsx": "^7.1.7",
         "posthog-js": "^1.32.4",
@@ -18255,6 +18256,11 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
+    },
+    "node_modules/markdown-it-deflist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
     },
     "node_modules/markdown-it-multimd-table": {
       "version": "4.2.0",
@@ -38689,6 +38695,11 @@
           "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
+    },
+    "markdown-it-deflist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
     },
     "markdown-it-multimd-table": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
     "markdown-it": "^13.0.1",
+    "markdown-it-deflist": "^2.1.0",
     "markdown-it-multimd-table": "^4.2.0",
     "markdown-to-jsx": "^7.1.7",
     "posthog-js": "^1.32.4",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
     "markdown-it": "^13.0.1",
+    "markdown-it-multimd-table": "^4.2.0",
     "markdown-to-jsx": "^7.1.7",
     "posthog-js": "^1.32.4",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
+    "markdown-it": "^13.0.1",
     "markdown-to-jsx": "^7.1.7",
     "posthog-js": "^1.32.4",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "lint-staged": {
     "**/*.+(js|ts|jsx|tsx)": [
-      "jest --findRelatedTests",
+      "jest --findRelatedTests --passWithNoTests",
       "npm run lint"
     ]
   },

--- a/src/components/Menu/ReactSelectStyles/Versions/no-padding-value-container-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/Versions/no-padding-value-container-styles.ts
@@ -1,10 +1,9 @@
-import { ValueContainerProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, ValueContainerProps } from 'react-select';
 
-export const noPaddingValueContainerStyles: StylesConfigFunction<
-  ValueContainerProps<ReactSelectOption, false, ReactSelectOptGroup>
-> = (provided) => ({
+export const noPaddingValueContainerStyles: (
+  provided: CSSObjectWithLabel,
+  props: ValueContainerProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   padding: '0',
 });

--- a/src/components/Menu/ReactSelectStyles/control-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/control-styles.ts
@@ -1,17 +1,17 @@
-import { ControlProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { ControlProps, CSSObjectWithLabel, GroupBase } from 'react-select';
 import { CustomReactSelectStyles } from './custom-react-select-styles';
 
 export const controlStyles: (
   customStyles: CustomReactSelectStyles,
-) => StylesConfigFunction<ControlProps<ReactSelectOption, false, ReactSelectOptGroup>> =
-  (customStyles) => (provided) => ({
-    ...provided,
-    ...customStyles,
-    fontWeight: '500',
-    boxShadow: 'none',
-    cursor: 'pointer',
-    fontFamily: `NEXT Book,Arial,Helvetica,sans-serif`,
-    fontSize: '14px',
-  });
+) => (
+  provided: CSSObjectWithLabel,
+  props: ControlProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (customStyles) => (provided) => ({
+  ...provided,
+  ...customStyles,
+  fontWeight: '500',
+  boxShadow: 'none',
+  cursor: 'pointer',
+  fontFamily: `NEXT Book,Arial,Helvetica,sans-serif`,
+  fontSize: '14px',
+});

--- a/src/components/Menu/ReactSelectStyles/dropdown-indicator-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/dropdown-indicator-styles.ts
@@ -1,10 +1,9 @@
-import { DropdownIndicatorProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, DropdownIndicatorProps, GroupBase } from 'react-select';
 
-export const dropdownIndicatorStyles: StylesConfigFunction<
-  DropdownIndicatorProps<ReactSelectOption, false, ReactSelectOptGroup>
-> = (provided) => ({
+export const dropdownIndicatorStyles: (
+  provided: CSSObjectWithLabel,
+  props: DropdownIndicatorProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   color: 'var(--color-cool-black)',
   '&:hover': {

--- a/src/components/Menu/ReactSelectStyles/group-heading-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/group-heading-styles.ts
@@ -1,10 +1,9 @@
-import { GroupHeadingProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, GroupHeadingProps } from 'react-select';
 
-export const groupHeadingStyles: StylesConfigFunction<
-  GroupHeadingProps<ReactSelectOption, false, ReactSelectOptGroup>
-> = (provided) => ({
+export const groupHeadingStyles: (
+  provided: CSSObjectWithLabel,
+  props: GroupHeadingProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   letterSpacing: '0.1em',
   color: '--var(cool-black)',

--- a/src/components/Menu/ReactSelectStyles/group.ts
+++ b/src/components/Menu/ReactSelectStyles/group.ts
@@ -1,10 +1,9 @@
-import { GroupProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, GroupProps } from 'react-select';
 
-export const groupStyles: StylesConfigFunction<GroupProps<ReactSelectOption, false, ReactSelectOptGroup>> = (
-  provided,
-) => ({
+export const groupStyles: (
+  provided: CSSObjectWithLabel,
+  props: GroupProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   padding: 0,
 });

--- a/src/components/Menu/ReactSelectStyles/menu-list-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/menu-list-styles.ts
@@ -1,10 +1,9 @@
-import { MenuListProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, MenuListProps } from 'react-select';
 
-export const menuListStyles: StylesConfigFunction<MenuListProps<ReactSelectOption, false, ReactSelectOptGroup>> = (
-  provided,
-) => ({
+export const menuListStyles: (
+  provided: CSSObjectWithLabel,
+  props: MenuListProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   height: 'initial',
   maxHeight: 'initial',

--- a/src/components/Menu/ReactSelectStyles/menu-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/menu-styles.ts
@@ -1,11 +1,12 @@
-import { MenuProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, MenuProps } from 'react-select';
 import { CustomReactSelectStyles } from './custom-react-select-styles';
 
 export const menuStyles: (
   customStyles: CustomReactSelectStyles,
-) => StylesConfigFunction<MenuProps<ReactSelectOption, false, ReactSelectOptGroup>> = (styles) => (provided) => ({
+) => (
+  provided: CSSObjectWithLabel,
+  props: MenuProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (styles) => (provided) => ({
   ...provided,
   ...styles,
   zIndex: 12,

--- a/src/components/Menu/ReactSelectStyles/option-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/option-styles.ts
@@ -1,11 +1,12 @@
-import { OptionProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, OptionProps } from 'react-select';
 import { CustomReactSelectStyles } from './custom-react-select-styles';
 
 export const optionStyles: (
   customStyles: CustomReactSelectStyles,
-) => StylesConfigFunction<OptionProps<ReactSelectOption, false, ReactSelectOptGroup>> =
+) => (
+  provided: CSSObjectWithLabel,
+  props: OptionProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel =
   ({ width, activeText }) =>
   (provided) => ({
     ...provided,

--- a/src/components/Menu/ReactSelectStyles/single-value-styles.ts
+++ b/src/components/Menu/ReactSelectStyles/single-value-styles.ts
@@ -1,10 +1,9 @@
-import { SingleValueProps } from 'react-select';
-import { StylesConfigFunction } from 'react-select/dist/declarations/src/styles';
-import { ReactSelectOptGroup, ReactSelectOption } from 'src/components';
+import { CSSObjectWithLabel, GroupBase, SingleValueProps } from 'react-select';
 
-export const singleValueStyles: StylesConfigFunction<
-  SingleValueProps<ReactSelectOption, false, ReactSelectOptGroup>
-> = (provided) => ({
+export const singleValueStyles: (
+  provided: CSSObjectWithLabel,
+  props: SingleValueProps<{ label: string; value: string }, false, GroupBase<{ label: string; value: string }>>,
+) => CSSObjectWithLabel = (provided) => ({
   ...provided,
   color: 'var(--color-active-orange)',
 });


### PR DESCRIPTION
__DO NOT MERGE__

## Description

Demo of markdown support. Working for existing .md files:
http://localhost:8000/docs/adapters/pubnub
http://localhost:8000/docs/adapters/pusher

Fully functioning, but some small things to tweak if we want to push through with this:
* Define what needs to be included, and what should never be included (e.g. exclude all READMEs, maybe pubnub/pusher)
* Implement a strategy for resolving markdown over textile
* Fix TypeScript errors that occur with `npm run debug:textile` to allow markdown translation.
* Anything else?
