### PR TITLE
Default api keys to correct init state

### DIFF
--- a/src/components/GlobalLoading/GlobalLoading.tsx
+++ b/src/components/GlobalLoading/GlobalLoading.tsx
@@ -22,6 +22,7 @@ import { loadBoomerang } from 'src/third-party/boomerang';
 import posthog from 'posthog-js';
 import { loadHeadway } from 'src/third-party/headway';
 import { sessionTracking } from './session-tracking';
+import { type UserApiKey } from 'src/components/blocks/software/Code/ApiKeyMenu';
 
 const hubspotTrackingId = process.env.GATSBY_HUBSPOT_TRACKING_ID;
 const boomerangEnabled = process.env.GATSBY_BOOMERANG_ENABLED;
@@ -45,9 +46,11 @@ const gtmSnippet = `(function (w, d, s, l, i) {
   f.parentNode.insertBefore(j, f);
 })(window, document, 'script', 'dataLayer', 'GTM-TZ37KKW');`;
 
+const apiKeysInit = { data: [] };
+
 const GlobalLoading: FC = ({ children }) => {
   const [sessionState, setSessionState] = useState<Record<string, string>>({});
-  const [apiKeys, setApiKeys] = useState({ data: [] });
+  const [apiKeys, setApiKeys] = useState<{ data: UserApiKey[] }>(apiKeysInit);
 
   useEffect(() => {
     const store = getRemoteDataStore();
@@ -61,7 +64,14 @@ const GlobalLoading: FC = ({ children }) => {
     connectState(selectSessionData, setSessionState);
     fetchSessionData(store, WEB_API_USER_DATA_ENDPOINT);
 
-    connectState(selectData(API_KEYS_REDUCER_KEY), setApiKeys);
+    connectState(selectData(API_KEYS_REDUCER_KEY), (state: { data?: UserApiKey[] }) => {
+      if (Array.isArray(state?.data)) {
+        return setApiKeys({ data: state.data });
+      } else {
+        setApiKeys(apiKeysInit);
+      }
+    });
+
     fetchApiKeyData(store, WEB_API_KEYS_DATA_ENDPOINT);
   }, []);
 


### PR DESCRIPTION
When updating via `connectState`, API keys could be set to `undefined` (for example, when the API is not reachable). We want to set them to `{ data: [] }` so they are always compatible with the code paths that use them.
