### PR TITLE
[EDU-1493] 2FA is now available to all account types

### DIFF
--- a/content/account/2fa.textile
+++ b/content/account/2fa.textile
@@ -6,10 +6,6 @@ meta_keywords: "2FA, two-factor, authentication, MFA"
 
 Two-factor authentication (2FA) is an authentication process requiring users to utilize two different forms of verification. 2FA for your Ably account requires your password and a security token sent to your mobile phone.
 
-<aside data-type='note'>
-<p>2FA is not available to Free tier accounts.</p>
-</aside>
-
 h2(#enable). Enable 2FA
 
 To enable 2FA for your own user login:


### PR DESCRIPTION
## Description

2FA is now available to all account types, not restricted to PAYG+

