### PR TITLE
Update lock attributes documentation

### DIFF
--- a/content/spaces/locking.textile
+++ b/content/spaces/locking.textile
@@ -51,8 +51,7 @@ const acquireLock = await space.locks.acquire(id);
 The following is an example of passing a set of @attributes@ when trying to acquire a lock:
 
 ```[javascript]
-const attributes = new Map();
-lockAttributes.set('component', 'cell-d3');
+const attributes = { component: 'cell-d3' };
 const acquireLock = await space.locks.acquire(id, { attributes });
 ```
 

--- a/content/spaces/locking.textile
+++ b/content/spaces/locking.textile
@@ -51,9 +51,9 @@ const acquireLock = await space.locks.acquire(id);
 The following is an example of passing a set of @attributes@ when trying to acquire a lock:
 
 ```[javascript]
-const lockAttributes = new Map();
+const attributes = new Map();
 lockAttributes.set('component', 'cell-d3');
-const acquireLock = await space.locks.acquire(id, { lockAttributes });
+const acquireLock = await space.locks.acquire(id, { attributes });
 ```
 
 The following is an example payload returned by @space.locks.acquire()@. The promise will resolve to a lock request with the @pending@ status:


### PR DESCRIPTION
## Description

Fixes the key name used in Spaces’ `LockOptions` type, and brings the lock attributes API in line with https://github.com/ably/spaces/pull/214.