### PR TITLE
[WEB-2843] Control API links are broken due to Gatsby pre-fetch.

### DIFF
--- a/src/components/Sidebar/SidebarLink.tsx
+++ b/src/components/Sidebar/SidebarLink.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import { SidebarHeading, SidebarHeadingProps } from './';
+import { checkLinkIsInternal } from '../blocks/external-references/AElementHelpers/check-link-is-internal';
 
 const onPageNav = /[#?]/;
 
@@ -16,7 +17,9 @@ export const SidebarLink = ({ to, alwaysExpanded = false, expandable = false, ..
     return <SidebarHeading href={to} {...props} />;
   }
 
-  return onPageNav.test(to) ? (
+  const isInternal = checkLinkIsInternal(to);
+
+  return onPageNav.test(to) || !isInternal ? (
     /**
      *  Relevant page of documentation: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#recommendations-for-programmatic-in-app-navigation
      *  "If you need this (in-app navigation) behavior, you should either use an anchor tag or import the navigate helper from gatsby"

--- a/src/components/blocks/external-references/A.test.tsx
+++ b/src/components/blocks/external-references/A.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { A } from '.';
 
@@ -24,6 +23,10 @@ const linkWithImageElement = {
   ],
   attribs: { href: '/images/diagrams/Channels-Presence.gif', target: '_blank' },
 };
+const nonDocsRelativeUrlElement = {
+  data: 'Lorem ipsum',
+  attribs: { href: '/api/control-api' },
+};
 
 describe('Different data provided to link elements results in different components', () => {
   it('Successfully renders Gatsby links', () => {
@@ -42,6 +45,11 @@ describe('Different data provided to link elements results in different componen
         Lorem ipsum
       </a>
     `);
+  });
+
+  it('Alters non-docs relative URLs into docs relative URLs', () => {
+    const { container } = render(<A {...nonDocsRelativeUrlElement} />);
+    expect(container.firstChild?.toString()).toBe('http://localhost/docs/api/control-api');
   });
 
   it('Successfully renders image without <a> element', () => {

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -8,6 +8,7 @@ import { HtmlAttributes, HtmlComponentProps } from '../../html-component-props';
 import './styles.css';
 import Img from './Img';
 import { filterAttribsForReact } from 'src/react-utilities';
+import { checkLinkIsInternal } from './AElementHelpers/check-link-is-internal';
 
 const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'>) => (
   <Link className="docs-link" data-testid="gatsby-link" to={to} {...props}>
@@ -29,9 +30,7 @@ const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
     }
   }
 
-  if (rawHref && /^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/.test(rawHref)) {
-    // The regex immediately above, /^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/,
-    // only checks if something is a relative URL starting with a slash, or a domain name.
+  if (checkLinkIsInternal(rawHref)) {
     let href = rawHref;
     if (/^\/(?!docs\/).*/.test(rawHref)) {
       // If the URL does not start with 'docs' but IS a relative URL, we prepend the documentation name.

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -17,7 +17,7 @@ const StyledGatsbyLink = ({ to, children, ...props }: Omit<GatsbyLinkProps<Recor
 );
 
 const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
-  const rawHref = attribs?.href;
+  const { href: rawHref, ...unspecifiedAttribs } = attribs ?? {};
 
   // If there is an image inside the link with src same as href, then nuke <a> and render <img> only
   if (Array.isArray(data)) {
@@ -45,7 +45,8 @@ const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
       </StyledGatsbyLink>
     );
   }
-  return GenericHtmlBlock('a')({ data, attribs: { ...attribs, className: 'docs-link' } });
+
+  return GenericHtmlBlock('a')({ data, attribs: { href, className: 'docs-link', ...unspecifiedAttribs } });
 };
 
 export default A;

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -29,9 +29,14 @@ const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
     }
   }
 
-  if (rawHref && /^(\/|https?:\/\/(?:www.)?ably.com\/docs).*/.test(rawHref)) {
+  if (rawHref && /^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/.test(rawHref)) {
+    // The regex immediately above, /^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/,
+    // only checks if something is a relative URL starting with a slash, or a domain name.
     let href = rawHref;
     if (/^\/(?!docs\/).*/.test(rawHref)) {
+      // If the URL does not start with 'docs' but IS a relative URL, we prepend the documentation name.
+      // This is not ideal, but it's because the relative URLs in the textile have been written where it is
+      // assumed that this behaviour will be implemented.
       href = `/${DOCUMENTATION_NAME}${rawHref}`;
     }
 

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -30,15 +30,15 @@ const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
     }
   }
 
-  if (checkLinkIsInternal(rawHref)) {
-    let href = rawHref;
-    if (/^\/(?!docs\/).*/.test(rawHref)) {
-      // If the URL does not start with 'docs' but IS a relative URL, we prepend the documentation name.
-      // This is not ideal, but it's because the relative URLs in the textile have been written where it is
-      // assumed that this behaviour will be implemented.
-      href = `/${DOCUMENTATION_NAME}${rawHref}`;
-    }
+  let href = rawHref;
+  if (rawHref && /^\/(?!docs\/).*/.test(rawHref)) {
+    // If the URL does not start with 'docs' but IS a relative URL, we prepend the documentation name.
+    // This is not ideal, but it's because the relative URLs in the textile have been written where it is
+    // assumed that this behaviour will be implemented.
+    href = `/${DOCUMENTATION_NAME}${rawHref}`;
+  }
 
+  if (checkLinkIsInternal(href)) {
     return (
       <StyledGatsbyLink to={href} {...{ ...attribs }}>
         <Html data={data} />

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
@@ -1,6 +1,15 @@
 import { assert, constantFrom, property, tuple, webPath, webUrl } from 'fast-check';
 import { checkLinkIsInternal } from './check-link-is-internal';
 
+describe('Check link is internal: unit tests', () => {
+  it('Asserts that an internal link is internal', () => {
+    expect(checkLinkIsInternal('/docs/api/sse')).toBe(true);
+  });
+  it('Asserts that an control API link is not internal', () => {
+    expect(checkLinkIsInternal('/docs/api/control-api')).toBe(false);
+  });
+});
+
 const passingRelativeLinks = webPath()
   .filter((webPath) => !!webPath)
   .filter((webPath) => !webPath.includes('/api/control-api'));
@@ -15,12 +24,12 @@ const controlAPIPath = tuple(
     'https://ably.com/docs/',
     'http://ably.com/docs/',
     'https://www.ably.com/docs/',
-    'http://www.abyly.com/docs/',
+    'http://www.ably.com/docs/',
     '/',
   ),
-).map(([webPath, validInternalPrefix]) => `${validInternalPrefix}api/control-api/${webPath}`);
+).map(([webPath, validInternalPrefix]) => `${validInternalPrefix}api/control-api${webPath}`);
 
-describe('Check link is internal', () => {
+describe('Check link is internal: Property tests', () => {
   it('Always identifies web paths as internal', () => {
     assert(
       property(passingRelativeLinks, (link) => {

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
@@ -1,0 +1,5 @@
+describe('Check link is internal', () => {
+  it('Identifies whether a link is internal or not', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
@@ -1,5 +1,49 @@
+import { assert, constantFrom, property, tuple, webPath, webUrl } from 'fast-check';
+import { checkLinkIsInternal } from './check-link-is-internal';
+
+const passingRelativeLinks = webPath()
+  .filter((webPath) => !!webPath)
+  .filter((webPath) => !webPath.includes('/api/control-api'));
+
+const nonAblyAbsoluteLinks = webUrl()
+  .filter((webUrl) => !webUrl.startsWith('https://ably.com'))
+  .filter((webUrl) => !webUrl.startsWith('https://www.ably.com'));
+
+const controlAPIPath = tuple(
+  webPath(),
+  constantFrom(
+    'https://ably.com/docs/',
+    'http://ably.com/docs/',
+    'https://www.ably.com/docs/',
+    'http://www.abyly.com/docs/',
+    '/',
+  ),
+).map(([webPath, validInternalPrefix]) => `${validInternalPrefix}api/control-api/${webPath}`);
+
 describe('Check link is internal', () => {
-  it('Identifies whether a link is internal or not', () => {
-    expect(true).toBe(true);
+  it('Always identifies web paths as internal', () => {
+    assert(
+      property(passingRelativeLinks, (link) => {
+        expect(checkLinkIsInternal(link)).toBe(true);
+      }),
+    );
+  });
+  it('Always identifies non-Ably absolute links as not being internal', () => {
+    assert(
+      property(nonAblyAbsoluteLinks, (link) => {
+        expect(checkLinkIsInternal(link)).toBe(false);
+      }),
+    );
+  });
+  it('Always identifies an empty link as not being internal', () => {
+    expect(checkLinkIsInternal('')).toBe(false);
+    expect(checkLinkIsInternal()).toBe(false);
+  });
+  it('Always identifies the control API link and children as not being internal', () => {
+    assert(
+      property(controlAPIPath, (link) => {
+        expect(checkLinkIsInternal(link)).toBe(false);
+      }),
+    );
   });
 });

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
@@ -1,4 +1,4 @@
-const DOCS_URLS_BUT_EXTERNAL = [/^(\/|https?:\/\/(?:www\.)?ably.com\/docs)(\/)*api\/control-api.*/];
+const DOCS_URLS_BUT_EXTERNAL = [/.*\/api\/control-api.*/];
 
 /**
  * This function is used to identify if a link should be handled by Gatsby

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
@@ -1,3 +1,5 @@
+const DOCS_URLS_BUT_EXTERNAL = [/^(\/|https?:\/\/(?:www\.)?ably.com\/docs)(\/)*api\/control-api.*/];
+
 /**
  * This function is used to identify if a link should be handled by Gatsby
  * as though part of a SPA (which will involve pre-fetching the link in question)
@@ -9,6 +11,22 @@
  * does not really exist in the Gatsby site if used in the incorrect place,
  * which will return an empty page to the user when navigating in the app.
  */
-export const checkLinkIsInternal = (link: string): boolean => {
-  return true;
+export const checkLinkIsInternal = (link?: string): link is string => {
+  // This function doubles as a type guard to ensure that a given link is at least a string
+  if (!link) {
+    return false;
+  }
+  if (/^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/.test(link)) {
+    // The regex immediately above, /^(\/|https?:\/\/(?:www\.)?ably.com\/docs).*/,
+    // only checks if something is a relative URL starting with a slash, or the Ably domain name
+    // followed by an explicit path to the /docs subsite.
+    // Special case matching:
+    for (const regex of DOCS_URLS_BUT_EXTERNAL) {
+      if (regex.test(link)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 };

--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.ts
@@ -1,0 +1,14 @@
+/**
+ * This function is used to identify if a link should be handled by Gatsby
+ * as though part of a SPA (which will involve pre-fetching the link in question)
+ * or should be treated as a normal ahref.
+ *
+ * This can have important consequences; Gatsby handling a link will only
+ * have the effect of improving performance (the page is pre-fetched, so loads
+ * faster), but it might have the negative consequence of fetching a page that
+ * does not really exist in the Gatsby site if used in the incorrect place,
+ * which will return an empty page to the user when navigating in the app.
+ */
+export const checkLinkIsInternal = (link: string): boolean => {
+  return true;
+};


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This PR is intended to prevent Gatsby from pre-fetching the page data for the (empty) Control API page, which in turn prevents the website from providing the Control API page when a link to that page is clicked from inside the Gatsby app.

It achieves this by using plain links rather than Gatsby Link elements when we detect that a link is pointing to the Control API page.

Unwanted behaviour:

Gatsby Link hovered => Gatsby pre-fetches page.json for /docs/api/control-api => Gatsby renders page for /docs/api/control-api when you click the Gatsby Link component.

Expected behaviour:

Link hovered => Link clicked => Whatever is returned from the provided URL is displayed to the user.

[WEB-2843](https://ably.atlassian.net/browse/WEB-2843)

## Review

To verify behaviour is working over and above reviewing the code:

1. Visit:
https://ably-docs-web-2843-cont-5vcugb.herokuapp.com/docs/api
Open the inspector and view requests.
Note that when you hover the mouse over any docs links on the page that do _not_ point to /docs/control/api, no requests ending in `page.json` are fired. This means Gatsby is not pre-fetching resources when mousing over /docs/control/api links.
On this preview app, the empty Control API **will** still show up. This is because there is no website page to take precedence, but the behaviour is now correct; the page is loaded separately, not pre-fetched and rendered over the website page.

2. In the docs repo, after setting up as normal (contact me (@MymmiJ) if you want to know how and don't already), run `gatsby clean && gatsby build --prefix-paths && gatsby serve --prefix-paths`. In case of errors, run `gatsby clean` separately, and try running `npm run clean` as well.

In the website repo, run `bin/dev` as usual.

Visit localhost:9000/docs and check various links on-page to ensure there is no issue.
Visit localhost:9000/docs/api and click the links to the Control API. You should be taken to the website version of the Control API.


[WEB-2843]: https://ably.atlassian.net/browse/WEB-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ