### PR TITLE
[EDU-1462] Update useLocation to useLocations

### DIFF
--- a/content/spaces/react.textile
+++ b/content/spaces/react.textile
@@ -21,7 +21,7 @@ The following hooks are available:
 
 - "useSpace":#useSpace := The @useSpace@ hook lets you subscribe to the current Space and receive Space state events and get current Space instance.
 - "useMembers":#useMembers := The @useMembers@ hook useful in building avatar stacks. Using @useMembers@ hook you can retrieve spaces members.
-- "useLocation":#useLocation := The @useLocation@ hook lets you subscribe to location events. Location events are emitted whenever a member changes location.
+- "useLocations":#useLocations := The @useLocations@ hook lets you subscribe to location events. Location events are emitted whenever a member changes location.
 - "useLocks":#useLocks := The @useLocks@ hook lets you subscribe to lock events by registering a listener. Lock events are emitted whenever the lock state transitions into @locked@ or @unlocked@.
 - "useLock":#useLock := The @useLock@ returns the status of a lock and, if it has been acquired, the member holding the lock.
 - "useCursors":#useCursors := The @useCursors@ allows you to track a member's pointer position updates across an application.
@@ -127,20 +127,20 @@ useMembers('update', (memberUpdate) => {
 });
 ```
 
-h3(#useLocation). useLocation
+h3(#useLocations). useLocations
 
-@useLocation@ enables you to subscribe to "location":/spaces/locations events. Location events are emitted whenever a member changes location.
+@useLocations@ enables you to subscribe to "location":/spaces/locations events. Location events are emitted whenever a member changes location.
 
 ```[react]
-useLocation((locationUpdate) => {
+useLocations((locationUpdate) => {
   console.log(locationUpdate);
 });
 ```
 
-@useLocation@ also enables you to update the current member location using the @update@ method provided by the hook. For example:
+@useLocations@ also enables you to update the current member location using the @update@ method provided by the hook. For example:
 
 ```[react]
-const { update } = useLocation((locationUpdate) => {
+const { update } = useLocations((locationUpdate) => {
   console.log(locationUpdate);
 });
 ```


### PR DESCRIPTION
## Description

The React Hook for locations was incorrectly listed as `useLocation` rather than `useLocations`. 
