### PR TITLE
[EDU-1365] - Fix Bug: When Java selected it displays javascript code

### DIFF
--- a/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
+++ b/src/components/blocks/wrappers/ConditionalChildrenLanguageDisplay.js
@@ -58,8 +58,8 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
         key.includes(REALTIME_SDK_INTERFACE),
       );
       const allAltDataRest = Object.entries(relevantGroup.data).filter(([key]) => key.includes(REST_SDK_INTERFACE));
-      const realtimeAltData = getCleanedSDKInterfaceAltData(allAltDataRealtime, language);
-      const restAltData = getCleanedSDKInterfaceAltData(allAltDataRest, language);
+      const realtimeAltData = getCleanedSDKInterfaceAltData(allAltDataRealtime, language, REALTIME_SDK_INTERFACE);
+      const restAltData = getCleanedSDKInterfaceAltData(allAltDataRest, language, REST_SDK_INTERFACE);
 
       return React.cloneElement(child, {
         language,
@@ -77,5 +77,5 @@ const ConditionalChildrenLanguageDisplay = ({ children }) => {
 
 export default ConditionalChildrenLanguageDisplay;
 
-const getCleanedSDKInterfaceAltData = (sdkInterfaceSingleData, language) =>
-  sdkInterfaceSingleData.map((e) => (e[0].includes(language) ? e[1] : null)).filter((n) => !!n);
+const getCleanedSDKInterfaceAltData = (sdkInterfaceSingleData, language, sdkInterface) =>
+  sdkInterfaceSingleData.map((e) => (e[0] === `${sdkInterface}_${language}` ? e[1] : null)).filter((n) => !!n);


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

* [EDU-1365](https://ably.atlassian.net/browse/EDU-1365)

In passing realtime and rest data the to `Pre` component `getCleanedSDKInterfaceAltData` function it filters the lanauge and for the case of the string `java` it was returning  `javascript` since we've used the `include` method. Need to change it to comparing actual value so it return the correct data.

## Review

Instructions on how to review the PR. 

* Test it in your local

[EDU-1365]: https://ably.atlassian.net/browse/EDU-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ