### PR TITLE
COL-681: Makes various corrections as stated in linked PR

### DIFF
--- a/content/livesync/connector/index.textile
+++ b/content/livesync/connector/index.textile
@@ -4,7 +4,7 @@ meta_description: "The Ably Database Connector is available as a Docker containe
 product: livesync
 ---
 
-The Ably Database Connector (ADBC) sends updates from your database to frontend clients through Ably "channels":/channels using the "outbox pattern":https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html. Whenever you update data in your database, this system records changes in an outbox table. The Database Connector detects these changes and publishes them as messages to specified channels. Client applications using the "Models SDK":/livesync/models/models subscribe to these channels to receive updates and refreshes to their local data. 
+The Ably Database Connector (ADBC) sends updates from your database to frontend clients through Ably "channels":/channels using the "outbox pattern":https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html. When you update data in your database, the changes are recorded in an outbox table. The Database Connector detects these changes and publishes them as messages to specified channels. Client applications using the "Models SDK":/livesync/models/models subscribe to these channels to receive updates to their local data. 
 
 The Database Connector is designed to run with your "existing database":#existing-db. However, you can run a "new database":#new-db if you prefer.
 
@@ -28,7 +28,7 @@ docker pull ghcr.io/ably-labs/adbc:latest
 
 h2(#existing-db). Run an existing database
 
-Use "Docker Compose":https://docs.docker.com/compose/ to run an exisiting "PostgreSQL":https://www.postgresql.org/ with the Database Connector.
+Use "Docker Compose":https://docs.docker.com/compose/ to run an existing "PostgreSQL":https://www.postgresql.org/ instance with the Database Connector. By default, Docker Compose automatically generates a PostgreSQL instance for you.
 
 Docker Compose sets up and runs a local development environment. You can create and start your PostgreSQL database and an instance of the Database Connector on your local machine. 
 
@@ -97,7 +97,8 @@ ADBC_NODES_TABLE_AUTO_CREATE=true
 The @docker-compose.yml@ will load this configuration into the @adbc@ container as environment variables.
 
 <aside data-type='important'>
-<p>If using an API key from a provider other than Ably, verify it has the @publish@ "capability":/auth/capabilities on all channels you intend to publish to. </p>
+<p>Ensure your API key has the @publish@ "capability":/auth/capabilities on the channels you require. 
+ </p>
 </aside>
 
 Run @docker compose up@ to build and run the Docker containers:
@@ -319,7 +320,7 @@ services:
 
 h3(#command). Command line flags
 
-Specify configuration options usinf CLI: 
+Specify configuration options using CLI: 
 
 * Use snake case for each option.
 * Prefix each with @--@.


### PR DESCRIPTION
This PR:

- Makes the corrections suggested on #2109

L7 👇 
> "This system" to me implies that the system does it for you automatically, but that is not the case, the developer has to record the change in the outbox table
> Also, maybe remove "refreshes"?

L31 👇 
> typo on existing
Also the docker compose creates a pg instance for you by default

L100 👇 
> This isn't quite right, only Ably can issue API keys to access Ably. Perhaps just "Ensure your API key has the publish capability ..."

L322
> typo

- Note: the suggestions were made after the PR was merged

[COL-681: Amends integration guidelines for existing systems with LiveSync](https://ably.atlassian.net/browse/COL-681)
