### PR TITLE
Bug: Fix Footer logo is missing by replacing ably-ui Logo to img

### DIFF
--- a/src/components/Footer/FooterTopNav/FooterLogo.tsx
+++ b/src/components/Footer/FooterTopNav/FooterLogo.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import Logo from '@ably/ui/core/Logo';
 
 export const FooterLogo = () => (
-  <>
-    <Logo dataId="footer-logo" href="/" />
-  </>
+  <a href="/" data-id="footer-logo" className="block" style={{ height: '2.125rem' }}>
+    <img src="/images/ably-logo.png" width="108px" alt="Ably logo" />
+  </a>
 );

--- a/src/types/ably-ui-core-images/ably-ui-logo-loading.d.ts
+++ b/src/types/ably-ui-core-images/ably-ui-logo-loading.d.ts
@@ -3,6 +3,7 @@ declare module '@ably/ui/core/Logo' {
   export interface LogoProps {
     dataId: string;
     href: string;
+    logoUrl: string;
   }
 
   const Logo: FunctionComponent<LogoProps>;


### PR DESCRIPTION
## Description

The `Logo` component from ably-ui seems doesnt work. 
Since none of the projects is using this component might as well not used it as its unstable

## Review

Instructions on how to review the PR. 

* Check all docs pages and make sure the logo is present
