### PR TITLE
EDU-88: Updates 'Connect to Ably' clientOptions for flutter

### DIFF
--- a/content/getting-started/quickstart.textile
+++ b/content/getting-started/quickstart.textile
@@ -407,7 +407,7 @@ ARTRealtime *ably = [[ARTRealtime alloc] initWithKey:@"{{API_KEY}}"];
 ```
 
 ```[flutter]
-final clientOptions = ably.ClientOptions.fromKey('{{API_KEY}}');
+final clientOptions = ably.ClientOptions(key: '{{API_KEY}}');
 final realtime = ably.Realtime(options: clientOptions);
 realtime.connection
   .on(ably.ConnectionEvent.connected)


### PR DESCRIPTION
This PR:

- Under Connect to Ably -- Updates clientOption in the code example for flutter

[EDU-88: Flutter quickstart guide needs updating](https://ably.atlassian.net/browse/EDU-88) 