### PR TITLE
EDU-149: Re-writes for clarity

### DIFF
--- a/content/protocols/sse.textile
+++ b/content/protocols/sse.textile
@@ -8,30 +8,35 @@ redirect_from:
   - /sse/versions/v1.1
 ---
 
-The Ably SSE and raw HTTP streaming API provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably SDK, or even an "MQTT":/protocols/mqtt library, is impractical.
+The Ably SSE (Server-Sent Events) API provides real-time event streams without needing a full SDK or an "MQTT":/protocols/mqtt library. "SSE":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events is a lightweight streaming layer over HTTP, primarily accessed through the " EventSource API":https://developer.mozilla.org/en-US/docs/Web/API/EventSource in modern web browsers — the preferred method to harness SSE.
 
-HTTP streaming enables a request from a client to be held by a server, allowing it to push data to the client without further requests. This, much like WebSockets, helps avoid the overhead involved in normal HTTP requests. "Server-sent events":https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events (SSE) provide a thin layer on top of HTTP streaming. A common use of SSE is through the use of "the EventSource API":https://developer.mozilla.org/en-US/docs/Web/API/EventSource in all modern web browsers.
+With HTTP streaming, servers can maintain client requests and transmit data without repetitive requests, offering efficiency akin to WebSockets.
 
-It is subscribe-only: you can not interact with the channel, including to publish, enter presence, query the presence set, attach and detach from channels (without closing and re-opening the stream), or anything else.
+SSE allows subscribe-only functionality. This means you can't:
 
-Customers who do not want to use an SDK on platforms that support SSE, and only require simple subscribe-only streams, may choose to use SSE because it's an open standard, simple, and requires no SDKs on the client-side. HTTP Streaming may be considered on platforms without an SSE client. However, where possible, it is strongly recommend to use an "Ably SDK":https://ably.com/download, as they provide "more features and higher reliability":/basics/use-ably, and the full use of our normal realtime messaging API.
+* Publish
+* Enter presence
+* Query the existing presence set
+* Attach and detach from channels without restarting the stream.
+
+Ably advise SSE for simplified, subscribe-only streams on platforms. Its status as an open standard eliminates the need for client-side SDKs. However, the "Ably SDK":https://ably.com/download is recommended overall for its "expanded features and superior reliability":/basics/use-ably.
 
 h2(#when-to-use). When to use the SSE adapter
 
-SSE is useful when dealing with devices with extremely limited memory, where using one of the Ably SDKs would not be possible. This is largely due to it being subscribe-only.
+SSE is an excellent alternative to Ably SDK in memory-limited environments.
 
-SSE is recommended if:
+h3(#Applicability-of-SSE). Applicability of SSE:
 
-* Ably does not offer a native library that supports your target platform
-* Ably offers a REST-only SDK for your target platform, but you need a realtime client
-* You have stringent memory restrictions
-* You only wish to subscribe to events on channels
+* When operating under severe memory constraints
+* Where no Ably native library is available for your desired platform
+* When Ably provides only a REST SDK for your designated platform, but a realtime client interface is requisite
+* Where the sole operation is the subscription to channel events
 
-The Ably SDKs and realtime protocol are recommended if:
+h3(#Advantages-of-Ably-SDKs-and-Realtime-Protocol). Advantages of Ably SDKs and Realtime Protocol:
 
-* You want a high quality of service and high availability even during significant events such as DNS failure or network partitions
-* You want access to features such as "publishing":/general/push/publish, "presence":/presence-occupancy/presence, "history":/storage-history/history, "push notifications":/general/push, "automatic payload encoding":/channels/options/encryption, "symmetric encryption":/channels/options/encryption
-* You want first class browser support with WebSockets
+* Assured high service quality and resilience, particularly in DNS (Domain Name System) disruptions or network partitioning scenarios.
+* Access to a comprehensive range of features including, but not limited to, "publishing":/general/push/publish, "presence":/presence-occupancy/presence, "history":/storage-history/history, "push notifications":/general/push, "automatic payload encoding":/channels/options/encryption, and "symmetric encryption":/channels/options/encryption.
+* Optimal compatibility with browsers via the WebSocket protocol.
 
 h2(#config). Configuration
 
@@ -50,29 +55,32 @@ eventSource.onmessage = function(event) {
 
 h2(#auth). Authentication
 
-It is possible to use either "basic auth":/auth/basic, with an "API key":/getting-started/setup, or "token auth":/auth/token,with a "token issued from your server":/auth/token, with SSE. It's recommended to use token auth on the client side for "security reasons":/auth, so you have control over who can connect. Basic auth, while lacking this control, is simpler (it doesn't require you to run an auth server), and you don't have to worry about the client obtaining a new token when the old one expires.
+Authentication with SSE allows for two methods: "basic auth":/auth/basic using an "API key":/getting-started/setup or "token auth":/auth/token, using a token from your server. For enhanced security and control over connections, token auth is recommended for client-side use. Basic auth is simpler as it omits the need for an auth server and the potential need for clients to refresh expired tokens.
+
+It is possible to use either "basic auth":/auth/basic, with an "API key":/getting-started/setup, or "token auth":/auth/token, with a "token issued from your server":/auth/token, with SSE. It's recommended to use token auth on the client side for "security reasons":/auth, so you have control over who can connect. Basic auth, while lacking this control, is simpler (it doesn't require you to run an auth server), and you don't have to worry about the client obtaining a new token when the old one expires.
 
 If using basic auth, you can use a querystring parameter of @key@ or an @Authorization: Basic <base64-encoded key>@ header. If using token auth, you can use an @accessToken@ querystring parameter or an @Authorization: Bearer <base64-encoded token>@ header. See "REST API authentication":/auth for more information.
 
 Note that "connection state":/connect is only retained for two minutes.
 
-The SSE protocol and the EventSource API are designed so that a dropped connection is resumed transparently; the client implementation will reconnect and supply a @lastEventId@ param that ensures that the resuming connection delivers any events that have arisen since the connection was dropped. Ably uses this mechanism to reattach all channels in a new connection to the exact point that had been reached in the prior connection.
+The SSE protocol and EventSource API seamlessly resume dropped connections. The client reconnects, supplying a @lastEventId@ parameter, ensuring no event is missed from the previous connection's endpoint. Ably uses this feature to resume channels from where they left off.
 
-When a token expires the connection will end. However, the default EventSource behavior of automated reconnection will not work, because the (expired) credentials are part of the connection URL. What is needed is for a new connection to be established, with an updated @accessToken@. The question then arises as to how to do that with continuity - that is, how to establish a new connection but supply the correct @lastEventId@ so that the new connection resumes from the point that the prior connection became disconnected.
+At the point of token expiration, the connection terminates. The default EventSource reconnection won't function due to the expired credentials embedded in the connection URL. The solution is initiating a new connection with an updated @accessToken@, ensuring continuity by providing the right @lastEventId@ for a seamless transition from the previous connection's endpoint.
 
 h3(#message-continuity-token-auth). Implementing message continuity with token auth
 
-Implementing transparent connection resumes when tokens need to be renewed requires a few additional steps - detecting token expiry and resuming the connection from the point of the last delivered message using the @lastEventId@ attribute.
+To enable transparent connection resumption when tokens must be renewed:
+
+# Detect token expiration.
+# Resume the connection precisely from the last delivered message using the @lastEventId@ attribute.
 
 h4(#detecting-token-expiry). Detecting token expiry
 
-When a connection is closed as a result of any error (that is, it's not just a dropped connection), then the @error@ event will occur on the @EventSource@ instance, and the data attribute of the event will contain an Ably error body with the information about the nature of error. In the case of a token error - that is an error arising from a problem with the auth token - the code in the error body will indicate that. Token errors have a code in the range @40140 <= code < 40150@. In such cases, the authentication can be retried with a new @accessToken@.
-
-In the future we plan to send an event on the connection that indicates that the token will expire imminently, which will allow a new connection to be established prior to the closure of the previous connection.
+If there is an error that causes a connection to be interrupted, the @error@ event will be activated on the`@EventSource@ instance. This applies to all types of connection disruptions. The data attribute of the event provides an Ably error body that describes the cause of the error. If the issue is related to the authorization token, the error code will indicate this. Token-related errors are identified by codes in the range of @40140 <= code < 40150@. In these situations, a new @accessToken@ can be obtained and authentication can be attempted again.
 
 h4(#specifying-lasteventid). Specifying the lastEventId
 
-Each message received will have a @lastEventId@ attribute containing the last id of any message received on the connection. When constructing a new connection, this value can be specified as a @lastEvent@ param in the URL.
+When you receive a message on a connection, it will include a @lastEventId@ attribute with the last @ID@. To set this value for a new connection, specify it as a @lastEvent@ parameter in the URL.
 
 The following is an example of implementing message continuity with token auth:
 
@@ -109,7 +117,13 @@ const connectToAbly = () => {
 connectToAbly();
 ```
 
-An important thing to note here is that the EventSource API tries to auto-reconnect and re-subscribe to the SSE endpoint when any error occurs, even the token expiry error like in this case. This means that upon manually re-subscribing to the SSE endpoint with a new token, there will be two active subscriptions to the endpoint - one with the old token which would continue to throw an error due to expired credentials and another with the new token. Hence, it is important to close the previous @EventSource@ subscription using @eventSource.close()@ before re-subscribing with the new token as shown in the snippet above.
+The EventSource API will automatically attempt to reconnect and re-subscribe to the SSE endpoint in case of errors, even if the token has expired. 
+
+Manually re-subscribing to the SSE endpoint with a fresh token inadvertently creates two active subscriptions: 
+# The expired token _that will consistently error out_
+# The new token
+
+To avoid this, close the previous @EventSource@ subscription with @eventSource.close()@ before starting a new one, as shown in the code snippet.
 
 You can take a look at a "demo app":https://sse-token-auth.glitch.me and "a complete code example for implementing message continuity in an SSE subscription when using token auth":https://glitch.com/edit/#!/sse-token-auth.
 
@@ -117,24 +131,24 @@ h2(#channel-options). Channel options
 
 In an SSE connection you can specify "channel options":/channels/options in two different ways:
 
-* with a query string in the channel name qualifier
-* as a query string in the connection URL
+# With a query string in the channel name qualifier
+# As a query string in the connection URL
 
-If specified as part of the connection URL the options will apply to all channels that connection attaches to. Using a channel name qualifier enables channel options to be applied to individual channels. Setting options using a channel name qualifier can also be used to override the options set in the connection URL for specific channels.
+By including options in the connection URL, they will apply to all attached channels. However, if you use a channel name qualifier, you can apply options to individual channels. This is useful if you need to override the options set in the connection URL for specific channels.
 
-A channel name qualifier is the square brackets at the start of the channel name. To specify the channel option @foo@ with value @bar@ on channel @baz@, the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, such as @[meta]log@, then the query string follows the existing qualifier, as in @[meta?foo=bar]log@.
+When creating a channel, you can use a qualifier in the form of square brackets at the beginning of the channel name. For example, to indicate the channel option with the name @foo@ with value @bar@ on a channel named @baz@ the qualified channel name would be @[?foo=bar]baz@. If the channel name already has a qualifier, like @[meta]log@, you can add a query string after the existing qualifier, such as @[meta?foo=bar]log@.
 
 The "rewind":/channels/options/rewind and "delta":/channels/options/deltas channel options are supported with SSE.
 
 h3(#delta-sse). Delta with SSE
 
-If subscribing to a channel in delta mode using SSE then you will need to decode any received delta messages yourself.
+If you subscribe to a channel in delta mode using SSE, you must decode any delta messages you receive.
 
-Some transports provide raw message payloads - that is, the content of the @data@ attribute of a @Message@ - without the accompanying metadata. That means that the recipient of the message does not have access to the @extras@ or @encoding@ attributes of the message that would ordinarily be used to decode delta message payloads.
+Certain transports may only provide the content of the @data@ attribute of a @message@, without any accompanying metadata. This means that the receiver of the message may not have access to the @extras@ or @encoding@ attributes typically used to decode message updates.
 
-In order to assist applications that use these transports, @vcdiff@ decoder libraries can check for the @vcdiff@ header at the start of the message payload as an inexact method of determining whether or not the message is a regular message or a delta. Note that, in order to rely on that check, you need to know that that header will not be present in any valid (uncompressed) message in your app. No valid JSON value, for example, will match the @vcdiff@ header check, so it is safe to perform this sniffing on JSON message payloads.
+To help applications utilizing these transports, `vcdiff` decoder libraries can examine the message payload's start for the vcdiff header. This is an approximate method for determining whether the message is a standard message or a delta. It's important to understand that, to depend on this check, you must ensure that the header is not present in any valid (uncompressed) message in your application. JSON messages, for instance, do not match the vcdiff header check, making it secure to conduct this sniffing on JSON message payloads.
 
-Read more in the "delta section":/channels/options/deltas.
+For more information, see "Deltas":/channels/options/deltas.
 
 h3(#delta-example). Delta example with SSE
 
@@ -210,9 +224,7 @@ For more information on enveloped and unenveloped SSE, please see the "SSE API":
 
 h3(#rewind-sse). Rewind with SSE
 
-The "@rewind@":/channels/options/rewind channel option enables a client to specify where to start an attachment from. This can be a point in time in the past, or a given number of messages.
-
-For example, to specify the @rewind@ channel option with the value @"1"@ using a querystring parameter, where it will apply to all channels:
+You can use the "@rewind@":/channels/options/rewind channel option to choose the starting point of an attachment, either by specifying a specific moment in the past or a certain number of messages. For example, apply the @rewind@ channel option with a value of @1@ to all channels using a querystring parameter.
 
 ```[javascript]
   var querystring = 'v=1.2&channels={{RANDOM_CHANNEL_NAME}}&rewind=1&key={{API_KEY}}';
@@ -231,7 +243,7 @@ Or to specify the same parameter but only applying to one channel of two, using 
 
 h2(#stats). Statistics
 
-It is possible to stream app "statistics":/metadata-stats/stats directly to the console using SSE, by connecting and subscribing to the metachannel "@[meta]stats:minute@":/metadata-stats/metadata/subscribe#stats.
+You can stream app "statistics":/metadata-stats/stats directly to the console using SSE by connecting and subscribing to the metachannel "@[meta]stats:minute@":/metadata-stats/metadata/subscribe#stats.
 
 The following is an example of subscribing to @[meta]stats:minute@:
 
@@ -247,7 +259,7 @@ event: message
 data: {"id":"MVphZHA7l9:0:0","timestamp":1633679346026,"encoding":"json","channel":"[meta]stats:minute","data":"{\"intervalId\":\"2021-10-08:07:48\",\"unit\":\"minute\",\"schema\":\"https://schemas.ably.com/json/app-stats-0.0.1.json\",\"entries\":{\"messages.all.all.count\":1,\"messages.all.messages.count\":1,\"messages.outbound.realtime.all.count\":1,\"messages.outbound.realtime.messages.count\":1,\"messages.outbound.all.all.count\":1,\"messages.outbound.all.messages.count\":1,\"connections.all.peak\":2,\"connections.all.min\":1,\"connections.all.mean\":1,\"connections.all.opened\":1}}","name":"update"}
 ```
 
-There can be a delay of up to one minute before the first statistics event. Use the "rewind channel option":#rewind-sse to retrieve the most recent event and subscribe to subsequent events.
+There may be a delay of up to one minute before receiving the initial statistics event. Use the "rewind channel option":#rewind-sse to retrieve the most recent event and subscribe to subsequent events.
 
 The following is an example curl command subscribing to @[meta]stats:minute@ with a rewind value of 1:
 


### PR DESCRIPTION
This PR:

- Completely overhauled the doc
- Removed conflicting subjects 
- Removed repetition
- Improved overall clarity 
- Implemented 'active voice'
- Fixed grammar
- Fixed typos
- Confirmed that this document only supports JS as the available language.

☝️ Completing the above task has fulfilled all requirements listed in the attached ticket:

- SSE acronym is undefined.
- The term 'raw HTTP streaming API' is unclear and possibly superfluous.
- Only the JavaScript option in the code sample switcher works; content limitations may be the cause.
- There are wording issues and typos to address.


[EDU-149: SSE documentation needs work](https://ably.atlassian.net/browse/EDU-149)
