### PR TITLE
EDU-61: Adds `flutter` to the set of languages available in /api/rest-sdk/types

### DIFF
--- a/content/api/realtime-sdk/types.textile
+++ b/content/api/realtime-sdk/types.textile
@@ -90,7 +90,7 @@ h3(#device-details).
   jsall: DeviceDetails
   ruby:  Ably::Models::DeviceDetails
 
-blang[jsall,ruby].
+blang[jsall,ruby,flutter].
   <%= partial partial_version('types/_device_details'), indent: 2, skip_first_indent: true %>
 
 h3(#error-info).

--- a/content/api/rest-sdk/types.textile
+++ b/content/api/rest-sdk/types.textile
@@ -15,6 +15,7 @@ languages:
   - objc
   - csharp
   - go
+  - flutter
 redirect_from:
   - /api/versions/v1.1/rest-sdk/types
   - /api/versions/v1.0/rest-sdk/types
@@ -78,9 +79,9 @@ h3(#error-info).
   ruby:    Ably::Models::ErrorInfo
   php:     Ably\Models\ErrorInfo
   csharp:  IO.Ably.ErrorInfo
+  flutter: ably.ErrorInfo
 
-blang[jsall,ruby,php,java,objc,swift].
-  <%= partial partial_version('types/_error_info'), indent: 2, skip_first_indent: true %>
+<%= partial partial_version('types/_error_info'), indent: 2, skip_first_indent: true %>
 
 h3(#message).
   default: Message

--- a/content/partials/types/_error_info.textile
+++ b/content/partials/types/_error_info.textile
@@ -15,8 +15,5 @@ h4.
 
 - <span lang="default">href</span><span lang="csharp">Href</span> := Ably may additionally include a URL to get more help on this error<br>__Type: @String@__
 
-<div lang="flutter">
-- href :=  Link pointing to ably docs with more details on the error<br>__Type: @String@__
-
-- requestId :=  Request ID with which the error can be identified<br>__Type: @String@__
-</div>
+blang[flutter].
+  - requestId :=  Request ID with which the error can be identified<br>__Type: @String@__


### PR DESCRIPTION
This PR:

- Adds `flutter` to the set of languages available in /api/rest-sdk/types
- Reviews the _**now**_ flutter /api/rest-sdk/types?lang=flutter page for the broken language block highlighted the attached ticket
- The review did not identify any language blocks that were broken -- indicating that the issue has been resolved

[EDU-61: Broken language block on rest/types](https://ably.atlassian.net/browse/EDU-61)