### PR TITLE
COL-552: Writes the 'What is LiveSync' page

### DIFF
--- a/content/livesync/index.textile
+++ b/content/livesync/index.textile
@@ -1,0 +1,43 @@
+---
+title: What is LiveSync?
+meta_description: "LiveSync enables you to synchronize changes in your database to frontend clients at scale."
+product: livesync
+---
+
+LiveSync enables you to synchronize changes in your database to frontend clients at scale. It integrates with your database of choice and leverages Ably's global message delivery network to sync data between your users in realtime.
+
+LiveSync is made up of two key components:
+
+- Database Connector := A backend service for broadcasting changes from your database in realtime.
+- Models SDK := A frontend library that simplifies subscribing to changes in data models and applying optimistic updates, merging them with confirmed updates.
+
+The following diagram provides a simplified overview of the LiveSync solution:
+
+h2(#db-connector). Database Connector
+
+The "Database Connector":/livesync/connector uses the "outbox pattern":https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html to broadcast application-specific change events from your database to frontend clients via "Ably Channels":/channels.
+
+When you update the data in your database, you record a change event transactionally in a dedicated "outbox table":https://docs.google.com/document/d/19BJ4oYC3ah4wFH0VS5Qv6qHe3qmRS_PpNLSytTOi9tc/edit#heading=h.r00ywdkts746. The Database Connector detects new changes in the outbox and publishes them as messages on Ably Channels. Using the Models SDK, your client applications subscribe to these change events and update their local state with the new data.
+
+The Database Connector is currently a Docker container image that can run on your own infrastructure. If you want to use an Ably-hosted version, please "reach out":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform.
+
+h2(#models-sdk). Models SDK
+
+The "Models SDK":/livesync/models/models enables you to easily create live and observable data models in your frontend applications, ensuring they remain synchronized with your database's state in realtime. By subscribing to a model, you receive the changes made by other users, enabling the creation of a seamless, multiplayer application experience.
+
+The Models SDK works as follows:
+
+- "Sync":/livesync/models/models#sync := Bootstrap the client state during the initial page load.
+- "Merge":/livesync/models/models#merge := Update the client state in response to realtime change events.
+- "Optimistic updates":/livesync/models/models#optimistic := Provide instantaneous feedback to the user when they change the data.
+- "Subscribe":/livesync/models/models#subscribe := Render changes to the model state in your application in realtime.
+
+The Models SDK is built on "Ably's JavaScript SDK":https://github.com/ably/ably-js and can be easily integrated into any front-end framework. The key advantages include:
+
+* "Authentication":/auth and "connection management":/connect are efficiently managed by the underlying Ably JavaScript SDK.
+
+* The Ably JavaScript SDK enables you to extend your application's functionality with "Pub/Sub Channels":/products/channels.
+
+h2(#dev-status). Development status
+
+LiveSync is currently in the public alpha stage, primarily intended for experimental use and not yet suitable for production environments. Your "feedback":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform will help in prioritizing improvements and fixes in subsequent releases.


### PR DESCRIPTION
This PR:

- Writes the 'What is LiveSync' page for the LiveSync alpha release
- Note: the new LiveSync tab in navigation  

[COL-552: What is Livesync page]
