### PR TITLE
[EDU-1447] Update React placement in Spaces table of contents

### DIFF
--- a/data/yaml/page-furniture/spacesSidebar.yaml
+++ b/data/yaml/page-furniture/spacesSidebar.yaml
@@ -7,6 +7,8 @@ items:
         link: /docs/spaces
       - label: 'SDK setup'
         link: /docs/spaces/setup
+      - label: 'React Hooks'
+        link: /docs/spaces/react
       - label: 'Space'
         link: /docs/spaces/space
       - label: 'Avatar stack'
@@ -17,5 +19,3 @@ items:
         link: /docs/spaces/cursors
       - label: 'Component locking'
         link: /docs/spaces/locking
-      - label: 'React Hooks'
-        link: /docs/spaces/react


### PR DESCRIPTION
## Description

This PR updates the Spaces table of contents to move React under the SDK setup page.

