### PR TITLE
DEU-225: Updates namespaces note - namespaces not needed to define ch…

### DIFF
--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -61,6 +61,7 @@ Namespaces can be used to apply operations to all channels within the namespace,
 <li>Exclude whitespace and wildcards, such as @*@</li>
 <li>Use the correct case, whether it be uppercase or lowercase</li></ul>
 <p>While Ably doesn't limit channel name and namespace length, be aware that the name appears in REST request URLs. Most browsers cap URLs at 2048 characters</p>
+<p>Namespaces don't need to be defined for a set of channels to be referred to in a capability. A resource specifier of foo:* (a glob expression) matches channel name foo:bar, even without foo namespace.</p>
 </aside>
 
 h2(#create). Create or retrieve a channel


### PR DESCRIPTION
This PR:

- Updates the 'Channel namespaces' note.
- Explains: Namespaces don't need to be defined for a set of channels to be referred to in a capability.

[EDU-225: Add note to channel namespaces about not explicitly defining them](https://ably.atlassian.net/browse/EDU-225)