### PR TITLE
COL-673: Amends Models examples

### DIFF
--- a/content/livesync/models/index.textile
+++ b/content/livesync/models/index.textile
@@ -105,7 +105,6 @@ To instantiate a Model you must provide a unique name. This identifies the model
 
 ```[javascript]
 const model = modelsClient.models.get({
-  name: 'myPost',
   channelName: 'post:123',
   sync,
   merge,

--- a/content/livesync/models/models.textile
+++ b/content/livesync/models/models.textile
@@ -22,7 +22,6 @@ Instantiate a model using a unique name. A unique name identifies the model on t
 
 ```[javascript]
 const model = modelsClient.models.get({
-  name: 'myPost',
   channelName: 'post:123',
   sync,
   merge,
@@ -59,7 +58,6 @@ The sync function needs to be registered when a model is "instantiated:":#create
 
 ```[javascript]
 const model = modelsClient.models.get({
-  name: 'myPost',
   channelName: 'post:123',
   sync,
   merge,
@@ -130,7 +128,6 @@ The merge function needs to be registered when a model is "instantiated:":#creat
 
 ```[javascript]
 const model = modelsClient.models.get({
-  name: 'myPost',
   channelName: 'post:123',
   sync,
   merge,


### PR DESCRIPTION
This PR:

- Removes `name` from `modelcClient` options throughout LiveSync docs.
- We don't require both `name` and `channelName` properties.

[COL-686: Remove the reference to `name` property from the docs](https://ably.atlassian.net/browse/COL-686)

