### PR TITLE
[EDU-1326] Fix - Page Title overflowed if too long

### DIFF
--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent as FC } from 'react';
 
 const PageTitle: FC = ({ children }) => (
-  <h1 id="title" className="ui-text-h1 my-40 col-span-2 whitespace-nowrap overflow-x-scroll">
+  <h1 id="title" className="ui-text-h1 my-40 col-span-2">
     {children}
   </h1>
 );


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

This was a kludgy fix for a temporary issue with Page Titles that is now just redundant and gets in the way, looks really weird because text just gets cut off.

* [Jira ticket](https://ably.atlassian.net/browse/EDU-1326).

## Review

Run gatsby clean && gatsby develop
Check page http://localhost:8000/docs/realtime/inband-occupancy, resize screen. Ensure that page title doesn't clip or get cut off.
* [Page to review](http://localhost:8000/docs/realtime/inband-occupancy)
