### PR TITLE
[EDU-1431] - Added sufficient padding to bottom of Docs navigation to display the last two items

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -26,7 +26,7 @@ export const Sidebar = ({
   return (
     <aside
       className={cn(
-        'transition-all fixed hidden h-screen md:block overflow-y-auto bg-extra-light-grey z-20 pt-24 left-0 w-244',
+        'transition-all fixed hidden h-screen md:block overflow-y-auto bg-extra-light-grey z-20 pt-24 pb-128 left-0 w-244',
         className,
       )}
       data-languages={languages}


### PR DESCRIPTION
## Description

The navigation bar on the left did not have enough spacing below it to display the full list of navigation items. `Limits` and `Platform Customization` weren't being displayed. 

This is what the bottom of the navigation looked like:
![image](https://github.com/ably/docs/assets/2411269/a2ffc239-8db8-41ec-8fec-e9cb2f7ae759)

This is what it should and will look like when merged:
![image](https://github.com/ably/docs/assets/2411269/5c47c93e-7b9a-4b6f-aa21-87d4255c5b2b)


* [Jira ticket](https://ably.atlassian.net/browse/EDU-1431).

## Review

Instructions on how to review the PR. 

Any of the Channels docs with the navigation on the left.
