### PR TITLE
Fix docs build

### DIFF
--- a/data/yaml/page-furniture/sidebar.yaml
+++ b/data/yaml/page-furniture/sidebar.yaml
@@ -59,6 +59,8 @@ items:
                 link: /docs/channels/options/deltas
               - label: 'Encryption'
                 link: /docs/channels/options/encryption
+          - label: 'How-to: publish and subscribe to channels'
+            link: /docs/how-to/pub-sub
       - label: 'Presence and occupancy'
         link: ''
         items:

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,17 +5,36 @@ import ProductNavigation from 'src/components/ProductNavigation';
 import { LeftSideBar } from 'src/components/StaticQuerySidebar';
 import { useSidebar } from 'src/contexts/SidebarContext';
 import GlobalLoading from '../GlobalLoading/GlobalLoading';
-import { Container, SidebarName } from 'src/components';
+import { Container, type SidebarName } from 'src/components';
 import { Header } from '../Header';
 import { Footer } from '../Footer';
 
 interface LayoutProps {
   isExtraWide?: boolean;
   showProductNavigation?: boolean;
-  currentProduct?: string;
+  currentProduct: string;
   noSidebar?: boolean;
   collapsibleSidebar?: boolean;
   children: ReactNode;
+}
+
+function assertNever(name: string): never {
+  throw new Error("Received unrecognized sidebar name: " + name);
+}
+
+const getSidebarName = (currentProduct: string): SidebarName => {
+  switch (currentProduct) {
+    case 'home':
+    case 'channels':
+    case 'SDKs':
+      return 'channels';
+    case 'api-reference':
+      return 'api-reference';
+    case 'spaces':
+      return 'spaces';
+    default:
+      return assertNever(currentProduct);
+  }
 }
 
 const Layout: React.FC<LayoutProps> = ({
@@ -26,7 +45,7 @@ const Layout: React.FC<LayoutProps> = ({
   noSidebar = false,
   collapsibleSidebar = false,
 }) => {
-  const sidebarName = currentProduct === 'home' ? 'channels' : currentProduct;
+  const sidebarName = getSidebarName(currentProduct);
   const showSidebar = !noSidebar;
 
   const { collapsed, setCollapsed, initialCollapsedState } = useSidebar();

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -51,6 +51,8 @@ const Layout: React.FC<LayoutProps> = ({
   const { collapsed, setCollapsed, initialCollapsedState } = useSidebar();
 
   useEffect(() => {
+    if (typeof initialCollapsedState === 'undefined' || !setCollapsed) return;
+
     setCollapsed(initialCollapsedState);
   }, [initialCollapsedState, setCollapsed]);
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -19,7 +19,7 @@ interface LayoutProps {
 }
 
 function assertNever(name: string): never {
-  throw new Error("Received unrecognized sidebar name: " + name);
+  throw new Error('Received unrecognized sidebar name: ' + name);
 }
 
 const getSidebarName = (currentProduct: string): SidebarName => {
@@ -35,7 +35,7 @@ const getSidebarName = (currentProduct: string): SidebarName => {
     default:
       return assertNever(currentProduct);
   }
-}
+};
 
 const Layout: React.FC<LayoutProps> = ({
   children,
@@ -51,7 +51,9 @@ const Layout: React.FC<LayoutProps> = ({
   const { collapsed, setCollapsed, initialCollapsedState } = useSidebar();
 
   useEffect(() => {
-    if (typeof initialCollapsedState === 'undefined' || !setCollapsed) return;
+    if (typeof initialCollapsedState === 'undefined' || !setCollapsed) {
+      return;
+    }
 
     setCollapsed(initialCollapsedState);
   }, [initialCollapsedState, setCollapsed]);

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -35,12 +35,13 @@ export const Sidebar = ({
   // if we navigate from a page where collapsible is true
   // then collapsed could be true when we re-render
   useEffect(() => {
-    if (!collapsible) {
-      setCollapsed(false);
-    }
+    if (!collapsible || !setCollapsed) return;
+
+    setCollapsed(false);
   }, [collapsible, setCollapsed]);
 
   const handleToggleSidebar = () => {
+    if (!setCollapsed) return;
     setCollapsed((prev) => !prev);
   };
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -35,13 +35,17 @@ export const Sidebar = ({
   // if we navigate from a page where collapsible is true
   // then collapsed could be true when we re-render
   useEffect(() => {
-    if (!collapsible || !setCollapsed) return;
+    if (!collapsible || !setCollapsed) {
+      return;
+    }
 
     setCollapsed(false);
   }, [collapsible, setCollapsed]);
 
   const handleToggleSidebar = () => {
-    if (!setCollapsed) return;
+    if (!setCollapsed) {
+      return;
+    }
     setCollapsed((prev) => !prev);
   };
 

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, createContext, useContext, useState } from 'react';
 
 interface SidebarContextProps {
-  collapsed: boolean;
-  setCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
-  initialCollapsedState: boolean;
+  collapsed?: boolean;
+  setCollapsed?: React.Dispatch<React.SetStateAction<boolean>>;
+  initialCollapsedState?: boolean;
 }
 
 const SidebarContext = createContext<SidebarContextProps | undefined>(undefined);
@@ -13,12 +13,11 @@ interface SidebarProviderProps {
   initialCollapsedState?: boolean;
 }
 
+const initialState = { collapsed: undefined, setCollapsed: undefined, initialCollapsedState: undefined };
+
 export const useSidebar = (): SidebarContextProps => {
   const context = useContext(SidebarContext);
-  if (!context) {
-    throw new Error('useSidebar must be used within a SidebarProvider');
-  }
-  return context;
+  return context || initialState;
 };
 
 export const SidebarProvider: React.FC<SidebarProviderProps> = ({ children, initialCollapsedState = false }) => {

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -6,18 +6,16 @@ interface SidebarContextProps {
   initialCollapsedState?: boolean;
 }
 
-const SidebarContext = createContext<SidebarContextProps | undefined>(undefined);
+const initialState = { collapsed: undefined, setCollapsed: undefined, initialCollapsedState: undefined };
+const SidebarContext = createContext<SidebarContextProps>(initialState);
 
 interface SidebarProviderProps {
   children: ReactNode;
   initialCollapsedState?: boolean;
 }
 
-const initialState = { collapsed: undefined, setCollapsed: undefined, initialCollapsedState: undefined };
-
 export const useSidebar = (): SidebarContextProps => {
-  const context = useContext(SidebarContext);
-  return context || initialState;
+  return useContext(SidebarContext);
 };
 
 export const SidebarProvider: React.FC<SidebarProviderProps> = ({ children, initialCollapsedState = false }) => {


### PR DESCRIPTION
The main fix here is an update to this part:
```
const context = useContext(SidebarContext);
  if (!context) {
    throw new Error('useSidebar must be used within a SidebarProvider');
  }
  return context;
```

I've modified what the `SidebarContext` initial value is, but removed the above, as it's quite normal for it to be false or incomplete. Interestingly, this would run on `build` and immediately fail but never be an issue in dev.

