### PR TITLE
[COL-527] Location event emitted on being removed from a space

### DIFF
--- a/content/spaces/locations.textile
+++ b/content/spaces/locations.textile
@@ -31,7 +31,7 @@ Subscribe to location events by registering a listener. Location events are emit
 All location changes are @update@ events. When a location update is received, clear the highlight from the UI component of the member's @previousLocation@ and add it to @currentLocation@.
 
 <aside data-type='note'>
-<p> A location update is also emitted when a member "leaves":/spaces/space#leave a space. The member's @currentLocation@ will be @null@ for these events so that any UI component highlighting can be cleared.</p>
+<p> A location update is also emitted when a member is "removed":/spaces/avatar#events from a space. The member's @currentLocation@ will be @null@ for these events so that any UI component highlighting can be cleared.</p>
 </aside>
 
 The following is an example of subscribing to location events:


### PR DESCRIPTION
## Description

This PR fixes a bug that states a location event is emitted when a member leaves a space. It instead should say that an event is emitted when a member is removed from a space.

See [JIRA](https://ably.atlassian.net/browse/COL-527) for further details.

