### PR TITLE
[EDU-1357] - Fix: Active tab disappears when switching from Rest/Realtime

### DIFF
--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -1,7 +1,7 @@
 import { useContext, FunctionComponent as FC } from 'react';
 import cn from 'classnames';
 import { PageLanguageContext } from 'src/contexts';
-import { createLanguageHrefFromDefaults, getLanguageDefaults } from 'src/components';
+import { createLanguageHrefFromDefaults, getLanguageDefaults, getLanguageFiltered } from 'src/components';
 import languageLabels from 'src/maps/language';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
@@ -16,10 +16,13 @@ const LanguageButton: FC<LanguageNavigationComponentProps> = ({
   isSDKSelected = false,
 }) => {
   const pageLanguage = useContext(PageLanguageContext);
-  const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(language, pageLanguage);
+  const selectedLanguage = getLanguageFiltered(language);
+  const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(
+    selectedLanguage,
+    pageLanguage,
+  );
 
   const handleClick = () => {
-    const selectedLanguage = language.includes('_') ? language.split('_', 2)[1] : language;
     const href = createLanguageHrefFromDefaults(
       isPageLanguageDefault,
       isLanguageDefault,

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -1,7 +1,7 @@
 import { useContext, FunctionComponent as FC } from 'react';
 import cn from 'classnames';
 import { PageLanguageContext } from 'src/contexts';
-import { createLanguageHrefFromDefaults, getLanguageDefaults, getLanguageFiltered } from 'src/components';
+import { createLanguageHrefFromDefaults, getLanguageDefaults, getFilteredLanguages } from 'src/components';
 import languageLabels from 'src/maps/language';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
@@ -16,7 +16,7 @@ const LanguageButton: FC<LanguageNavigationComponentProps> = ({
   isSDKSelected = false,
 }) => {
   const pageLanguage = useContext(PageLanguageContext);
-  const selectedLanguage = getLanguageFiltered(language);
+  const selectedLanguage = getFilteredLanguages(language);
   const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(
     selectedLanguage,
     pageLanguage,

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -3,11 +3,12 @@ import languageLabels from '../../../maps/language';
 import { MenuItemButton } from '../../Menu/MenuItemButton';
 import Html from '../Html';
 import { LanguageNavigation } from '../../Menu/LanguageNavigation';
-import { LanguageButton, ReactSelectOption } from 'src/components';
+import { getLanguageFiltered, LanguageButton, ReactSelectOption } from 'src/components';
 import { LanguageNavigationProps } from '../../Menu/LanguageNavigation';
 import { HtmlComponentProps, HtmlComponentPropsData, ValidReactElement } from 'src/components/html-component-props';
-import { DEFAULT_LANGUAGE } from '../../../../data/createPages/constants';
+import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_INTERFACE } from '../../../../data/createPages/constants';
 import { SingleValue } from 'react-select';
+import { getSDKInterface } from './ConditionalChildrenLanguageDisplay';
 
 const LocalLanguageAlternatives = ({
   languages,
@@ -25,7 +26,7 @@ const LocalLanguageAlternatives = ({
 
   const setLocalSelected = (value: string) => {
     setSelected(data ? data[value] : '');
-    setSelectedLanguage(value);
+    setSelectedLanguage(getLanguageFiltered(value));
   };
 
   const onClick = ({ currentTarget: { value } }: MouseEvent<HTMLButtonElement>) => {
@@ -44,20 +45,24 @@ const LocalLanguageAlternatives = ({
     .map((lang) => {
       // Site navigation button
       if (!localChangeOnly) {
+        const selectedSDK = getSDKInterface();
         return {
           Component: LanguageButton,
-          props: { language: lang },
+          props: { language: lang, sdkInterface: selectedSDK || DEFAULT_PREFERRED_INTERFACE },
           content: languageLabels[lang] ?? lang,
         };
       }
       // Local button, if global language option doesn't exist
+
+      const selectedLanguageFiltered = getLanguageFiltered(selectedLanguage);
+      const languageFiltered = getLanguageFiltered(lang);
       return {
         Component: MenuItemButton,
         props: {
           language: lang,
           onClick,
           value: lang,
-          isSelected: lang === selectedLanguage,
+          isSelected: languageFiltered === selectedLanguageFiltered,
         },
         content: languageLabels[lang] ?? lang,
       };

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -3,7 +3,7 @@ import languageLabels from '../../../maps/language';
 import { MenuItemButton } from '../../Menu/MenuItemButton';
 import Html from '../Html';
 import { LanguageNavigation } from '../../Menu/LanguageNavigation';
-import { getLanguageFiltered, LanguageButton, ReactSelectOption } from 'src/components';
+import { getFilteredLanguages, LanguageButton, ReactSelectOption } from 'src/components';
 import { LanguageNavigationProps } from '../../Menu/LanguageNavigation';
 import { HtmlComponentProps, HtmlComponentPropsData, ValidReactElement } from 'src/components/html-component-props';
 import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_INTERFACE } from '../../../../data/createPages/constants';
@@ -26,7 +26,7 @@ const LocalLanguageAlternatives = ({
 
   const setLocalSelected = (value: string) => {
     setSelected(data ? data[value] : '');
-    setSelectedLanguage(getLanguageFiltered(value));
+    setSelectedLanguage(getFilteredLanguages(value));
   };
 
   const onClick = ({ currentTarget: { value } }: MouseEvent<HTMLButtonElement>) => {
@@ -54,8 +54,8 @@ const LocalLanguageAlternatives = ({
       }
       // Local button, if global language option doesn't exist
 
-      const selectedLanguageFiltered = getLanguageFiltered(selectedLanguage);
-      const languageFiltered = getLanguageFiltered(lang);
+      const selectedLanguageFiltered = getFilteredLanguages(selectedLanguage);
+      const languageFiltered = getFilteredLanguages(lang);
       return {
         Component: MenuItemButton,
         props: {

--- a/src/components/common/language-defaults.ts
+++ b/src/components/common/language-defaults.ts
@@ -34,5 +34,5 @@ export const createLanguageHrefFromDefaults = (
  Need to filter the language if the language is rest_ or realtime_ ex: rest_javascript
  it needs to return the language only without the sdk interface indicator
  */
-export const getLanguageFiltered = (language: string) =>
+export const getFilteredLanguages = (language: string) =>
   language.includes('_') ? language.split('_', 2)[1] : language;

--- a/src/components/common/language-defaults.ts
+++ b/src/components/common/language-defaults.ts
@@ -29,3 +29,10 @@ export const createLanguageHrefFromDefaults = (
   const sdkInterfaceParam = sdkInterface != '' ? `&sdkInterface=${sdkInterface}` : '';
   return `${languageParam}${sdkInterfaceParam}`;
 };
+
+/*
+ Need to filter the language if the language is rest_ or realtime_ ex: rest_javascript
+ it needs to return the language only without the sdk interface indicator
+ */
+export const getLanguageFiltered = (language: string) =>
+  language.includes('_') ? language.split('_', 2)[1] : language;


### PR DESCRIPTION
## Description

* language buttons are displayed in the MenuItemButton first so need to filter the language of rest/realtime when selected
* add sdkInterface when clicking language buttons
* add global function to filter language to remove rest/realtime
* Language Button able to filter language

A PR description indicating the purpose of the PR.

[EDU-1357](https://ably.atlassian.net/browse/EDU-1357)


## Not Cover in this PR
While testing I found another bugs
- Selecting languages on other code should also update the realtime/rest code box
- Also weirdly the code changes in the ealtime/rest code box
They are currently in a separate ticket [EDU-1358](https://ably.atlassian.net/browse/EDU-1358)



[EDU-1357]: https://ably.atlassian.net/browse/EDU-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-1358]: https://ably.atlassian.net/browse/EDU-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ