### PR TITLE
[EDU-1359] - Change the Realtime/Rest Tab to be independent rather than part of the pageLoad

### DIFF
--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -49,22 +49,18 @@ A @Channel@ object is a reference to a single channel and is uniquely identified
 
 The following is an example of creating a channel:
 
-REALTIME-CODE
 
-```[realtime_jsall]
-var channel = realtime.channels.get('channelName');
-```
 
 ```[realtime_java]
-Channel channel = realtime.channels.get("channelName");
+Channel channel = realtime.channels.get("channelName"); realtime
 ```
 
 ```[realtime_csharp]
-IRealtimeChannel channel = realtime.Channels.Get("channelName");
+IRealtimeChannel channel = realtime.Channels.Get("channelName"); realtime
 ```
 
 ```[realtime_ruby]
-channel = realtime.channels.get('channelName')
+channel = realtime.channels.get('channelName') realtime
 ```
 
 ```[realtime_objc]
@@ -79,22 +75,17 @@ let channel = realtime.channels.get("channelName")
 final channel = realtime.channels.get('channelName');
 ```
 
-REST-CODE
-
-```[rest_jsall]
-var channel = rest.channels.get('channelName');
-```
 
 ```[rest_java]
-Channel channel = rest.channels.get("channelName");
+Channel channel = rest.channels.get("channelName"); rest
 ```
 
 ```[rest_csharp]
-Channel channel = rest.Channels.Get("channelName");
+Channel channel = rest.Channels.Get("channelName"); rest
 ```
 
 ```[rest_ruby]
-channel = rest.channels.get('channelName')
+channel = rest.channels.get('channelName') rest
 ```
 
 ```[rest_python]

--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -12,6 +12,7 @@ languages:
   - python
   - ruby
   - swift
+  - go
 ---
 
 Channels are used to separate "messages":/channels/messages into different topics. They provide a way to implement the Publish-Subscribe (Pub/Sub) architectural pattern. Pub/Sub enables any number of publishers to publish messages to a channel, and any number of subscribers to be subscribed to a channel to receive them, with publishers and subscribers completely decoupled from one another.
@@ -49,7 +50,13 @@ A @Channel@ object is a reference to a single channel and is uniquely identified
 
 The following is an example of creating a channel:
 
+```[realtime_javascript]
+var channel = realtime.channels.get('channelName');
+```
 
+```[realtime_nodejs]
+var channel = realtime.channels.get('channelName');
+```
 
 ```[realtime_java]
 Channel channel = realtime.channels.get("channelName"); realtime
@@ -75,6 +82,13 @@ let channel = realtime.channels.get("channelName")
 final channel = realtime.channels.get('channelName');
 ```
 
+```[rest_javascript]
+var channel = rest.channels.get('channelName');
+```
+
+```[rest_nodejs]
+var channel = rest.channels.get('channelName');
+```
 
 ```[rest_java]
 Channel channel = rest.channels.get("channelName"); rest
@@ -117,24 +131,30 @@ h2(#attach). Attach to a channel
 Attaching to a channel ensures that it is created in the Ably system and that all messages published on the channel are received by any channel listeners registered by calling "subscribe()":/api/realtime-sdk/channels#subscribe. Ably will start to stream messages to a client as soon as they have attached, regardless of whether or not they have yet subscribed. Attach is only available to the realtime interface.
 
 Channels are not pre-configured or provisioned by Ably in advance. They are created on demand when clients attach, and remain active until such time that there are no remaining attached clients.
-
+state
 Note that "@attach()@":/api/realtime-sdk/channels#attach can be called explicitly, however it's more common for a client to "subscribe":#subscribe, which will automatically initiate the attach.
 
 The following example explicitly attaches to a channel, which results in the channel being provisioned in Ably's global realtime cluster. This channel will remain available globally until there are no more clients attached to the channel:
 
-```[jsall]
+```[realtime_javascript]
 realtime.channels.get('chatroom').attach(function(err) {
   console.log('"chatroom" exists and is now available globally in every datacenter');
 });
 ```
 
-```[ruby]
+```[realtime_nodejs]
+realtime.channels.get('chatroom').attach(function(err) {
+  console.log('"chatroom" exists and is now available globally in every datacenter');
+});
+```
+
+```[realtime_ruby]
 realtime.channels.get('chatroom').attach do |channel|
   puts "'chatroom' exists and is now available globally in every datacenter"
 end
 ```
 
-```[java]
+```[realtime_java]
 Channel channel = realtime.channels.get("chatroom");
 channel.on(new ChannelStateListener() {
   @Override
@@ -148,26 +168,26 @@ channel.on(new ChannelStateListener() {
 });
 ```
 
-```[csharp]
+```[realtime_csharp]
 IRealtimeChannel channel = realtime.Channels.Get("chatroom");
 channel.Attach((success, error) => {
   Console.WriteLine("'chatroom' exists and is now available globally");
 });
 ```
 
-
-```[objc]. [[realtime.channels get:@"chatroom" options:options] attach:^(ARTErrorInfo *error) {
+```[realtime_objc]
+[[realtime.channels get:@"chatroom" options:options] attach:^(ARTErrorInfo *error) {
   NSLog(@"'chatroom' exists and is now available globally in every datacenter");
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 realtime.channels.get("chatroom").attach { error in
   print("'chatroom' exists and is now available globally in every datacenter")
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
 final channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
 final channelMessageSubscription = channel
   .on()
@@ -193,21 +213,28 @@ A channel will automatically close when all of the following criteria are met:
 
 The following is an example of detaching from a channel:
 
-```[jsall]
+```[realtime_javascript]
 channel.detach();
 channel.on('detached', function(stateChange) {
   console.log('detached from the channel ' + channel.name);
 };
 ```
 
-```[ruby]
+```[realtime_nodejs]
+channel.detach();
+channel.on('detached', function(stateChange) {
+  console.log('detached from the channel ' + channel.name);
+};
+```
+
+```[realtime_ruby]
 channel.detach
 channel.on(:detached) do |channel_state_change|
   puts "detached from the channel #{channel.name}"
 end
 ```
 
-```[java]
+```[realtime_java]
 channel.detach();
 channel.on(ChannelEvent.detached, new ChannelStateListener() {
   @Override
@@ -218,28 +245,28 @@ channel.on(ChannelEvent.detached, new ChannelStateListener() {
 });
 ```
 
-```[csharp]
+```[realtime_csharp]
 Channel.Detach();
 channel.On(ChannelEvent.Detached, stateChange => {
   Console.WriteLine("detached from the channel " + channel.Name)
 });
 ```
 
-```[objc]
+```[realtime_objc]
 [channel detach]
 [channel on:ARTChannelEventDetached callback:^(ARTChannelStateChange *stateChange) {
   NSLog(@"detached from the channel ", channel.name);
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 channel.detach()
 channel.on(.detached) { stateChange in
   print("detached from the channel \(channel.name)")
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
 channel.detach();
 final stateChangeListener = channel
   .on(ably.ChannelEvent.detached)
@@ -255,114 +282,110 @@ Use the "@publish()@":/api/realtime-sdk/channels#publish method to send messages
 
 The following is an example of publishing a message to a channel:
 
-REALTIME-CODE
-
-```[javascript]
+```[realtime_javascript]
   var realtime = new Ably.Realtime('{{API_KEY}}');
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.publish('example', 'message data');
 ```
 
-```[nodejs]
+```[realtime_nodejs]
   var Ably = require('ably');
   var realtime = new Ably.Realtime('{{API_KEY}}');
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.publish("example", "message data");
 ```
 
-```[ruby]
+```[realtime_ruby]
   realtime = Ably::Realtime.new('{{API_KEY}}')
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}')
   channel.publish 'example', 'message data'
 ```
 
-```[java]
+```[realtime_java]
   AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}");
   channel.publish("example", "message data");
 ```
 
-```[csharp]
+```[realtime_csharp]
   AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
   IRealtimeChannel channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
   channel.Publish("example", "message data");
 ```
 
-```[objc]
+```[realtime_objc]
 ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
 [channel publish:@"example" data:@"message data"];
 ```
 
-```[swift]
+```[realtime_swift]
 let realtime = ARTRealtime(key: "{{API_KEY}}")
 let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}")
 channel.publish("example", data: "message data")
 ```
 
-```[flutter]
+```[realtime_flutter]
   final realtime = ably.Realtime(key: '{{API_KEY}}');
   final channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
   await channel.publish(name: 'example', data: 'message data');
 ```
 
-REST-CODE
-
-```[javascript]
+```[rest_javascript]
   var rest = new Ably.Rest('{{API_KEY}}');
   var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.publish('example', 'message data');
 ```
 
-```[nodejs]
+```[rest_nodejs]
   var rest = new Ably.Rest('{{API_KEY}}');
   var channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.publish('example', 'message data');
 ```
 
-```[ruby]
+```[rest_ruby]
   rest = Ably::Rest.new('{{API_KEY}}')
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
   channel.publish 'example', 'message data'
 ```
 
-```[python]
+```[rest_python]
   rest = AblyRest('{{API_KEY}}')
   channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}')
   channel.publish(u'example', u'message data')
 ```
 
-```[php]
+```[rest_php]
   $rest = new Ably\AblyRest('{{API_KEY}}');
   $channel = $rest->channels->get('{{RANDOM_CHANNEL_NAME}}');
   $channel->publish('example', 'message data');
 ```
 
-```[java]
+```[rest_java]
   AblyRest rest = new AblyRest("{{API_KEY}}");
   Channel channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}");
   channel.publish("example", "message data");
 ```
 
-```[csharp]
+```[rest_csharp]
   AblyRest rest = new AblyRest("{{API_KEY}}");
   var channel = rest.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
   await channel.PublishAsync("example", "message data");
 ```
 
-```[objc]
+```[rest_objc]
   ARTRest *rest = [[ARTRest alloc] initWithKey:@"{{API_KEY}}"];
   ARTRestChannel *channel = [rest.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
   [channel publish:@"example" data:@"message data"];
 ```
 
-```[swift]
+```[rest_swift]
   let rest = ARTRest(key: "{{API_KEY}}")
   let channel = rest.channels.get("{{RANDOM_CHANNEL_NAME}}")
   channel.publish("example", data: "message data")
 ```
 
-```[go]
+```[rest_go]
   rest, err := ably.NewREST(ably.WithKey("{{API_KEY}}"))
   if err != nil {
       panic(err)
@@ -373,7 +396,7 @@ REST-CODE
   }
 ```
 
-```[flutter]
+```[rest_flutter]
   final rest = ably.Rest('{{API_KEY}}');
   final channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.publish(name: 'example', data: 'message data');
@@ -391,7 +414,7 @@ The REST interface enables you to publish messages to multiple channels with a s
 
 The following is an example of a batch publish request using the "@request()@":/api/rest-sdk#request method to query the "batch REST API":/api/rest-api#batch-publish:
 
-```[javascript]
+```[rest_javascript]
 var ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 var content = { "channels": [ "test1", "test2" ], "messages": { "data": 'myData' } }
 ablyRest.request('post', '/messages', null, content, null,
@@ -535,25 +558,31 @@ Transient publishing is when a client publishes messages without attaching to a 
 
 The following is an example of publishing without attaching to a channel:
 
-```[jsall]
+```[realtime_javascript]
 var channel = realtime.channels.get('chatroom');
 // The publish below will not attach you to the channel
 channel.publish('action', 'boom!');
 ```
 
-```[ruby]
+```[realtime_nodejs]
+var channel = realtime.channels.get('chatroom');
+// The publish below will not attach you to the channel
+channel.publish('action', 'boom!');
+```
+
+```[realtime_ruby]
 channel = realtime.channels.get('chatroom')
 # The publish below will not attach you to the channel
 channel.publish 'action', 'boom!'
 ```
 
-```[swift]
+```[realtime_swift]
 let channel = realtime.channels.get("chatroom")
 // The publish below will not attach you to the channel
 channel.publish("action", data: "boom!")
 ```
 
-```[flutter]
+```[realtime_flutter]
 final channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
 // The publish below will not attach you to the channel
 await channel.publish(name: 'example', data: 'message data');
@@ -569,7 +598,7 @@ If idempotent publishing is enabled using the @idempotentRestPublishing@ "@Clien
 
 It is also possible to manually specify message IDs. The following is an example of how you might do this:
 
-```[javascript]
+```[rest_javascript]
 const rest = new Ably.Rest('{{API_KEY}}');
 const channel = rest.channels.get('{{RANDOM_CHANNEL_NAME}}');
 channel.publish([{data: 'payload', id: 'unique123'}]);
@@ -599,7 +628,7 @@ A client can subscribe to all messages published to a channel by passing a lambd
 
 The following is an example of registering a listener for all messages:
 
-```[javascript]
+```[realtime_javascript]
   var realtime = new Ably.Realtime('{{API_KEY}}');
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
   channel.subscribe(function(message) {
@@ -607,7 +636,7 @@ The following is an example of registering a listener for all messages:
   });
 ```
 
-```[nodejs]
+```[realtime_nodejs]
   var Ably = require('ably');
   var realtime = new Ably.Realtime('{{API_KEY}}');
   var channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
@@ -616,7 +645,7 @@ The following is an example of registering a listener for all messages:
   });
 ```
 
-```[ruby]
+```[realtime_ruby]
   realtime = Ably::Realtime.new('{{API_KEY}}')
   channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}')
   channel.subscribe do |message|
@@ -624,7 +653,7 @@ The following is an example of registering a listener for all messages:
   end
 ```
 
-```[java]
+```[realtime_java]
   AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
   Channel channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}");
   channel.subscribe(new MessageListener() {
@@ -635,7 +664,7 @@ The following is an example of registering a listener for all messages:
   });
 ```
 
-```[csharp]
+```[realtime_csharp]
   AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
   IRealtimeChannel channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
   channel.Subscribe(message => {
@@ -643,7 +672,7 @@ The following is an example of registering a listener for all messages:
   });
 ```
 
-```[objc]
+```[realtime_objc]
 ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}"];
 [channel subscribe:^(ARTMessage *message) {
@@ -651,7 +680,7 @@ ARTRealtimeChannel *channel = [realtime.channels get:@"{{RANDOM_CHANNEL_NAME}}"]
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 let realtime = ARTRealtime(key: "{{API_KEY}}")
 let channel = realtime.channels.get("{{RANDOM_CHANNEL_NAME}}")
 channel.subscribe { message in
@@ -659,7 +688,7 @@ channel.subscribe { message in
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
   final realtime = ably.Realtime(key: '{{API_KEY}}');
   final channel = realtime.channels.get('{{RANDOM_CHANNEL_NAME}}');
   final channelMessageSubscription = channel
@@ -672,14 +701,21 @@ channel.subscribe { message in
 
 The following is an example of registering a listener for a specific message name:
 
-```[jsall]
+```[realtime_javascript]
 channel.subscribe('myEvent', function(message) {
   console.log('message received for event ' + message.name);
   console.log('message data:' + message.data);
 });
 ```
 
-```[java]
+```[realtime_nodejs]
+channel.subscribe('myEvent', function(message) {
+  console.log('message received for event ' + message.name);
+  console.log('message data:' + message.data);
+});
+```
+
+```[realtime_java]
 channel.subscribe("myEvent", new MessageListener() {
   @Override
   public void onMessage(Message message) {
@@ -688,7 +724,7 @@ channel.subscribe("myEvent", new MessageListener() {
 });
 ```
 
-```[csharp]
+```[realtime_csharp]
 channel.Subscribe("myEvent", message =>
 {
     Console.WriteLine($"message received for event {message.Name}");
@@ -696,28 +732,28 @@ channel.Subscribe("myEvent", message =>
 });
 ```
 
-```[ruby]
+```[realtime_ruby]
 channel.subscribe('myEvent') do |message|
   puts "message received for event #{message.name}"
   puts "message data: #{message.data}"
 end
 ```
 
-```[swift]
+```[realtime_swift]
 channel.subscribe("myEvent") { message in
     print("message received for event \(message.name)")
     print("message data: \(message.data)")
 }
 ```
 
-```[objc]
+```[realtime_objc]
 [channel subscribe:@"myEvent" callback:^(ARTMessage *message) {
     NSLog(@"message received for event %@", message.name);
     NSLog(@"message data: %@", message.data);
 }];
 ```
 
-```[flutter]
+```[realtime_flutter]
 final channelMessageSubscription = channel
   .subscribe(name: 'myEvent')
   .listen((ably.Message message) {
@@ -733,7 +769,7 @@ Normally, errors in attaching to a channel are communicated through the "attach(
 
 The following is an example of implicitly attaching to a channel and publishing a message:
 
-```[jsall]
+```[realtime_javascript]
 var channel = realtime.channels.get('chatroom');
 channel.subscribe('action', function(message) { // implicit attach
   console.log('Message received '' + message.data);
@@ -741,7 +777,15 @@ channel.subscribe('action', function(message) { // implicit attach
 channel.publish('action', 'boom!');
 ```
 
-```[ruby]
+```[realtime_nodejs]
+var channel = realtime.channels.get('chatroom');
+channel.subscribe('action', function(message) { // implicit attach
+  console.log('Message received '' + message.data);
+});
+channel.publish('action', 'boom!');
+```
+
+```[realtime_ruby]
 channel = realtime.channels.get('chatroom')
 channel.subscribe('action') do |message| # implicit attach
   puts "Message received: #{message}";
@@ -749,7 +793,7 @@ end
 channel.publish 'action', 'boom!'
 ```
 
-```[java]
+```[realtime_java]
 Channel channel = realtime.channels.get("chatroom");
 /* Implicit attach when subscribing */
 channel.subscribe(new MessageListener() {
@@ -761,13 +805,13 @@ channel.subscribe(new MessageListener() {
 channel.publish("action", "boom!");
 ```
 
-```[csharp]
+```[realtime_csharp]
 IRealtimeChannel channel = realtime.Channels.Get("chatroom");
 channel.Subscribe(message => Console.WriteLine("Message received: " + message.Data));
 channel.Publish("action", "boom");
 ```
 
-```[objc]
+```[realtime_objc]
 ARTRealtimeChannel *channel = [realtime.channels get:@"chatroom" options:options];
 [channel subscribe:@"action" callback:^(ARTMessage *message) {
     NSLog(@"Message received: %@", message.data);
@@ -775,7 +819,7 @@ ARTRealtimeChannel *channel = [realtime.channels get:@"chatroom" options:options
 [channel publish:@"action" data:@"boom!"];
 ```
 
-```[swift]
+```[realtime_swift]
 let channel = realtime.channels.get("chatroom")
 channel.subscribe("action") { message in
     print("Message received: \(message.data)")
@@ -783,7 +827,7 @@ channel.subscribe("action") { message in
 channel.publish("action", data: "boom!")
 ```
 
-```[flutter]
+```[realtime_flutter]
 final channel = realtime.channels.get('chatroom');
 /* Implicit attach when subscribing */
 channel.subscribe(name: 'action').listen((ably.Message message) {
@@ -808,7 +852,7 @@ Unsubscribing from a channel removes previously registered listeners that were a
 
 The following is an example of removing listeners registered for a single event and an example of removing listeners registered for all events:
 
-```[jsall]
+```[realtime_javascript]
 /* remove the listener registered for a single event */
 channel.unsubscribe('myEvent', myListener);
 
@@ -816,7 +860,15 @@ channel.unsubscribe('myEvent', myListener);
 channel.unsubscribe(myListener);
 ```
 
-```[java]
+```[realtime_nodejs]
+/* remove the listener registered for a single event */
+channel.unsubscribe('myEvent', myListener);
+
+/* remove the listener registered for all events */
+channel.unsubscribe(myListener);
+```
+
+```[realtime_java]
 /* remove a single listener */
 channel.unsubscribe(myListener);
 
@@ -824,7 +876,7 @@ channel.unsubscribe(myListener);
 channel.unsubscribe("myEvent", myListener);
 ```
 
-```[csharp]
+```[realtime_csharp]
 /* remove a single listener */
 channel.Unsubscribe(myHandler);
 
@@ -832,7 +884,7 @@ channel.Unsubscribe(myHandler);
 channel.Unsubscribe("myEvent", myHandler);
 ```
 
-```[ruby]
+```[realtime_ruby]
 # remove the listener proc registered for a single event
 channel.unsubscribe("myEvent", &my_proc)
 
@@ -840,7 +892,7 @@ channel.unsubscribe("myEvent", &my_proc)
 channel.unsubscribe(&my_proc)
 ```
 
-```[objc]
+```[realtime_objc]
 // remove the listener registered for a single event
 [channel unsubscribe:@"myEvent" listener:listener];
 
@@ -848,7 +900,7 @@ channel.unsubscribe(&my_proc)
 [channel unsubscribe:listener];
 ```
 
-```[swift]
+```[realtime_swift]
 // remove the listener registered for a single event
 channel.unsubscribe("myEvent", listener: listener)
 
@@ -856,7 +908,7 @@ channel.unsubscribe("myEvent", listener: listener)
 channel.unsubscribe(listener)
 ```
 
-```[flutter]
+```[realtime_flutter]
 channelMessageSubscription.cancel();
 ```
 
@@ -962,7 +1014,7 @@ As with all events from an @EventEmitter@ in the Ably library, @this@ within the
 
 The @Channel@ object can also emit one event that is not a state change: an @update@ event. This happens when there's a change to channel conditions for which the channel state doesn't change. For example, a partial loss of message continuity on a channel (typically after a resume) for which the channel state remains @attached@ would lead to an @update@ event being emitted, with both @current@ and @previous@ set to "@attached@", and the @resumed@ flag set to @false@. So if you get such an event, you'll know there may be messages you've missed on the channel, and if necessary you can use "history":/api/realtime-sdk/channels#history to retrieve them.
 
-```[jsall]
+```[realtime_javascript]
 channel.on('attached', function(stateChange) {
   console.log('channel ' + channel.name + ' is now attached');
   console.log('Message continuity on this channel ' + \
@@ -970,14 +1022,22 @@ channel.on('attached', function(stateChange) {
 });
 ```
 
-```[ruby]
+```[realtime_nodejs]
+channel.on('attached', function(stateChange) {
+  console.log('channel ' + channel.name + ' is now attached');
+  console.log('Message continuity on this channel ' + \
+    (stateChange.resumed ? 'was' : 'was not') + ' preserved');
+});
+```
+
+```[realtime_ruby]
 channel.on(:attached) do |channel_state_change|
   puts "channel #{channel.name} is now attached"
   puts "Message continuity #{channel_state_change.resumed ? 'was' : 'was not'} preserved"
 end
 ```
 
-```[java]
+```[realtime_java]
 channel.on(ChannelEvent.attached, new ChannelStateListener() {
   @Override
   public void onChannelStateChanged(ChannelStateChange stateChange) {
@@ -991,7 +1051,7 @@ channel.on(ChannelEvent.attached, new ChannelStateListener() {
 });
 ```
 
-```[csharp]
+```[realtime_csharp]
 IRealtimeChannel channel = realtime.Channels.Get("chatroom");
 channel.On(ChannelEvent.Attached, stateChange => {
   Console.WriteLine("channel " + channel.Name + " is now attached");
@@ -1003,7 +1063,7 @@ channel.On(ChannelEvent.Attached, stateChange => {
 });
 ```
 
-```[objc]
+```[realtime_objc]
 [channel on:ARTChannelEventAttached callback:^(ARTChannelStateChange *stateChange) {
   NSLog(@"channel %@ is now attached", channel.name);
   if (stateChange.resumed) {
@@ -1014,7 +1074,7 @@ channel.On(ChannelEvent.Attached, stateChange => {
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 channel.on(.attached) { stateChange in
   print("channel \(channel.name) is now attached")
   if (stateChange.resumed) {
@@ -1025,7 +1085,7 @@ channel.on(.attached) { stateChange in
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
 final stateChangeListener = channel
   .on(ably.ChannelEvent.attached)
   .listen((ably.ChannelStateChange state) {
@@ -1041,7 +1101,7 @@ final stateChangeListener = channel
 
 Alternatively, a listener may be registered so that it receives all state change events.
 
-```[jsall]
+```[realtime_javascript]
 var myListener = function(stateChange) {
   console.log('channel state is ' + stateChange.current);
   console.log('previous state was ' + stateChange.previous);
@@ -1052,13 +1112,24 @@ var myListener = function(stateChange) {
 channel.on(myListener);
 ```
 
-```[ruby]
+```[realtime_nodejs]
+var myListener = function(stateChange) {
+  console.log('channel state is ' + stateChange.current);
+  console.log('previous state was ' + stateChange.previous);
+  if(stateChange.reason) {
+    console.log('the reason for the state change was: ' + stateChange.reason.toString());
+  }
+});
+channel.on(myListener);
+```
+
+```[realtime_ruby]
 channel.on do |channel_state_change|
   puts "channel state is #{channel_state_change.current}"
 end
 ```
 
-```[java]
+```[realtime_java]
 channel.on(new ChannelStateListener() {
   @Override
   public void onChannelStateChanged(ChannelStateChange stateChange, ErrorInfo reason) {
@@ -1067,23 +1138,23 @@ channel.on(new ChannelStateListener() {
 });
 ```
 
-```[csharp]
+```[realtime_csharp]
 channel.On(stateChange => Console.WriteLine("channel state is " + stateChange.Current));
 ```
 
-```[objc]
+```[realtime_objc]
 ARTEventListener *listener = [channel on:^(ARTChannelStateChange *stateChange) {
     NSLog(@"channel state is %@", stateChange.current);
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 let listener = channel.on { stateChange in
     print("channel state is \(stateChange.current)")
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
 final stateChangeListener = channel
   .on()
   .subscribe((ably.ChannelStateChange stateChange) {
@@ -1094,7 +1165,7 @@ final stateChangeListener = channel
 
 Previously registered listeners can be removed individually or all together.
 
-```[jsall]
+```[realtime_javascript]
   /* remove the listener registered for a single event */
   channel.off('attached', myListener);
 
@@ -1102,7 +1173,15 @@ Previously registered listeners can be removed individually or all together.
   channel.off(myListener);
 ```
 
-```[ruby]
+```[realtime_nodejs]
+  /* remove the listener registered for a single event */
+  channel.off('attached', myListener);
+
+  /* remove the listener registered for all events */
+  channel.off(myListener);
+```
+
+```[realtime_ruby]
   # remove the listener proc registered for a single event
   channel.off(:attached, &my_proc)
 
@@ -1110,7 +1189,7 @@ Previously registered listeners can be removed individually or all together.
   channel.off(&my_proc)
 ```
 
-```[java]
+```[realtime_java]
   /* remove the listener registered for a single event */
   channel.off(ChannelEvent.attached, channelStateListener);
 
@@ -1118,7 +1197,7 @@ Previously registered listeners can be removed individually or all together.
   channel.off(channelStateListener);
 ```
 
-```[csharp]
+```[realtime_csharp]
   // remove the listener registered for a single event
   channel.Off(ChannelEvent.Attached, channelStateListener);
 
@@ -1126,7 +1205,7 @@ Previously registered listeners can be removed individually or all together.
   channel.Off(channelStateListener);
 ```
 
-```[objc]
+```[realtime_objc]
   // remove the listener registered for a single event
   [channel off:ARTChannelEventAttached listener:listener];
 
@@ -1134,7 +1213,7 @@ Previously registered listeners can be removed individually or all together.
   [channel off:listener];
 ```
 
-```[swift]
+```[realtime_swift]
   // remove the listener registered for a single event
   channel.off(.attached, listener: listener)
 
@@ -1142,7 +1221,7 @@ Previously registered listeners can be removed individually or all together.
   channel.off(listener)
 ```
 
-```[flutter]
+```[realtime_flutter]
     // cancel stream subscription on the listener to stop receiving the events
     stateChangeListener.cancel();
 ```
@@ -1153,7 +1232,7 @@ Channel attach and detach operations are asynchronous. After initiating an attac
 
 Ably SDKs will attempt to automatically recover from non-fatal error conditions. However, you can handle them yourself if you prefer by subscribing to channel state changes, or <span lang="default">using the callbacks available</span><span lang="java">waiting for a result</span> when explicitly calling "@attach()@":/api/realtime-sdk/channels#attach.
 
-```[jsall]
+```[realtime_javascript]
 realtime.channels.get('private:chatroom').attach(function(err) {
   if (err) {
     console.error('Attach failed: ' + err);
@@ -1161,14 +1240,22 @@ realtime.channels.get('private:chatroom').attach(function(err) {
 });
 ```
 
-```[ruby]
+```[realtime_nodejs]
+realtime.channels.get('private:chatroom').attach(function(err) {
+  if (err) {
+    console.error('Attach failed: ' + err);
+  }
+});
+```
+
+```[realtime_ruby]
 deferrable = realtime.channels.get('private:chatroom').attach
 deferrable.errback do |error|
   puts "Attach failed: #{error}"
 end
 ```
 
-```[java]
+```[realtime_java]
 Channel channel = realtime.channels.get("private:chatroom");
 channel.on(new ChannelStateListener() {
   @Override
@@ -1183,7 +1270,7 @@ channel.on(new ChannelStateListener() {
 channel.attach();
 ```
 
-```[csharp]
+```[realtime_csharp]
 IRealtimeChannel privateChannel = realtime.Channels.Get("private:chatroom");
 privateChannel.Attach((_, error) => {
     if (error != null)
@@ -1193,7 +1280,7 @@ privateChannel.Attach((_, error) => {
 });
 ```
 
-```[objc]
+```[realtime_objc]
 [[realtime.channels get:@"private:chatroom"] attach:^(ARTErrorInfo *error) {
     if (error) {
         NSLog(@"Attach failed: %@", error);
@@ -1201,7 +1288,7 @@ privateChannel.Attach((_, error) => {
 }];
 ```
 
-```[swift]
+```[realtime_swift]
 realtime.channels.get("private:chatroom").attach { error in
     if let error = error {
         print("Attach failed: \(error)")
@@ -1209,7 +1296,7 @@ realtime.channels.get("private:chatroom").attach { error in
 }
 ```
 
-```[flutter]
+```[realtime_flutter]
 Channel channel = realtime.channels.get('private:chatroom');
 channel.on().listen((ably.ChannelStateChange stateChange) {
   switch (stateChange.current) {

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -1,9 +1,7 @@
 ---
-title: Quickstart Guide
+title: Quickstart guide
 meta_description: "A quickstart guide to learn the basics of integrating the Ably realtime platform into your application."
 meta_keywords: "Ably, realtime, platform, quickstart, getting started, basics"
-section: root
-index: 10
 languages:
   - javascript
   - java
@@ -16,15 +14,6 @@ languages:
   - csharp
   - flutter
   - go
-jump_to:
-  Help with:
-    - Create an Ably account#step-0
-    - Add the Ably SDK#step-1
-    - Connect to Ably#step-2
-    - Subscribe to a channel#step-3
-    - Publish a message#step-4
-    - Close a connection#step-5
-    - Next steps#next-steps
 ---
 
 Welcome to Ably. This guide shows you how to integrate Ably's realtime platform into an application.
@@ -39,7 +28,7 @@ You'll learn how to:
 
 p(tip#terms). The terms used in the guide such as 'connection', 'channel', 'message', 'publish' and 'subscribe' are described in the "glossary":/glossary.
 
-Ably Client Library SDKs are available in multiple programming languages. Some SDKs have a realtime and a REST interface, while others only have a REST interface. The "SDK downloads":https://ably.com/download page lists availability. For further information on when it's best to use the realtime or REST SDK, see "the best practice guide":/best-practice-guide#choosing-between-realtime-rest-mqtt.
+Ably SDKs are available in multiple programming languages. Some SDKs have a realtime and a REST interface, while others only have a REST interface. The "SDK downloads":https://ably.com/download page lists availability. For further information on when it's best to use the realtime or REST interface, see "how to use Ably":/basics/use-ably.
 
 You're currently viewing the guide in <span lang="javascript">JavaScript</span><span lang="nodejs">Node.js</span><span lang="java">Java</span><span lang="ruby">Ruby</span><span lang="objc">Objective-C</span><span lang="python">Python</span><span lang="php">PHP</span><span lang="swift">Swift</span><span lang="csharp">C# .NET</span><span lang="flutter">Flutter</span><span lang="go">Go</span>. If you would like to view it in another language, use the selector above to change it.
 
@@ -59,7 +48,9 @@ blang[javascript].
 
   To get started with your project, reference the SDK within the @<head>@ of an HTML page:
 
-  bc[html]. <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
+  ```[html]
+  <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
+  ```
 
   The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
 
@@ -102,30 +93,42 @@ blang[python].
 
   To get started with your project, install the SDK:
 
-  bc[sh]. pip install ably
+  ```[sh]
+  pip install ably
+  ```
 
   Import the SDK with:
 
-  bc[python]. from ably import AblyRest
+  ```[python]
+  from ably import AblyRest
+  ```
 
   You will also need to install the @asyncio@ module:
 
-  bc[sh]. pip install asyncio
+  ```[sh]
+  pip install asyncio
+  ```
 
   Import the @asyncio@ module with:
 
-  bc[python]. import asyncio
+  ```[python]
+  import asyncio
+  ```
 
 blang[php].
   The Ably Client Library SDK is available as a composer package on "packagist":https://packagist.org/packages/ably/ably-php. Note that the PHP SDK only implements the REST interface.
 
   To get started with your project, install the SDK:
 
-  bc[sh]. composer require ably/ably-php --update-no-dev
+  ```[sh]
+  composer require ably/ably-php --update-no-dev
+  ```
 
   Include the composer's autoloader with:
 
-  bc[php]. require_once __DIR__ . '/vendor/autoload.php';
+  ```[php]
+  require_once __DIR__ . '/vendor/autoload.php';
+  ```
 
 blang[java].
   The Ably Client Library SDK is available on "GitHub":https://github.com/ably/ably-java and hosted on "Maven Central":https://mvnrepository.com/repos/central.
@@ -256,11 +259,13 @@ blang[go].
 
   Import the packages into your Go file:
 
-  bc[go]. import (
+  ```[go]
+  import (
       "context"
       "fmt"
       "github.com/ably/ably-go/ably"
   )
+  ```
 
 h2(#step-2). Connect to Ably
 
@@ -272,30 +277,22 @@ blang[python,php].
 
 *Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/auth/token should be used instead.
 
-bc[rest_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js REST
+```[javascript]
+// For the full code sample see here: https://github.com/ably/quickstart-js
 const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
+```
 
-bc[realtime_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js REALTIME
-let ably = new Ably.Realtime.Promise('{{API_KEY}}');
-await ably.connection.once('connected');
-console.log('Connected to Ably!');
-
-bc[realtime_nodejs]. // For the full code sample see here: https://github.com/ably/quickstart-js
+```[nodejs]
+// For the full code sample see here: https://github.com/ably/quickstart-js
 const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
+```
 
-bc[rest_nodejs]. // For the full code sample see here: https://github.com/ably/quickstart-js
-const ably = new Ably.Realtime.Promise('{{API_KEY}}');
-await ably.connection.once('connected');
-console.log('Connected to Ably!');
-
-
-
-
-bc[realtime_java]. ClientOptions options = new ClientOptions("{{API_KEY}}");
+```[java]
+ClientOptions options = new ClientOptions("{{API_KEY}}");
 AblyRealtime ably = new AblyRealtime(options);
 ably.connection.on(ConnectionState.connected, new ConnectionStateListener() {
   @Override
@@ -314,16 +311,19 @@ ably.connection.on(ConnectionState.connected, new ConnectionStateListener() {
     }
   }
 });
+```
 
-bc[realtime_ruby]. EventMachine.run do -
-  foo = bar
+```[ruby]
+EventMachine.run do
   ably = Ably::Realtime.new(key: '{{API_KEY}}')
   ably.connection.on(:connected) do
     puts "Connected to Ably!"
   end
 end
+```
 
-bc[realtime_swift]. let ably = ARTRealtime(key: "{{API_KEY}}")
+```[swift]
+let ably = ARTRealtime(key: "{{API_KEY}}")
 ably.connection.on { stateChange in
     let stateChange = stateChange
     switch stateChange.current {
@@ -335,19 +335,25 @@ ably.connection.on { stateChange in
         break
     }
 }
+```
 
-bc[realtime_csharp]. var ably = new AblyRealtime("{{API_KEY}}");
+```[csharp]
+var ably = new AblyRealtime("{{API_KEY}}");
 ably.Connection.On(ConnectionEvent.Connected, args =>
 {
   Console.Out.WriteLine("Connected to Ably!");
 });
+```
 
-bc[realtime_objc]. ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+```[objc]
+ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 [ably.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *stateChange) {
     NSLog(@"Connected to Ably!");
 }];
+```
 
-bc[realtime_flutter]. final clientOptions = ably.ClientOptions.fromKey('{{API_KEY}}');
+```[flutter]
+final clientOptions = ably.ClientOptions.fromKey('{{API_KEY}}');
 final realtime = ably.Realtime(options: clientOptions);
 realtime.connection
   .on(ably.ConnectionEvent.connected)
@@ -363,8 +369,10 @@ realtime.connection
         break;
     }
 });
+```
 
-bc[rest_go]. // Instantiate the Ably client. Calling ably.WithAutoConnect(false) is optional
+```[go]
+// Instantiate the Ably client. Calling ably.WithAutoConnect(false) is optional
 // but ensures that you don't miss state changes.
 client, err := ably.NewRealtime(ably.WithKey("{{API_KEY}}"), ably.WithAutoConnect(false))
 if err != nil {
@@ -374,6 +382,7 @@ client.Connection.OnAll(func(change ably.ConnectionStateChange) {
     fmt.Printf("Connection event: %s state=%s reason=%s\n", change.Event, change.Current, change.Reason)
 })
 client.Connect()
+```
 
 h2(#step-3). Subscribe to a channel
 
@@ -430,43 +439,56 @@ await channel.subscribe('greeting', (message) => {
   });
 ```
 
-bc[realtime_swift]. let channel = ably.channels.get("quickstart")
+```[swift]
+let channel = ably.channels.get("quickstart")
 channel.subscribe("greeting") { message in
     print("Received a greeting message in realtime:\(message.data as! String)")
 }
+```
 
-bc[realtime_csharp]. var channel = ably.Channels.Get("quickstart");
+```[csharp]
+var channel = ably.Channels.Get("quickstart");
 channel.Subscribe(message =>
 {
   Console.Out.WriteLine("Received a greeting message in realtime: {0}", message.Data);
 });
+```
 
-bc[objc]. ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
+```[objc]
+ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
 [channel subscribe:@"greeting" callback:^(ARTMessage *message) {
     NSLog(@"Received a greeting message in realtime: %@", message.data);
 }];
+```
 
-bc[flutter]. final channel = realtime.channels.get('quickstart');
+```[flutter]
+final channel = realtime.channels.get('quickstart');
 channel.subscribe().listen((message) {
       print('Received a greeting message in realtime: ${message.data}');
     }
   );
+```
 
-bc[go]. channel := client.Channels.Get("quickstart")
+```[go]
+channel := client.Channels.Get("quickstart")
 _, err = channel.Subscribe(context.Background(), "greeting", func(msg *ably.Message) {
     fmt.Printf("Received message : '%v'\n", msg.Data)
 })
 if err != nil {
     panic(err)
 }
+```
 
 h2(#step-4). Publish a message
 
 The following example code publishes a message to the @quickstart@ channel with the name @greeting@ and the contents @hello!@.
 
-bc[jsall]. await channel.publish('greeting', 'hello!');
+```[jsall]
+await channel.publish('greeting', 'hello!');
+```
 
-bc[realtime_java]. Channel channel = ably.channels.get("quickstart");
+```[java]
+Channel channel = ably.channels.get("quickstart");
 channel.publish("greeting", "hello", new CompletionListener() {
   @Override
   public void onSuccess() {
@@ -477,41 +499,55 @@ channel.publish("greeting", "hello", new CompletionListener() {
     System.out.println("Message not sent, error occurred: " + reason.message);
   }
 });
+```
 
-bc[rest_csharp]. var channel = ably.Channels.Get("quickstart");
+```[csharp]
+var channel = ably.Channels.Get("quickstart");
 channel.Publish("greeting", "hello!");
+```
 
-bc[realtime_csharp]. var channel = ably.Channels.Get("quickstart");
-channel.Publish("greeting", "hello!");
-
-bc[rest_python]. async def main():
+```[python]
+async def main():
   ably = AblyRest('{{API_KEY}}')
   channel = ably.channels.get('quickstart')
   await channel.publish(u'greeting', u'hello!')
   # other code such as publish, close
 asyncio.run(main())
+```
 
-bc[realtime_ruby]. channel = ably.channels.get('quickstart')
+```[ruby]
+channel = ably.channels.get('quickstart')
 channel.publish 'greeting', 'hello!'
+```
 
-bc[rest_php]. $client = new Ably\AblyRest('{{API_KEY}}');
+```[php]
+$client = new Ably\AblyRest('{{API_KEY}}');
 $channel = $client->channels->get('quickstart');
 $channel->publish('greeting', 'hello!');
+```
 
-bc[realtime_swift]. let channel = ably.channels.get("quickstart")
+```[swift]
+let channel = ably.channels.get("quickstart")
 channel.publish("greeting", data: "hello!")
+```
 
-bc[realtime_objc]. ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
+```[objc]
+ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
 [channel publish:@"greeting" data:@"hello!"];
+```
 
-bc[realtime_flutter]. final channel = realtime.channels.get('quickstart');
+```[flutter]
+final channel = realtime.channels.get('quickstart');
 await channel.publish(name: 'greeting', data: 'hello!');
+```
 
-bc[realtime_go]. channel := client.Channels.Get("quickstart")
+```[go]
+channel := client.Channels.Get("quickstart")
 err = channel.Publish(context.Background(), "greeting", "hello!")
 if err != nil {
     panic(err)
 }
+```
 
 h3(#rest-api). Publish with the REST API
 
@@ -519,9 +555,11 @@ It's possible to interact directly with the "HTTP REST API":/rest-api even thoug
 
 Copy the following @curl@ code sample into your terminal to publish a message and view the response in your browser.
 
-bc[sh]. curl https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/publish \
+```[sh]
+curl https://rest.ably.io/channels/{{RANDOM_CHANNEL_NAME}}/publish \
   --user "{{API_KEY}}" \
   --data "name=greeting&data=Hello"
+```
 
 h2(#step-5). Close a connection to Ably
 
@@ -533,13 +571,18 @@ blang[default,javascript].
 blang[php].
   The <span lang="php">PHP</span> SDK is only available with a REST interface. You will need to use one of the realtime libraries to create or manage a connection to Ably. Use the language selector above to select a language with realtime support.
 
-bc[javascript]. ably.close(); // runs synchronously
+```[javascript]
+ably.close(); // runs synchronously
 console.log('Closed the connection to Ably.');
+```
 
-bc[nodejs]. ably.close(); // runs synchronously
+```[nodejs]
+ably.close(); // runs synchronously
 console.log('Closed the connection to Ably.');
+```
 
-bc[java]. ably.connection.close();
+```[java]
+ably.connection.close();
 ably.connection.on(ConnectionState.closed, new ConnectionStateListener() {
   @Override
   public void onConnectionStateChanged(ConnectionStateChange state) {
@@ -557,16 +600,22 @@ ably.connection.on(ConnectionState.closed, new ConnectionStateListener() {
     }
   }
 });
+```
 
-bc[python]. await ably.close()
+```[python]
+await ably.close()
 print('Closed the connection to Ably.')
+```
 
-bc[ruby]. ably.connection.close
+```[ruby]
+ably.connection.close
 ably.connection.on(:closed) do
   puts "Closed the connection to Ably!"
 end
+```
 
-bc[swift]. ably.connection.close()
+```[swift]
+ably.connection.close()
 ably.connection.on { stateChange in
     let stateChange = stateChange
     switch stateChange.current {
@@ -578,19 +627,25 @@ ably.connection.on { stateChange in
         break
     }
 }
+```
 
-bc[csharp]. ably.Connection.Close();
+```[csharp]
+ably.Connection.Close();
 ably.Connection.On(ConnectionEvent.Closed, args =>
 {
   Console.Out.WriteLine("Closed the connection to Ably.");
 });
+```
 
-bc[objc]. [ably.connection close];
+```[objc]
+[ably.connection close];
 [ably.connection on:ARTRealtimeConnectionEventClosed callback:^(ARTConnectionStateChange *stateChange) {
     NSLog(@"Closed the connection to Ably.");
 }];
+```
 
-bc[flutter]. realtime.connection.close();
+```[flutter]
+realtime.connection.close();
 realtime.connection
   .on(ably.ConnectionEvent.closed)
   .listen((ably.ConnectionStateChange stateChange) async {
@@ -605,19 +660,20 @@ realtime.connection
         break;
     }
 });
+```
 
-bc[go]. client.Connection.On(ably.ConnectionEventClosed, func(change ably.ConnectionStateChange) {
+```[go]
+client.Connection.On(ably.ConnectionEventClosed, func(change ably.ConnectionStateChange) {
     fmt.Println("Closed the connection to Ably.")
 })
 client.Close()
+```
 
 h2(#next-steps). Next steps
 
 This guide introduced the basic concepts of Ably and illustrated how easy it is to build applications with it. The next steps are to:
 
-* Read more about the "key concepts":/key-concepts.
-* Find out more about the "Realtime Client Library SDK":/realtime.
-* Find out more about the "REST Client Library SDK":/rest.
+* Read more about "Ably":/basics/ably.
+* Find out more about the "SDKs":/getting-started/sdks.
 * Try out some "tutorials":/tutorials.
 * Provision Ably apps using the "Control API":/control-api.
-

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -364,7 +364,7 @@ realtime.connection
     }
 });
 
-bc[go]. // Instantiate the Ably client. Calling ably.WithAutoConnect(false) is optional
+bc[rest_go]. // Instantiate the Ably client. Calling ably.WithAutoConnect(false) is optional
 // but ensures that you don't miss state changes.
 client, err := ably.NewRealtime(ably.WithKey("{{API_KEY}}"), ably.WithAutoConnect(false))
 if err != nil {

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -430,12 +430,12 @@ await channel.subscribe('greeting', (message) => {
   });
 ```
 
-bc[swift]. let channel = ably.channels.get("quickstart")
+bc[realtime_swift]. let channel = ably.channels.get("quickstart")
 channel.subscribe("greeting") { message in
     print("Received a greeting message in realtime:\(message.data as! String)")
 }
 
-bc[csharp]. var channel = ably.Channels.Get("quickstart");
+bc[realtime_csharp]. var channel = ably.Channels.Get("quickstart");
 channel.Subscribe(message =>
 {
   Console.Out.WriteLine("Received a greeting message in realtime: {0}", message.Data);

--- a/content/root/quick-start-guide.textile
+++ b/content/root/quick-start-guide.textile
@@ -272,12 +272,12 @@ blang[python,php].
 
 *Note*: The connection example uses basic authentication to pass the API key from the application to Ably. Basic authentication should not be used client-side in a production environment, such as in a browser, to avoid exposing the API key. "Token authentication":/auth/token should be used instead.
 
-bc[rest_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js
+bc[rest_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js REST
 const ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
 
-bc[realtime_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js
+bc[realtime_javascript]. // For the full code sample see here: https://github.com/ably/quickstart-js REALTIME
 let ably = new Ably.Realtime.Promise('{{API_KEY}}');
 await ably.connection.once('connected');
 console.log('Connected to Ably!');
@@ -295,7 +295,7 @@ console.log('Connected to Ably!');
 
 
 
-bc[java]. ClientOptions options = new ClientOptions("{{API_KEY}}");
+bc[realtime_java]. ClientOptions options = new ClientOptions("{{API_KEY}}");
 AblyRealtime ably = new AblyRealtime(options);
 ably.connection.on(ConnectionState.connected, new ConnectionStateListener() {
   @Override
@@ -323,7 +323,7 @@ bc[realtime_ruby]. EventMachine.run do -
   end
 end
 
-bc[swift]. let ably = ARTRealtime(key: "{{API_KEY}}")
+bc[realtime_swift]. let ably = ARTRealtime(key: "{{API_KEY}}")
 ably.connection.on { stateChange in
     let stateChange = stateChange
     switch stateChange.current {
@@ -336,18 +336,18 @@ ably.connection.on { stateChange in
     }
 }
 
-bc[csharp]. var ably = new AblyRealtime("{{API_KEY}}");
+bc[realtime_csharp]. var ably = new AblyRealtime("{{API_KEY}}");
 ably.Connection.On(ConnectionEvent.Connected, args =>
 {
   Console.Out.WriteLine("Connected to Ably!");
 });
 
-bc[objc]. ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
+bc[realtime_objc]. ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 [ably.connection on:ARTRealtimeConnectionEventConnected callback:^(ARTConnectionStateChange *stateChange) {
     NSLog(@"Connected to Ably!");
 }];
 
-bc[flutter]. final clientOptions = ably.ClientOptions.fromKey('{{API_KEY}}');
+bc[realtime_flutter]. final clientOptions = ably.ClientOptions.fromKey('{{API_KEY}}');
 final realtime = ably.Realtime(options: clientOptions);
 realtime.connection
   .on(ably.ConnectionEvent.connected)
@@ -466,7 +466,7 @@ The following example code publishes a message to the @quickstart@ channel with 
 
 bc[jsall]. await channel.publish('greeting', 'hello!');
 
-bc[java]. Channel channel = ably.channels.get("quickstart");
+bc[realtime_java]. Channel channel = ably.channels.get("quickstart");
 channel.publish("greeting", "hello", new CompletionListener() {
   @Override
   public void onSuccess() {
@@ -478,33 +478,36 @@ channel.publish("greeting", "hello", new CompletionListener() {
   }
 });
 
-bc[csharp]. var channel = ably.Channels.Get("quickstart");
+bc[rest_csharp]. var channel = ably.Channels.Get("quickstart");
 channel.Publish("greeting", "hello!");
 
-bc[python]. async def main():
+bc[realtime_csharp]. var channel = ably.Channels.Get("quickstart");
+channel.Publish("greeting", "hello!");
+
+bc[rest_python]. async def main():
   ably = AblyRest('{{API_KEY}}')
   channel = ably.channels.get('quickstart')
   await channel.publish(u'greeting', u'hello!')
   # other code such as publish, close
 asyncio.run(main())
 
-bc[ruby]. channel = ably.channels.get('quickstart')
+bc[realtime_ruby]. channel = ably.channels.get('quickstart')
 channel.publish 'greeting', 'hello!'
 
-bc[php]. $client = new Ably\AblyRest('{{API_KEY}}');
+bc[rest_php]. $client = new Ably\AblyRest('{{API_KEY}}');
 $channel = $client->channels->get('quickstart');
 $channel->publish('greeting', 'hello!');
 
-bc[swift]. let channel = ably.channels.get("quickstart")
+bc[realtime_swift]. let channel = ably.channels.get("quickstart")
 channel.publish("greeting", data: "hello!")
 
-bc[objc]. ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
+bc[realtime_objc]. ARTRealtimeChannel *channel = [ably.channels get:@"quickstart"];
 [channel publish:@"greeting" data:@"hello!"];
 
-bc[flutter]. final channel = realtime.channels.get('quickstart');
+bc[realtime_flutter]. final channel = realtime.channels.get('quickstart');
 await channel.publish(name: 'greeting', data: 'hello!');
 
-bc[go]. channel := client.Channels.Get("quickstart")
+bc[realtime_go]. channel := client.Channels.Get("quickstart")
 err = channel.Publish(context.Background(), "greeting", "hello!")
 if err != nil {
     panic(err)

--- a/data/createPages/constants.ts
+++ b/data/createPages/constants.ts
@@ -1,7 +1,10 @@
 export const DEFAULT_LANGUAGE = 'default';
 export const DEFAULT_PREFERRED_LANGUAGE = 'javascript';
-export const DEFAULT_PREFERRED_INTERFACE = 'realtime';
-export const SDK_INTERFACES = ['realtime', 'rest'];
+
+export const REALTIME_SDK_INTERFACE = 'realtime';
+export const REST_SDK_INTERFACE = 'rest';
+export const DEFAULT_PREFERRED_INTERFACE = REALTIME_SDK_INTERFACE;
+export const SDK_INTERFACES = [REALTIME_SDK_INTERFACE, REST_SDK_INTERFACE];
 const TEXT_LANGUAGE = 'text';
 const HYPERTEXT_LANGUAGE = 'html';
 const YETANOTHERMARKUP_LANGUAGE = 'yaml';

--- a/src/components/LanguageButton/LanguageButton.test.tsx
+++ b/src/components/LanguageButton/LanguageButton.test.tsx
@@ -9,7 +9,7 @@ import { safeWindow } from 'src/utilities';
 
 describe(`<LanguageButton />`, () => {
   it('renders default state button', () => {
-    render(<LanguageButton language="javascript" />);
+    render(<LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" />);
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
       <button
         class="button"
@@ -21,7 +21,7 @@ describe(`<LanguageButton />`, () => {
   it('renders active state button', () => {
     render(
       <PageLanguageContext.Provider value="javascript">
-        <LanguageButton language="javascript" />
+        <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" />
       </PageLanguageContext.Provider>,
     );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
@@ -36,7 +36,7 @@ describe(`<LanguageButton />`, () => {
   it('changes localstorage value on click', async () => {
     render(
       <PageLanguageContext.Provider value="python">
-        <LanguageButton language="javascript" />
+        <LanguageButton selectedSDKInterfaceTab="realtime" language="javascript" />
       </PageLanguageContext.Provider>,
     );
 

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -7,7 +7,7 @@ import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
 import { button, isActive } from '../Menu/MenuItemButton/MenuItemButton.module.css';
 
-const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, selectedSDKInterfaceTab }) => {
+const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language }) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedLanguage = getFilteredLanguages(language);
   const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(
@@ -20,25 +20,16 @@ const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, select
     cacheVisitPreferredLanguage(isPageLanguageDefault, selectedLanguage, href);
   };
 
-  const filterLanguage = languageSDKInterfaceClean(language, selectedSDKInterfaceTab);
-
   return (
-    <>
-      {filterLanguage != '' ? (
-        <button
-          className={cn(button, {
-            [isActive]: isLanguageActive,
-          })}
-          onClick={handleClick}
-        >
-          {languageLabels[filterLanguage] ?? filterLanguage}
-        </button>
-      ) : null}
-    </>
+    <button
+      className={cn(button, {
+        [isActive]: isLanguageActive,
+      })}
+      onClick={handleClick}
+    >
+      {languageLabels[language] ?? language}
+    </button>
   );
 };
 
 export default LanguageButton;
-
-export const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
-  language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -6,15 +6,8 @@ import languageLabels from 'src/maps/language';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
 import { button, isActive } from '../Menu/MenuItemButton/MenuItemButton.module.css';
-import { DEFAULT_PREFERRED_INTERFACE } from '../../../data/createPages/constants';
 
-const LanguageButton: FC<LanguageNavigationComponentProps> = ({
-  language,
-  sdkInterface = DEFAULT_PREFERRED_INTERFACE,
-  isSDK = false,
-  isEnabled = true,
-  isSDKSelected = false,
-}) => {
+const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, selectedSDKInterfaceTab }) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedLanguage = getFilteredLanguages(language);
   const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(
@@ -23,34 +16,29 @@ const LanguageButton: FC<LanguageNavigationComponentProps> = ({
   );
 
   const handleClick = () => {
-    const href = createLanguageHrefFromDefaults(
-      isPageLanguageDefault,
-      isLanguageDefault,
-      selectedLanguage,
-      sdkInterface,
-    );
-    cacheVisitPreferredLanguage(isPageLanguageDefault, selectedLanguage, href, sdkInterface);
+    const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, selectedLanguage);
+    cacheVisitPreferredLanguage(isPageLanguageDefault, selectedLanguage, href);
   };
 
-  return isSDK ? (
-    <button
-      className={`font-medium font-sans  focus:outline-none px-24  ${isSDKSelected ? 'bg-charcoal-grey' : ''}
-      ${isEnabled ? 'text-mid-grey' : 'text-disabled-tab-button cursor-default'}
-      `}
-      onClick={isEnabled ? handleClick : () => null}
-    >
-      {languageLabels[sdkInterface] ?? sdkInterface}
-    </button>
-  ) : (
-    <button
-      className={cn(button, {
-        [isActive]: isLanguageActive,
-      })}
-      onClick={handleClick}
-    >
-      {languageLabels[language] ?? language}
-    </button>
+  const filterLanguage = languageSDKInterfaceClean(language, selectedSDKInterfaceTab);
+
+  return (
+    <>
+      {filterLanguage != '' ? (
+        <button
+          className={cn(button, {
+            [isActive]: isLanguageActive,
+          })}
+          onClick={handleClick}
+        >
+          {languageLabels[filterLanguage] ?? filterLanguage}
+        </button>
+      ) : null}
+    </>
   );
 };
 
 export default LanguageButton;
+
+export const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
+  language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;

--- a/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
+++ b/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
@@ -5,7 +5,6 @@ import { longLanguageLabels } from '../../../maps/language';
 import { ReactSelectOption } from 'src/components';
 import { PREFERRED_LANGUAGE_KEY } from '../../../utilities/language/constants';
 import { createLanguageHrefFromDefaults, getLanguageDefaults } from '../../common/language-defaults';
-import { getSDKInterface } from 'src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay';
 
 import { navigate } from 'gatsby';
 import {
@@ -71,13 +70,7 @@ export const LanguageDropdownSelector = ({
       onChange={(newValue) => {
         const newLanguage = newValue?.value ?? DEFAULT_LANGUAGE;
         const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(newLanguage, language);
-        const selectedSDKInterface = getSDKInterface();
-        const href = createLanguageHrefFromDefaults(
-          isPageLanguageDefault,
-          isLanguageDefault,
-          newLanguage,
-          selectedSDKInterface,
-        );
+        const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, newLanguage);
         if (isPageLanguageDefault) {
           safeWindow.localStorage.clear();
         } else {

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent as FC, useContext, useState } from 'react';
+import React, { Dispatch, FunctionComponent as FC, SetStateAction, useContext, useState } from 'react';
 import { SingleValue } from 'react-select';
 import {
   createLanguageHrefFromDefaults,
@@ -39,6 +39,8 @@ export interface LanguageNavigationProps {
   onSelect?: (newValue: SingleValue<ReactSelectOption>) => void;
   SDKSelected?: string;
   allListOfLanguages?: string[];
+  selectedSDKInterfaceTab: string;
+  setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }
 
 const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<ReactSelectOption>) => {
@@ -60,6 +62,8 @@ const LanguageNavigation = ({
   selectedLanguage,
   onSelect,
   allListOfLanguages,
+  selectedSDKInterfaceTab,
+  setSelectedSDKInterfaceTab,
 }: LanguageNavigationProps) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedPageLanguage = pageLanguage === DEFAULT_LANGUAGE ? DEFAULT_PREFERRED_LANGUAGE : pageLanguage;
@@ -72,8 +76,6 @@ const LanguageNavigation = ({
 
   // const realtimeCode = getLanguageItemsIfHasSDKInte  rface(items, 'realtime');
   // const restCode = getLanguageItemsIfHasSDKInterface(items, 'rest');
-
-  const [selectedSDKInterfaceTab, setSelectedSDKInterfaceTab] = useState(DEFAULT_PREFERRED_INTERFACE);
 
   const isSDKInterFacePresent = allListOfLanguages
     ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -36,6 +36,7 @@ export interface LanguageNavigationProps {
   allListOfLanguages?: string[];
   selectedSDKInterfaceTab: string;
   setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
+  setPreviousSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }
 
 const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<ReactSelectOption>) => {
@@ -59,6 +60,7 @@ const LanguageNavigation = ({
   allListOfLanguages,
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
+  setPreviousSDKInterfaceTab,
 }: LanguageNavigationProps) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedPageLanguage = pageLanguage === DEFAULT_LANGUAGE ? DEFAULT_PREFERRED_LANGUAGE : pageLanguage;
@@ -88,6 +90,7 @@ const LanguageNavigation = ({
           selectedSDKInterfaceTab={selectedSDKInterfaceTab}
           setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
           sdkInterfaceAvailable={sdkInterfaceAvailable}
+          setPreviousSDKInterfaceTab={setPreviousSDKInterfaceTab}
         />
       ) : null}
 

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -1,6 +1,5 @@
-import React, { FunctionComponent as FC, useCallback, useContext, useState } from 'react';
+import React, { FunctionComponent as FC, useContext, useState } from 'react';
 import { SingleValue } from 'react-select';
-
 import {
   createLanguageHrefFromDefaults,
   getFilteredLanguages,
@@ -17,11 +16,8 @@ import {
   SDK_INTERFACES,
 } from '../../../../data/createPages/constants';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
-
 import { dropdownContainer, horizontalNav } from './LanguageNavigation.module.css';
-import LanguageButton from '../../LanguageButton/LanguageButton';
-import Icon from '@ably/ui/core/Icon';
-import { getSDKInterface } from '../../blocks/wrappers/ConditionalChildrenLanguageDisplay';
+import SDKInterfacePanel from '../../SDKInterfacePanel/SDKInterfacePanel';
 
 export interface LanguageNavigationComponentProps {
   language: string;
@@ -29,9 +25,7 @@ export interface LanguageNavigationComponentProps {
   onClick?: (event: { target: { value: string } }) => void;
   value?: string;
   isSelected?: boolean;
-  isSDK?: boolean;
-  isEnabled?: boolean;
-  isSDKSelected?: boolean;
+  selectedSDKInterfaceTab: string;
 }
 
 export interface LanguageNavigationProps {
@@ -44,74 +38,29 @@ export interface LanguageNavigationProps {
   selectedLanguage?: string;
   onSelect?: (newValue: SingleValue<ReactSelectOption>) => void;
   SDKSelected?: string;
+  allListOfLanguages?: string[];
 }
 
-const changePageOnSelect =
-  (pageLanguage: string, sdkInterface: string) => (newValue: SingleValue<ReactSelectOption>) => {
-    if (newValue) {
-      const language = newValue.value;
-      const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
-        getFilteredLanguages(language),
-        pageLanguage,
-      );
-      const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language, sdkInterface);
-      cacheVisitPreferredLanguage(isPageLanguageDefault, language, href, sdkInterface);
-    }
-  };
+const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<ReactSelectOption>) => {
+  if (newValue) {
+    const language = newValue.value;
+    const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
+      getFilteredLanguages(language),
+      pageLanguage,
+    );
 
-const SDKToolTip = ({ tooltip }: { tooltip: string }) => {
-  const [tooltipHover, setTooltipHover] = useState(false);
-  const showTooltipHover = useCallback(() => setTooltipHover(true), []);
-  const hideTooltipHover = useCallback(() => setTooltipHover(false), []);
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-label={tooltip}
-      className="flex flex-row w-full justify-start mt-2"
-      onMouseOver={showTooltipHover}
-      onMouseOut={hideTooltipHover}
-    >
-      <Icon name="icon-gui-info" size="1.25rem" color="mid-grey" additionalCSS="mt-12 ml-16" />
-      {tooltipHover ? (
-        <aside
-          className="w-240 max-w-240 absolute box-border
-          whitespace-pre-wrap bg-white shadow-tooltip rounded border border-light-grey
-          text-cool-black font-sans p-16 text-center text-p3 leading-5 cursor-default -ml-160 -mt-88"
-        >
-          {tooltip}
-        </aside>
-      ) : null}
-    </div>
-  );
-};
-
-const SDKNavigation = ({ selectedLanguage, SDKSelected }: LanguageNavigationProps) => {
-  let sdkSelectedTab = '';
-  if (SDKSelected != null) {
-    sdkSelectedTab = SDK_INTERFACES.includes(SDKSelected) ? SDKSelected : DEFAULT_PREFERRED_INTERFACE;
+    const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language);
+    cacheVisitPreferredLanguage(isPageLanguageDefault, language, href);
   }
-
-  return (
-    <div className="bg-dark-grey border-charcoal-grey text-white border-b-4 flex justify-end">
-      <menu data-testid="menuSDK" className="flex md:overflow-x-auto pl-0 justify-end md:justify-start h-48 mr-16 my-0">
-        {SDK_INTERFACES.map((sdkInterface) => (
-          <LanguageButton
-            key={sdkInterface}
-            language={selectedLanguage || DEFAULT_PREFERRED_LANGUAGE}
-            sdkInterface={sdkInterface || DEFAULT_PREFERRED_INTERFACE}
-            isSDK={true}
-            isSDKSelected={sdkSelectedTab === sdkInterface}
-            // isEnabled={sdkTabsActive?.includes(sdkInterface)}
-          />
-        ))}
-        <SDKToolTip tooltip="Tooltips display informative text when users hover over, focus on, or tap an element." />
-      </menu>
-    </div>
-  );
 };
 
-const LanguageNavigation = ({ items, localChangeOnly, selectedLanguage, onSelect }: LanguageNavigationProps) => {
+const LanguageNavigation = ({
+  items,
+  localChangeOnly,
+  selectedLanguage,
+  onSelect,
+  allListOfLanguages,
+}: LanguageNavigationProps) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedPageLanguage = pageLanguage === DEFAULT_LANGUAGE ? DEFAULT_PREFERRED_LANGUAGE : pageLanguage;
   const actualSelectedLanguage = localChangeOnly ? selectedLanguage : selectedPageLanguage;
@@ -119,22 +68,23 @@ const LanguageNavigation = ({ items, localChangeOnly, selectedLanguage, onSelect
   const value = options.find((option) => option.value === actualSelectedLanguage);
 
   const shouldUseLocalChanges = localChangeOnly && !!onSelect;
-  const onSelectChange = shouldUseLocalChanges
-    ? onSelect
-    : changePageOnSelect(pageLanguage, DEFAULT_PREFERRED_INTERFACE);
-  const selectedSDK = getSDKInterface();
-  const realtimeCode = getLanguageItemsIfHasSDKInterface(items, 'realtime');
-  const restCode = getLanguageItemsIfHasSDKInterface(items, 'rest');
+  const onSelectChange = shouldUseLocalChanges ? onSelect : changePageOnSelect(pageLanguage);
+
+  // const realtimeCode = getLanguageItemsIfHasSDKInte  rface(items, 'realtime');
+  // const restCode = getLanguageItemsIfHasSDKInterface(items, 'rest');
+
+  const [selectedSDKInterfaceTab, setSelectedSDKInterfaceTab] = useState(DEFAULT_PREFERRED_INTERFACE);
+
+  const isSDKInterFacePresent = allListOfLanguages
+    ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)
+    : [false];
 
   return (
     <>
-      {realtimeCode.includes(true) || restCode.includes(true) ? (
-        <SDKNavigation
-          items={items}
-          localChangeOnly={localChangeOnly}
-          selectedLanguage={selectedLanguage}
-          onSelect={onSelect}
-          SDKSelected={selectedSDK}
+      {isSDKInterFacePresent.includes(true) ? (
+        <SDKInterfacePanel
+          selectedSDKInterfaceTab={selectedSDKInterfaceTab}
+          setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
         />
       ) : null}
 
@@ -142,7 +92,7 @@ const LanguageNavigation = ({ items, localChangeOnly, selectedLanguage, onSelect
         <div className="border-b border-charcoal-grey w-full">
           <menu data-testid="menu" className={horizontalNav}>
             {items.map(({ Component, props, content }, index) => (
-              <Component {...props} key={index}>
+              <Component {...props} selectedSDKInterfaceTab={selectedSDKInterfaceTab} key={index}>
                 {content}
               </Component>
             ))}
@@ -158,11 +108,14 @@ const LanguageNavigation = ({ items, localChangeOnly, selectedLanguage, onSelect
 
 export default LanguageNavigation;
 
-const getLanguageItemsIfHasSDKInterface = (
-  items: {
-    Component: FC<LanguageNavigationComponentProps>;
-    props: LanguageNavigationComponentProps;
-    content: string;
-  }[],
-  sdkInterface: string,
-) => items.map((languageItem) => languageItem.props.language.includes(sdkInterface));
+// const getLanguageItemsIfHasSDKInterface = (
+//   items: {
+//     Component: FC<LanguageNavigationComponentProps>;
+//     props: LanguageNavigationComponentProps;
+//     content: string;
+//   }[],
+//   sdkInterface: string,
+// ) => items.map((languageItem) => languageItem.props.language.includes(sdkInterface));
+
+const checkIfLanguageHasSDKInterface = (allLanguage: string[], sdkInterfaces: string[]) =>
+  allLanguage.map((language) => sdkInterfaces.includes(language.includes('_') ? language.split('_', 2)[0] : ''));

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -9,12 +9,7 @@ import {
 } from 'src/components';
 import { PageLanguageContext } from 'src/contexts';
 
-import {
-  DEFAULT_LANGUAGE,
-  DEFAULT_PREFERRED_LANGUAGE,
-  DEFAULT_PREFERRED_INTERFACE,
-  SDK_INTERFACES,
-} from '../../../../data/createPages/constants';
+import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE, SDK_INTERFACES } from '../../../../data/createPages/constants';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { dropdownContainer, horizontalNav } from './LanguageNavigation.module.css';
 import SDKInterfacePanel from '../../SDKInterfacePanel/SDKInterfacePanel';
@@ -25,7 +20,6 @@ export interface LanguageNavigationComponentProps {
   onClick?: (event: { target: { value: string } }) => void;
   value?: string;
   isSelected?: boolean;
-  selectedSDKInterfaceTab: string;
 }
 
 export interface LanguageNavigationProps {
@@ -74,12 +68,18 @@ const LanguageNavigation = ({
   const shouldUseLocalChanges = localChangeOnly && !!onSelect;
   const onSelectChange = shouldUseLocalChanges ? onSelect : changePageOnSelect(pageLanguage);
 
-  // const realtimeCode = getLanguageItemsIfHasSDKInte  rface(items, 'realtime');
-  // const restCode = getLanguageItemsIfHasSDKInterface(items, 'rest');
-
   const isSDKInterFacePresent = allListOfLanguages
     ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)
     : [false];
+  const sdkInterfaceAvailable = [];
+  if (isSDKInterFacePresent && allListOfLanguages) {
+    if (isLanguageSDKInterfaceIsAvailable(allListOfLanguages, 'realtime')) {
+      sdkInterfaceAvailable.push('realtime');
+    }
+    if (isLanguageSDKInterfaceIsAvailable(allListOfLanguages, 'rest')) {
+      sdkInterfaceAvailable.push('rest');
+    }
+  }
 
   return (
     <>
@@ -87,6 +87,7 @@ const LanguageNavigation = ({
         <SDKInterfacePanel
           selectedSDKInterfaceTab={selectedSDKInterfaceTab}
           setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
+          sdkInterfaceAvailable={sdkInterfaceAvailable}
         />
       ) : null}
 
@@ -94,7 +95,7 @@ const LanguageNavigation = ({
         <div className="border-b border-charcoal-grey w-full">
           <menu data-testid="menu" className={horizontalNav}>
             {items.map(({ Component, props, content }, index) => (
-              <Component {...props} selectedSDKInterfaceTab={selectedSDKInterfaceTab} key={index}>
+              <Component {...props} key={index}>
                 {content}
               </Component>
             ))}
@@ -110,14 +111,8 @@ const LanguageNavigation = ({
 
 export default LanguageNavigation;
 
-// const getLanguageItemsIfHasSDKInterface = (
-//   items: {
-//     Component: FC<LanguageNavigationComponentProps>;
-//     props: LanguageNavigationComponentProps;
-//     content: string;
-//   }[],
-//   sdkInterface: string,
-// ) => items.map((languageItem) => languageItem.props.language.includes(sdkInterface));
-
 const checkIfLanguageHasSDKInterface = (allLanguage: string[], sdkInterfaces: string[]) =>
   allLanguage.map((language) => sdkInterfaces.includes(language.includes('_') ? language.split('_', 2)[0] : ''));
+
+const isLanguageSDKInterfaceIsAvailable = (allLanguage: string[], sdkInterface: string) =>
+  allLanguage.map((language) => language.includes(`${sdkInterface}_`)).includes(true);

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -20,6 +20,7 @@ export interface LanguageNavigationComponentProps {
   onClick?: (event: { target: { value: string } }) => void;
   value?: string;
   isSelected?: boolean;
+  selectedSDKInterfaceTab: string;
 }
 
 export interface LanguageNavigationProps {
@@ -71,16 +72,15 @@ const LanguageNavigation = ({
   const isSDKInterFacePresent = allListOfLanguages
     ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)
     : [false];
-  const sdkInterfaceAvailable = [];
+  const sdkInterfaceAvailable: string[] = [];
   if (isSDKInterFacePresent && allListOfLanguages) {
-    if (isLanguageSDKInterfaceIsAvailable(allListOfLanguages, 'realtime')) {
-      sdkInterfaceAvailable.push('realtime');
-    }
-    if (isLanguageSDKInterfaceIsAvailable(allListOfLanguages, 'rest')) {
-      sdkInterfaceAvailable.push('rest');
-    }
+    // pass all languages for both realtime and rest
+    SDK_INTERFACES.map((sdkInterface) => {
+      if (isLanguageSDKInterfaceIsAvailable(allListOfLanguages, sdkInterface)) {
+        sdkInterfaceAvailable.push(sdkInterface);
+      }
+    });
   }
-
   return (
     <>
       {isSDKInterFacePresent.includes(true) ? (

--- a/src/components/Menu/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItemButton/MenuItemButton.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent as FC, HTMLAttributes } from 'react';
 import cn from 'classnames';
 import { button, isActive } from './MenuItemButton.module.css';
-import { languageSDKInterfaceClean } from '../../LanguageButton/LanguageButton';
 
 type Props = {
   isSelected?: boolean;
@@ -9,23 +8,13 @@ type Props = {
   language: string;
 } & HTMLAttributes<HTMLButtonElement>;
 
-const MenuItemButton: FC<Props> = ({ isSelected = false, selectedSDKInterfaceTab, ...props }) => {
-  let filterLanguage = props.language;
-  if (selectedSDKInterfaceTab) {
-    filterLanguage = props ? languageSDKInterfaceClean(props.language, selectedSDKInterfaceTab) : '';
-    props = { ...props, language: filterLanguage };
-  }
-  return (
-    <>
-      {filterLanguage != '' ? (
-        <button
-          className={cn(button, {
-            [isActive]: isSelected,
-          })}
-          {...props}
-        />
-      ) : null}
-    </>
-  );
-};
+const MenuItemButton: FC<Props> = ({ isSelected = false, ...props }) => (
+  <button
+    className={cn(button, {
+      [isActive]: isSelected,
+    })}
+    {...props}
+  />
+);
+
 export default MenuItemButton;

--- a/src/components/Menu/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItemButton/MenuItemButton.tsx
@@ -1,18 +1,31 @@
 import React, { FunctionComponent as FC, HTMLAttributes } from 'react';
 import cn from 'classnames';
 import { button, isActive } from './MenuItemButton.module.css';
+import { languageSDKInterfaceClean } from '../../LanguageButton/LanguageButton';
 
 type Props = {
   isSelected?: boolean;
+  selectedSDKInterfaceTab: string;
+  language: string;
 } & HTMLAttributes<HTMLButtonElement>;
 
-const MenuItemButton: FC<Props> = ({ isSelected = false, ...props }) => (
-  <button
-    className={cn(button, {
-      [isActive]: isSelected,
-    })}
-    {...props}
-  />
-);
-
+const MenuItemButton: FC<Props> = ({ isSelected = false, selectedSDKInterfaceTab, ...props }) => {
+  let filterLanguage = props.language;
+  if (selectedSDKInterfaceTab) {
+    filterLanguage = props ? languageSDKInterfaceClean(props.language, selectedSDKInterfaceTab) : '';
+    props = { ...props, language: filterLanguage };
+  }
+  return (
+    <>
+      {filterLanguage != '' ? (
+        <button
+          className={cn(button, {
+            [isActive]: isSelected,
+          })}
+          {...props}
+        />
+      ) : null}
+    </>
+  );
+};
 export default MenuItemButton;

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -33,24 +33,25 @@ const SDKToolTip = ({ tooltip }: { tooltip: string }) => {
 const SDKInterfacePanel = ({
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
+  sdkInterfaceAvailable = SDK_INTERFACES,
 }: {
   selectedSDKInterfaceTab: string;
   setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
+  sdkInterfaceAvailable: string[];
 }) => {
-  const isTabEnabled = true;
-
   return (
     <div className="bg-dark-grey border-charcoal-grey text-white border-b-4 flex justify-end">
-      <menu data-testid="menuSDK" className="flex md:overflow-x-auto pl-0 justify-end md:justify-start h-48 mr-16 my-0">
-        {SDK_INTERFACES.map((sdkInterface) => (
+      <menu
+        data-testid="menuSDKInterface"
+        className="flex md:overflow-x-auto pl-0 justify-end md:justify-start h-48 mr-16 my-0"
+      >
+        {sdkInterfaceAvailable.map((sdkInterface) => (
           <button
             key={sdkInterface}
-            className={`font-medium font-sans  focus:outline-none px-24  ${
+            className={`font-medium font-sans  focus:outline-none px-24 text-mid-grey ${
               selectedSDKInterfaceTab === sdkInterface ? 'bg-charcoal-grey' : ''
-            }
-      ${isTabEnabled ? 'text-mid-grey' : 'text-disabled-tab-button cursor-default'}
-      `}
-            onClick={isTabEnabled ? () => setSelectedSDKInterfaceTab(sdkInterface) : () => null}
+            }`}
+            onClick={() => setSelectedSDKInterfaceTab(sdkInterface)}
           >
             {languageLabels[sdkInterface] ?? sdkInterface}
           </button>

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -1,0 +1,64 @@
+import { SDK_INTERFACES } from '../../../data/createPages/constants';
+import React, { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import Icon from '@ably/ui/core/Icon';
+import languageLabels from '../../maps/language';
+
+const SDKToolTip = ({ tooltip }: { tooltip: string }) => {
+  const [tooltipHover, setTooltipHover] = useState(false);
+  const showTooltipHover = useCallback(() => setTooltipHover(true), []);
+  const hideTooltipHover = useCallback(() => setTooltipHover(false), []);
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={tooltip}
+      className="flex flex-row w-full justify-start mt-2"
+      onMouseOver={showTooltipHover}
+      onMouseOut={hideTooltipHover}
+    >
+      <Icon name="icon-gui-info" size="1.25rem" color="mid-grey" additionalCSS="mt-12 ml-16" />
+      {tooltipHover ? (
+        <aside
+          className="w-240 max-w-240 absolute box-border
+          whitespace-pre-wrap bg-white shadow-tooltip rounded border border-light-grey
+          text-cool-black font-sans p-16 text-center text-p3 leading-5 cursor-default -ml-160 -mt-88"
+        >
+          {tooltip}
+        </aside>
+      ) : null}
+    </div>
+  );
+};
+
+const SDKInterfacePanel = ({
+  selectedSDKInterfaceTab,
+  setSelectedSDKInterfaceTab,
+}: {
+  selectedSDKInterfaceTab: string;
+  setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
+}) => {
+  const isTabEnabled = true;
+
+  return (
+    <div className="bg-dark-grey border-charcoal-grey text-white border-b-4 flex justify-end">
+      <menu data-testid="menuSDK" className="flex md:overflow-x-auto pl-0 justify-end md:justify-start h-48 mr-16 my-0">
+        {SDK_INTERFACES.map((sdkInterface) => (
+          <button
+            key={sdkInterface}
+            className={`font-medium font-sans  focus:outline-none px-24  ${
+              selectedSDKInterfaceTab === sdkInterface ? 'bg-charcoal-grey' : ''
+            }
+      ${isTabEnabled ? 'text-mid-grey' : 'text-disabled-tab-button cursor-default'}
+      `}
+            onClick={isTabEnabled ? () => setSelectedSDKInterfaceTab(sdkInterface) : () => null}
+          >
+            {languageLabels[sdkInterface] ?? sdkInterface}
+          </button>
+        ))}
+        <SDKToolTip tooltip="Tooltips display informative text when users hover over, focus on, or tap an element." />
+      </menu>
+    </div>
+  );
+};
+
+export default SDKInterfacePanel;

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -1,4 +1,4 @@
-import { SDK_INTERFACES } from '../../../data/createPages/constants';
+import { REALTIME_SDK_INTERFACE, REST_SDK_INTERFACE, SDK_INTERFACES } from '../../../data/createPages/constants';
 import React, { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import Icon from '@ably/ui/core/Icon';
 import languageLabels from '../../maps/language';
@@ -34,11 +34,18 @@ const SDKInterfacePanel = ({
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
   sdkInterfaceAvailable = SDK_INTERFACES,
+  setPreviousSDKInterfaceTab,
 }: {
   selectedSDKInterfaceTab: string;
   setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
   sdkInterfaceAvailable: string[];
+  setPreviousSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }) => {
+  const handleTabChanges = (sdkInterface: string) => {
+    setSelectedSDKInterfaceTab(sdkInterface);
+    setPreviousSDKInterfaceTab(sdkInterface === REALTIME_SDK_INTERFACE ? REST_SDK_INTERFACE : REALTIME_SDK_INTERFACE);
+  };
+
   return (
     <div className="bg-dark-grey border-charcoal-grey text-white border-b-4 flex justify-end">
       <menu
@@ -51,7 +58,7 @@ const SDKInterfacePanel = ({
             className={`font-medium font-sans  focus:outline-none px-24 text-mid-grey ${
               selectedSDKInterfaceTab === sdkInterface ? 'bg-charcoal-grey' : ''
             }`}
-            onClick={() => setSelectedSDKInterfaceTab(sdkInterface)}
+            onClick={() => handleTabChanges(sdkInterface)}
           >
             {languageLabels[sdkInterface] ?? sdkInterface}
           </button>

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -74,18 +74,28 @@ const Pre = ({
 
   const sdkInterfaceData = selectedSDKInterfaceTab === REALTIME_SDK_INTERFACE ? realtimeAltData : restAltData;
 
+  const newDataWithSDKOrNot = isSDKInterface && isArray(sdkInterfaceData) ? sdkInterfaceData : data;
+
   /* When pageLoad if realtime is not present then by default display Rest */
   if (selectedSDKInterfaceTab === REALTIME_SDK_INTERFACE && isEmpty(realtimeAltData) && !isEmpty(restAltData)) {
     setSelectedSDKInterfaceTab(REST_SDK_INTERFACE);
   }
 
-  const newDataWithSDKOrNot = isSDKInterface && isArray(sdkInterfaceData) ? sdkInterfaceData : data;
-
-  const dataWithoutPTags = isArray(newDataWithSDKOrNot)
+  let dataWithoutPTags = isArray(newDataWithSDKOrNot)
     ? newDataWithSDKOrNot.map((child) =>
         child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
       )
     : newDataWithSDKOrNot;
+
+  /* Cleanup if the language passed has realtime or rest so it will highlight the code correctly */
+  if (isSDKInterface && dataWithoutPTags && typeof dataWithoutPTags !== 'string') {
+    dataWithoutPTags = dataWithoutPTags.map((child) => ({
+      ...child,
+      attribs: {
+        lang: cleanIfLanguageHasSDKInterface(child.attribs.lang),
+      },
+    }));
+  }
 
   return (
     <div
@@ -125,3 +135,9 @@ const Pre = ({
 };
 
 export default Pre;
+
+const cleanIfLanguageHasSDKInterface = (language: string) => {
+  return language.includes(`${REALTIME_SDK_INTERFACE}_`) || language.includes(`${REST_SDK_INTERFACE}_`)
+    ? language.split('_', 2)[1]
+    : language;
+};

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -10,7 +10,7 @@ import { HtmlComponentProps, ValidReactElement } from '../../html-component-prop
 import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
 import { MultilineCodeContent } from './Code/MultilineCodeContent';
-import { isArray } from 'lodash';
+import { isArray, isEmpty } from 'lodash';
 import { getFilteredLanguages } from 'src/components/common';
 
 type PreProps = HtmlComponentProps<'pre'> & {
@@ -68,6 +68,11 @@ const Pre = ({
   // rendering the data unreadable.
 
   const sdkInterfaceData = selectedSDKInterfaceTab === 'realtime' ? realtimeAltData : restAltData;
+
+  /* When pageLoad if realtime is not present then by default display Rest */
+  if (selectedSDKInterfaceTab === 'realtime' && isEmpty(realtimeAltData) && !isEmpty(restAltData)) {
+    setSelectedSDKInterfaceTab('rest');
+  }
 
   const dataWithoutPTags =
     isSDKInterface && sdkInterfaceData

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -5,7 +5,12 @@ import Html from '../Html';
 import { PageLanguageContext } from 'src/contexts';
 import languageLabels from 'src/maps/language';
 import LocalLanguageAlternatives from '../wrappers/LocalLanguageAlternatives';
-import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_INTERFACE } from '../../../../data/createPages/constants';
+import {
+  DEFAULT_LANGUAGE,
+  DEFAULT_PREFERRED_INTERFACE,
+  REALTIME_SDK_INTERFACE,
+  REST_SDK_INTERFACE,
+} from '../../../../data/createPages/constants';
 import { HtmlComponentProps, ValidReactElement } from '../../html-component-props';
 import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
@@ -67,28 +72,20 @@ const Pre = ({
   // This fixes an issue where paragraphs are added into <pre> elements, which resets the font stylings to black
   // rendering the data unreadable.
 
-  const sdkInterfaceData = selectedSDKInterfaceTab === 'realtime' ? realtimeAltData : restAltData;
+  const sdkInterfaceData = selectedSDKInterfaceTab === REALTIME_SDK_INTERFACE ? realtimeAltData : restAltData;
 
   /* When pageLoad if realtime is not present then by default display Rest */
-  if (selectedSDKInterfaceTab === 'realtime' && isEmpty(realtimeAltData) && !isEmpty(restAltData)) {
-    setSelectedSDKInterfaceTab('rest');
+  if (selectedSDKInterfaceTab === REALTIME_SDK_INTERFACE && isEmpty(realtimeAltData) && !isEmpty(restAltData)) {
+    setSelectedSDKInterfaceTab(REST_SDK_INTERFACE);
   }
 
-  const dataWithoutPTags =
-    isSDKInterface && sdkInterfaceData
-      ? isArray(sdkInterfaceData)
-        ? sdkInterfaceData.map((child) =>
-            child.name === HtmlDataTypes.p
-              ? {
-                  ...child,
-                  name: HtmlDataTypes.div,
-                }
-              : child,
-          )
-        : data
-      : isArray(data)
-      ? data.map((child) => (child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child))
-      : data;
+  const newDataWithSDKOrNot = isSDKInterface && isArray(sdkInterfaceData) ? sdkInterfaceData : data;
+
+  const dataWithoutPTags = isArray(newDataWithSDKOrNot)
+    ? newDataWithSDKOrNot.map((child) =>
+        child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
+      )
+    : newDataWithSDKOrNot;
 
   return (
     <div

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -1,11 +1,11 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import cn from 'classnames';
 import Icon from '@ably/ui/core/Icon';
 import Html from '../Html';
 import { PageLanguageContext } from 'src/contexts';
 import languageLabels from 'src/maps/language';
 import LocalLanguageAlternatives from '../wrappers/LocalLanguageAlternatives';
-import { DEFAULT_LANGUAGE } from '../../../../data/createPages/constants';
+import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_INTERFACE } from '../../../../data/createPages/constants';
 import { HtmlComponentProps, ValidReactElement } from '../../html-component-props';
 import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
@@ -42,6 +42,10 @@ const Pre = ({
   };
 
   const dataTreatedAsCode = data && !isString(data) && every((element) => element.type === HtmlDataTypes.text, data);
+
+  /*  selectedInterfaceTab useState  */
+  const [selectedSDKInterfaceTab, setSelectedSDKInterfaceTab] = useState(DEFAULT_PREFERRED_INTERFACE);
+
   if (dataTreatedAsCode) {
     // We know that the first child's data is a string because we've confirmed the element type in dataTreatedAsCode
     const stringToRender = reduce((acc, curr) => acc.concat((curr.data as string) ?? ''), '', data);
@@ -63,7 +67,7 @@ const Pre = ({
   // This fixes an issue where paragraphs are added into <pre> elements, which resets the font stylings to black
   // rendering the data unreadable.
 
-  const sdkInterfaceData = !isEmpty(realtimeAltData) ? realtimeAltData : restAltData;
+  const sdkInterfaceData = selectedSDKInterfaceTab === 'realtime' ? realtimeAltData : restAltData;
 
   const dataWithoutPTags =
     isSDKInterface && sdkInterfaceData
@@ -107,7 +111,8 @@ const Pre = ({
             data={altData}
             initialData={dataWithoutPTags}
             localChangeOnly={shouldDisplayTip}
-            isSDKInterface={isSDKInterface}
+            selectedSDKInterfaceTab={selectedSDKInterfaceTab}
+            setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
           />
         ) : (
           <Html data={dataWithoutPTags} />

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -10,7 +10,7 @@ import { HtmlComponentProps, ValidReactElement } from '../../html-component-prop
 import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
 import { MultilineCodeContent } from './Code/MultilineCodeContent';
-import { isArray, isEmpty } from 'lodash';
+import { isArray } from 'lodash';
 import { getFilteredLanguages } from 'src/components/common';
 
 type PreProps = HtmlComponentProps<'pre'> & {

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -50,26 +50,18 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
     const relevantGroup = childLanguageGroups.find((group) => group.index === index);
 
     if (relevantGroup && relevantGroup.data && relevantGroup.languages.length > 1) {
-      const realtimeCode = Object.entries(relevantGroup.data).filter(([key]) => key.includes('realtime'));
-      const restCode = Object.entries(relevantGroup.data).filter(([key]) => key.includes('rest'));
-      const realtimeCodeLanguages = realtimeCode
-        .map((e) => (e[0].includes(language) ? e[1] : null))
-        .filter(function (n) {
-          return n;
-        });
-      const restCodeLanguages = restCode
-        .map((e) => (e[0].includes(language) ? e[1] : null))
-        .filter(function (n) {
-          return n;
-        });
+      const allAltDataRealtime = Object.entries(relevantGroup.data).filter(([key]) => key.includes('realtime'));
+      const allAltDataRest = Object.entries(relevantGroup.data).filter(([key]) => key.includes('rest'));
+      const realtimeAltData = getCleanedSDKInterfaceAltData(allAltDataRealtime, language);
+      const restAltCode = getCleanedSDKInterfaceAltData(allAltDataRest, language);
 
       return React.cloneElement(child, {
         language,
         languages: relevantGroup.languages,
         altData: relevantGroup.data,
-        isSDKInterface: !isEmpty(realtimeCode) || !isEmpty(restCodeLanguages),
-        realtimeAltData: !isEmpty(realtimeCodeLanguages) ? realtimeCodeLanguages[0] : null,
-        restAltData: !isEmpty(restCodeLanguages) ? restCodeLanguages[0] : null,
+        isSDKInterface: !isEmpty(realtimeAltData) || !isEmpty(restAltCode),
+        realtimeAltData: !isEmpty(realtimeAltData) ? realtimeAltData[0] : null,
+        restAltData: !isEmpty(restAltCode) ? restAltCode[0] : null,
       });
     }
     return child;
@@ -77,3 +69,10 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
 };
 
 export default ConditionalChildrenLanguageDisplay;
+
+const getCleanedSDKInterfaceAltData = (sdkInterfaceSingleData, language) =>
+  sdkInterfaceSingleData
+    .map((e) => (e[0].includes(language) ? e[1] : null))
+    .filter(function (n) {
+      return n;
+    });

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -1,5 +1,5 @@
 import React, { Children, useContext } from 'react';
-import { DEFAULT_PREFERRED_INTERFACE, IGNORED_LANGUAGES_FOR_DISPLAY } from '../../../../data/createPages/constants';
+import { IGNORED_LANGUAGES_FOR_DISPLAY } from '../../../../data/createPages/constants';
 import PageLanguageContext from '../../../contexts/page-language-context';
 import { makeGroup, assignPrimary, addToFilter, isIrrelevantForLanguageDisplay } from './language-utilities';
 import { PREFERRED_INTERFACE_KEY, safeWindow } from '../../../utilities';
@@ -17,7 +17,6 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
       }
       return;
     }
-
     if (attribs.lang && !IGNORED_LANGUAGES_FOR_DISPLAY.includes(attribs.lang)) {
       if (!currentGroup) {
         currentGroup = makeGroup(attribs.lang, index, props.data);
@@ -52,25 +51,26 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
     const relevantGroup = childLanguageGroups.find((group) => group.index === index);
 
     if (relevantGroup && relevantGroup.data && relevantGroup.languages.length > 1) {
-      const selectedInterface = getSDKInterface();
-      /*
-        Check first if the languages consists of REST or Realtime ex: rest_ or realtime_
-        Then fetch only th languages if it has realtime or rest ex: rest_javascript
-       */
       const realtimeCode = Object.entries(relevantGroup.data).filter(([key]) => key.includes('realtime'));
       const restCode = Object.entries(relevantGroup.data).filter(([key]) => key.includes('rest'));
-      const realtimeCodeLanguages = realtimeCode.map((e) => e[0]);
-      const restCodeLanguages = restCode.map((e) => e[0]);
+      const realtimeCodeLanguages = realtimeCode
+        .map((e) => (e[0].includes(language) ? e[1] : null))
+        .filter(function (n) {
+          return n;
+        });
+      const restCodeLanguages = restCode
+        .map((e) => (e[0].includes(language) ? e[1] : null))
+        .filter(function (n) {
+          return n;
+        });
 
       return React.cloneElement(child, {
         language,
-        languages:
-          !isEmpty(realtimeCode) || !isEmpty(restCodeLanguages)
-            ? selectedInterface === DEFAULT_PREFERRED_INTERFACE
-              ? realtimeCodeLanguages
-              : restCodeLanguages
-            : relevantGroup.languages,
+        languages: relevantGroup.languages,
         altData: relevantGroup.data,
+        isSDKInterface: !isEmpty(realtimeCode) || !isEmpty(restCodeLanguages),
+        realtimeAltData: !isEmpty(realtimeCodeLanguages) ? realtimeCodeLanguages[0] : null,
+        restAltData: !isEmpty(restCodeLanguages) ? restCodeLanguages[0] : null,
       });
     }
     return child;
@@ -78,14 +78,3 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
 };
 
 export default ConditionalChildrenLanguageDisplay;
-
-export const getSDKInterface = () => {
-  // Able to identify which tab is selected
-  /*
-      If sdkInterface is present in the URL then return the
-      If not then get the PREFERRED_INTERFACE_KEY stored in the local storage
-   */
-  const urlParams = new URLSearchParams(typeof window !== 'undefined' && window.location.search);
-  const preferredSDKInterfaceStored = safeWindow.localStorage.getItem(PREFERRED_INTERFACE_KEY);
-  return urlParams.get('sdkInterface') || preferredSDKInterfaceStored || PREFERRED_INTERFACE_KEY;
-};

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -2,7 +2,6 @@ import React, { Children, useContext } from 'react';
 import { IGNORED_LANGUAGES_FOR_DISPLAY } from '../../../../data/createPages/constants';
 import PageLanguageContext from '../../../contexts/page-language-context';
 import { makeGroup, assignPrimary, addToFilter, isIrrelevantForLanguageDisplay } from './language-utilities';
-import { PREFERRED_INTERFACE_KEY, safeWindow } from '../../../utilities';
 import { isEmpty } from 'lodash';
 
 const ConditionalChildrenLanguageDisplay = ({ children }) => {

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -53,17 +53,18 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
       const allAltDataRealtime = Object.entries(relevantGroup.data).filter(([key]) => key.includes('realtime'));
       const allAltDataRest = Object.entries(relevantGroup.data).filter(([key]) => key.includes('rest'));
       const realtimeAltData = getCleanedSDKInterfaceAltData(allAltDataRealtime, language);
-      const restAltCode = getCleanedSDKInterfaceAltData(allAltDataRest, language);
+      const restAltData = getCleanedSDKInterfaceAltData(allAltDataRest, language);
 
       return React.cloneElement(child, {
         language,
         languages: relevantGroup.languages,
         altData: relevantGroup.data,
-        isSDKInterface: !isEmpty(realtimeAltData) || !isEmpty(restAltCode),
-        realtimeAltData: !isEmpty(realtimeAltData) ? realtimeAltData[0] : null,
-        restAltData: !isEmpty(restAltCode) ? restAltCode[0] : null,
+        isSDKInterface: !isEmpty(realtimeAltData) || !isEmpty(restAltData),
+        realtimeAltData: !isEmpty(realtimeAltData) ? realtimeAltData[0] : [],
+        restAltData: !isEmpty(restAltData) ? restAltData[0] : [],
       });
     }
+
     return child;
   });
 };

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -1,5 +1,9 @@
 import React, { Children, useContext } from 'react';
-import { IGNORED_LANGUAGES_FOR_DISPLAY } from '../../../../data/createPages/constants';
+import {
+  IGNORED_LANGUAGES_FOR_DISPLAY,
+  REALTIME_SDK_INTERFACE,
+  REST_SDK_INTERFACE,
+} from '../../../../data/createPages/constants';
 import PageLanguageContext from '../../../contexts/page-language-context';
 import { makeGroup, assignPrimary, addToFilter, isIrrelevantForLanguageDisplay } from './language-utilities';
 import { isEmpty } from 'lodash';
@@ -50,8 +54,10 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
     const relevantGroup = childLanguageGroups.find((group) => group.index === index);
 
     if (relevantGroup && relevantGroup.data && relevantGroup.languages.length > 1) {
-      const allAltDataRealtime = Object.entries(relevantGroup.data).filter(([key]) => key.includes('realtime'));
-      const allAltDataRest = Object.entries(relevantGroup.data).filter(([key]) => key.includes('rest'));
+      const allAltDataRealtime = Object.entries(relevantGroup.data).filter(([key]) =>
+        key.includes(REALTIME_SDK_INTERFACE),
+      );
+      const allAltDataRest = Object.entries(relevantGroup.data).filter(([key]) => key.includes(REST_SDK_INTERFACE));
       const realtimeAltData = getCleanedSDKInterfaceAltData(allAltDataRealtime, language);
       const restAltData = getCleanedSDKInterfaceAltData(allAltDataRest, language);
 
@@ -72,8 +78,4 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
 export default ConditionalChildrenLanguageDisplay;
 
 const getCleanedSDKInterfaceAltData = (sdkInterfaceSingleData, language) =>
-  sdkInterfaceSingleData
-    .map((e) => (e[0].includes(language) ? e[1] : null))
-    .filter(function (n) {
-      return n;
-    });
+  sdkInterfaceSingleData.map((e) => (e[0].includes(language) ? e[1] : null)).filter((n) => !!n);

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.test.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.test.tsx
@@ -68,13 +68,13 @@ const props = {
 
 describe('<LocalLanguageAlternatives />', () => {
   it('renders correctly', () => {
-    const { container } = render(<LocalLanguageAlternatives {...props} />);
+    const { container } = render(<LocalLanguageAlternatives isSDKInterface={false} {...props} />);
     expect(container).toMatchSnapshot();
     expect(screen.getByTestId('menu')).toBeInTheDocument();
   });
 
   it("doesn't render the menu bar when only one language", () => {
-    render(<LocalLanguageAlternatives {...props} languages={['javascript', '']} />);
+    render(<LocalLanguageAlternatives isSDKInterface={false} {...props} languages={['javascript', '']} />);
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 });

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MouseEvent } from 'react';
+import React, { useState, MouseEvent, useEffect } from 'react';
 import languageLabels from '../../../maps/language';
 import { MenuItemButton } from '../../Menu/MenuItemButton';
 import Html from '../Html';
@@ -6,23 +6,39 @@ import { LanguageNavigation } from '../../Menu/LanguageNavigation';
 import { getFilteredLanguages, LanguageButton, ReactSelectOption } from 'src/components';
 import { LanguageNavigationProps } from '../../Menu/LanguageNavigation';
 import { HtmlComponentProps, HtmlComponentPropsData, ValidReactElement } from 'src/components/html-component-props';
-import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_INTERFACE } from '../../../../data/createPages/constants';
+import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE } from '../../../../data/createPages/constants';
 import { SingleValue } from 'react-select';
-import { getSDKInterface } from './ConditionalChildrenLanguageDisplay';
+
+import { isEmpty } from 'lodash';
 
 const LocalLanguageAlternatives = ({
   languages,
   data,
   initialData,
   localChangeOnly,
+  isSDKInterface,
 }: {
   languages: string[];
   data?: Record<string, string | HtmlComponentProps<ValidReactElement>[] | null>;
   initialData: HtmlComponentPropsData;
   localChangeOnly: boolean;
+  isSDKInterface: boolean;
 }) => {
   const [selected, setSelected] = useState(initialData);
   const [selectedLanguage, setSelectedLanguage] = useState(languages[0]);
+  useEffect(() => {
+    setSelected(initialData);
+  }, [initialData]);
+
+  // if (isSDKInterface) {
+  //   if (initialData != null) {
+  //     console.log(initialData[0].attribs.lang);
+  //   }
+  // }
+  if (isSDKInterface) {
+    //   console.log(selected[0].attribs.lang);
+    //  console.log(selectedLanguage);
+  }
 
   const setLocalSelected = (value: string) => {
     setSelected(data ? data[value] : '');
@@ -39,16 +55,19 @@ const LocalLanguageAlternatives = ({
     }
   };
 
+  const sdkInterfaceLanguages = !isEmpty(languages) ? languagesSDKInterface(languages) : [];
+  languages = !isEmpty(sdkInterfaceLanguages) ? sdkInterfaceLanguages : languages;
+
   const languageItems = languages
     .filter((lang) => lang !== DEFAULT_LANGUAGE)
     .filter((lang) => lang !== '')
     .map((lang) => {
       // Site navigation button
+
       if (!localChangeOnly) {
-        const selectedSDK = getSDKInterface();
         return {
           Component: LanguageButton,
-          props: { language: lang, sdkInterface: selectedSDK || DEFAULT_PREFERRED_INTERFACE },
+          props: { language: lang || DEFAULT_PREFERRED_LANGUAGE },
           content: languageLabels[lang] ?? lang,
         };
       }
@@ -68,6 +87,12 @@ const LocalLanguageAlternatives = ({
       };
     });
 
+  /*
+selectedLanguage = initial language selected when the page loads
+selected = allData of selected language
+allListOfLanguages = array of all language keys
+ */
+
   return (
     <>
       <LanguageNavigation
@@ -75,6 +100,7 @@ const LocalLanguageAlternatives = ({
         localChangeOnly={localChangeOnly}
         selectedLanguage={selectedLanguage}
         onSelect={onSelect}
+        allListOfLanguages={data ? Object.entries(data).map(([key]) => key) : []}
       />
       <Html data={selected} />
     </>
@@ -82,3 +108,10 @@ const LocalLanguageAlternatives = ({
 };
 
 export default LocalLanguageAlternatives;
+
+const languagesSDKInterface = (allLanguage: string[]) =>
+  allLanguage
+    .map((language) => (language.includes(`_`) ? language : ''))
+    .filter(function (n: string) {
+      return n;
+    });

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -18,6 +18,7 @@ const LocalLanguageAlternatives = ({
   localChangeOnly,
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
+  setPreviousSDKInterfaceTab,
 }: {
   languages: string[];
   data?: Record<string, string | HtmlComponentProps<ValidReactElement>[] | null>;
@@ -25,6 +26,7 @@ const LocalLanguageAlternatives = ({
   localChangeOnly: boolean;
   selectedSDKInterfaceTab: string;
   setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
+  setPreviousSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }) => {
   const [selected, setSelected] = useState(initialData);
   const [selectedLanguage, setSelectedLanguage] = useState(languages[0]);
@@ -95,6 +97,7 @@ const LocalLanguageAlternatives = ({
         allListOfLanguages={data ? Object.entries(data).map(([key]) => key) : []}
         selectedSDKInterfaceTab={selectedSDKInterfaceTab}
         setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
+        setPreviousSDKInterfaceTab={setPreviousSDKInterfaceTab}
       />
       <Html data={selected} />
     </>

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MouseEvent, useEffect } from 'react';
+import React, { useState, MouseEvent, useEffect, Dispatch, SetStateAction } from 'react';
 import languageLabels from '../../../maps/language';
 import { MenuItemButton } from '../../Menu/MenuItemButton';
 import Html from '../Html';
@@ -16,29 +16,21 @@ const LocalLanguageAlternatives = ({
   data,
   initialData,
   localChangeOnly,
-  isSDKInterface,
+  selectedSDKInterfaceTab,
+  setSelectedSDKInterfaceTab,
 }: {
   languages: string[];
   data?: Record<string, string | HtmlComponentProps<ValidReactElement>[] | null>;
   initialData: HtmlComponentPropsData;
   localChangeOnly: boolean;
-  isSDKInterface: boolean;
+  selectedSDKInterfaceTab: string;
+  setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }) => {
   const [selected, setSelected] = useState(initialData);
   const [selectedLanguage, setSelectedLanguage] = useState(languages[0]);
   useEffect(() => {
     setSelected(initialData);
   }, [initialData]);
-
-  // if (isSDKInterface) {
-  //   if (initialData != null) {
-  //     console.log(initialData[0].attribs.lang);
-  //   }
-  // }
-  if (isSDKInterface) {
-    //   console.log(selected[0].attribs.lang);
-    //  console.log(selectedLanguage);
-  }
 
   const setLocalSelected = (value: string) => {
     setSelected(data ? data[value] : '');
@@ -55,7 +47,8 @@ const LocalLanguageAlternatives = ({
     }
   };
 
-  const sdkInterfaceLanguages = !isEmpty(languages) ? languagesSDKInterface(languages) : [];
+  /* filter only languages that are realtime or rest */
+  const sdkInterfaceLanguages = !isEmpty(languages) ? languagesSDKInterface(languages, selectedSDKInterfaceTab) : [];
   languages = !isEmpty(sdkInterfaceLanguages) ? sdkInterfaceLanguages : languages;
 
   const languageItems = languages
@@ -87,12 +80,6 @@ const LocalLanguageAlternatives = ({
       };
     });
 
-  /*
-selectedLanguage = initial language selected when the page loads
-selected = allData of selected language
-allListOfLanguages = array of all language keys
- */
-
   return (
     <>
       <LanguageNavigation
@@ -101,6 +88,8 @@ allListOfLanguages = array of all language keys
         selectedLanguage={selectedLanguage}
         onSelect={onSelect}
         allListOfLanguages={data ? Object.entries(data).map(([key]) => key) : []}
+        selectedSDKInterfaceTab={selectedSDKInterfaceTab}
+        setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
       />
       <Html data={selected} />
     </>
@@ -109,9 +98,9 @@ allListOfLanguages = array of all language keys
 
 export default LocalLanguageAlternatives;
 
-const languagesSDKInterface = (allLanguage: string[]) =>
+const languagesSDKInterface = (allLanguage: string[], selectedSDKInterface: string) =>
   allLanguage
-    .map((language) => (language.includes(`_`) ? language : ''))
+    .map((language) => (language.includes(`${selectedSDKInterface}_`) ? language : ''))
     .filter(function (n: string) {
       return n;
     });

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -57,10 +57,13 @@ const LocalLanguageAlternatives = ({
     .map((lang) => {
       // Site navigation button
 
-      if (!localChangeOnly) {
+      const languageSelected = lang || DEFAULT_PREFERRED_LANGUAGE;
+      const filterLanguageForLangButton = languageSDKInterfaceClean(languageSelected, selectedSDKInterfaceTab);
+
+      if (!localChangeOnly && filterLanguageForLangButton != '') {
         return {
           Component: LanguageButton,
-          props: { language: lang || DEFAULT_PREFERRED_LANGUAGE },
+          props: { language: filterLanguageForLangButton },
           content: languageLabels[lang] ?? lang,
         };
       }
@@ -68,10 +71,12 @@ const LocalLanguageAlternatives = ({
 
       const selectedLanguageFiltered = getFilteredLanguages(selectedLanguage);
       const languageFiltered = getFilteredLanguages(lang);
+      const filterLanguageForMenuButton = languageSDKInterfaceClean(lang, selectedSDKInterfaceTab);
+
       return {
         Component: MenuItemButton,
         props: {
-          language: lang,
+          language: filterLanguageForMenuButton != '' ? filterLanguageForMenuButton : lang,
           onClick,
           value: lang,
           isSelected: languageFiltered === selectedLanguageFiltered,
@@ -97,6 +102,9 @@ const LocalLanguageAlternatives = ({
 };
 
 export default LocalLanguageAlternatives;
+
+const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
+  language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;
 
 const languagesSDKInterface = (allLanguage: string[], selectedSDKInterface: string) =>
   allLanguage

--- a/src/components/common/language-defaults.test.ts
+++ b/src/components/common/language-defaults.test.ts
@@ -77,8 +77,8 @@ describe('createLanguageHrefFromDefaults', () => {
   it('Returns a string in the format ./?lang=my-language if the language is not DEFAULT_LANGUAGE', () => {
     assert(
       property(boolean(), constant(false), string(), (isPageLanguageDefault, isLanguageDefault, language) => {
-        expect(createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language, 'realtime')).toBe(
-          `./?lang=${language}&sdkInterface=realtime`,
+        expect(createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language)).toBe(
+          `./?lang=${language}`,
         );
       }),
     );
@@ -86,9 +86,7 @@ describe('createLanguageHrefFromDefaults', () => {
   it('Returns a string in the format ./ if the language is DEFAULT_LANGUAGE and the pageLanguage is not DEFAULT_LANGUAGE', () => {
     assert(
       property(constant(false), constant(true), string(), (isPageLanguageDefault, isLanguageDefault, language) => {
-        expect(createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language, 'realtime')).toBe(
-          './&sdkInterface=realtime',
-        );
+        expect(createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language)).toBe('./');
       }),
     );
   });

--- a/src/components/common/language-defaults.ts
+++ b/src/components/common/language-defaults.ts
@@ -21,13 +21,12 @@ export const createLanguageHrefFromDefaults = (
   isPageLanguageDefault: boolean,
   isLanguageDefault: boolean,
   language: string,
-  sdkInterface?: string,
 ): string => {
   const languageParam = isPageLanguageDefault
     ? `./?lang=${language}`
     : `./${isLanguageDefault ? '' : `?lang=${language}`}`;
-  const sdkInterfaceParam = sdkInterface != '' ? `&sdkInterface=${sdkInterface}` : '';
-  return `${languageParam}${sdkInterfaceParam}`;
+
+  return `${languageParam}`;
 };
 
 /*

--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -20,7 +20,6 @@ import { LeftSideBar } from 'src/components/StaticQuerySidebar';
 import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE, IGNORED_LANGUAGES } from '../../data/createPages/constants';
 import { DOCUMENTATION_PATH } from '../../data/transform/constants';
 import { AblyDocument, AblyDocumentMeta, AblyTemplateData } from './template-data';
-import { getSDKInterface } from '../components/blocks/wrappers/ConditionalChildrenLanguageDisplay';
 
 const getMetaDataDetails = (
   document: AblyDocument,
@@ -100,13 +99,8 @@ const Template = ({
           ? DEFAULT_PREFERRED_LANGUAGE
           : filteredLanguages[0];
         const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(usableLanguage, language);
-        const selectedSDKInterface = getSDKInterface();
-        const href = createLanguageHrefFromDefaults(
-          isPageLanguageDefault,
-          isLanguageDefault,
-          usableLanguage,
-          selectedSDKInterface,
-        );
+
+        const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, usableLanguage);
         navigate(href);
         return;
       }

--- a/src/utilities/language/cache-visit-preferred-language.ts
+++ b/src/utilities/language/cache-visit-preferred-language.ts
@@ -1,17 +1,11 @@
 import { navigate } from 'gatsby';
-import { PREFERRED_LANGUAGE_KEY, PREFERRED_INTERFACE_KEY, safeWindow } from 'src/utilities';
+import { PREFERRED_LANGUAGE_KEY, safeWindow } from 'src/utilities';
 
-export const cacheVisitPreferredLanguage = (
-  isPageLanguageDefault: boolean,
-  language: string,
-  href: string,
-  sdkInterface: string,
-) => {
+export const cacheVisitPreferredLanguage = (isPageLanguageDefault: boolean, language: string, href: string) => {
   if (isPageLanguageDefault) {
     safeWindow.localStorage.clear();
   } else {
     safeWindow.localStorage.setItem(PREFERRED_LANGUAGE_KEY, language);
-    safeWindow.localStorage.setItem(PREFERRED_INTERFACE_KEY, sdkInterface);
   }
   navigate(href);
 };


### PR DESCRIPTION
## Description

[EDU-1359](https://ably.atlassian.net/browse/EDU-1359)
[EDU-1368](https://ably.atlassian.net/browse/EDU-1368)
[EDU-1367](https://ably.atlassian.net/browse/EDU-1367)

- All changes are added on this PR related to Rest/Realtime.
- The team decided that the new Realtime/Rest Tab to be independent rather than part of the pageLoad. So this means we will change the previous changes we have done and apply this new feature.
-  The textile changes will be reverted later


##  The Changes are

- Removed `sdkInterface` storing in local storage and adding in the URL parameters
- Cleanup from last changes so it will work on all  codebox once language selection changes when pageload
- If rest/realtime present in codebox, it should independently switch
- The language navigation should work accordingly when switching
- When switching language it should still work on other codeboxes
- the code will show Realtime by default and switching language
- the code will show Rest by default and switching language
- InfoBox display to Rest/Realtime codebox  if language doesn't exist when pageloads
- If only one either Rest/Realtime are available should display navigation
- Design Changes as per Lenka’s updated design
- If Rest ( not the default when page load) is the only tab it should auto default
- If language not present to the Realtime tab, by default it goes to Rest

**Bug fixing after changes:**
- When localOnlyChange it doesn't work properly
- JEST Test failures to fixed
- Code highlight doesn't work in the rest/realtime tabs
- Switching REST: the code box should show default if the selected language is not present
- If language doesnt exist in Realtime when tab clicks it just stays on REST

## Not Included in this PR but added as a separate ticket

- When selecting Rest/Realtime it should display infoBox if language is not existed and select default one ( make sure this works properly) -  [EDU-1366](https://ably.atlassian.net/browse/EDU-1366)
- BUG: When Java selected it displays javascript code - [EDU-1365](https://ably.atlassian.net/browse/EDU-1365)
- Add Jest Tests - [EDU-1364](https://ably.atlassian.net/browse/EDU-1364)

## Review

Instructions on how to review the PR. 

* Please run this branch to your local and use Mark's updated textile


[EDU-1359]: https://ably.atlassian.net/browse/EDU-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EDU-1351]: https://ably.atlassian.net/browse/EDU-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EDU-1366]: https://ably.atlassian.net/browse/EDU-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EDU-1368]: https://ably.atlassian.net/browse/EDU-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EDU-1367]: https://ably.atlassian.net/browse/EDU-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ