### PR TITLE
Fix wording in `untilAttach` documentation

### DIFF
--- a/content/storage-history/history.textile
+++ b/content/storage-history/history.textile
@@ -325,7 +325,7 @@ The following example will subscribe to the channel and relay the last 3 message
 
 h4(#until-attach). History with untilAttach
 
-It is possible to obtain message history that is continuous with the realtime messages received on an attached channel, in the backwards direction from the point of attachment. When a channel instance is attached, it's automatically populated by the Ably service with the serial number of the last published message on the channel. As such the serial number can be used to make a history request to the Ably service for all messages received since the channel was attached. Any new messages therefore are received in real time via the attached channel, and any historical messages are accessible via the history method.
+It is possible to obtain message history that is continuous with the realtime messages received on an attached channel, in the backwards direction from the point of attachment. When a channel instance is attached, it's automatically populated by the Ably service with the serial number of the last published message on the channel. As such the serial number can be used to make a history request to the Ably service for all messages published before the channel was attached. Any new messages therefore are received in real time via the attached channel, and any historical messages are accessible via the history method.
 
 In order to benefit from this functionality, the @untilAttach@ option can be used when making history requests on attached channels. If the channel is not yet attached, this will result in an error.
 


### PR DESCRIPTION
- "since" → "before" (wording was incorrect)
- "received" → "published" ("received" suggests that it’s something that the client received, which it wasn’t because we’re talking about messages they missed)
