### PR TITLE
Fix message interactions signature

### DIFF
--- a/content/realtime/messages.textile
+++ b/content/realtime/messages.textile
@@ -481,7 +481,7 @@ blang[jsall].
   For example, if you wanted to send an emoji reaction to the previous message above you could send something such as the following:
 
   bc[jsall]. function sendReaction(emoji) {
-    channel.publish('event_name', { body: emoji, extras: { ref: { type: "com.ably.reaction", timeserial: "1656424960320-1" } } })
+    channel.publish({ name: 'event_name', data: emoji, extras: { ref: { type: "com.ably.reaction", timeserial: "1656424960320-1" } } })
   }
 
   h3(#interactions-listener). Creating a Listener


### PR DESCRIPTION
Message reactions can only be published with the `publish(Message)` or `publish(Message[])` signatures, not with the `publish(name, data)` signature.