### PR TITLE
[EDU-1385]: Hide API Version label

### DIFF
--- a/src/components/Menu/TopCodeMenu.tsx
+++ b/src/components/Menu/TopCodeMenu.tsx
@@ -21,10 +21,6 @@ const TopCodeMenu = ({ languages, versionData }: { languages: string[]; versionD
     >
       <HorizontalMenu variant={HorizontalMenuVariant.end}>
         <HomePageLink />
-        <div className="flex justify-end items-center col-span-1">
-          <span className="inline"> API v {LATEST_ABLY_API_VERSION_STRING}</span>
-        </div>
-
         {showLanguageSelector ? (
           <LanguageDropdownSelector language={pageLanguage} languages={languages} showDefaultLink={showDefaultLink} />
         ) : null}


### PR DESCRIPTION
## Description
[EDU-1385](url)

## Review
The API version label is no longer displayed next to the language selector dropdown.


[EDU-1385]: https://ably.atlassian.net/browse/EDU-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ