### PR TITLE
EDU-208: Adds action numbers to all  PresenceAction code examples

### DIFF
--- a/content/partials/versions/v1.1/types/_presence_action.textile
+++ b/content/partials/versions/v1.1/types/_presence_action.textile
@@ -3,11 +3,11 @@ blang[jsall].
 
   ```[javascript]
     var PresenceActions = [
-      'absent', // (reserved for internal use)
-      'present',
-      'enter',
-      'leave',
-      'update'
+      'absent',  // 0  (reserved for internal use)
+      'present', // 1
+      'enter',   // 2
+      'leave',   // 3
+      'update'   // 4
     ]
   ```
 
@@ -42,11 +42,11 @@ blang[python].
 
   ```[python]
     class PresenceAction(object):
-      ABSENT = 0    # (reserved for internal use)
+      ABSENT  = 0  (reserved for internal use)
       PRESENT = 1
-      ENTER = 2
-      LEAVE = 3
-      UPDATE = 4
+      ENTER   = 2
+      LEAVE   = 3
+      UPDATE  = 4
   ```
 
 blang[php].
@@ -112,21 +112,21 @@ blang[objc,swift].
 
   ```[objc]
     typedef NS_ENUM(NSUInteger, ARTPresenceAction) {
-        ARTPresenceAbsent, // reserved for internal use
-        ARTPresencePresent,
-        ARTPresenceEnter,
-        ARTPresenceLeave,
-        ARTPresenceUpdate
+        ARTPresenceAbsent,  0 // reserved for internal use
+        ARTPresencePresent, 1
+        ARTPresenceEnter,   2
+        ARTPresenceLeave,   3
+        ARTPresenceUpdate   4
     };
   ```
 
   ```[swift]
     enum ARTPresenceAction : UInt {
-      case Absent // reserved for internal use
-      case Present
-      case Enter
-      case Leave
-      case Update
+      case Absent  // 0 reserved for internal use
+      case Present // 1
+      case Enter   // 2
+      case Leave   // 3
+      case Update  // 4
     }
   ```
 
@@ -135,11 +135,11 @@ blang[go].
 
   ```[go]
   const (
-    PresenceAbsent = 0
+    PresenceAbsent  = 0
     PresencePresent = 1
-    PresenceEnter = 2
-    PresenceLeave = 3
-    PresenceUpdate = 4
+    PresenceEnter   = 2
+    PresenceLeave   = 3
+    PresenceUpdate  = 4
   )
   ```
 


### PR DESCRIPTION
This PR:

- Adds `action numbers` to **ALL** `PresenceAction` code examples (some `PresenceAction` code examples did not have any numbers)

[EDU-208: Add presenceAction numbers for all languages](https://ably.atlassian.net/browse/EDU-208) 