### PR TITLE
[FIX] Update generated SDK links

### DIFF
--- a/content/api/index.textile
+++ b/content/api/index.textile
@@ -40,8 +40,8 @@ The API references generated from source code are structured by classes. The com
 The SDKs that have API references generated from source code are:
 
 * "Java":https://ably.com/docs/sdk/java/v1.2/
-* "JavaScript (callbacks)":https://ably.com/docs/sdk/js/v1.2/callbacks
-* "JavaScript (promises)":https://ably.com/docs/sdk/js/v1.2/promises
+* "JavaScript - callbacks":https://ably.com/docs/sdk/js/v1.2/callbacks
+* "JavaScript - promises":https://ably.com/docs/sdk/js/v1.2/promises
 * "Objective-C":https://ably.com/docs/sdk/cocoa/v1.2/
 * "Ruby":https://ably.com/docs/sdk/ruby/v1.2/
 * "Swift":https://ably.com/docs/sdk/cocoa/v1.2/

--- a/content/api/index.textile
+++ b/content/api/index.textile
@@ -10,10 +10,10 @@ jump_to:
     - REST API#rest-api
     - SSE API#sse
     - Control API#control-api
-    - Further information#further-information 
+    - Further information#further-information
 ---
 
-This section of the documentation contains the API references for Ably.  
+This section of the documentation contains the API references for Ably.
 
 The following API references are available:
 
@@ -25,9 +25,9 @@ The following API references are available:
 
 h2(#sdks). Client library SDKs
 
-Depending on availability, an Ably client library SDK may support both a realtime interface and a REST interface. Some SDKs only provide a REST interface. You can check availability on the "SDK page":https://ably.com/download. 
+Depending on availability, an Ably client library SDK may support both a realtime interface and a REST interface. Some SDKs only provide a REST interface. You can check availability on the "SDK page":https://ably.com/download.
 
-The "realtime interface":/api/realtime-sdk allows your client to both publish and subscribe to a channel, but the REST interface only allows you to publish to a channel. The "REST interface":/api/rest-sdk can also be used for non-recurring operations such as obtaining statistics, or checking status. The REST interface has less resource impact, as it is much simpler than the realtime interface. 
+The "realtime interface":/api/realtime-sdk allows your client to both publish and subscribe to a channel, but the REST interface only allows you to publish to a channel. The "REST interface":/api/rest-sdk can also be used for non-recurring operations such as obtaining statistics, or checking status. The REST interface has less resource impact, as it is much simpler than the realtime interface.
 
 Typically the REST interface is used on the server, as the server's main task is to authenticate clients, but does not usually need to subscribe to a channel to obtain realtime events.
 
@@ -35,10 +35,11 @@ h3(#auto-generated). API references generated from source code
 
 API references generated from the source code are available for the realtime and REST client library SDKs. They have been generated for each SDK using tooling common to that language, such as "Jazzy":https://github.com/realm/jazzy for Swift and Objective-C, and "YARD":https://yardoc.org/ for Ruby.
 
-The API references generated from source code are structured by classes. The combined API references, featuring all languages, are organized by Ably features and strictly separate the realtime and REST interfaces. 
+The API references generated from source code are structured by classes. The combined API references, featuring all languages, are organized by Ably features and strictly separate the realtime and REST interfaces.
 
 The SDKs that have API references generated from source code are:
 
+* "Java":https://ably.com/docs/sdk/java/v1.2/
 * "JavaScript (callbacks)":https://ably.com/docs/sdk/js/v1.2/callbacks
 * "JavaScript (promises)":https://ably.com/docs/sdk/js/v1.2/promises
 * "Objective-C":https://ably.com/docs/sdk/cocoa/v1.2/
@@ -66,4 +67,4 @@ In addition to the API references listed previously, our developer documentation
 * "Realtime and REST interface use cases":/realtime#realtime-vs-rest
 * "REST API - Overview":/rest-api
 * "SSE API - Overview":/sse
-* "Control API - Overview":/control-api 
+* "Control API - Overview":/control-api


### PR DESCRIPTION
## Description

Fixed two small issues on `/docs/api`:

* Missing link to the Java SDK
* JavaScript links weren't being displayed correctly due to textile turning parens into title attributes

Before:

![API Reference 2023-06-02 16-56-06](https://github.com/ably/docs/assets/8756/0edddeec-8b0d-4f7f-bd71-1b147ed8cb74)

After:

![API Reference 2023-06-02 16-56-35](https://github.com/ably/docs/assets/8756/ac1553ce-4e20-4f70-bc3c-f8260027247c)


## Review

Instructions on how to review the PR. 

* [Page to review](link)
