### PR TITLE
Publish docs: clarify atomicity guarantees and what it means to group messages into a single publish

### DIFF
--- a/content/api/realtime-sdk/channels.textile
+++ b/content/api/realtime-sdk/channels.textile
@@ -173,6 +173,13 @@ bq(definition#publish-msg-array).
 
 Publish several messages on this channel. A <span lang="default">callback</span><span lang="java">listener</span><span lang="ruby">block</span> may optionally be passed in to this call to be notified of success <span lang="default">or failure</span><span lang="ruby"></span> of the operation.<span lang="jsall,ruby,swift"> When publish is called with this client library, it "won't attempt to implicitly attach to the channel":/channels#transient-publish.</span><span lang="default"> If the channel is @initialized@ (i.e. no attempt to attach has yet been made for this channel), then calling @publish@ will implicitly attach the channel.</span>
 
+The entire @messages@ array is published atomically. This means that:
+
+* Either they will all be successfully published or none of them will
+* The "max message size":/general/limits#message-size limit applies to the total size of all messages in the array
+* The publish will only count as a single message for the purpose of "per-channel rate limit":/general/limits#message-publish-rate
+* If you are using client-specified message IDs, "they must conform to certain restrictions":https://faqs.ably.com/client-specified-message-id-restrictions-for-multiple-messages-published-atomically
+
 h4. Parameters
 
 - <div lang="default">name</div> := event name for the published message<br>__Type: @String@__

--- a/content/api/rest-sdk/channels.textile
+++ b/content/api/rest-sdk/channels.textile
@@ -143,7 +143,14 @@ bq(definition#publish-msg-array).
   go:       (c <notextile>*</notextile>RestChannel) PublishAll(messages []<notextile>*</notextile>proto.Message) (error "ErrorInfo":#error-info)
   flutter:  Future<void> publish({List<"Message":#message> messages})
 
-Publish several messages on this channel. <span lang="jsall,objc,swift">A callback may optionally be passed in to this call to be notified of success or failure of the operation.</span><span lang="java">A listener may optionally be passed in to this call to be notified of success or failure of the operation.</span><span lang="ruby">A callback may optionally be passed in to this call to be notified of success of the operation.</span> It is worth noting that "there are additional considerations and constraints if you want to publish multiple messages idempotently in one publish operation with client-supplied IDs.":https://faqs.ably.com/client-specified-message-id-restrictions-for-multiple-messages-published-atomically
+Publish several messages on this channel. <span lang="jsall,objc,swift">A callback may optionally be passed in to this call to be notified of success or failure of the operation.</span><span lang="java">A listener may optionally be passed in to this call to be notified of success or failure of the operation.</span><span lang="ruby">A callback may optionally be passed in to this call to be notified of success of the operation.</span>
+
+The entire @messages@ array is published atomically. This means that:
+
+* Either they will all be successfully published or none of them will
+* The "max message size":/general/limits#message-size limit applies to the total size of all messages in the array
+* The publish will only count as a single message for the purpose of "per-channel rate limit":/general/limits#message-publish-rate
+* If you are using client-specified message IDs for publish idempotency, "they must conform to certain restrictions":https://faqs.ably.com/client-specified-message-id-restrictions-for-multiple-messages-published-atomically
 
 h4. Parameters
 

--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -475,13 +475,20 @@ function(err, response) {
 
 h4(#batch-requests). Batch requests
 
-Each batch publish request can contain a single @BatchSpec@ object, or an array of @BatchSpec@ objects. Each @BatchSpec@ object contains a single channel name or an array of channel names in the @channels@ property. The @messages@ property then contains a single message or an array of messages.
+Each batch publish request can contain a single @BatchSpec@ object, or an array of @BatchSpec@ objects. Each @BatchSpec@ object contains a single channel name or an array of channel names in the @channels@ property. The @messages@ property then contains a single message or an array of messages. Each @BatchSpec@ will then publish each of its messages to each of its channels.
 
-This means that in a single request N number of messages can be published to N number of channels, with the following limits:
+The messages grouped into a single @BatchSpec@ are published atomically. This means that:
 
-* Each requests can only query 100 different channels. If the same channel name appears in multiple @BatchSpec@ objects within a single request, it only counts as one channel towards the 100 channel limit per batch request.
+* Either they will all be successfully published or none of them will
+* The "max message size":/general/limits#message-size limit applies to the total size of all messages in in a @BatchSpec@
+* Each @BatchSpec@ will only count as a single message for the purpose of the "per-channel rate limit":/general/limits#message-publish-rate
+
+So if you do not need the atomicity guarantee and might be in danger of exceeding the max message size limit, you can put each message into its own @BatchSpec@ (relative ordering will still be preserved). Conversely, if you are publishing many hundreds of small messages and are in danger of exceeding the max per-channel message rate, you group them into a fewer @BatchSpecs@.
+
+The batch request as a whole is subject to the following limits:
+
+* Each request can only include 100 different channels. If the same channel name appears in multiple @BatchSpec@ objects within a single request, it only counts as one channel towards the 100 channel limit per batch request.
 * Each request has a maximum body size of 2MiB.
-* The total size of all messages in a @messages@ array of a @BatchSpec@ object must be less than the "message limit":/general/limits#message-size for each channel. If the total message size exceeds the limit for a single channel then the messages should be split into multiple @BatchSpec@ objects instead.
 
 The following is an example of a single @BatchSpec@ object publishing a single message to 2 channels:
 


### PR DESCRIPTION
## Review

- https://ably.com/docs/api/realtime-sdk/channels?lang=nodejs#publish
- https://ably.com/docs/api/rest-sdk/channels?lang=nodejs#publish
- https://ably.com/docs/channels#batch-publish
