### PR TITLE
Fix REST doc's usage of ABLY_KEY_NAME -> API_KEY_NAME

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -1176,7 +1176,7 @@ Provides a mechanism to revoke tokens, where @keyName@ is @appId.keyId@.
 
 Example request:
 
-bc[sh]. curl -u "{{API_KEY}}" -X POST https://rest.ably.io/keys/{{ABLY_KEY_NAME}}/revokeTokens \
+bc[sh]. curl -u "{{API_KEY}}" -X POST https://rest.ably.io/keys/{{API_KEY_NAME}}/revokeTokens \
     --header "Accept: application/json" \
     --header "Content-Type: application/json" \
     --data '{"targets": [ "clientId:client1@example.com" ]}'


### PR DESCRIPTION
The text ABLY_KEY_NAME is not properly replaced with the user's/the demo api key name, so this ensures this usage is in-line with the rest of page's API_KEY_NAME usage.

> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

The text `ABLY_KEY_NAME` is not properly replaced with the user's/the demo api key name, so this ensures this usage is in-line with the rest of page's `API_KEY_NAME` usage.

## Review

Instructions on how to review the PR. 

The text changed from ABLY_KEY_NAME should match the text used for Ably API Key names used throughout the rest of the page, API_KEY_NAME.