### PR TITLE
[EDU-1388] Fix on page navigation for Asset Tracking

### DIFF
--- a/content/asset-tracking/example-apps.textile
+++ b/content/asset-tracking/example-apps.textile
@@ -16,9 +16,9 @@ jump_to:
 
 Asset Tracking SDK repositories provide example apps for subscribing and publishing. You can test out the sample apps using the emulator provided with the developer tools for your platform.
 
-blang[kotlin].
-  h2(#using). Using the example apps
+h2(#using). Using the example apps
 
+blang[kotlin].
   The following procedure uses Android Studio by way of example, you can also use other tools such as Gradle.
 
   1. Download and install "Android Studio":https://developer.android.com/studio, if not already available on your development system.
@@ -64,8 +64,6 @@ blang[kotlin].
   </a>
 
 blang[swift].
-  h2(#using). Using the example apps
-
   1. Clone the Ably Asset Tracking SDK Swift "GitHub repo":https://github.com/ably/ably-asset-tracking-swift.
   2. Open @AblyAssetTracking.xcworkspace@ in Xcode. This workspace includes a "Swift package containing the SDKs, and several example apps":https://github.com/ably/ably-asset-tracking-swift#package-structure.
   3. Configure your @~/.netrc@ file with your Mapbox secret access token that enables you to download the Mapbox SDK. You can find instructions on how to do this "in the Mapbox docs":https://docs.mapbox.com/ios/search/guides/install/#configure-credentials.
@@ -95,8 +93,6 @@ blang[swift].
   </a>
 
 blang[javascript].
-  h2(#using). Using the example apps
-
   The JavaScript example app only supports the Subscribing SDK. To use it, you must first run one of the publishing example apps to generate location data.
 
   1. Clone the Ably Asset Tracking SDK JavaScript "GitHub repo":https://github.com/ably/ably-asset-tracking-js.

--- a/content/asset-tracking/index.textile
+++ b/content/asset-tracking/index.textile
@@ -7,7 +7,6 @@ meta_keywords: "Ably, Asset Tracking SDK, Mapbox, Mapbox Navigation SDK, Mapbox 
 languages:
   - kotlin
   - swift
-  - javascript
 jump_to:
   Help with:
     - Dynamic resolution#dynamic-resolution


### PR DESCRIPTION
## Description

This PR fixes the on page navigation for Asset Tracking. This was loading as empty for both pages. The index page had JS has a listed language even though there aren't any JS samples. The example page had all headers hidden under `blangs`. 

See [JIRA](https://ably.atlassian.net/browse/EDU-1388) for further information. 

## Review

Load the Asset Tracking pages and ensure the on page navigation renders first time.
