### PR TITLE
Fix issue where codeblock not displaying correctly if surrounded by a div

### DIFF
--- a/content/partials/types/_push_admin.textile
+++ b/content/partials/types/_push_admin.textile
@@ -81,12 +81,10 @@ bq(definition#device-get-id).
   swift,objc: get(deviceId: ArtDeviceId, callback: ((ARTDeviceDetails?, ARTErrorInfo?) -> Void)
   java,android: "DeviceDetails":#device-details get(String deviceId)
 
-<div lang="java,android">
+blang[java,android].
 
-bq(definition#device-get-id-async).
-  java,android: getAsync(String deviceId, Callback<"DeviceDetails"/api/rest-sdk/push-admin#device-details> callback)
-
-</div>
+  bq(definition#device-get-id-async).
+    java,android: getAsync(String deviceId, Callback<"DeviceDetails":/api/rest-sdk/push-admin#device-details> callback)
 
 bq(definition#device-get-device).
   default: get("DeviceDetails":#device-details device, callback("ErrorInfo":/api/realtime-sdk/types#error-info err, "DeviceDetails":#device-details device))

--- a/content/partials/versions/v1.1/types/_push_admin.textile
+++ b/content/partials/versions/v1.1/types/_push_admin.textile
@@ -81,12 +81,10 @@ bq(definition#device-get-id).
   swift,objc: get(deviceId: ArtDeviceId, callback: ((ARTDeviceDetails?, ARTErrorInfo?) -> Void)
   java,android: "DeviceDetails":#device-details get(String deviceId)
 
-<div lang="java,android">
+blang[java,android].
 
-bq(definition#device-get-id-async).
-  java,android: getAsync(String deviceId, Callback<"DeviceDetails"/api/rest-sdk/push-admin#device-details> callback)
-
-</div>
+  bq(definition#device-get-id-async).
+    java,android: getAsync(String deviceId, Callback<"DeviceDetails":/api/rest-sdk/push-admin#device-details> callback)
 
 bq(definition#device-get-device).
   default: get("DeviceDetails":#device-details device, callback("ErrorInfo":/api/realtime-sdk/types#error-info err, "DeviceDetails":#device-details device))


### PR DESCRIPTION
## Description

If Java is selected within the Rest API section of the docs, then under the `DeviceRegistrations object` section, there is a broken codeblock. This is due to textile not knowing how to handle a div surrounding this codeblock.

![Screenshot 2023-10-17 at 12 48 56](https://github.com/ably/docs/assets/2411269/d4195315-94a3-45bf-ba3c-1ae9c3aba4f9)
 

* [Jira ticket](https://ably.atlassian.net/browse/EDU-1433).

