### PR TITLE
fix formatting on token revocation

### DIFF
--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -453,7 +453,7 @@ All target specifiers are formatted as: @key:<string>@.
 By default, supported target specifiers are:
 
 - clientId := This target specifier will match tokens that have the specified @clientId@. For example, @targets: ["clientId:client1.example.com"]@ matches tokens containing the @clientId@ of @client1.example.com@.
-- revocationKey := This target specifier will match tokens that have the specified @revocationKey@. For example: @targets: ["revocationKey:users.group1.example.com"]@ matches tokens containing the @revocationKey@ of @users.group.example.com@.
+- revocationKey := This target specifier will match tokens that have the specified @revocationKey@. For example: @targets: ["revocationKey:users.group1.example.com"]@ matches tokens containing the @revocationKey@ of @users.group1.example.com@.
 
 The following target specifier can also be enabled for you by Ably, should your use case require it:
 

--- a/content/core-features/authentication.textile
+++ b/content/core-features/authentication.textile
@@ -452,8 +452,8 @@ All target specifiers are formatted as: @key:<string>@.
 
 By default, supported target specifiers are:
 
-- clientId := This target specifier will match tokens that have the specified @clientId@. For example, <code>targets: ["clientId:client1@example.com"]</code> matches tokens containing the @clientId@ of <code>client1@example.com</code>.
-- revocationKey := This target specifier will match tokens that have the specified @revocationKey@. For example: <code>targets: ["revocationKey:users.group1@example.com"]</code> matches tokens containing the @revocationKey@ of <code>users.group1@example.com</code>.
+- clientId := This target specifier will match tokens that have the specified @clientId@. For example, @targets: ["clientId:client1.example.com"]@ matches tokens containing the @clientId@ of @client1.example.com@.
+- revocationKey := This target specifier will match tokens that have the specified @revocationKey@. For example: @targets: ["revocationKey:users.group1.example.com"]@ matches tokens containing the @revocationKey@ of @users.group.example.com@.
 
 The following target specifier can also be enabled for you by Ably, should your use case require it:
 
@@ -464,7 +464,7 @@ h4. API endpoint
 The Ably REST API contains the following endpoint for token revocation:
 
 ```
-POST /keys/<keyName>/revokeTokens
+POST /keys/{{keyName}}/revokeTokens
 ```
 
 Where the @keyName@ is @appId.keyId@.


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Fixes the formatting on the token revocation sections around code snippets. Some of the examples were updated to remove the `@` symbol, as textile wasn't liking this.

## Review

- `npm run edit`
- Look at the `/docs/core-features/authentication#revocable-tokens` page