### PR TITLE
Remove gatsby-plugin-manifest

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -65,12 +65,5 @@ export const plugins = [
     },
     __key: 'yaml-page-content',
   },
-  // Meta Data & Environment variables
-  {
-    resolve: `gatsby-plugin-manifest`,
-    options: {
-      icon: 'src/images/favicon.png',
-    },
-  },
   `gatsby-plugin-client-side-redirect`, // Keep this last in the list; Source: https://www.gatsbyjs.com/plugins/gatsby-plugin-client-side-redirect/
 ];


### PR DESCRIPTION
This plugin enables a manifest for PWA, native-app like shortcuts on mobile.

However, past including this plugin no work has been done to route correctly both the manifest and the icons included, hence this is broken.

We should remove the plugin for now (so the manifest is not generated) and implement correctly in the future. (as just having this in will log errors in browsers)
