### PR TITLE
[FIX]: use-search useEffect dependencies 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,15 @@
       "plugins": ["@typescript-eslint"],
       "rules": {
         // disable the rule for all files
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "destructuredArrayIgnorePattern": "^_",
+            "ignoreRestSiblings": true
+          }
+        ],
         "react/react-in-jsx-scope": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "curly": ["error"],

--- a/src/components/Header/SearchBar/SearchBar.tsx
+++ b/src/components/Header/SearchBar/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef, useState, useEffect } from 'react';
+import { ChangeEvent, useRef, useState, useEffect, useCallback } from 'react';
 import useKeyboardShortcut from 'use-keyboard-shortcut';
 import cn from 'classnames';
 import Icon from '@ably/ui/core/Icon';
@@ -39,9 +39,9 @@ export const SearchBar = ({
   } = useSearch({
     addsearchApiKey: process.env.GATSBY_ADDSEARCH_API_KEY,
     enableParamsSync: true,
-    configureClient: ({ client }) => {
+    configureClient: useCallback(({ client }) => {
       client.setThrottleTime(800);
-    },
+    }, []),
   });
 
   const handleSearch = ({ target }: ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/use-search/use-search.ts
+++ b/src/hooks/use-search/use-search.ts
@@ -1,4 +1,4 @@
-import { Dispatch, useEffect, useReducer } from 'react';
+import { Dispatch, useEffect, useReducer, useCallback } from 'react';
 // @ts-ignore - addsearch has no types
 import AddSearchClient from 'addsearch-js-client';
 
@@ -172,10 +172,10 @@ interface UseSearchProps {
 const useSearch = ({ addsearchApiKey, enableParamsSync = false, pageLength = 10, configureClient }: UseSearchProps) => {
   const [state, dispatch] = useReducer(reducer, { ...initialState, enableParamsSync });
   const { client, query, page } = state;
-  const setup = setupAction(dispatch);
-  const setResults = setResultsAction(dispatch);
-  const search = searchAction(dispatch);
-  const setLoading = setLoadingAction(dispatch);
+  const setup = useCallback((payload: SetupActionPayload) => setupAction(dispatch)(payload), []);
+  const setResults = useCallback((payload: SetResultsPayload) => setResultsAction(dispatch)(payload), []);
+  const search = useCallback((payload: { query: string }) => searchAction(dispatch)(payload), []);
+  const setLoading = useCallback(() => setLoadingAction(dispatch), []);
 
   useEffect(() => {
     if (!addsearchApiKey) {
@@ -183,7 +183,7 @@ const useSearch = ({ addsearchApiKey, enableParamsSync = false, pageLength = 10,
     }
 
     setup({ addsearchApiKey, url: new URL(window.location.href) });
-  }, [addsearchApiKey]);
+  }, [addsearchApiKey, setup]);
 
   useEffect(() => {
     if (!client) {
@@ -230,7 +230,7 @@ const useSearch = ({ addsearchApiKey, enableParamsSync = false, pageLength = 10,
         results: null,
       });
     });
-  }, [query, page, pageLength, client]);
+  }, [query, page, pageLength, client, configureClient, setLoading, setResults]);
 
   return {
     state,

--- a/src/hooks/use-search/use-search.ts
+++ b/src/hooks/use-search/use-search.ts
@@ -151,22 +151,19 @@ const initialState: State = {
   loading: false,
 };
 
+interface ConfigureClientData {
+  // NOTE: `client` is the AddSearchClient instance that is not typed
+  client: unknown;
+  query?: string;
+  page: State['page'];
+  pageLength: number;
+}
+
 interface UseSearchProps {
   addsearchApiKey?: string;
   enableParamsSync?: boolean;
   pageLength?: number;
-  configureClient?: ({
-    client,
-    query,
-    page,
-    pageLength,
-  }: {
-    // NOTE: `client` is the AddSearchClient instance that is not typed
-    client: any;
-    query?: string;
-    page: State['page'];
-    pageLength: number;
-  }) => void;
+  configureClient?: (data: ConfigureClientData) => void;
 }
 
 const useSearch = ({ addsearchApiKey, enableParamsSync = false, pageLength = 10, configureClient }: UseSearchProps) => {


### PR DESCRIPTION
## Description

We are not certain all functions in useEffect hooks inside useSearch hook will not change, so in order to prevent any unwanted behaviour (like failing tests because of infinite loop), I've wrapped them all inside useCallback so they will be same by reference.

## Review
In console type:

`npm run test`

and check if all tests are passing or Search.spec.tsx is going indefinitely
