### PR TITLE
COL-649: Updates Models install section with API ref link, updated co…

### DIFF
--- a/content/livesync/models/index.textile
+++ b/content/livesync/models/index.textile
@@ -53,11 +53,15 @@ import { Realtime } from 'ably/promises';
 Instantiate a realtime client using the Ably JavaScript SDK and pass the generated client into the Models constructor:
 
 ```[javascript]
-const client = new Realtime.Promise({ key: '{{API_KEY}}' });
-const modelsClient = new ModelsClient({ client });
+const ably = new Realtime.Promise({ key: '...' });
+const modelsClient = new ModelsClient({ ably });
 ```
 
 h3(#options). ClientOptions
+
+<aside data-type='note'>
+<p>View the "API references":https://sdk.ably.com/builds/ably-labs/models/main/typedoc/ for the Models SDK.</p>
+</aside>
 
 In addition to the underlying Ably realtime client, you can provide a number of other "@ClientOptions@":/api/realtime-sdk/types#client-options to configure the behavior of the Models SDK:
 
@@ -68,6 +72,7 @@ In addition to the underlying Ably realtime client, you can provide a number of 
 - @eventBufferOptions@ := used to configure the in-memory sliding-window buffer used for reordering and deduplication.
 - @optimisticEventOptions@ := is used to configure how "optimistic events":/livesync/models/models#optimistic are applied.
 - @logLevel@ := configures the log level used to control the verbosity of log output. One of @fatal@, @error@, @warn@, @info@, @debug@, or @trace@.
+- @ModelsClient@ := captures a collection of named model instances used in your application and provides methods for creating new models.
 
 The following is an example of setting @ClientOptions@ when instantiating the Models SDK:
 


### PR DESCRIPTION
This PR:

- A code sample is updated in the install section of the Models page for LiveSync.
- The API reference link has been added under the `clientOptions` section.
- A `ModelsClient` entry has been added to the definition list.

[COL-649:  Update Models install code example and ClientOptions table](https://ably.atlassian.net/browse/COL-649)