### PR TITLE
A couple of fixes to Spaces docs

### DIFF
--- a/content/spaces/avatar.textile
+++ b/content/spaces/avatar.textile
@@ -20,7 +20,7 @@ The following four event types are emitted by members:
 - @remove@ := A member has been removed from the members list after the "@offlineTimeout@":/spaces/space#options period has elapsed. This enables members to appear greyed out in the avatar stack to indicate that they recently left for the period of time between their @leave@ and @remove@ events.
 
 <aside data-type='note'>
-<p>Members "enter,":/spaces/space#enter "leave,":/spaces/space#leave and "update":/spaces/space#update-profile a "space":/spaces/space directly. The @members@ namespace is used to subscribe to these updates.</p>
+<p>Members "enter":/spaces/space#enter, "leave":/spaces/space#leave, and "update":/spaces/space#update-profile a "space":/spaces/space directly. The @members@ namespace is used to subscribe to these updates.</p>
 </aside>
 
 h2(#subscribe). Subscribe to member events
@@ -297,4 +297,4 @@ h2(#foundations). Avatar stack foundations
 
 The Spaces SDK is built upon existing Ably functionality available in Ably's Core SDKs. Understanding which core features are used to provide the abstractions in the Spaces SDK enables you to manage space state and build additional functionality into your application.
 
-Avatar stacks build upon the functionality of the Pub/Sub Channels "presence":/presence-occupancy/presence feature. Members are entered into the presence set when they "enter the space.":/spaces/space#enter
+Avatar stacks build upon the functionality of the Pub/Sub Channels "presence":/presence-occupancy/presence feature. Members are entered into the presence set when they "enter the space":/spaces/space#enter.

--- a/content/spaces/cursors.textile
+++ b/content/spaces/cursors.textile
@@ -119,7 +119,7 @@ The default value is 25ms which is optimal for the majority of use cases. If you
 
 h3(#pagination). paginationLimit
 
-The volume of messages sent can be high when using live cursors. Because of this, the last known position of every members' cursor is obtained from "history.":/storage-history/history The @paginationLimit@ is the number of pages that should be searched to find the last position of each cursor. The default is 5.
+The volume of messages sent can be high when using live cursors. Because of this, the last known position of every members' cursor is obtained from "history":/storage-history/history. The @paginationLimit@ is the number of pages that should be searched to find the last position of each cursor. The default is 5.
 
 h2(#retrieve). Retrieve cursors
 

--- a/content/spaces/locations.textile
+++ b/content/spaces/locations.textile
@@ -212,4 +212,4 @@ h2(#foundations). Member location foundations
 
 The Spaces SDK is built upon existing Ably functionality available in Ably's Core SDKs. Understanding which core features are used to provide the abstractions in the Spaces SDK enables you to manage space state and build additional functionality into your application.
 
-Member locations build upon the functionality of the Pub/Sub Channels "presence":/presence-occupancy/presence feature. Members are entered into the presence set when they "enter the space.":/spaces/space#enter
+Member locations build upon the functionality of the Pub/Sub Channels "presence":/presence-occupancy/presence feature. Members are entered into the presence set when they "enter the space":/spaces/space#enter.

--- a/content/spaces/locking.textile
+++ b/content/spaces/locking.textile
@@ -28,11 +28,11 @@ A lock will be in one of the following states:
 
 The following lock state transitions may occur:
 
-* None --> @pending@: a member calls "@acquire()@":#acquire to request a lock.
-* @pending@ --> @locked@: the requesting member holds the lock.
-* @pending@ --> @unlocked@: the requesting member does not hold the lock, since another member already holds it.
-* @locked@ --> @unlocked@: the lock was either explicitly "released":#release by the member, or their request was invalidated by a concurrent request which took precedence.
-* @unlocked@ --> @locked@: the requesting member reacquired a lock they previously held.
+* None → @pending@: a member calls "@acquire()@":#acquire to request a lock.
+* @pending@ → @locked@: the requesting member holds the lock.
+* @pending@ → @unlocked@: the requesting member does not hold the lock, since another member already holds it.
+* @locked@ → @unlocked@: the lock was either explicitly "released":#release by the member, or their request was invalidated by a concurrent request which took precedence.
+* @unlocked@ → @locked@: the requesting member reacquired a lock they previously held.
 
 Only transitions that result in a @locked@ or @unlocked@ status will emit a lock event that members can "@subscribe()@":#subscribe to.
 

--- a/content/spaces/setup.textile
+++ b/content/spaces/setup.textile
@@ -13,12 +13,12 @@ h2(#authenticate). Authenticate
 An "API key":/auth#api-keys is required to authenticate with Ably. API keys are used either to authenticate directly with Ably using "basic authentication":/auth/basic, or to generate tokens for untrusted clients using "token authentication":/auth/token.
 
 <aside data-type='important'>
-<p>The examples use "basic authentication":/auth/basic to demonstrate features for convenience. In your own applications, basic authentication should never be used on the client-side as it exposes your Ably API key. Instead use "token authentication.":/auth/token</p>
+<p>The examples use "basic authentication":/auth/basic to demonstrate features for convenience. In your own applications, basic authentication should never be used on the client-side as it exposes your Ably API key. Instead use "token authentication":/auth/token.</p>
 </aside>
 
 "Sign up":https://ably.com/sign-up to Ably to create an API key in the "dashboard":https://ably.com/dashboard or use the "Control API":/account/control-api to create an API programmatically.
 
-API keys and tokens have a set of capabilities assigned to them that specify which operations, such as @subscribe@ or @publish@ can be performed on which resources. To use the Spaces SDK, the API key requires the following "capabilities:":/auth/capabilities
+API keys and tokens have a set of capabilities assigned to them that specify which operations, such as @subscribe@ or @publish@ can be performed on which resources. To use the Spaces SDK, the API key requires the following "capabilities":/auth/capabilities:
 
 * Publish
 * Subscribe

--- a/content/spaces/space.textile
+++ b/content/spaces/space.textile
@@ -83,7 +83,7 @@ await space.enter({
 
 h3(#update-profile). Update profile data
 
-Profile data can be updated at any point after entering a space by calling @updateProfileData()@. This will emit an @update@ event. If a client hasn't yet entered the space, @updateProfileData()@ will instead "enter the space,":#enter with the profile data, and emit an "@enter@":/spaces/members#events event.
+Profile data can be updated at any point after entering a space by calling @updateProfileData()@. This will emit an @update@ event. If a client hasn't yet entered the space, @updateProfileData()@ will instead "enter the space":#enter, with the profile data, and emit an "@enter@":/spaces/members#events event.
 
 The following is an example of updating profile data:
 
@@ -238,5 +238,5 @@ space.channel.on('attached', (stateChange) => {
 ```
 
 <aside data-type='note'>
-<p>Due to the high frequency at which updates are streamed for cursor movements, live cursors utilizes its own "channel.":/channels</p>
+<p>Due to the high frequency at which updates are streamed for cursor movements, live cursors utilizes its own "channel":/channels.</p>
 </aside>


### PR DESCRIPTION
## Description

A couple of tweaks to the Spaces documentation.

### Replace `-->` with a Unicode arrow

Before:

<img width="520" alt="image" src="https://github.com/ably/docs/assets/53756884/53c802bd-2a00-4ea5-8b18-46c00414005f">

After:

<img width="520" alt="image" src="https://github.com/ably/docs/assets/53756884/1bada2dc-49d9-46a4-af06-c66ae3c0c291">

### Move punctuation outside of link text in Spaces documentation

Looks wrong to my eyes, and if it’s an intentional style choice then it’s not one that’s consistently applied within the Spaces documentation.