### PR TITLE
[FIX] consistently use port 8000 everywhere in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To build and serve locally:
 
 `npm run rebuild`
 
-Visit `localhost:9000` for homepage.
+Visit `localhost:8000` for homepage.
 
 ## Redirects
 

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,6 +1,6 @@
 const herokuAppSite = process.env.HEROKU_APP_NAME
   ? `https://${process.env.HEROKU_APP_NAME}.herokuapp.com`
-  : 'http://localhost:9000';
+  : 'http://localhost:8000';
 
 const mainWebsite = process.env.GATSBY_ABLY_MAIN_WEBSITE ?? 'http://localhost:3000';
 

--- a/src/utilities/assets/src-from-docs-site.ts
+++ b/src/utilities/assets/src-from-docs-site.ts
@@ -1,6 +1,6 @@
 const herokuAppSite = process.env.HEROKU_APP_NAME
   ? `https://${process.env.HEROKU_APP_NAME}.herokuapp.com`
-  : 'http://localhost:9000';
+  : 'http://localhost:8000';
 
 const sitePrefix = process.env.GATSBY_DOCS_SITE_URL ?? herokuAppSite;
 


### PR DESCRIPTION
## Description

Gatsby defaults to using port `8000` in development, and we have some places in the code that we inconsistently use port `9000` as a default value. The results are that you get an inconsistent development experience if you don't have any environment variables set up.

By changing our custom values back to port `8000` we get a nice consistent experience where you can just clone the repo and run `npm run development` and get cracking.

## Review

This is best done by cloning the repo afresh, installing the dependencies, running `npm run development`, and opening up the site and seeing there are no issues loading images (like the Ably logo)