### PR TITLE
Add missing href attribute to ErrorInfo object

### DIFF
--- a/content/partials/types/_error_info.textile
+++ b/content/partials/types/_error_info.textile
@@ -13,6 +13,8 @@ h4.
 
 - <span lang="default">cause</span><span lang="csharp">Cause</span> :=  Information pertaining to what caused the error where available<br>__Type: @ErrorInfo@__
 
+- <span lang="default">href</span><span lang="csharp">Href</span> := Ably may additionally include a URL to get more help on this error<br>__Type: @String@__
+
 <div lang="flutter">
 - href :=  Link pointing to ably docs with more details on the error<br>__Type: @String@__
 


### PR DESCRIPTION
See https://sdk.ably.com/builds/ably/specification/main/features/#TI4.  This attribute is missing from the docs.

As an aside, @m-hulbert my editor added a linefeed after the last line. According to the [.editorconfig](https://github.com/ably/docs/blob/main/.editorconfig#L6), this should happen automatically on all edits. Is everyone who works on this repo automatically using the standardised editor config?