### PR TITLE
COL-650: Fixes the links to the 'Google Form hosted' LiveSync feedback form 

### DIFF
--- a/content/livesync/connector/index.textile
+++ b/content/livesync/connector/index.textile
@@ -17,7 +17,7 @@ docker pull ghcr.io/ably-labs/adbc:latest
 ```
 
 <aside data-type='note'>
-<p>Please "reach out":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewformif you have any feedback or prefer to use an Ably-hosted version of LiveSync.</p>
+<p>Please "reach out":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform if you have any feedback or prefer to use an Ably-hosted version of LiveSync.</p>
 </aside>
 
 h2(#docker). Run using Docker Compose

--- a/content/livesync/models/index.textile
+++ b/content/livesync/models/index.textile
@@ -15,7 +15,7 @@ The following diagram provides a simplified overview of the Models SDK:
 </a>
 
 <aside data-type='note'>
-<p>Please "reach out":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewformif you have any feedback or prefer to use an Ably-hosted version of LiveSync.</p>
+<p>Please "reach out":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform if you have any feedback or prefer to use an Ably-hosted version of LiveSync.</p>
 </aside>
 
 h2(#authenticate). Authenticate


### PR DESCRIPTION
This PR:

- Fixes the links to the 'Google Form hosted' LiveSync feedback form.

[COL-650: Fix feedback form link](https://ably.atlassian.net/browse/COL-650)
