### PR TITLE
[CHORE] Remove API Streamer tutorials category

### DIFF
--- a/config/tutorials/tutorials.json
+++ b/config/tutorials/tutorials.json
@@ -29,12 +29,6 @@
       "icon": "lightning",
       "name": "Integrations",
       "desc": "Fun tutorials on how to make use of various libraries and JS frameworks with Ably."
-    },
-    {
-      "id": "api-hub",
-      "icon": "api-streamer-monotone",
-      "name": "API Streamer and Hub",
-      "desc": "Fun tutorials on how to make use of various libraries and JS frameworks with Ably."
     }
   ],
   "groups": {

--- a/content/tutorials/_live-flight-tracking.textile
+++ b/content/tutorials/_live-flight-tracking.textile
@@ -4,7 +4,6 @@ authors:
   author_name: Abraham Agiri Junior
   author_profile_url: https://github.com/codeekage
 category:
-- api-hub
 - channels
 date_published: '2020-03-06T09:30:08+00:00'
 excerpt: Build a live flight tracker in React Native using an open data stream from

--- a/content/tutorials/demo-ably-airtable-starter-kit.textile
+++ b/content/tutorials/demo-ably-airtable-starter-kit.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-11-11T10:12:36Z'
 last_updated: '2020-11-11T10:12:36Z'
 excerpt: A fully functional starter kit which enables you to store realtime messages from Ably into Airtable via WebHooks.

--- a/content/tutorials/demo-ably-rock-paper-scissors.textile
+++ b/content/tutorials/demo-ably-rock-paper-scissors.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2021-09-16T09:24:41Z'
 last_updated: '2021-09-16T09:24:41Z'
 excerpt: A multiplayer game of rock, paper, scissors ... with a twist.

--- a/content/tutorials/demo-agile-flush-vue-app.textile
+++ b/content/tutorials/demo-agile-flush-vue-app.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2021-11-25T09:31:04Z'
 last_updated: '2021-11-25T09:31:04Z'
 excerpt: Collaborate with your colleagues to calculate time estimates for your next sprint, with this online planning poker app! Built with VueJS and NodeJS, this is a great example of using pub/sub messaging to build a simple, browser-based realtime collaboration tool.

--- a/content/tutorials/demo-decorate-a-tree-2020.textile
+++ b/content/tutorials/demo-decorate-a-tree-2020.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-12-18T14:48:25Z'
 last_updated: '2020-12-18T14:48:25Z'
 excerpt: Decorate and share your own Christmas tree in realtime! This demo uses the browser’s native drag and drop functionality and pub/sub messaging. Tree state is persisted with Azure Blob Storage.

--- a/content/tutorials/demo-depict-it.textile
+++ b/content/tutorials/demo-depict-it.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-08-21T10:29:37Z'
 last_updated: '2020-08-21T10:29:37Z'
 excerpt: A fun peer-to-peer multiplayer drawing game built with VueJS using Ably channels.

--- a/content/tutorials/demo-fully-featured-scalable-chat-app.textile
+++ b/content/tutorials/demo-fully-featured-scalable-chat-app.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2021-09-23T13:21:13Z'
 last_updated: '2021-09-23T13:21:13Z'
 excerpt: An example of how to architect a fully-featured, scalable chat app. With user authentication, channel management, message history, and other chat-specific features.

--- a/content/tutorials/demo-jamstack-sync-stream-video.textile
+++ b/content/tutorials/demo-jamstack-sync-stream-video.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2021-03-01T10:44:57Z'
 last_updated: '2021-03-01T10:44:57Z'
 excerpt: Build your own video watch party app using Jamstack architecture. See who's online and chat with your friends as you enjoy a movie together.

--- a/content/tutorials/demo-led-matrix-jumper.textile
+++ b/content/tutorials/demo-led-matrix-jumper.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2019-11-28T15:23:09Z'
 last_updated: '2019-11-28T15:23:09Z'
 excerpt: A wearable tech demo that ensures that your Christmas jumper is always displaying the right festive imagery to match the currently-playing song! Built with Arduino and Node.js.

--- a/content/tutorials/demo-live-caption-demo.textile
+++ b/content/tutorials/demo-live-caption-demo.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-12-04T15:46:55Z'
 last_updated: '2020-12-04T15:46:55Z'
 excerpt: A live captioning app that translates your speech to a wearable display. Perfect for being understood when wearing a mask! Built with Ably, MQTT, and Azure Cognitive Service (ACS).

--- a/content/tutorials/demo-multiplayer-games-scalable-networking-framework.textile
+++ b/content/tutorials/demo-multiplayer-games-scalable-networking-framework.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-10-22T14:30:33Z'
 last_updated: '2020-10-22T14:30:33Z'
 excerpt: A scalable networking framework for building web-based multiplayer games. It uses vanilla JS on the client and NodeJS on the server.

--- a/content/tutorials/demo-nextjs-chat-app.textile
+++ b/content/tutorials/demo-nextjs-chat-app.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2021-01-07T09:39:52Z'
 last_updated: '2021-01-07T09:39:52Z'
 excerpt: A basic chat app built with Ably and NextJS and hosted on Vercel. This demo shows you how to implement realtime messaging using Ably, which is not currently possible with Vercel Serverless Functions as they cannot maintain a WebSocket connection.

--- a/content/tutorials/demo-realtime-midi-player.textile
+++ b/content/tutorials/demo-realtime-midi-player.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-08-20T09:48:18Z'
 last_updated: '2020-08-20T09:48:18Z'
 excerpt: A realtime MIDI keyboard in the browser. Uses Web APIs and pub/sub to create a virtual jam session.

--- a/content/tutorials/demo-realtime-multiplayer-space-invaders.textile
+++ b/content/tutorials/demo-realtime-multiplayer-space-invaders.textile
@@ -14,7 +14,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-05-21T22:43:39Z'
 last_updated: '2020-05-21T22:43:39Z'
 excerpt: A realtime multiplayer Space Invaders game built with Ably and the Phaser 3 game framework. The game runs in the browser and its state is managed by a central NodeJS server.

--- a/content/tutorials/demo-realtime-quiz-framework.textile
+++ b/content/tutorials/demo-realtime-quiz-framework.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-10-22T14:30:33Z'
 last_updated: '2020-10-22T14:30:33Z'
 excerpt: A base networking framework for building a scalable realtime quiz or EdTech test platform with Ably. It uses VueJS on the client and NodeJS on the server and is scalable as your needs grow.

--- a/content/tutorials/demo-whiteboard.textile
+++ b/content/tutorials/demo-whiteboard.textile
@@ -13,7 +13,6 @@ category:
 - channels
 - reactor-integrations
 - push-notifications
-- api-hub
 date_published: '2020-09-14T10:42:32Z'
 last_updated: '2020-09-14T10:42:32Z'
 excerpt: A collaborative, interactive, multi-user whiteboard, built with vanilla JS and pub/sub messaging.

--- a/content/tutorials/live-bitcoin-pricing.textile
+++ b/content/tutorials/live-bitcoin-pricing.textile
@@ -11,7 +11,6 @@ authors:
   author_profile_url: https://www.telerik.com/kendo-ui
 category:
 - channels
-- api-hub
 date_published: '2019-09-04T14:35:51+01:00'
 excerpt: Learn how to build a live bitcoin pricing chart in Angular using Ably and
   KendoUI

--- a/content/tutorials/tfl-live-tracking-fitbit.textile
+++ b/content/tutorials/tfl-live-tracking-fitbit.textile
@@ -8,7 +8,6 @@ authors:
   author_profile_url: https://github.com/vardhanapoorv
 category:
 - channels
-- api-hub
 date_published: '2020-01-18T19:42:56+05:30'
 excerpt: Learn how to build a FitBit Clockface app using the Ably TFL data stream
   to prompt users when to start for the station


### PR DESCRIPTION
## Description

This will remove the "API Streamer and Hub" tab on the tutorials page on the website.

* Epic: WEB-3239
* Ticket: WEB-3245

## Review

Not much to review this side, once merged and updated in the website we'll have one less tab on `/tutorials`

