### PR TITLE
[EDU-1370] - REST/realtime tab should display with only 1 tab and 1 interface & fix infobox issue

### DIFF
--- a/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
+++ b/src/components/Menu/LanguageDropdownSelector/LanguageDropdownSelector.tsx
@@ -5,7 +5,6 @@ import { longLanguageLabels } from '../../../maps/language';
 import { ReactSelectOption } from 'src/components';
 import { PREFERRED_LANGUAGE_KEY } from '../../../utilities/language/constants';
 import { createLanguageHrefFromDefaults, getLanguageDefaults } from '../../common/language-defaults';
-
 import { navigate } from 'gatsby';
 import {
   DEFAULT_LANGUAGE,

--- a/src/components/Menu/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItemButton/MenuItemButton.tsx
@@ -4,8 +4,6 @@ import { button, isActive } from './MenuItemButton.module.css';
 
 type Props = {
   isSelected?: boolean;
-  selectedSDKInterfaceTab: string;
-  language: string;
 } & HTMLAttributes<HTMLButtonElement>;
 
 const MenuItemButton: FC<Props> = ({ isSelected = false, ...props }) => (

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -168,7 +168,7 @@ const Pre = ({
 
 export default Pre;
 
-const cleanIfLanguageHasSDKInterface = (language: string) =>
+export const cleanIfLanguageHasSDKInterface = (language: string) =>
   language.includes(`${REALTIME_SDK_INTERFACE}_`) || language.includes(`${REST_SDK_INTERFACE}_`)
     ? language.split('_', 2)[1]
     : language;

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -38,6 +38,15 @@ const Pre = ({
 }: PreProps): ReactElement => {
   const pageLanguage = useContext(PageLanguageContext);
 
+  /*  selectedInterfaceTab useState  */
+  const [selectedSDKInterfaceTab, setSelectedSDKInterfaceTab] = useState(DEFAULT_PREFERRED_INTERFACE);
+  const [previousSDKInterfaceTab, setPreviousSDKInterfaceTab] = useState('');
+
+  /* only pass the languages that are SDK interface active */
+  if (isSDKInterface && languages) {
+    languages = getLanguagesSDKInterface(languages, selectedSDKInterfaceTab);
+  }
+
   const hasCode =
     languages?.some((lang) => getFilteredLanguages(lang) === pageLanguage) || pageLanguage === DEFAULT_LANGUAGE;
   const shouldDisplayTip = !hasCode && languages?.length !== undefined;
@@ -47,10 +56,6 @@ const Pre = ({
   };
 
   const dataTreatedAsCode = data && !isString(data) && every((element) => element.type === HtmlDataTypes.text, data);
-
-  /*  selectedInterfaceTab useState  */
-  const [selectedSDKInterfaceTab, setSelectedSDKInterfaceTab] = useState(DEFAULT_PREFERRED_INTERFACE);
-  const [previousSDKInterfaceTab, setPreviousSDKInterfaceTab] = useState('');
 
   if (dataTreatedAsCode) {
     // We know that the first child's data is a string because we've confirmed the element type in dataTreatedAsCode
@@ -167,3 +172,10 @@ const cleanIfLanguageHasSDKInterface = (language: string) =>
   language.includes(`${REALTIME_SDK_INTERFACE}_`) || language.includes(`${REST_SDK_INTERFACE}_`)
     ? language.split('_', 2)[1]
     : language;
+
+const getLanguagesSDKInterface = (allLanguage: string[], selectedSDKInterface: string) =>
+  allLanguage
+    .map((language) => (language.includes(`${selectedSDKInterface}_`) ? language : ''))
+    .filter(function (n: string) {
+      return n;
+    });

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -174,8 +174,4 @@ export const cleanIfLanguageHasSDKInterface = (language: string) =>
     : language;
 
 const getLanguagesSDKInterface = (allLanguage: string[], selectedSDKInterface: string) =>
-  allLanguage
-    .map((language) => (language.includes(`${selectedSDKInterface}_`) ? language : ''))
-    .filter(function (n: string) {
-      return n;
-    });
+  allLanguage.map((language) => (language.includes(`${selectedSDKInterface}_`) ? language : '')).filter((s) => s);

--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -53,7 +53,7 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
     }
     const relevantGroup = childLanguageGroups.find((group) => group.index === index);
 
-    if (relevantGroup && relevantGroup.data && relevantGroup.languages.length > 1) {
+    if (relevantGroup && relevantGroup.data && relevantGroup.languages.length >= 1) {
       const allAltDataRealtime = Object.entries(relevantGroup.data).filter(([key]) =>
         key.includes(REALTIME_SDK_INTERFACE),
       );
@@ -65,7 +65,7 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
         language,
         languages: relevantGroup.languages,
         altData: relevantGroup.data,
-        isSDKInterface: !isEmpty(realtimeAltData) || !isEmpty(restAltData),
+        isSDKInterface: !isEmpty(allAltDataRealtime) || !isEmpty(allAltDataRest),
         realtimeAltData: !isEmpty(realtimeAltData) ? realtimeAltData[0] : [],
         restAltData: !isEmpty(restAltData) ? restAltData[0] : [],
       });

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -8,8 +8,8 @@ import { LanguageNavigationProps } from '../../Menu/LanguageNavigation';
 import { HtmlComponentProps, HtmlComponentPropsData, ValidReactElement } from 'src/components/html-component-props';
 import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE } from '../../../../data/createPages/constants';
 import { SingleValue } from 'react-select';
-
-import { isEmpty } from 'lodash';
+import { isObject } from 'lodash';
+import { cleanIfLanguageHasSDKInterface } from '../software/Pre';
 
 const LocalLanguageAlternatives = ({
   languages,
@@ -35,7 +35,20 @@ const LocalLanguageAlternatives = ({
   }, [initialData]);
 
   const setLocalSelected = (value: string) => {
-    setSelected(data ? data[value] : '');
+    const selectedLocalData = data ? data[value] : '';
+    if (selectedLocalData != null && isObject(selectedLocalData[0])) {
+      /* when rest/realtime languages are passed from local they are not trimmed yet so we need to trim here */
+      const selectedLocalDataLang = selectedLocalData[0].attribs ? selectedLocalData[0].attribs.lang : '';
+      const cleanSelectedLocalData = [
+        {
+          ...selectedLocalData[0],
+          attribs: {
+            lang: selectedLocalDataLang ? cleanIfLanguageHasSDKInterface(selectedLocalDataLang) : '',
+          },
+        },
+      ];
+      setSelected(cleanSelectedLocalData);
+    }
     setSelectedLanguage(getFilteredLanguages(value));
   };
 

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -36,9 +36,9 @@ const LocalLanguageAlternatives = ({
 
   const setLocalSelected = (value: string) => {
     const selectedLocalData = data ? data[value] : '';
-    if (selectedLocalData != null && isObject(selectedLocalData[0])) {
-      /* when rest/realtime languages are passed from local they are not trimmed yet so we need to trim here */
-      const selectedLocalDataLang = selectedLocalData[0].attribs ? selectedLocalData[0].attribs.lang : '';
+    if (selectedLocalData !== null && isObject(selectedLocalData?.[0])) {
+      /* when rest/realtime languages are passed from local they are not trimmed yet, so we need to trim here */
+      const selectedLocalDataLang = selectedLocalData[0]?.attribs?.lang;
       const cleanSelectedLocalData = [
         {
           ...selectedLocalData[0],

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -49,10 +49,6 @@ const LocalLanguageAlternatives = ({
     }
   };
 
-  /* filter only languages that are realtime or rest */
-  const sdkInterfaceLanguages = !isEmpty(languages) ? languagesSDKInterface(languages, selectedSDKInterfaceTab) : [];
-  languages = !isEmpty(sdkInterfaceLanguages) ? sdkInterfaceLanguages : languages;
-
   const languageItems = languages
     .filter((lang) => lang !== DEFAULT_LANGUAGE)
     .filter((lang) => lang !== '')
@@ -108,10 +104,3 @@ export default LocalLanguageAlternatives;
 
 const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
   language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;
-
-const languagesSDKInterface = (allLanguage: string[], selectedSDKInterface: string) =>
-  allLanguage
-    .map((language) => (language.includes(`${selectedSDKInterface}_`) ? language : ''))
-    .filter(function (n: string) {
-      return n;
-    });

--- a/src/utilities/language/constants.ts
+++ b/src/utilities/language/constants.ts
@@ -1,2 +1,1 @@
 export const PREFERRED_LANGUAGE_KEY = 'preferred_language';
-export const PREFERRED_INTERFACE_KEY = 'preferred_interface';


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

* [EDU-1370](https://ably.atlassian.net/browse/EDU-1370)
* [EDU-1366](https://ably.atlassian.net/browse/EDU-1366)

**Fixed the following issues**
- When selecting Rest/Realtime it should display infoBox if language is not existed and select default one
- REST/realtime tab should display with only 1 tab and 1 interface
- When local language change the code highlight is gone

**Description of the Changes:**
- Able to display the tabs if the rest or realtime code is 1 only
- changed the condition to minimum of 1 in returning the relevant group and didn't break existing code box
- removed extra splitting in the LocalLangAlternatives component since we are already splitting the language from Pre component
- in the setLocalSelected, when rest/realtime languages are passed from local they are not trimmed yet so we need to trim the language so it will highlight correctly



## Review

Instructions on how to review the PR. 

* Run the branch in your local and check the page


[EDU-1370]: https://ably.atlassian.net/browse/EDU-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-1366]: https://ably.atlassian.net/browse/EDU-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ