### PR TITLE
COL-675: Fixes indentation errors in docker compose example

### DIFF
--- a/content/livesync/connector/index.textile
+++ b/content/livesync/connector/index.textile
@@ -40,43 +40,42 @@ To begin, create a @docker-compose.yml@ file with the following contents:
 version: '3'
 
 services:
- adbc:
-   image: ghcr.io/ably-labs/adbc:latest
-   env_file:
-     - adbc.env # load config from env file
-
-   ## Uncomment below if you want to load config from your adbc.yaml file,
-   ## which takes precendence over config from the env.
-   # volumes:
-   #   - ./adbc.yaml:/adbc.yaml:ro # mount yaml config file
-
-   depends_on:
-     postgres:
-       condition: service_healthy
-   networks:
-     adbc_network:
+  adbc:
+    image: ghcr.io/ably-labs/adbc:latest
+    env_file:
+      - adbc.env # load config from env file
+    # Uncomment below if you want to load config from your adbc.yaml file,
+    # which takes precedence over config from the env.
+    # volumes:
+    #   - ./adbc.yaml:/adbc.yaml:ro # mount yaml config file
+    depends_on:
       postgres:
-   image: postgres:11-alpine
-   ports:
-     - 5432:5432
-   environment:
-     POSTGRES_USER: postgres
-     POSTGRES_PASSWORD: postgres
-     POSTGRES_DB: postgres
-   healthcheck:
-     test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
-     interval: 2s
-     retries: 30
-   networks:
-     adbc_network:
-   volumes:
-     - adbc_postgres_data:/var/lib/postgresql/data
+        condition: service_healthy
+    networks:
+      - adbc_network
+
+  postgres:
+    image: postgres:11-alpine
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
+      interval: 2s
+      retries: 30
+    networks:
+      - adbc_network
+    volumes:
+      - adbc_postgres_data:/var/lib/postgresql/data
 
 volumes:
- adbc_postgres_data:
+  adbc_postgres_data:
 
 networks:
- adbc_network:
+  adbc_network:
 ```
 
 h3(#docker-configure). Configure in Docker Compose


### PR DESCRIPTION
This PR:

- Ensured Postgres is listed under services at the same level as Adbc rather than being nested within Adbc's configuration.
- Fixed indentation issues to match the YAML format correctly.
- Changed the 'network' format for both services from a nested to a list (for consistency).

[COL-675: Fix indentation in docker compose docs](https://ably.atlassian.net/browse/COL-675)