### PR TITLE
EDU-181: Adds note about idempotent publish to message ID description

### DIFF
--- a/content/channels/messages.textile
+++ b/content/channels/messages.textile
@@ -35,7 +35,7 @@ The following are the properties of a message:
 
 - name := The name of the message.
 - data := The contents of the message. Also known as the message payload. 
-- id := A unique ID assigned by Ably to each message.
+- id := Each message sent through Ably is assigned a unique ID. Update this ID if you are using idempotent publishing.
 - clientId := The "ID of the client":/auth/identified-clients that published the message.
 - connectionId := The ID of the connection used to publish the message.
 - timestamp := The timestamp of when the message was received by Ably, as milliseconds since the Unix epoch.


### PR DESCRIPTION
This PR:

- Adds note to the `ID` section of the message properties table. 
- Informs user to update the ID if using idempotent publishing.

[EDU-181: Adds note about idempotent publish to message ID description](https://ably.atlassian.net/browse/EDU-181)