### PR TITLE
[EDU-1319]: Ignore textile 'links' with just punctuation and/or control characters

### DIFF
--- a/data/transform/pre-parser/textile-js-workarounds/fix-links.test.ts
+++ b/data/transform/pre-parser/textile-js-workarounds/fix-links.test.ts
@@ -15,6 +15,46 @@ describe('Fixes duplicate quoted links for textile-js', () => {
   });
 });
 
+describe('Does not render bits of code as links', () => {
+  it('ignores bits of code when it comes to parsing links', () => {
+    /**
+     * The broken example would look like this:
+     * "x-ably-capability": "{\<a href="[\">*\</a>"*\"]}"
+     * Ticket: https://ably.atlassian.net/browse/EDU-1319
+     **/
+    expect(
+      fixHtmlElementsInLinks(`
+    var claims = {
+      "iat": currentTime, /* current time in seconds */
+      "exp": currentTime + 3600, /* time of expiration in seconds */
+      "x-ably-capability": "{\\"*\\":[\\"*\\"]}"
+    }  
+  `),
+    ).toBe(`
+    var claims = {
+      "iat": currentTime, /* current time in seconds */
+      "exp": currentTime + 3600, /* time of expiration in seconds */
+      "x-ably-capability": "{\\"*\\":[\\"*\\"]}"
+    }  
+  `);
+    expect(
+      fixPunctuationInLinks(`
+    var claims = {
+      "iat": currentTime, /* current time in seconds */
+      "exp": currentTime + 3600, /* time of expiration in seconds */
+      "x-ably-capability": "{\\"*\\":[\\"*\\"]}"
+    }  
+  `),
+    ).toBe(`
+    var claims = {
+      "iat": currentTime, /* current time in seconds */
+      "exp": currentTime + 3600, /* time of expiration in seconds */
+      "x-ably-capability": "{\\"*\\":[\\"*\\"]}"
+    }  
+  `);
+  });
+});
+
 describe('Fixes punctuation in links for textile-js', () => {
   it('Deliberately renders links followed by punctuation so as to remove punctuation from the link', () => {
     expect(

--- a/data/transform/pre-parser/textile-js-workarounds/fix-links.ts
+++ b/data/transform/pre-parser/textile-js-workarounds/fix-links.ts
@@ -4,11 +4,25 @@
 // force the element to be an <a href>
 export const fixDuplicateQuoteLinks: StringTransformation = (content) => content.replace(/"(@[^"]*@)"[^:]/g, '$1');
 
+/**
+ * The regex in this comment block is used throughout to identify valid link content.
+ * To avoid errors when parsing code, the heuristic that the link text must contain at
+ * least one printable character, not including underscore, has been relied upon.
+ * [^">] => identifies non-quote and non-angle-bracket characters
+ * [a-zA-Z0-9] => identifies alphanumeric characters
+ * "([^">]*[a-zA-Z0-9]+[^">]*)" => identifies valid link text
+ *
+ * \w has been deliberately avoided because '_', which \w includes, could be part of code.
+ */
+
 // HTML elements immediately after links cause difficulties for the parser, appearing in links.
 export const fixHtmlElementsInLinks: StringTransformation = (content) =>
-  content.replace(/"([^"<]+)":([^)\]@,\s<>"]+)</gm, '<a href="$2">$1</a><');
+  content.replace(/"([^">]*[a-zA-Z0-9]+[^">]*)":([^)\]@,\s<>"]+)</gm, '<a href="$2">$1</a><');
 
 // Punctuation immediately after links is interpreted correctly by textile-js; but was not by Nanoc.
 // We need to remove it to retain parity.
 export const fixPunctuationInLinks: StringTransformation = (content) =>
-  content.replace(/"([^"<]+)":([^)\]@,\s<>\d{}}"]+?)(\.?)([)\]@,\s<>{}"])/gm, '<a href="$2">$1</a>$3$4');
+  content.replace(
+    /"([^">]*[a-zA-Z0-9]+[^">]*)":([^)\]@,\s<>\d{}}"]+?)(\.?)([)\]@,\s<>{}"])/gm,
+    '<a href="$2">$1</a>$3$4',
+  );


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

> This bug appears on [the Authentication page](https://ably.com/docs/core-features/authentication#jwt-embed-process) (specifically [here](https://github.com/ably/docs/blob/main/content/core-features/authentication.textile?plain=1#L168) in the code), the code inside the codeblock is being erroneously transformed into a link. It seems to be interpreting ```{{"*\":[}}``` as ```{{<a href="[\">*\</a>}}``` despite being inside of a code block.

Note; textile-js does try to interpret content inside ```<pre>``` blocks, and nanoc had a mixture of behaviours when interpreting content inside code blocks; we need our own parser if we're going to reliably interpret content inside ```<pre>``` blocks with the correct level of additional markup applied, or to rewrite what we have.

* [Jira ticket](https://ably.atlassian.net/browse/EDU-1319).

## Review

Instructions on how to review the PR. 

* [Page to review - check that x-ably-capability key is correct](http://localhost:8000/docs/core-features/authentication#jwt-embed-process)
* [Page to review - check that links on this page are not broken](http://localhost:8000/docs/quick-start-guide?lang=javascript)
