### PR TITLE
Token revocation: add warning that issuedBefore does not work with normal tokens

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -1188,7 +1188,7 @@ h5. Options
 The request body has the following properties:
 
 - targets := An array of "target specifier":/core-features/authentication#target-specifiers strings.
-- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected. **Please note: issuedBefore currently only works with JWTs, not normal Ably tokens. We hope to fix this soon. Please "contact us":http://ably.com/support for more information.**
+- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future, or more than an hour in the past will be rejected. **Note: @issuedBefore@ currently only works with JWTs.**
 - allowReauthMargin := The @allowReauthMargin@ bool permits a token renewal cycle to take place without needing established connections to be dropped, by postponing enforcement to 30 seconds in the future, and sending any existing connections a hint to obtain (and upgrade the connection to use) a new token. It defaults to @false@, meaning that the effect is near-immediate.
 
 h5. Returns

--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -1188,7 +1188,7 @@ h5. Options
 The request body has the following properties:
 
 - targets := An array of "target specifier":/core-features/authentication#target-specifiers strings.
-- issuedBefore := If @issuedBefore@ is not specified, it is set to the current time. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected.
+- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected. **Please note: issuedBefore currently only works with JWTs, not normal Ably tokens. We hope to fix this soon. Please "contact us":http://ably.com/support for more information.**
 - allowReauthMargin := The @allowReauthMargin@ bool permits a token renewal cycle to take place without needing established connections to be dropped, by postponing enforcement to 30 seconds in the future, and sending any existing connections a hint to obtain (and upgrade the connection to use) a new token. It defaults to @false@, meaning that the effect is near-immediate.
 
 h5. Returns

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -441,7 +441,7 @@ h4. Revocation keys
 
 Designating a revocation key for a token, or a group of tokens, enables the revocation process to be used at any level of granularity, depending on the needs of the application.
 
-To designate a revocation key, include the following additional claim:
+This method of revocation only works for JWTs, not traditional tokens (which have no such field). To designate a revocation key, include the following additional claim in the JWT:
 
 - x-ably-revocation-key := a string used to identify which token(s) to revoke in the revocation request.
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -487,7 +487,7 @@ In that request, the request body has the following form:
 The request body has the following properties:
 
 - targets := An array of "target specifier":#target-specifiers strings.
-- issuedBefore := Optional number. A Unix timestamp in milliseconds where tokens issued before this time are invalidated. If @issuedBefore@ is not specified, it is set to the current time. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected.
+- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected. **Please note: issuedBefore currently only works with JWTs, not normal Ably tokens. We hope to fix this soon. Please "contact us":http://ably.com/support for more information.**
 - allowReauthMargin := Optional boolean. The @allowReauthMargin@ boolean permits a token renewal cycle to take place without needing established connections to be dropped, by postponing enforcement to 30 seconds in the future, and sending any existing connections a hint to obtain (and upgrade the connection to use) a new token. It defaults to @false@, meaning that the effect is near-immediate.
 
 When invoking the revocation API, a client must prove possession of the key used to issue the tokens to be revoked. You can't use a key to revoke a token issued from a different key. This can be done by using basic authentication, using the API key itself.

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -487,7 +487,7 @@ In that request, the request body has the following form:
 The request body has the following properties:
 
 - targets := An array of "target specifier":#target-specifiers strings.
-- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future or more than an hour in the past will be rejected. **Please note: issuedBefore currently only works with JWTs, not normal Ably tokens. We hope to fix this soon. Please "contact us":http://ably.com/support for more information.**
+- issuedBefore := Optional number (Unix timestamp in milliseconds); if not specified it is set to the current time. The token revocation only applies to tokens issued before this timestamp. A request with an @issuedBefore@ in the future, or more than an hour in the past will be rejected. **Note: @issuedBefore@ currently only works with JWTs.**
 - allowReauthMargin := Optional boolean. The @allowReauthMargin@ boolean permits a token renewal cycle to take place without needing established connections to be dropped, by postponing enforcement to 30 seconds in the future, and sending any existing connections a hint to obtain (and upgrade the connection to use) a new token. It defaults to @false@, meaning that the effect is near-immediate.
 
 When invoking the revocation API, a client must prove possession of the key used to issue the tokens to be revoked. You can't use a key to revoke a token issued from a different key. This can be done by using basic authentication, using the API key itself.

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -439,9 +439,9 @@ Initial connections to Ably and REST requests can incur a small latency cost whe
 
 h4. Revocation keys
 
-Designating a revocation key for a token, or a group of tokens, enables the revocation process to be used at any level of granularity, depending on the needs of the application.
+Designating a revocation key for a token, or a group of tokens, enables the revocation process to be used at any level of granularity, depending on the needs of the application. This method of revocation only works for JWTs, as traditional tokens do not contain this field.
 
-This method of revocation only works for JWTs, not traditional tokens (which have no such field). To designate a revocation key, include the following additional claim in the JWT:
+To designate a revocation key, include the following additional claim in the JWT:
 
 - x-ably-revocation-key := a string used to identify which token(s) to revoke in the revocation request.
 


### PR DESCRIPTION
core-feature/auth and rest-api -- add warnings for a bug we have 

context: https://ably-real-time.slack.com/archives/C8SPU4589/p1673614895790359?thread_ts=1673356100.438359&cid=C8SPU4589