### PR TITLE
[FIX] Build nginx with newer zlib version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
           name: Build nginx
           environment:
             STACK: heroku-22
-            ZLIB_VERSION: 1.2.13
+            ZLIB_VERSION: 1.3
           command: |
             if [ ! -x /usr/local/bin/nginx ]; then
               mkdir buildpack


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

The heroku buildpack script we're using can't find the version of zlib anymore and needs to be updated to load older versions. This is breaking CI needlessly.

## Review

CI for this branch should pass (or at least the nginx build step)