### PR TITLE
[EDU-1406] Correct inbound and outbound message rate descriptions

### DIFF
--- a/content/general/limits.textile
+++ b/content/general/limits.textile
@@ -288,15 +288,15 @@ The number of channels per connection is a "quantity-based limit":#quantity. If 
 
 h3(#outbound-message). Outbound message rate
 
-The outbound message rate limit is the maximum rate at which messages can be published on a "realtime connection":/connect
+The outbound message rate limit is the maximum rate at which messages can be received on a "realtime connection.":/connect
 
 If the outbound message rate is exceeded for a connection, a "local instantaneous rate limit":#local-rates will be applied to that connection.
 
 h3(#inbound-message). Inbound message rate
 
-The inbound message rate limit is the maximum rate at which messages can be received on a "realtime connection":/connect
+The inbound message rate limit is the maximum rate at which messages can be published on a "realtime connection.":/connect
 
-If the inbound message rate is exceeded for a connection, a "local rate limit":#local-rates will be applied to that connection.
+If the inbound message rate is exceeded for a connection, a "local instantaneous rate limit":#local-rates will be applied to that connection.
 
 h3(#connection-state). Connection state TTL
 


### PR DESCRIPTION
## Description

This PR swaps the descriptions for inbound and outbound message rate limits. They were originally written the wrong way around.

See [JIRA](https://ably.atlassian.net/browse/EDU-1406) for further details.
