### PR TITLE
chore: update zlib version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
           name: Build nginx
           environment:
             STACK: heroku-22
-            ZLIB_VERSION: 1.3
+            ZLIB_VERSION: 1.3.1
           command: |
             if [ ! -x /usr/local/bin/nginx ]; then
               mkdir buildpack


### PR DESCRIPTION
# Explain why this change is being made.

We are using heroku nginx script to run [install-nginx] job in circleci. It uses the latest version of the zlib installed for this script to run properly.

https://raw.githubusercontent.com/heroku/heroku-buildpack-nginx/main/scripts/build_nginx

```
....
ZLIB_VERSION=${ZLIB_VERSION-1.2.13}
zlib_url=http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
....
```

# Explain how this is accomplished.

Update the zlib version on CircleCI