### PR TITLE
[ACT-163] Broken links in MDX

### DIFF
--- a/data/onCreateNode/create-graphql-schema-customization.ts
+++ b/data/onCreateNode/create-graphql-schema-customization.ts
@@ -40,4 +40,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
     }
   `;
   createTypes(typeDefs);
+
+  // Schema update for site, so we always have an assetPrefix
+  const siteType = `
+    type Site implements Node {
+      assetPrefix: String
+    }
+`;
+  createTypes(siteType);
 };

--- a/how-tos/pub-sub/how-to.mdx
+++ b/how-tos/pub-sub/how-to.mdx
@@ -71,8 +71,8 @@ Click the **Unsubscribe** button to unsubscribe a client from that sport. They s
 
 The following reading explain the concepts of pub/sub and channels in more depth:
 
-* The [channels](/channels) page has everything you need to know about channels, and [publishing](/channels#publish) and [subscribing](/channels#subscribe) to messages.
-* Read [how to use Ably](/basics/use-ably) for further information on the REST and realtime interfaces.
-* The API references for [`publish()`](/api/rest-sdk/channels#publish), [`subscribe()`](/api/realtime-sdk/channels#subscribe) and [`unsubscribe()`](api/realtime-sdk/channels#unsubscribe) explain how each method works.
+* The [channels](/docs/channels) page has everything you need to know about channels, and [publishing](/docs/channels#publish) and [subscribing](/docs/channels#subscribe) to messages.
+* Read [how to use Ably](/docs/basics/use-ably) for further information on the REST and realtime interfaces.
+* The API references for [`publish()`](/docs/api/rest-sdk/channels#publish), [`subscribe()`](/docs/api/realtime-sdk/channels#subscribe) and [`unsubscribe()`](/docs/api/realtime-sdk/channels#unsubscribe) explain how each method works.
 
-Sign up for free to get started in your own Ably account. See which [platforms and languages](/getting-started/sdks) Ably supports and [get started](/getting-started/setup) on your own project by setting up an SDK.
+Sign up for free to get started in your own Ably account. See which [platforms and languages](/docs/sdks) Ably supports and [get started](/docs/getting-started/setup) on your own project by setting up an SDK.

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
   // NOTE: This is a workaround for compilation issues with .d.ts files
   transformIgnorePatterns: [
-    `node_modules/(?!(gatsby|gatsby-script|use-keyboard-shortcut|react-medium-image-zoom|@react-hook/media-query)/)`,
+    `node_modules/(?!(gatsby|gatsby-script|use-keyboard-shortcut|react-medium-image-zoom|@react-hook/media-query|@mdx-js/react)/)`,
   ],
   globals: {
     __PATH_PREFIX__: ``,

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -10,11 +10,11 @@ export default function Link<TState>({ children, to, ...props }: React.PropsWith
      *  Relevant page of documentation: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#recommendations-for-programmatic-in-app-navigation
      *  "If you need this (in-app navigation) behavior, you should either use an anchor tag or import the navigate helper from gatsby"
      */
-    <a href={to} {...props}>
+    <a href={to} data-testid="link-external" {...props}>
       {children}
     </a>
   ) : (
-    <GatsbyLink to={to} {...props}>
+    <GatsbyLink to={to} data-testid="link-internal" {...props}>
       {children}
     </GatsbyLink>
   );

--- a/src/components/Markdown/MarkdownProvider.test.tsx
+++ b/src/components/Markdown/MarkdownProvider.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useStaticQuery } from 'gatsby';
+import { render } from '@testing-library/react';
+import { Anchor } from 'src/components/Markdown/MarkdownProvider';
+
+describe('<Anchor/>', () => {
+  describe('with assetPrefix', () => {
+    beforeEach(() => {
+      useStaticQuery.mockReturnValue({
+        site: {
+          assetPrefix: 'http://example.com',
+        },
+      });
+    });
+
+    it('fixes broken assetPrefix links from MDX', () => {
+      const { getByTestId } = render(<Anchor href="http:/example.com/docs/channels">Example docs</Anchor>);
+      const a = getByTestId('link-internal');
+
+      expect(a).toHaveAttribute('href', '/docs/channels');
+    });
+
+    it('preserves absolute links', () => {
+      const { getByTestId } = render(<Anchor href="http://example.org/">Example.org</Anchor>);
+      const a = getByTestId('link-external');
+
+      expect(a).toHaveAttribute('href', 'http://example.org/');
+    });
+  });
+
+  describe('without assetPrefix', () => {
+    beforeEach(() => {
+      useStaticQuery.mockReturnValue({
+        site: {
+          assetPrefix: undefined,
+        },
+      });
+    });
+
+    it('does nothing to the links from MDX', () => {
+      const { getByTestId } = render(<Anchor href="/docs/channels">Example docs</Anchor>);
+      const a = getByTestId('link-internal');
+
+      expect(a).toHaveAttribute('href', '/docs/channels');
+    });
+  });
+});

--- a/src/components/Markdown/MarkdownProvider.tsx
+++ b/src/components/Markdown/MarkdownProvider.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import Link from 'src/components/Link';
 import { CodeBlock } from './CodeBlock';
@@ -27,11 +28,38 @@ const Paragraph: FC<JSX.IntrinsicElements['p']> = ({ children, ...props }) => (
   </p>
 );
 
-const Anchor: FC<JSX.IntrinsicElements['a']> = ({ children, href, ...props }) => (
-  <Link to={href!} className="docs-link" {...props}>
-    {children}
-  </Link>
-);
+export const Anchor: FC<JSX.IntrinsicElements['a']> = ({ children, href, ...props }) => {
+  /**
+   * Inspired by https://github.com/gatsbyjs/gatsby/issues/21462#issuecomment-605606702
+   * to work around the issues with broken links being emitted by gatsby-plugin-mdx when
+   * specifying an assetPrefix (like we do in production). So what we do is we "break"
+   * the asset prefix pretty much like gatsby-plugin-mdx does [1], and if we find the
+   * broken prefix on the URL we strip it off again...
+   *
+   * 1. https://github.com/gatsbyjs/gatsby/blob/3d4d6a6e222cf3bff3f2c2cdfb0cc539bad2403a/packages/gatsby-plugin-mdx/src/remark-path-prefix-plugin.ts#L18-L28
+   */
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        assetPrefix
+      }
+    }
+  `);
+
+  let cleanHref = href;
+  const assetPrefix = site.assetPrefix ?? '';
+  const brokenAssetPrefix = assetPrefix.replace('://', ':/');
+
+  if (href.startsWith(brokenAssetPrefix)) {
+    cleanHref = href.slice(brokenAssetPrefix.length);
+  }
+
+  return (
+    <Link to={cleanHref} className="docs-link" {...props}>
+      {children}
+    </Link>
+  );
+};
 
 const Ul: FC<JSX.IntrinsicElements['ul']> = ({ children, ...props }) => (
   <ul className="ui-unordered-list" {...props}>


### PR DESCRIPTION
## Description

Extracted from #2101, this fixes the issues with rendering links in MDX files when an `assetPrefix` has been set during compilation (like we do). 

The fix is inspired by comments on gatsbyjs/gatsby#21462 

* ACT-163

## Review

Visit `/docs/how-to/pub-sub` and ensure the links in "Further reading" work.

* [Pub/Sub How-to](https://ably-docs-act-163-broke-9igs11.herokuapp.com/docs/how-to/pub-sub)
