### PR TITLE
Clarify publish on behalf

### DIFF
--- a/content/api/realtime-sdk/connection.textile
+++ b/content/api/realtime-sdk/connection.textile
@@ -90,7 +90,7 @@ h6(#key).
 
 A unique private connection key @String@ used to recover or resume a connection, assigned by Ably. When recovering a connection explicitly, the <span lang="default">@recoveryKey@</span><span lang="ruby">@recovery_key@</span> is used in the @recover@ "client options":/api/realtime-sdk#client-options as it contains both the @key@ and the last message @serial@.
 
-This private connection key can also be used by other REST clients to publish on behalf of this client. See the "publishing over REST on behalf of a realtime client documentation":/rest/channels#publish-on-behalf  for more info.
+This private connection key can also be used by other REST clients to publish on behalf of this client. See the "publishing over REST on behalf of a realtime client documentation":/rest/messages#publish-on-behalf  for more info.
 
 h6(#recovery-key).
   default: recoveryKey

--- a/content/api/rest-sdk/messages.textile
+++ b/content/api/rest-sdk/messages.textile
@@ -88,6 +88,13 @@ h6(#connection-id).
 
 The connection ID of the publisher of this message.<br>__Type: @String@__
 
+h6(#connection-key).
+  default: connectionKey
+  csharp,go: ConnectionKey
+  ruby,python: connection_key
+
+A connection key, which can optionally be included for a REST publish as part of the "publishing over REST on behalf of a realtime client functionality":/rest/messages#publish-on-behalf.<br>__Type: @String@__
+
 h6(#timestamp).
   default: timestamp
   csharp,go: Timestamp

--- a/content/rest/messages.textile
+++ b/content/rest/messages.textile
@@ -183,9 +183,13 @@ channel.publish([{data: 'payload', id: 'unique123'}]);
 
 h4(#publish-on-behalf). Publishing on behalf of realtime connection
 
-Message published using the REST API may be done so on behalf of an existing realtime connection when a valid @connectionKey@ is present in the published message. For example, if you want to publish a message using the REST client library so that it appears to come from an existing connected realtime client, then the connection's "private (secret) connection key":/api/realtime-sdk/connection#key must be included.
+Message can be published using the REST API on behalf of an existing realtime connection, such that they appear to have been published by that realtime client.
 
-If the @connectionKey@ is invalid or belongs to a connection that has since been closed, then the publish operation will fail.
+To do this, the rest publisher must have obtained "the @connectionKey@ of the realtime client":/api/realtime-sdk/connection#key (which, unlike the connection id, is a secret of the client unless explicitly shared). That can then set that "as a @connectionKey@ in the root of the published message":/api/rest-sdk/messages#connection-key .
+
+Note that if the realtime connection is "'identified', that is, bound to a clientId":https://faqs.ably.com/authenticated-and-identified-clients , then the REST publish must include that same clientId (either "in the message itself":/api/rest-sdk/messages#client-id to apply to only that message, in the common case that the REST client is able to assume any clientId, or using a REST client bound to that clientId). Conversely, if the realtime connection is not bound to a clientId, the REST publish must also not include a clientId. The reason for this is that if your auth server issues a token bound to a specific clientId, a realtime client using that token can't bypass that restriction by asking a REST client to publish on its behalf.
+
+If the @connectionKey@ is invalid, or the REST publisher is using a different app to the realtime client, or the clientIds do not match between the realtime connection and the rest publish, the publish operation will fail.
 
 h3(#message-history). Retrieving message history
 


### PR DESCRIPTION
Context: https://ably-real-time.slack.com/archives/C8SPU4589/p1680713169502179 -- we underdocument the publish-on-behalf thing.

I went back and forth a bit about whether to explicitly include a sentence like "(Note that this restriction is not enforced for connectionKeys issued to realtime connections using older versions of the realtime protocol)". Ultimately ended up not, it's not very actionable and unnecessarily confuse/complicates it.

Main page to review: rest/messages#publish-on-behalf