### PR TITLE
Added note to top of Python version of tutorial stating UNIX is supported, not Windows

### DIFF
--- a/content/tutorials/mqtt-snake.textile
+++ b/content/tutorials/mqtt-snake.textile
@@ -38,6 +38,8 @@ blang[go].
 blang[python].
   h4. The complete source code for each step of "this tutorial is available on Github":https://github.com/ably/tutorials/commits/mqtt-snake-python.
 
+  *Note:* The Python version of this tutorial requires the installation of "Curses":https://docs.python.org/3/howto/curses.html library. However, this library will only work on *Unix-based machines*, not *Windows*.
+
 Ably Realtime provides support for a number of protocols with its pub/sub system, one of which is "MQTT":http://mqtt.org/. MQTT is an open ISO standard providing a lightweight messaging protocol for small sensors and mobile devices, optimized for high-latency or unreliable networks. In most cases we recommend use of the "Ably client library SDKs":https://ably.com/download where you can, due to their far richer feature sets such as presence, automatic encoding and decoding of data types, and much more. However, MQTT can be great for use with languages we don't currently support, as well as when you have stringent bandwidth restrictions or wish to avoid vendor lock-in.
 
 blang[javascript].


### PR DESCRIPTION
## Description

The Python tutorial for MQTT Snake requires a Python library called Curses. There have been attempts to get this working on Windows, but no one has been successful. So this is just a note in the tutorial to state the Python version will only be functional on Unix based systems.

* [Jira ticket](https://ably.atlassian.net/browse/EDU-207).

## Review


* [Page to review](https://ably.com/tutorials/mqtt-snake#tutorial-step-3)
