### PR TITLE
fix: Fixes issue where lang dropdown was not updating

### DIFF
--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -1,7 +1,13 @@
 import React, { FunctionComponent as FC, useCallback, useContext, useState } from 'react';
 import { SingleValue } from 'react-select';
 
-import { createLanguageHrefFromDefaults, getLanguageDefaults, ReactSelectOption, Select } from 'src/components';
+import {
+  createLanguageHrefFromDefaults,
+  getFilteredLanguages,
+  getLanguageDefaults,
+  ReactSelectOption,
+  Select,
+} from 'src/components';
 import { PageLanguageContext } from 'src/contexts';
 
 import {
@@ -44,7 +50,10 @@ const changePageOnSelect =
   (pageLanguage: string, sdkInterface: string) => (newValue: SingleValue<ReactSelectOption>) => {
     if (newValue) {
       const language = newValue.value;
-      const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(language, pageLanguage);
+      const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
+        getFilteredLanguages(language),
+        pageLanguage,
+      );
       const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language, sdkInterface);
       cacheVisitPreferredLanguage(isPageLanguageDefault, language, href, sdkInterface);
     }

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -11,6 +11,7 @@ import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
 import { MultilineCodeContent } from './Code/MultilineCodeContent';
 import { isArray } from 'lodash';
+import { getFilteredLanguages } from 'src/components/common';
 
 type PreProps = HtmlComponentProps<'pre'> & {
   language: string;
@@ -20,7 +21,8 @@ type PreProps = HtmlComponentProps<'pre'> & {
 
 const Pre = ({ data, languages, altData, attribs }: PreProps): ReactElement => {
   const pageLanguage = useContext(PageLanguageContext);
-  const hasCode = languages?.some((lang) => lang === pageLanguage) || pageLanguage === DEFAULT_LANGUAGE;
+  const hasCode =
+    languages?.some((lang) => getFilteredLanguages(lang) === pageLanguage) || pageLanguage === DEFAULT_LANGUAGE;
   const shouldDisplayTip = !hasCode && languages?.length !== undefined;
   const withModifiedClassname = {
     ...attribs,


### PR DESCRIPTION
## Description

Because languages can have a prefix of `rest` or `realtime`, the language dropdown was not automatically updating to the language selected in the code box any more. 
Fixed this by using the `getFilteredLanguage` method

## Review

Instructions on how to review the PR. 

* [Page to review](link)
