### PR TITLE
fix: ably java connection event listening

### DIFF
--- a/content/realtime/connection.textile
+++ b/content/realtime/connection.textile
@@ -47,7 +47,7 @@ ably.connection.on(:connected) do
 end
 
 bc[java]. AblyRealtime ably = new AblyRealtime("{{API_KEY}}");
-ably.connection.on('connected', new ConnectionStateListener() {
+ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
   @Override
   public void onConnectionStateChanged(ConnectionStateChange change) {
     System.out.println("Connected to Ably!");


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Fixes the `ably-java` connection example as it does not compile.

Issue reported at:

https://github.com/ably/ably-java/issues/937
https://github.com/ably/ably-java/issues/640

## Review

Load page, go to realtime SDK -> connection, and look at the first example :)

[* [Page to review](link)](http://localhost:8000/docs/realtime/connection?lang=java)
