### PR TITLE
[EDU-1377] - Code blocks should always change global language

### DIFF
--- a/src/components/LanguageButton/LanguageButton.test.tsx
+++ b/src/components/LanguageButton/LanguageButton.test.tsx
@@ -10,7 +10,7 @@ import { safeWindow } from 'src/utilities';
 describe(`<LanguageButton />`, () => {
   it('renders default state button', () => {
     render(
-      <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLanguageForPre="javascript" />,
+      <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLocalLanguage="javascript" />,
     );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
       <button
@@ -23,7 +23,7 @@ describe(`<LanguageButton />`, () => {
   it('renders active state button', () => {
     render(
       <PageLanguageContext.Provider value="javascript">
-        <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLanguageForPre="javascript" />
+        <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLocalLanguage="javascript" />
       </PageLanguageContext.Provider>,
     );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
@@ -38,7 +38,7 @@ describe(`<LanguageButton />`, () => {
   it('changes localstorage value on click', async () => {
     render(
       <PageLanguageContext.Provider value="python">
-        <LanguageButton selectedSDKInterfaceTab="realtime" language="javascript" selectedLanguageForPre="javascript" />
+        <LanguageButton selectedSDKInterfaceTab="realtime" language="javascript" selectedLocalLanguage="javascript" />
       </PageLanguageContext.Provider>,
     );
 

--- a/src/components/LanguageButton/LanguageButton.test.tsx
+++ b/src/components/LanguageButton/LanguageButton.test.tsx
@@ -9,10 +9,12 @@ import { safeWindow } from 'src/utilities';
 
 describe(`<LanguageButton />`, () => {
   it('renders default state button', () => {
-    render(<LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" />);
+    render(
+      <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLanguageForPre="javascript" />,
+    );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
       <button
-        class="button"
+        class="button isActive"
       >
         JavaScript
       </button>
@@ -21,7 +23,7 @@ describe(`<LanguageButton />`, () => {
   it('renders active state button', () => {
     render(
       <PageLanguageContext.Provider value="javascript">
-        <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" />
+        <LanguageButton language="javascript" selectedSDKInterfaceTab="realtime" selectedLanguageForPre="javascript" />
       </PageLanguageContext.Provider>,
     );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
@@ -36,7 +38,7 @@ describe(`<LanguageButton />`, () => {
   it('changes localstorage value on click', async () => {
     render(
       <PageLanguageContext.Provider value="python">
-        <LanguageButton selectedSDKInterfaceTab="realtime" language="javascript" />
+        <LanguageButton selectedSDKInterfaceTab="realtime" language="javascript" selectedLanguageForPre="javascript" />
       </PageLanguageContext.Provider>,
     );
 

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -7,13 +7,16 @@ import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
 import { button, isActive } from '../Menu/MenuItemButton/MenuItemButton.module.css';
 
-const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, selectedLanguageForPre }) => {
+const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, selectedLocalLanguage }) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedLanguage = getTrimmedLanguage(language);
   const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(selectedLanguage, pageLanguage);
-  /* separated the isLanguageActive as we will pass a pageLanguage that is not only from the context lang, but a condition
-  where the context page lang is not present in the languages we will pass the first language of the languages */
-  const { isLanguageActive } = getLanguageDefaults(selectedLanguage, selectedLanguageForPre);
+  /*
+  separate the isLanguageActive variable because we will pass a pageLanguage value that is not always from the useContext(PageLanguageContext),
+  so if the  useContext(PageLanguageContext) is not present in the languages we will pass the first language of the languages
+   eg: selected global language: PHP but the languages are: [js, ruby]  so it will pass js now as php is not present
+   */
+  const { isLanguageActive } = getLanguageDefaults(selectedLanguage, selectedLocalLanguage);
 
   const handleClick = () => {
     const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, selectedLanguage);

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -1,19 +1,19 @@
 import { useContext, FunctionComponent as FC } from 'react';
 import cn from 'classnames';
 import { PageLanguageContext } from 'src/contexts';
-import { createLanguageHrefFromDefaults, getLanguageDefaults, getFilteredLanguages } from 'src/components';
+import { createLanguageHrefFromDefaults, getLanguageDefaults, getTrimmedLanguage } from 'src/components';
 import languageLabels from 'src/maps/language';
 import { cacheVisitPreferredLanguage } from 'src/utilities';
 import { LanguageNavigationComponentProps } from '../Menu/LanguageNavigation';
 import { button, isActive } from '../Menu/MenuItemButton/MenuItemButton.module.css';
 
-const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language }) => {
+const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language, selectedLanguageForPre }) => {
   const pageLanguage = useContext(PageLanguageContext);
-  const selectedLanguage = getFilteredLanguages(language);
-  const { isLanguageDefault, isPageLanguageDefault, isLanguageActive } = getLanguageDefaults(
-    selectedLanguage,
-    pageLanguage,
-  );
+  const selectedLanguage = getTrimmedLanguage(language);
+  const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(selectedLanguage, pageLanguage);
+  /* separated the isLanguageActive as we will pass a pageLanguage that is not only from the context lang, but a condition
+  where the context page lang is not present in the languages we will pass the first language of the languages */
+  const { isLanguageActive } = getLanguageDefaults(selectedLanguage, selectedLanguageForPre);
 
   const handleClick = () => {
     const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, selectedLanguage);

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -21,7 +21,7 @@ export interface LanguageNavigationComponentProps {
   value?: string;
   isSelected?: boolean;
   selectedSDKInterfaceTab?: string;
-  selectedLanguageForPre: string;
+  selectedLocalLanguage: string;
 }
 
 export interface LanguageNavigationProps {

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, FunctionComponent as FC, SetStateAction, useContext, u
 import { SingleValue } from 'react-select';
 import {
   createLanguageHrefFromDefaults,
-  getFilteredLanguages,
+  getTrimmedLanguage,
   getLanguageDefaults,
   ReactSelectOption,
   Select,
@@ -20,7 +20,8 @@ export interface LanguageNavigationComponentProps {
   onClick?: (event: { target: { value: string } }) => void;
   value?: string;
   isSelected?: boolean;
-  selectedSDKInterfaceTab: string;
+  selectedSDKInterfaceTab?: string;
+  selectedLanguageForPre: string;
 }
 
 export interface LanguageNavigationProps {
@@ -29,9 +30,6 @@ export interface LanguageNavigationProps {
     props: LanguageNavigationComponentProps;
     content: string;
   }[];
-  localChangeOnly?: boolean;
-  selectedLanguage?: string;
-  onSelect?: (newValue: SingleValue<ReactSelectOption>) => void;
   SDKSelected?: string;
   allListOfLanguages?: string[];
   selectedSDKInterfaceTab: string;
@@ -43,7 +41,7 @@ const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<Reac
   if (newValue) {
     const language = newValue.value;
     const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
-      getFilteredLanguages(language),
+      getTrimmedLanguage(language),
       pageLanguage,
     );
 
@@ -54,9 +52,7 @@ const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<Reac
 
 const LanguageNavigation = ({
   items,
-  localChangeOnly,
-  selectedLanguage,
-  onSelect,
+
   allListOfLanguages,
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
@@ -64,12 +60,10 @@ const LanguageNavigation = ({
 }: LanguageNavigationProps) => {
   const pageLanguage = useContext(PageLanguageContext);
   const selectedPageLanguage = pageLanguage === DEFAULT_LANGUAGE ? DEFAULT_PREFERRED_LANGUAGE : pageLanguage;
-  const actualSelectedLanguage = localChangeOnly ? selectedLanguage : selectedPageLanguage;
   const options = items.map((item) => ({ label: item.content, value: item.props.language }));
-  const value = options.find((option) => option.value === actualSelectedLanguage);
+  const value = options.find((option) => option.value === selectedPageLanguage);
 
-  const shouldUseLocalChanges = localChangeOnly && !!onSelect;
-  const onSelectChange = shouldUseLocalChanges ? onSelect : changePageOnSelect(pageLanguage);
+  const onSelectChange = changePageOnSelect(pageLanguage);
 
   const isSDKInterFacePresent = allListOfLanguages
     ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -8,6 +8,7 @@ import LocalLanguageAlternatives from '../wrappers/LocalLanguageAlternatives';
 import {
   DEFAULT_LANGUAGE,
   DEFAULT_PREFERRED_INTERFACE,
+  DEFAULT_PREFERRED_LANGUAGE,
   REALTIME_SDK_INTERFACE,
   REST_SDK_INTERFACE,
 } from '../../../../data/createPages/constants';
@@ -16,7 +17,7 @@ import HtmlDataTypes from '../../../../data/types/html';
 import { isString, every, reduce } from 'lodash/fp';
 import { MultilineCodeContent } from './Code/MultilineCodeContent';
 import { isArray, isEmpty } from 'lodash';
-import { getFilteredLanguages } from 'src/components/common';
+import { getTrimmedLanguage } from 'src/components/common';
 
 type PreProps = HtmlComponentProps<'pre'> & {
   language: string;
@@ -48,7 +49,7 @@ const Pre = ({
   }
 
   const hasCode =
-    languages?.some((lang) => getFilteredLanguages(lang) === pageLanguage) || pageLanguage === DEFAULT_LANGUAGE;
+    languages?.some((lang) => getTrimmedLanguage(lang) === pageLanguage) || pageLanguage === DEFAULT_LANGUAGE;
   const shouldDisplayTip = !hasCode && languages?.length !== undefined;
   const withModifiedClassname = {
     ...attribs,
@@ -153,10 +154,11 @@ const Pre = ({
             languages={languages}
             data={altData}
             initialData={dataWithoutPTags}
-            localChangeOnly={shouldDisplayTip}
+            isSDKInterface={isSDKInterface}
             selectedSDKInterfaceTab={selectedSDKInterfaceTab}
             setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
             setPreviousSDKInterfaceTab={setPreviousSDKInterfaceTab}
+            selectedPageLanguage={pageLanguage || DEFAULT_PREFERRED_LANGUAGE}
           />
         ) : (
           <Html data={dataWithoutPTags} />

--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`<Pre /> should successfully render Code elements with language 1`] = `
         data-testid="menu"
       >
         <button
-          class="button"
+          class="button isActive"
         >
           JavaScript
         </button>

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.test.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-
 import LocalLanguageAlternatives from './LocalLanguageAlternatives';
 
 const props = {
@@ -56,6 +55,7 @@ const props = {
   },
   languages: ['javascript', 'ruby', 'csharp'],
   localChangeOnly: false,
+  isSDKInterface: false,
   initialData: [
     {
       data: [{ data: "await ably.close()\nprint('Closed the connection to Ably.')", type: 'text', name: 'text' }],
@@ -64,17 +64,68 @@ const props = {
       attribs: { lang: 'python' },
     },
   ],
+  setSelectedSDKInterfaceTab: () => {
+    throw new Error('Function not implemented.');
+  },
+  setPreviousSDKInterfaceTab: () => {
+    throw new Error('Function not implemented.');
+  },
 };
 
 describe('<LocalLanguageAlternatives />', () => {
   it('renders correctly', () => {
-    const { container } = render(<LocalLanguageAlternatives isSDKInterface={false} {...props} />);
+    const { container } = render(
+      <LocalLanguageAlternatives selectedPageLanguage="javascript" selectedSDKInterfaceTab="realtime" {...props} />,
+    );
     expect(container).toMatchSnapshot();
     expect(screen.getByTestId('menu')).toBeInTheDocument();
   });
 
   it("doesn't render the menu bar when only one language", () => {
-    render(<LocalLanguageAlternatives isSDKInterface={false} {...props} languages={['javascript', '']} />);
+    render(
+      <LocalLanguageAlternatives
+        selectedPageLanguage="javascript"
+        selectedSDKInterfaceTab="realtime"
+        {...props}
+        languages={['javascript', '']}
+      />,
+    );
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('renders when we have multiple languages and selectedPageLanguage is present', () => {
+    render(
+      <LocalLanguageAlternatives
+        {...props}
+        languages={['javascript', 'nodejs', 'java', 'ruby', 'swift', 'csharp', 'objc', 'flutter', 'go']}
+        selectedSDKInterfaceTab="rest"
+        selectedPageLanguage="javascript"
+      />,
+    );
+    expect(screen.getByTestId('menu')).toBeInTheDocument();
+  });
+
+  it('renders when we have SDK multiple languages and selectedPageLanguage is an SDK Interface language', () => {
+    render(
+      <LocalLanguageAlternatives
+        {...props}
+        languages={['javascript', 'nodejs', 'java', 'ruby', 'swift', 'csharp', 'objc', 'flutter', 'go']}
+        selectedSDKInterfaceTab="rest"
+        selectedPageLanguage="rest_javascript"
+      />,
+    );
+    expect(screen.getByTestId('menu')).toBeInTheDocument();
+  });
+
+  it('doesnt renders when  selectedPageLanguage is not present in the languages', () => {
+    render(
+      <LocalLanguageAlternatives
+        {...props}
+        languages={['javascript', 'nodejs', 'java', 'ruby', 'swift', 'csharp', 'objc', 'flutter', 'go']}
+        selectedSDKInterfaceTab="realtime"
+        selectedPageLanguage="php"
+      />,
+    );
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 });

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -1,108 +1,70 @@
-import React, { useState, MouseEvent, useEffect, Dispatch, SetStateAction } from 'react';
+import React, { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import languageLabels from '../../../maps/language';
-import { MenuItemButton } from '../../Menu/MenuItemButton';
 import Html from '../Html';
 import { LanguageNavigation } from '../../Menu/LanguageNavigation';
-import { getFilteredLanguages, LanguageButton, ReactSelectOption } from 'src/components';
+import { getTrimmedLanguage, LanguageButton } from 'src/components';
 import { LanguageNavigationProps } from '../../Menu/LanguageNavigation';
 import { HtmlComponentProps, HtmlComponentPropsData, ValidReactElement } from 'src/components/html-component-props';
 import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE } from '../../../../data/createPages/constants';
-import { SingleValue } from 'react-select';
-import { isObject } from 'lodash';
-import { cleanIfLanguageHasSDKInterface } from '../software/Pre';
 
 const LocalLanguageAlternatives = ({
   languages,
   data,
   initialData,
-  localChangeOnly,
+  isSDKInterface,
   selectedSDKInterfaceTab,
   setSelectedSDKInterfaceTab,
   setPreviousSDKInterfaceTab,
+  selectedPageLanguage,
 }: {
   languages: string[];
   data?: Record<string, string | HtmlComponentProps<ValidReactElement>[] | null>;
   initialData: HtmlComponentPropsData;
-  localChangeOnly: boolean;
+  isSDKInterface: boolean;
   selectedSDKInterfaceTab: string;
   setSelectedSDKInterfaceTab: Dispatch<SetStateAction<string>>;
   setPreviousSDKInterfaceTab: Dispatch<SetStateAction<string>>;
+  selectedPageLanguage: string;
 }) => {
   const [selected, setSelected] = useState(initialData);
-  const [selectedLanguage, setSelectedLanguage] = useState(languages[0]);
+
   useEffect(() => {
     setSelected(initialData);
   }, [initialData]);
 
-  const setLocalSelected = (value: string) => {
-    const selectedLocalData = data ? data[value] : '';
-    if (selectedLocalData !== null && isObject(selectedLocalData?.[0])) {
-      /* when rest/realtime languages are passed from local they are not trimmed yet, so we need to trim here */
-      const selectedLocalDataLang = selectedLocalData[0]?.attribs?.lang;
-      const cleanSelectedLocalData = [
-        {
-          ...selectedLocalData[0],
-          attribs: {
-            lang: selectedLocalDataLang ? cleanIfLanguageHasSDKInterface(selectedLocalDataLang) : '',
-          },
-        },
-      ];
-      setSelected(cleanSelectedLocalData);
-    }
-    setSelectedLanguage(getFilteredLanguages(value));
-  };
-
-  const onClick = ({ currentTarget: { value } }: MouseEvent<HTMLButtonElement>) => {
-    setLocalSelected(value);
-  };
-
-  const onSelect = (newValue: SingleValue<ReactSelectOption>) => {
-    if (newValue) {
-      setLocalSelected(newValue.value);
-    }
-  };
-
-  const languageItems = languages
+  const filteredLanguagesWithoutDefault = languages
     .filter((lang) => lang !== DEFAULT_LANGUAGE)
-    .filter((lang) => lang !== '')
-    .map((lang) => {
-      // Site navigation button
+    .filter((lang) => lang !== '');
 
-      const languageSelected = lang || DEFAULT_PREFERRED_LANGUAGE;
-      const filterLanguageForLangButton = languageSDKInterfaceClean(languageSelected, selectedSDKInterfaceTab);
+  const isPreHasLanguageSelected = checkIfPreHaveLanguageSelected(
+    filteredLanguagesWithoutDefault,
+    selectedPageLanguage,
+    selectedSDKInterfaceTab,
+    isSDKInterface,
+  );
 
-      if (!localChangeOnly && filterLanguageForLangButton != '') {
-        return {
-          Component: LanguageButton,
-          props: { language: filterLanguageForLangButton },
-          content: languageLabels[lang] ?? lang,
-        };
-      }
-      // Local button, if global language option doesn't exist
+  const languageItems = filteredLanguagesWithoutDefault.map((lang) => {
+    // Site navigation button
 
-      const selectedLanguageFiltered = getFilteredLanguages(selectedLanguage);
-      const languageFiltered = getFilteredLanguages(lang);
-      const filterLanguageForMenuButton = languageSDKInterfaceClean(lang, selectedSDKInterfaceTab);
+    const languageSelected = lang || DEFAULT_PREFERRED_LANGUAGE;
+    const filterLanguageForLangButton = languageSDKInterfaceClean(languageSelected, selectedSDKInterfaceTab);
 
+    if (filterLanguageForLangButton != '') {
       return {
-        Component: MenuItemButton,
+        Component: LanguageButton,
         props: {
-          language: filterLanguageForMenuButton != '' ? filterLanguageForMenuButton : lang,
-          onClick,
-          value: lang,
-          isSelected: languageFiltered === selectedLanguageFiltered,
+          language: filterLanguageForLangButton,
+          selectedLanguageForPre: isPreHasLanguageSelected ? selectedPageLanguage : getTrimmedLanguage(languages[0]),
         },
         content: languageLabels[lang] ?? lang,
       };
-    });
+    }
+  });
 
   return (
     <>
       <LanguageNavigation
         items={languageItems as LanguageNavigationProps['items']}
-        localChangeOnly={localChangeOnly}
-        selectedLanguage={selectedLanguage}
-        onSelect={onSelect}
         allListOfLanguages={data ? Object.entries(data).map(([key]) => key) : []}
         selectedSDKInterfaceTab={selectedSDKInterfaceTab}
         setSelectedSDKInterfaceTab={setSelectedSDKInterfaceTab}
@@ -117,3 +79,16 @@ export default LocalLanguageAlternatives;
 
 const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
   language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;
+
+/* this method helps us to determine if an array of languages has a pageSelected present, a condition added if it is an SDK Interface, so we can compare the values correctly */
+const checkIfPreHaveLanguageSelected = (
+  languages: string[],
+  selectedPageLanguage: string,
+  selectedSDKInterfaceTab: string,
+  isSDKInterface: boolean,
+) =>
+  languages
+    .map((lang) =>
+      isSDKInterface ? lang === `${selectedSDKInterfaceTab}_${selectedPageLanguage}` : lang === selectedPageLanguage,
+    )
+    .includes(true);

--- a/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
+++ b/src/components/blocks/wrappers/LocalLanguageAlternatives.tsx
@@ -36,7 +36,7 @@ const LocalLanguageAlternatives = ({
     .filter((lang) => lang !== DEFAULT_LANGUAGE)
     .filter((lang) => lang !== '');
 
-  const isPreHasLanguageSelected = checkIfPreHaveLanguageSelected(
+  const hasLocalLanguageSelected = checkIfLocalLanguageSelected(
     filteredLanguagesWithoutDefault,
     selectedPageLanguage,
     selectedSDKInterfaceTab,
@@ -54,7 +54,7 @@ const LocalLanguageAlternatives = ({
         Component: LanguageButton,
         props: {
           language: filterLanguageForLangButton,
-          selectedLanguageForPre: isPreHasLanguageSelected ? selectedPageLanguage : getTrimmedLanguage(languages[0]),
+          selectedLocalLanguage: hasLocalLanguageSelected ? selectedPageLanguage : getTrimmedLanguage(languages[0]),
         },
         content: languageLabels[lang] ?? lang,
       };
@@ -80,15 +80,16 @@ export default LocalLanguageAlternatives;
 const languageSDKInterfaceClean = (language: string, selectedTab: string) =>
   language.includes(`_`) ? (language.includes(`${selectedTab}_`) ? language.split('_', 2)[1] : '') : language;
 
-/* this method helps us to determine if an array of languages has a pageSelected present, a condition added if it is an SDK Interface, so we can compare the values correctly */
-const checkIfPreHaveLanguageSelected = (
+/* this function helps us to determine if an array of languages has a pageSelected present, a condition added if it is an SDK Interface, so we can compare the values correctly */
+const checkIfLocalLanguageSelected = (
   languages: string[],
   selectedPageLanguage: string,
   selectedSDKInterfaceTab: string,
   isSDKInterface: boolean,
 ) =>
-  languages
-    .map((lang) =>
-      isSDKInterface ? lang === `${selectedSDKInterfaceTab}_${selectedPageLanguage}` : lang === selectedPageLanguage,
-    )
-    .includes(true);
+  languages.reduce((acc, lang) => {
+    const localLanguageSelected = isSDKInterface
+      ? lang === `${selectedSDKInterfaceTab}_${selectedPageLanguage}`
+      : lang === selectedPageLanguage;
+    return localLanguageSelected || acc;
+  }, false);

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
       data-testid="menu"
     >
       <button
-        class="button"
+        class="button isActive"
       >
         JavaScript
       </button>

--- a/src/components/common/language-defaults.ts
+++ b/src/components/common/language-defaults.ts
@@ -33,5 +33,4 @@ export const createLanguageHrefFromDefaults = (
  Need to filter the language if the language is rest_ or realtime_ ex: rest_javascript
  it needs to return the language only without the sdk interface indicator
  */
-export const getFilteredLanguages = (language: string) =>
-  language.includes('_') ? language.split('_', 2)[1] : language;
+export const getTrimmedLanguage = (language: string) => (language.includes('_') ? language.split('_', 2)[1] : language);


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

* [EDU-1377](https://ably.atlassian.net/browse/EDU-1377)

### Changes done:
- Removed the `localChange` functionality and component parameters so it always reload whenever they select new language.
- In the `LocalLanguageAlternatives`, removed the `MenuItemButton` component as it wont be used anymore and other event handling function for `localChange`
- Renamed the function from `getFilteredLanguages` to `getTrimmedLanguage` so its more easier to understand the use of the function

**So for the issue if the language is not present in an SDK Interface codebox, changes are:** 

- Added a `checkIfPreHaveLanguageSelected` method, helps us to determine if an array of languages has a `pageSelected` lang present, a condition was also added if it is an SDK Interface, so we can compare the values correctly .

- So if language is present in the languages then return the `pageLanguage` if not then return the first language of the array

- In the `LanguageButton`, separate the `isLanguageActive` constant  as we will pass a either a `pageLanguage`  from the context lang or if context page lang is not present in the languages we will pass the first language of the languages
- Update snapshot tests 


## Review

Instructions on how to review the PR. 

* run it in your local and check channels and quick started page.
* Need to test a page with SDK Interface codebox and just normal codebox with languages
* Should have one codebox that has language that other codeboxes doesnt it to test the localChange doesnt work anymore.


[EDU-1377]: https://ably.atlassian.net/browse/EDU-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ