### PR TITLE
EDU-1428--Adds example characters to note on restrictions that apply to channel names and namespaces

### DIFF
--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -55,12 +55,12 @@ The following are examples of channels that are all part of the 'customer' names
 Namespaces can be used to apply operations to all channels within the namespace, such as "capabilities":/auth/capabilities, "channel rules":#rules and "integration rules":/general/integrations.
 
 <aside data-type='note'>
-<p>The following restrictions apply to channel names and namespaces:</p>
-<ul><li>They are case sensitive</li>
-<li>They can't start with @[@ or @:@</li>
-<li>They can't be empty</li>
-<li>They can't contain newline characters or wildcards</li></ul>
-<p>Additionally, Ably doesn't enforce a length restriction on the name of a channel. However, the channel name is included in the URL for REST requests, and many browsers have restrictions on URLs over 2048 characters.</p>
+<p>Restrictions for channel names and namespaces:</p>
+<ul><li>Avoid starting names with @[@ or @:@</li>
+<li>Ensure names aren't empty</li>
+<li>Exclude whitespace and wildcards, such as @*@</li>
+<li>Use the correct case, whether it be uppercase or lowercase</li></ul>
+<p>While Ably doesn't limit channel name and namespace length, be aware that the name appears in REST request URLs. Most browsers cap URLs at 2048 characters</p>
 </aside>
 
 h2(#create). Create or retrieve a channel


### PR DESCRIPTION
## Description

On the /docs/channels page:

- Changed the writing style to active voice.
- Removed 'new line character' and 'whitespace'

[EDU-1428](https://ably.atlassian.net/browse/EDU-1428)



[EDU-1428]: https://ably.atlassian.net/browse/EDU-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ