### PR TITLE
[EDU-1398] Fix push API reference display bug

### DIFF
--- a/content/partials/types/_push_channel.textile
+++ b/content/partials/types/_push_channel.textile
@@ -1,8 +1,7 @@
 <div lang="java,android,swift,objc">
 A @PushChannel@ is a property of a "@RealtimeChannel@":/api/realtime-sdk/channels#properties or "@RestChannel@":/api/rest-sdk/channels#properties. It provides "push devices":/general/push#platform-support the ability to subscribe and unsubscribe to push notifications on channels.
 
-h4.
-  Methods
+h4. Methods
 
 h6(#subscribe-device).
   default: subscribeDevice


### PR DESCRIPTION
## Description

This PR fixes a display bug in the push API references on the following 2 pages:

* `api/realtime-sdk/push`
* `api/rest-sdk/push-admin`

It caused a heading to not be parsed correctly and display in textile format.

## Review

* [Realtime](https://ably-docs-edu-1398-push-yu03hl.herokuapp.com/docs/api/realtime-sdk/push?lang=android#subscribe-device)
* [REST](https://ably-docs-edu-1398-push-yu03hl.herokuapp.com/docs/api/rest-sdk/push-admin?lang=android#subscribe-device)