### PR TITLE
[EDU-1354] Update tooltip and message copy

### DIFF
--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.test.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.test.tsx
@@ -14,13 +14,13 @@ describe(`<SDKInterfacePanel />`, () => {
     render(<SDKInterfacePanel {...SDKInterfacePanelProps} />);
     expect(
       screen.getByRole('button', {
-        name: /REALTIME/i,
+        name: 'Realtime',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
-        name: /REST/i,
+        name: 'REST',
       }),
     ).toBeInTheDocument();
   });
@@ -29,7 +29,7 @@ describe(`<SDKInterfacePanel />`, () => {
     render(<SDKInterfacePanel {...SDKInterfacePanelProps} />);
     expect(
       screen.getByRole('button', {
-        name: /REALTIME/i,
+        name: 'Realtime',
       }),
     ).toHaveClass('bg-charcoal-grey');
   });
@@ -38,12 +38,12 @@ describe(`<SDKInterfacePanel />`, () => {
     render(<SDKInterfacePanel {...SDKInterfacePanelProps} selectedSDKInterfaceTab="rest" />);
     expect(
       screen.getByRole('button', {
-        name: /REST/i,
+        name: 'REST',
       }),
     ).toHaveClass('bg-charcoal-grey');
     expect(
       screen.getByRole('button', {
-        name: /REALTIME/i,
+        name: 'Realtime',
       }),
     ).not.toHaveClass('bg-charcoal-grey');
   });
@@ -52,13 +52,13 @@ describe(`<SDKInterfacePanel />`, () => {
     render(<SDKInterfacePanel {...SDKInterfacePanelProps} sdkInterfaceAvailable={['realtime']} />);
     expect(
       screen.getByRole('button', {
-        name: /REALTIME/i,
+        name: 'Realtime',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', {
-        name: /REST/i,
+        name: 'REST',
       }),
     ).not.toBeInTheDocument();
   });
@@ -68,12 +68,12 @@ describe(`<SDKInterfacePanel />`, () => {
 
     expect(
       screen.queryByRole('button', {
-        name: /REALTIME/i,
+        name: 'Realtime',
       }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /REST/i,
+        name: 'REST',
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -63,7 +63,7 @@ const SDKInterfacePanel = ({
             {languageLabels[sdkInterface] ?? sdkInterface}
           </button>
         ))}
-        <SDKToolTip tooltip="Tooltips display informative text when users hover over, focus on, or tap an element." />
+        <SDKToolTip tooltip="Ably SDKs may contain a realtime and a REST interface, each of which satisfy different use cases." />
       </menu>
     </div>
   );

--- a/src/components/blocks/software/Pre.test.tsx
+++ b/src/components/blocks/software/Pre.test.tsx
@@ -63,7 +63,9 @@ describe('<Pre />', () => {
         />
       </PageLanguageContext.Provider>,
     );
-    expect(screen.getByText('we don’t yet have a relevant code sample', { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByText("code sample for this example, or this feature isn't supported in", { exact: false }),
+    ).toBeInTheDocument();
   });
 
   it('should render code block when no languages are passed', () => {

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -115,8 +115,8 @@ const Pre = ({
     isSDKInterface && isArray(sdkInterfaceData) && !isEmpty(sdkInterfaceData) ? sdkInterfaceData : data;
   let dataWithoutPTags = isArray(newDataWithSDKOrNot)
     ? newDataWithSDKOrNot.map((child) =>
-        child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
-      )
+      child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
+    )
     : newDataWithSDKOrNot;
 
   /* Cleanup if the language passed has realtime or rest, so it will highlight the code correctly */
@@ -142,10 +142,10 @@ const Pre = ({
             <Icon name="icon-gui-info" size="1rem" />
           </div>
           <div className="ml-8 leading-normal">
-            You’re currently reading the{' '}
-            <span className="font-semibold">{languageLabels[pageLanguage] ?? pageLanguage}</span> docs but we don’t yet
-            have a relevant code sample. You can explore equivalent samples below. To visit the docs for other
-            languages, select the language using the dropdown at the top of the page.
+            You’re currently viewing the{' '}
+            <span className="font-semibold">{languageLabels[pageLanguage] ?? pageLanguage}</span> docs. There either isn't a {' '}
+            {languageLabels[pageLanguage] ?? pageLanguage} code sample for this example, or this feature isn't supported in {' '}
+            {languageLabels[pageLanguage] ?? pageLanguage}. Switch language to view this example in a different language, or <a className="docs-link" href="/docs/getting-started/sdks">check which SDKs support this feature.</a>
           </div>
         </aside>
       )}

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -115,8 +115,8 @@ const Pre = ({
     isSDKInterface && isArray(sdkInterfaceData) && !isEmpty(sdkInterfaceData) ? sdkInterfaceData : data;
   let dataWithoutPTags = isArray(newDataWithSDKOrNot)
     ? newDataWithSDKOrNot.map((child) =>
-      child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
-    )
+        child.name === HtmlDataTypes.p ? { ...child, name: HtmlDataTypes.div } : child,
+      )
     : newDataWithSDKOrNot;
 
   /* Cleanup if the language passed has realtime or rest, so it will highlight the code correctly */
@@ -143,9 +143,13 @@ const Pre = ({
           </div>
           <div className="ml-8 leading-normal">
             You’re currently viewing the{' '}
-            <span className="font-semibold">{languageLabels[pageLanguage] ?? pageLanguage}</span> docs. There either isn't a {' '}
-            {languageLabels[pageLanguage] ?? pageLanguage} code sample for this example, or this feature isn't supported in {' '}
-            {languageLabels[pageLanguage] ?? pageLanguage}. Switch language to view this example in a different language, or <a className="docs-link" href="/docs/getting-started/sdks">check which SDKs support this feature.</a>
+            <span className="font-semibold">{languageLabels[pageLanguage] ?? pageLanguage}</span> docs. There either
+            isn&apos;t a {languageLabels[pageLanguage] ?? pageLanguage} code sample for this example, or this feature
+            isn&apos;t supported in {languageLabels[pageLanguage] ?? pageLanguage}. Switch language to view this example
+            in a different language, or{' '}
+            <a className="docs-link" href="/docs/getting-started/sdks">
+              check which SDKs support this feature.
+            </a>
           </div>
         </aside>
       )}

--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`<Pre /> should successfully render code elements with  only Realtime la
           Realtime
         </button>
         <div
-          aria-label="Tooltips display informative text when users hover over, focus on, or tap an element."
+          aria-label="Ably SDKs may contain a realtime and a REST interface, each of which satisfy different use cases."
           class="flex flex-row w-full justify-start mt-2"
           role="button"
           tabindex="0"
@@ -257,7 +257,7 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
           Realtime
         </button>
         <div
-          aria-label="Tooltips display informative text when users hover over, focus on, or tap an element."
+          aria-label="Ably SDKs may contain a realtime and a REST interface, each of which satisfy different use cases."
           class="flex flex-row w-full justify-start mt-2"
           role="button"
           tabindex="0"
@@ -389,7 +389,7 @@ exports[`<Pre /> should successfully render code elements with both Rest and Rea
           REST
         </button>
         <div
-          aria-label="Tooltips display informative text when users hover over, focus on, or tap an element."
+          aria-label="Ably SDKs may contain a realtime and a REST interface, each of which satisfy different use cases."
           class="flex flex-row w-full justify-start mt-2"
           role="button"
           tabindex="0"


### PR DESCRIPTION
## Description

This PR updates the copy for the REST/realtime selector tooltip, and also updates the message that displays when a code block is displayed that doesn't support the currently selected language.

See [JIRA](https://ably.atlassian.net/browse/EDU-1354) for full details.