### PR TITLE
[FIX]: Quickstart script activation, fix API key subscriptions on retrieval

### DIFF
--- a/src/redux/api-key/remote-api-key-data.ts
+++ b/src/redux/api-key/remote-api-key-data.ts
@@ -48,7 +48,11 @@ const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>)
    */
   if (window.ably?.docs && !window.ably.docs.DOCS_API_KEY) {
     window.ably.docs.DOCS_API_KEY = apiKeyData[0].apiKeys[0].whole_key;
-    window.ably.docs.onApiKeyRetrieved();
+    try {
+      window.ably.docs.onApiKeyRetrieved();
+    } catch (e) {
+      console.error(e);
+    }
   }
   /**
    * Supporting ad hoc scripts; the preceding lines can be removed when ad hoc scripts are.

--- a/src/redux/api-key/remote-api-key-data.ts
+++ b/src/redux/api-key/remote-api-key-data.ts
@@ -44,11 +44,15 @@ const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>)
     }),
   );
   /**
-   * Supporting ad hoc scripts; the following 3 lines can be removed when ad hoc scripts are.
+   * Supporting ad hoc scripts; the following lines can be removed when ad hoc scripts are.
    */
-  if (window.ably?.docs) {
+  if (window.ably?.docs && !window.ably.docs.DOCS_API_KEY) {
     window.ably.docs.DOCS_API_KEY = apiKeyData[0].apiKeys[0].whole_key;
+    window.ably.docs.onApiKeyRetrieved();
   }
+  /**
+   * Supporting ad hoc scripts; the preceding lines can be removed when ad hoc scripts are.
+   */
   return {
     ...payload,
     data: apiKeyData,


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Causes subscription to curl requests to be activated on API key retrieval in quickstart script.

## Review

To review, in your local variables ensure that you set:
```DUPLICATE_KEY_ISSUE_OVERRIDE=$valueFromWebsiteProdHerokuNode```

Run the website application as usual.

Build and serve the docs app with ```--prefix-paths```, ```gatsby build --prefix-paths && gatsby serve --prefix-paths```

Got to localhost:9000/docs/quickstart-guide and try to run the first curl command on the page. You should see an alert appear.