### PR TITLE
[EDU-1200] Add page for SDK setup instructions

### DIFF
--- a/content/getting-started/setup.textile
+++ b/content/getting-started/setup.textile
@@ -1,0 +1,302 @@
+---
+title: SDK setup
+meta_description: "Install and instantiate an Ably SDK to get started with Ably."
+languages:
+  - csharp
+  - flutter
+  - java
+  - javascript
+  - nodejs
+  - objc
+  - php
+  - python
+  - ruby
+  - swift
+  - go
+---
+
+Use these instructions to setup an Ably SDK. "How to use Ably":/basics/use-ably outlines the differences between the realtime and REST interfaces in Ably SDKs and the other possible ways to use Ably.
+
+h2(#api). Get an API key
+
+An "API key":/auth#api-keys is required to instantiate a client and authenticate with Ably. "Sign up":https://ably.com/sign-up to Ably to create an API key in the "dashboard":https://ably.com/dashboard or use the "Control API":/account/control-api to create an API programmatically.
+
+h2(#install). Install and instantiate a client
+
+Ably SDKs provide a consistent and idiomatic API across a variety of "supported platforms":/getting-started/sdks#sdks. They contain a realtime and a REST interface, each of which can be used to satisfy different use cases. Choose which SDK you'd like to start using by selecting the language from the dropdown menu above.
+
+blang[javascript].
+  The JavaScript SDK is available via CDN. To get started with your project, reference the SDK within the @<head>@ of an HTML page. The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
+
+  When including the SDK from CDN, Ably recommends that you lock into major version @1@ of the library. This means that you will automatically receive minor and patch updates but you will never receive breaking changes. For example, if you lock into major version @1@ using "@https://cdn.ably.com/lib/ably.min-1.js@", you will receive all minor updates and patch fixes automatically. Additionally, the @.min@ suffix can be dropped if you want the non-minified version for debugging.
+
+  ```[html]
+  <script lang="text/javascript" src="https://cdn.ably.com/lib/ably.min-1.js"></script>
+  ```
+
+blang[nodejs].
+  The NodeJS SDK is available as an "NPM module":https://www.npmjs.com/package/ably. To get started with your project, install the package.
+
+  ```[sh]
+  npm install ably
+  ```
+
+blang[ruby].
+  The Ruby SDK is available as a "Gem":https://rubygems.org/gems/ably. To get started with your project, install the Gem and add it to your Gemfile.
+
+  The realtime interface must be run within an "EventMachine reactor":https://github.com/eventmachine/eventmachine which provides an asynchronous evented framework for the library to run within. 
+
+  ```[sh]
+  # Install the gem
+  gem install ably
+
+  # To use the REST-only SDK
+  gem install ably-rest
+  ```
+
+  ```[ruby]
+  # Add the gem to your Gemfile
+  gem 'ably'
+
+  # To use the REST-only SDK
+  gem 'ably-rest'
+  ```
+
+blang[java].
+  The Java SDK is available on "GitHub":https://github.com/ably/ably-java and hosted on "Maven Central":https://mvnrepository.com/repos/central. To get started with your project, add the SDK into your @build.gradle@ dependencies section and a reference to Maven in the repositories section if it isn't included by default.
+
+
+  ```[java]
+  // For Java applications
+  dependencies {
+    implementation 'io.ably:ably-java:1.2.0'
+  }
+
+  repositories {
+    mavenCentral()
+  }
+
+  // For Android applications
+  dependencies {
+    implementation 'io.ably:ably-android:1.2.0'
+  }
+
+  repositories {
+    mavenCentral()
+  }
+  ```
+
+blang[csharp].
+  The .NET SDK is hosted on "GitHub":https://github.com/ably/ably-dotnet and is also available as a "Nuget package":https://www.nuget.org/packages/ably.io/. To get started with your project, install the package into your project directory using the .NET CLI, or from the Package Manager Console.
+
+  ```[sh]
+  dotnet add package ably.io --version [version]
+  ```
+
+  ```[text]
+  PM> Install-Package ably.io
+  ```
+
+blang[objc].
+  The Objective-C SDK is available as a CocoaPod. To get started with your project, add the SDK to your Podfile and run @pod install@. 
+
+  ```[text]
+  pod 'Ably'
+  ```
+
+  ```[sh]
+  pod install
+  ```
+
+blang[swift].
+  The Swift SDK is available as a CocoaPod. To get started with your project, add the SDK to your Podfile and run @pod install@. 
+
+  ```[text]
+  pod 'Ably'
+  ```
+
+  ```[sh]
+  pod install
+  ```
+
+blang[flutter].
+  The Flutter SDK is hosted on "GitHub":https://github.com/ably/ably-flutter and available as a "Flutter plugin":https://pub.dev/packages/ably_flutter. To get started with your project, update your @pubspec.yaml@ with the Ably package and import it into your Dart file.
+
+  ```[yaml]
+  # ...
+  ably-flutter: [version]
+  # ...
+  ```
+
+  ```[flutter]
+  import 'package:ably_flutter/ably_flutter.dart' as ably;
+  ```
+
+blang[go].
+  The Go SDK is hosted on "Github":https://github.com/ably/ably-go. To get started with your project, install the SDK by running the @go get@ command, and import it into your Go file.
+
+  ```[go]
+  go get -u github.com/ably/ably-go/ably
+  ```
+
+  ```[go]
+  import (
+      "context"
+      "fmt"
+      "github.com/ably/ably-go/ably"
+  )
+  ```
+
+blang[python].
+  The Python SDK is available from "PyPI":https://pypi.org/project/ably/. To get started with your project install the SDK using @pip@. Note that the Python SDK only implements the REST interface and also requires @asyncio@ to run.
+
+  Ably supports both string and binary payloads. To avoid ambiguity, it is recommended that strings passed to the library for publishing to Ably, for example, as an event name or payload data, should be unicode strings. In Python 3 this is the normal string type, but in Python 2 it is not. Ably suggests that you prefix string literals with the @u@ prefix and to explicitly decode any user input, such as @raw_input().decode(sys.stdin.encoding@.
+
+  ```[sh]
+  pip install ably
+  pip install asyncio
+  ```
+
+  ```[python]
+  from ably import AblyRest
+  import asyncio
+  ```
+
+blang[php].
+  The PHP SDK is available as a composer package on "packagist":https://packagist.org/packages/ably/ably-php. To get started with your project, install the SDK and include the composer's autoloader. Note that the PHP SDK only implements the REST interface.
+
+  ```[sh]
+  composer require ably/ably-php --update-no-dev
+  ```
+
+  ```[php]
+  require_once __DIR__ . '/../vendor/autoload.php';
+  ```
+
+Run the following to instantiate a client:
+
+```[realtime_javascript]
+// Using promises
+const realtime = new Ably.Realtime.Promise({ key: apiKey });
+
+// Using callbacks
+const realtime = new Ably.Realtime({ key: apiKey });
+```
+
+```[realtime_nodejs]
+// Using promises
+const Ably = require('ably');
+const realtime = new Ably.Realtime.Promise({ key: apiKey });
+
+// Using callbacks
+const Ably = require('ably');
+const realtime = new Ably.Realtime({ key: apiKey });
+```
+
+```[realtime_ruby]
+EventMachine.run do
+  ably = Ably::Realtime.new(key: api_key)
+end
+```
+
+```[realtime_java]
+import io.ably.lib.types.*;
+import io.ably.lib.realtime.*;
+ClientOptions options = new ClientOptions(apiKey);
+AblyRealtime realtime = new AblyRealtime(options);
+```
+
+```[realtime_csharp]
+using IO.Ably;
+using IO.Ably.Realtime;
+ClientOptions clientOptions = new ClientOptions("<API Key>");
+AblyRealtime realtime = new AblyRealtime(clientOptions);
+```
+
+```[realtime_objc]
+ARTRealtime realtime = [[ARTRealtime alloc] initWithKey:apiKey];
+```
+
+```[realtime_swift]
+let realtime = ARTRealtime(key: apiKey)
+```
+
+```[realtime_flutter]
+final clientOptions = ably.ClientOptions(key: '<API_KEY>');
+ably.Realtime realtime = ably.Realtime(options: clientOptions);
+```
+
+```[realtime_go]
+client, err := ably.NewRealtime(ably.WithKey("{{API_KEY}}"))
+if err != nil {
+    panic(err)
+}
+```
+
+```[rest_javascript]
+var rest = new Ably.Rest({ key: apiKey });
+```
+
+```[rest_nodejs]
+var Ably = require('ably');
+var rest = new Ably.Rest({ key: apiKey });
+```
+
+```[rest_ruby]
+ably = Ably::Rest.new(key: api_key)
+```
+
+```[rest_java]
+import io.ably.lib.types.*;
+import io.ably.lib.rest.*;
+ClientOptions options = new ClientOptions(apiKey);
+AblyRest rest = new AblyRest(options);
+```
+
+```[rest_csharp]
+using IO.Ably;
+ClientOptions clientOptions = new ClientOptions(ApiKey);
+AblyRest rest = new AblyRest(clientOptions);
+```
+
+```[rest_objc]
+ARTRest rest = [[ARTRest alloc] initWithKey:apiKey];
+```
+
+```[rest_swift]
+let rest = ARTRest(key: apiKey)
+```
+
+```[rest_flutter]
+final clientOptions = ably.ClientOptions(key: '<API_KEY>');
+ably.Rest rest = ably.Rest(options: clientOptions);
+```
+
+```[rest_go]
+client, err := ably.NewREST(ably.WithKey("xxx:xxx"))
+if err != nil {
+        panic(err)
+}
+```
+
+```[rest_python]
+from ably import AblyRest
+client = AblyRest(api_key)
+```
+
+```[rest_php]
+$ably = new Ably\AblyRest(apiKey);
+```
+
+h2(#options). Client options
+
+@ClientOptions@ enable the client connection to be configured when instantiating the client. 
+
+Properties that can be set include those used to:
+
+* authenticate the client, such as @key@ if using "basic authentication":/auth/basic, or an @authUrl@ or @authCallback@ if using "token authentication":/auth/token. 
+* customize client behavior, such as using @echoMessages@ to set whether messages published by the client are received by them, or @idempotentRestPublishing@ to enable idempotent publishing.
+* set retry and timeout durations.
+* set environment names and fallbacks if using a "custom environment":/platform-customization.
+
+See the API references for a full list of properties available to the "realtime":/api/realtime-sdk#client-options and "REST":/api/rest-sdk?#client-options interfaces.

--- a/content/getting-started/setup.textile
+++ b/content/getting-started/setup.textile
@@ -19,7 +19,7 @@ Use these instructions to setup an Ably SDK. "How to use Ably":/basics/use-ably 
 
 h2(#api). Get an API key
 
-An "API key":/auth#api-keys is required to instantiate a client and authenticate with Ably. "Sign up":https://ably.com/sign-up to Ably to create an API key in the "dashboard":https://ably.com/dashboard or use the "Control API":/account/control-api to create an API programmatically.
+An "API key":/auth#api-keys is required to instantiate a client and authenticate with Ably. API keys are used either to "authenticate directly":/auth/basic, or to generate "Tokens":/auth/token for untrusted clients. "Sign up":https://ably.com/sign-up to Ably to create an API key in the "dashboard":https://ably.com/dashboard or use the "Control API":/account/control-api to create an API programmatically.
 
 h2(#install). Install and instantiate a client
 
@@ -28,7 +28,7 @@ Ably SDKs provide a consistent and idiomatic API across a variety of "supported 
 blang[javascript].
   The JavaScript SDK is available via CDN. To get started with your project, reference the SDK within the @<head>@ of an HTML page. The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
 
-  When including the SDK from CDN, Ably recommends that you lock into major version @1@ of the library. This means that you will automatically receive minor and patch updates but you will never receive breaking changes. For example, if you lock into major version @1@ using "@https://cdn.ably.com/lib/ably.min-1.js@", you will receive all minor updates and patch fixes automatically. Additionally, the @.min@ suffix can be dropped if you want the non-minified version for debugging.
+  When including the SDK from CDN, Ably recommends that you lock into major version @1@ of the library. This means that you will automatically receive minor updates and patches, but you will never receive breaking changes. For example, if you lock into major version @1@ using "@https://cdn.ably.com/lib/ably.min-1.js@", you will receive all minor updates and patch fixes automatically. Additionally, the @.min@ suffix can be dropped if you want the non-minified version for debugging.
 
   ```[html]
   <script lang="text/javascript" src="https://cdn.ably.com/lib/ably.min-1.js"></script>
@@ -44,7 +44,7 @@ blang[nodejs].
 blang[ruby].
   The Ruby SDK is available as a "Gem":https://rubygems.org/gems/ably. To get started with your project, install the Gem and add it to your Gemfile.
 
-  The realtime interface must be run within an "EventMachine reactor":https://github.com/eventmachine/eventmachine which provides an asynchronous evented framework for the library to run within. 
+  The realtime interface must be run within an "EventMachine reactor":https://github.com/eventmachine/eventmachine which provides an asynchronous evented framework for the library. 
 
   ```[sh]
   # Install the gem
@@ -150,7 +150,7 @@ blang[go].
 blang[python].
   The Python SDK is available from "PyPI":https://pypi.org/project/ably/. To get started with your project install the SDK using @pip@. Note that the Python SDK only implements the REST interface and also requires @asyncio@ to run.
 
-  Ably supports both string and binary payloads. To avoid ambiguity, it is recommended that strings passed to the library for publishing to Ably, for example, as an event name or payload data, should be unicode strings. In Python 3 this is the normal string type, but in Python 2 it is not. Ably suggests that you prefix string literals with the @u@ prefix and to explicitly decode any user input, such as @raw_input().decode(sys.stdin.encoding@.
+  Ably supports both string and binary payloads. To avoid ambiguity, it is recommended that strings passed to the library for publishing to Ably, for example, as an event name or payload data, should be unicode strings. In Python 3 this is the normal string type, but in Python 2 it is not. Ably suggests that you prefix string literals with the @u@ prefix and to explicitly decode any user input, such as @raw_input().decode(sys.stdin.encoding)@.
 
   ```[sh]
   pip install ably
@@ -227,7 +227,7 @@ ably.Realtime realtime = ably.Realtime(options: clientOptions);
 ```
 
 ```[realtime_go]
-client, err := ably.NewRealtime(ably.WithKey("{{API_KEY}}"))
+client, err := ably.NewRealtime(ably.WithKey("apiKey"))
 if err != nil {
     panic(err)
 }
@@ -273,9 +273,9 @@ ably.Rest rest = ably.Rest(options: clientOptions);
 ```
 
 ```[rest_go]
-client, err := ably.NewREST(ably.WithKey("xxx:xxx"))
+client, err := ably.NewREST(ably.WithKey("apiKey"))
 if err != nil {
-        panic(err)
+    panic(err)
 }
 ```
 

--- a/data/yaml/page-furniture/sidebar.yaml
+++ b/data/yaml/page-furniture/sidebar.yaml
@@ -12,8 +12,10 @@ items:
     items:
       - label: "Quickstart guide"
         link: /docs/getting-started/quickstart
-      - label: "Available SDKS"
+      - label: "Available SDKs"
         link: /docs/getting-started/sdks
+      - label: "SDK setup"
+        link: /docs/getting-started/setup
   - label: "Authentication"
     link: ""
     items:


### PR DESCRIPTION
## Description

This PR adds a page covering the setup instructions for SDKs. It combines the existing REST and realtime usage pages and adds more context related to API keys and ClientOptions.

See [JIRA](https://ably.atlassian.net/browse/EDU-1200) for further information.

## Review

View `/docs/getting-started/setup` to review this new page.
