### PR TITLE
Update app.json to use specific buildpack version

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
             "url": "heroku/nodejs"
         },
         {
-            "url": "heroku-community/nginx"
+            "url": "https://github.com/heroku/heroku-buildpack-nginx.git#de18c06943c1467e52b0948be88f9ec5ed026370"
         }
     ]
 }


### PR DESCRIPTION
Our nginx templating is written for Ruby <3.2.2 and so we can't use the latest buildpack anymore (which downloads 3.2.2). This is a preventative fix so we can update our templating so a newer version of Ruby is supported.