### PR TITLE
DTP-670: Amends naming to camel case

### DIFF
--- a/content/livesync/models/index.textile
+++ b/content/livesync/models/index.textile
@@ -121,7 +121,7 @@ h3(#sync). Create a sync function
 Create a simple sync function that loads the post and its comments. The response should contain both:
 
 1. The data used to initialize the model.
-2. The maximum "SequenceID":/livesync/models/models#sequence from the "outbox table":/livesync/connector/database#outbox.
+2. The maximum "SequenceId":/livesync/models/models#sequence from the "outbox table":/livesync/connector/database#outbox.
 
 ```[javascript]
 async function sync(id: number, page: number) {
@@ -134,7 +134,7 @@ Below is an example result from the sync function:
 
 ```[json]
 {
-  "sequenceID": "1",
+  "sequenceId": "1",
   "data": {
     "id": 123,
     "text": "Hello World",
@@ -153,7 +153,7 @@ type Post = {
 };
 ```
 
-The sync endpoint on the backend returns the post data as well as a "@sequenceID@":/livesync/models/models#sequence which defines the point in the stream of change events that corresponds to this version of the data. You can obtain the @sequenceID@ by reading the largest @sequenceID@ from the "outbox table":/livesync/connector/database#outbox in the same transaction that queries the post data.
+The sync endpoint on the backend returns the post data as well as a "@sequenceId@":/livesync/models/models#sequence which defines the point in the stream of change events that corresponds to this version of the data. You can obtain the @sequenceId@ by reading the largest @sequenceId@ from the "outbox table":/livesync/connector/database#outbox in the same transaction that queries the post data.
 
 h3(#merge). Create a merge function
 
@@ -176,16 +176,16 @@ Whenever new comments are added to the post, the model will be updated in realti
 The following function will add a new comment using a backend endpoint:
 
 ```[javascript]
-async function updatePost(id: number, mutationID: string, comment: string) {
+async function updatePost(id: number, mutationId: string, comment: string) {
   const result = await fetch(`/api/post/${id}/comments`, {
     method: 'POST',
-    body: JSON.stringify({ mutationID, comment }),
+    body: JSON.stringify({ mutationId, comment }),
   });
   return result.json();
 }
 ```
 
-On the backend, the endpoint inserts the new comment in the database and transactionally writes an @addComment@ change event with the provided @mutationID@ to the outbox table. This change event record is then broadcast to other clients subscribed to this model via the "Database Connector":/livesync/connector. The following example demonstrates this:
+On the backend, the endpoint inserts the new comment in the database and transactionally writes an @addComment@ change event with the provided @mutationId@ to the outbox table. This change event record is then broadcast to other clients subscribed to this model via the "Database Connector":/livesync/connector. The following example demonstrates this:
 
 ```[sql]
 BEGIN;
@@ -203,7 +203,7 @@ Use "optimistic updates":/livesync/models/models#optimistic to instantly update 
 ```[javascript]
 // optimistically apply the changes to the model
 const [confirmation, cancel] = await model.optimistic({
-    mutationID: 'my-mutation-id',
+    mutationId: 'my-mutation-id',
     name: 'addComment',
     data: 'New comment!',
 });

--- a/content/livesync/models/models.textile
+++ b/content/livesync/models/models.textile
@@ -30,7 +30,7 @@ const model = modelsClient.models.get({
 
 h2(#sync). Sync functions
 
-The sync function instructs your model to initialize with the latest data from the backend and is necessary when creating a model. It can be any function that optionally accepts parameters and returns a promise with the latest state of your data model, along with a "@sequenceID@":#sequence.
+The sync function instructs your model to initialize with the latest data from the backend and is necessary when creating a model. It can be any function that optionally accepts parameters and returns a promise with the latest state of your data model, along with a "@sequenceId@":#sequence.
 
 The following is an example sync function that fetches the latest model state from your database:
 
@@ -45,7 +45,7 @@ The following example is an output from the sync function:
 
 ```[json]
 {
-  "sequenceID": "1",
+  "sequenceId": "1",
   "data": {
     "id": 123,
     "text": "Hello World",
@@ -72,13 +72,13 @@ await model.sync(123, 1);
 
 The SDK automatically attempts to re-execute the sync function in the case of an error, as specified by the @syncOptions.retryStrategy@ defined in your "@ClientOptions@":/livesync/models#options.
 
-h3(#sequence). SequenceID
+h3(#sequence). Sequence ID
 
-The @sequenceID@ enables the SDK to identify the point in the stream of change events that corresponds to the current version of the database's state.
+The @sequenceId@ enables the SDK to identify the point in the stream of change events that corresponds to the current version of the database's state.
 
-Internally, the SDK replays change events starting from the point indicated by the @sequenceID@ to update the model state with any realtime changes occurring since the state was read from the database. 
+Internally, the SDK replays change events starting from the point indicated by the @sequenceId@ to update the model state with any realtime changes occurring since the state was read from the database. 
 
-The sync function calls your backend endpoint to retrieve the highest @sequenceID@ present in the outbox when reading the state:
+The sync function calls your backend endpoint to retrieve the highest @sequenceId@ present in the outbox when reading the state:
 
 ```[sql]
 -- Start a database transaction
@@ -95,11 +95,11 @@ Use the *read committed transaction isolation level* for the correct function, w
 
 h3(#history). Replay from history
 
-The SDK must initialize the model's state using the sync function and then precisely apply a sequence of change events from your backend, beginning at the correct point in the stream. This starting point is the @sequenceID@ your backend endpoint returns.
+The SDK must initialize the model's state using the sync function and then precisely apply a sequence of change events from your backend, beginning at the correct point in the stream. This starting point is the @sequenceId@ your backend endpoint returns.
 
 After the SDK executes the sync function, it internally connects to the "channel":/channels and begins "subscribing":/channels to live, yet unprocessed, messages.  It then paginates backward through the channel's message history, starting from the attachment point, using "@untilAttach@":/storage-history/history#until-attach. The number of items on each page can be configured via the @syncOptions.historyPageSize@ defined in your "@ClientOptions@":/livesync/models#options. 
 
-When a message is sent to the @sequenceID@, the model processes subsequent messages to maintain continuity with live messages. If the target @sequenceID@ is unreachable, there is insufficient message history to resume from the correct point to update the model. The SDK will attempt a re-sync. It re-syncs by calling the sync function again to acquire a newer version of the model state.
+When a message is sent to the @sequenceId@, the model processes subsequent messages to maintain continuity with live messages. If the target @sequenceId@ is unreachable, there is insufficient message history to resume from the correct point to update the model. The SDK will attempt a re-sync. It re-syncs by calling the sync function again to acquire a newer version of the model state.
 
 The amount of history available to query on the channel is determined by your "message storage":/storage-history/storage configuration on the channel. This configuration must match the @syncOptions.messageRetentionPeriod@ defined in your "@ClientOptions@":/livesync/models#options. The SDK uses this configuration option as a hint as to whether to resynchronize via the sync function and skip paginating through history when messages are expected to have expired.
 
@@ -147,7 +147,7 @@ Change events from your backend are delivered to the SDK as messages over the "c
 
 The SDK supports a short buffering time buffering for change events, facilitating short-term reordering and de-duplication. By default, his feature is not enabled. To activate it, set the @eventBufferOptions.bufferMS@ in the "@ClientOption@":/livesync/models#options to a non-zero value.
 
-When using the event buffer, change events are de-duplicated and ordered according to their "@message.ID@":/api/realtime-sdk/messages#id, which corresponds to the change event's "@sequenceID@":#sequence.
+When using the event buffer, change events are de-duplicated and ordered according to their "@message.ID@":/api/realtime-sdk/messages#id, which corresponds to the change event's "@sequenceId@":#sequence.
 
 By default, the events in the buffer are ordered numerically if the @message.ID@ can be coerced to a number. Otherwise, events will be ordered lexicographically by their @message.ID@. You can specify a custom ordering based on any part of the message via the @eventBufferOptions.eventOrderer@ "@ClientOption@":/livesync/models#options.
 
@@ -173,7 +173,7 @@ The following demonstrates an optimistic update to implementing changes in the m
 ```[javascript]
 // optimistically apply the changes to the model
 const [confirmation, cancel] = await model.optimistic({
-    mutationID: 'my-mutation-id',
+    mutationId: 'my-mutation-id',
     name: 'addComment',
     data: 'New comment!',
 });
@@ -194,11 +194,11 @@ try {
 </aside>
 
 
-h3(#mutation). MutationID
+h3(#mutation). Mutation ID
 
 The SDK requires a mechanism to identify when a change event received from the backend matches an optimistic event that has already been applied locally.
 
-To achieve this, your clients need to assign a unique @mutationID@ to each optimistic event. This ID can be any string, though it's commonly a "UUID":https://www.npmjs.com/package/uuid. The @mutationID@ must be sent to your backend and included in the confirmation event that your backend writes to the outbox:
+To achieve this, your clients need to assign a unique @mutationId@ to each optimistic event. This ID can be any string, though it's commonly a "UUID":https://www.npmjs.com/package/uuid. The @mutationId@ must be sent to your backend and included in the confirmation event that your backend writes to the outbox:
 
 ```[sql]
 BEGIN;


### PR DESCRIPTION
This PR:

- Updates all code references of `sequenceID` and `mutationID` to camelCase -> `sequenceId` and `mutationId`.

[DTP-670: Standardize camelCase naming](https://ably.atlassian.net/browse/DTP-670)

