### PR TITLE
[ACT-116]: Add SDKs link in hamburger menu on mobile

### DIFF
--- a/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarLinkItem.tsx
+++ b/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarLinkItem.tsx
@@ -4,7 +4,7 @@ import { HamburgerSidebarItemContainer } from '.';
 export const HamburgerSidebarLinkItem = ({ link, label }: { link: string; label: string }) => (
   <HamburgerSidebarItemContainer>
     <a
-      className="text-16
+      className="text-16 font-medium
                 focus-within:outline-none focus-within:text-gui-focus"
       href={link}
       rel="nofollow noopener"

--- a/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarRenderer.tsx
+++ b/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarRenderer.tsx
@@ -14,6 +14,12 @@ export type HamburgerMenuProps = {
   sidebarName: SidebarName;
 };
 
+const SDKsLinkData = {
+  link: '/docs/sdks',
+  label: 'SDKs',
+  level: 0,
+};
+
 export const dataToHamburgerSidebarItem = (sidebarItemData: SidebarData) =>
   sidebarItemData.dropdownData ? (
     <HamburgerSidebarDropdownPopulatedItem key={sidebarItemData.label} {...sidebarItemData} />
@@ -45,11 +51,14 @@ export const HamburgerSidebarRenderer = ({ className, data, sidebarName }: Hambu
     [dataItemsWithAdHocReplacements, expandedMenu],
   );
 
+  // if dataItems length is 1 it means user has entered in deeper level of list, SDKs should be only on level 0
+  const dataWithSDKsLink = dataItems.length === 1 ? dataItems : [...dataItems, SDKsLinkData];
+
   const sidebarContents =
     dataItems.length === 1 && !!dataItems[0].dropdownData ? (
       <HamburgerSidebarDropdownPopulatedItem key={0} {...dataItems[0]} />
     ) : (
-      <ol className={className}>{dataItems.map(dataToHamburgerSidebarItem)}</ol>
+      <ol className={className}>{dataWithSDKsLink.map(dataToHamburgerSidebarItem)}</ol>
     );
 
   return (


### PR DESCRIPTION
## Description

Add SDKs link to hamburger menu list on first level.

* [ACT-116](https://ably.atlassian.net/browse/ACT-116).

## Review

Make screen small as a mobile device, click on hamburger menu, make sure SDKs link looks like the rest of list items ( minus chevron), and it should lead to /docs/sdks page

* [Docs page]()
