### PR TITLE
COL-678: Removes async form the merge function code example

### DIFF
--- a/content/livesync/models/models.textile
+++ b/content/livesync/models/models.textile
@@ -115,11 +115,11 @@ A merge function is required when you instantiate a model. The merge function in
 The following example is a merge function, invoked for all events received on the channel name specified in the model:
 
 ```[javascript]
-async function merge(state: Post, event: OptimisticEvent | ConfirmedEvent) {
+function merge(state: Post, event: OptimisticEvent | ConfirmedEvent) {
   if (event.name === 'addComment') {
      return {
     ...state,
-    comments: state.comments.concat([event.data]),
+    comments: state.comgit pull ments.concat([event.data]),
   };
    }
  // handle other event types

--- a/content/livesync/models/models.textile
+++ b/content/livesync/models/models.textile
@@ -119,7 +119,7 @@ function merge(state: Post, event: OptimisticEvent | ConfirmedEvent) {
   if (event.name === 'addComment') {
      return {
     ...state,
-    comments: state.comgit pull ments.concat([event.data]),
+    comments: state.comments.concat([event.data]),
   };
    }
  // handle other event types


### PR DESCRIPTION
This PR:

- Removes `async` from the merge function code example.

[COL-678: Update docs with the latest merge function changes](https://ably.atlassian.net/browse/COL-678)