### PR TITLE
Fix docs home image

### DIFF
--- a/src/components/Homepage/BodySection/Card/SdkCard.tsx
+++ b/src/components/Homepage/BodySection/Card/SdkCard.tsx
@@ -18,10 +18,6 @@ export const SdkCard = ({ title, content, image, callToAction }: CardProps) => (
       ) : null}
     </div>
 
-    <StaticImage
-      src={`/images/homepage/${image}.png}`}
-      srcSet={`/images/homepage/${image}.png, /images/homepage/${image}@2x.png 2x`}
-      style={{ maxWidth: '409px' }}
-    />
+    <StaticImage src={`/images/homepage/${image}@2x.png`} style={{ maxWidth: '409px' }} />
   </div>
 );


### PR DESCRIPTION
`srcSet` will not get transformed to get the correct `ASSET_PREFIX` and so will never work on the `ably.com` domain. That, and a rogue `}` in the src 😮‍💨 .
