### PR TITLE
[FIX] Remove pathPrefix from redirects generated by `redirect_from`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,11 +153,18 @@ jobs:
             ./bin/assert-redirect.sh /docs/ https://localhost/docs
             ./bin/assert-success.sh /docs/channels
       - run:
-          name: Smoke test quickstart redirects
+          name: Smoke test trailing slash redirects
           command: |
             ./bin/assert-success.sh /docs/getting-started/quickstart
             ./bin/assert-redirect.sh /docs/getting-started/quickstart/ \
                                      https://localhost/docs/getting-started/quickstart
+      - run:
+          name: Smoke test redirect_from redirects
+          command: |
+            ./bin/assert-redirect.sh /docs/how-ably-works \
+                                     http://localhost/docs/key-concepts
+            ./bin/assert-redirect.sh /docs/rest/history \
+                                     http://localhost/docs/storage-history/history
       - run:
           name: Test website redirects
           command: |

--- a/config/client-lib-development-guide-redirects.conf
+++ b/config/client-lib-development-guide-redirects.conf
@@ -2,12 +2,12 @@
 # on docs.ably.com, but have moved to sdk.ably.com and are no longer available
 # in the Gatsby toolchain.
 
-/client-lib-development-guide/comet https://sdk.ably.com/builds/ably/specification/main/comet/;
-/client-lib-development-guide/encryption https://sdk.ably.com/builds/ably/specification/main/encryption/;
-/client-lib-development-guide/feature-prioritisation https://sdk.ably.com/builds/ably/specification/main/feature-prioritisation/;
-/client-lib-development-guide/features https://sdk.ably.com/builds/ably/specification/main/features/;
-/client-lib-development-guide/protocol https://sdk.ably.com/builds/ably/specification/main/protocol/;
-/client-lib-development-guide/test-api https://sdk.ably.com/builds/ably/specification/main/test-api/;
-/client-lib-development-guide/versioning https://sdk.ably.com/builds/ably/specification/main/versioning/;
-/client-lib-development-guide/websocket https://sdk.ably.com/builds/ably/specification/main/websocket/;
-/client-lib-development-guide https://sdk.ably.com/builds/ably/specification/main/;
+/docs/client-lib-development-guide/comet https://sdk.ably.com/builds/ably/specification/main/comet/;
+/docs/client-lib-development-guide/encryption https://sdk.ably.com/builds/ably/specification/main/encryption/;
+/docs/client-lib-development-guide/feature-prioritisation https://sdk.ably.com/builds/ably/specification/main/feature-prioritisation/;
+/docs/client-lib-development-guide/features https://sdk.ably.com/builds/ably/specification/main/features/;
+/docs/client-lib-development-guide/protocol https://sdk.ably.com/builds/ably/specification/main/protocol/;
+/docs/client-lib-development-guide/test-api https://sdk.ably.com/builds/ably/specification/main/test-api/;
+/docs/client-lib-development-guide/versioning https://sdk.ably.com/builds/ably/specification/main/versioning/;
+/docs/client-lib-development-guide/websocket https://sdk.ably.com/builds/ably/specification/main/websocket/;
+/docs/client-lib-development-guide https://sdk.ably.com/builds/ably/specification/main/;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -77,6 +77,18 @@ http {
     # Removes trailing slashes everywhere (by redirecting)
     rewrite ^/(.*)/$ <%= ENV['SKIP_HTTPS'] == 'true' ? '$scheme' : 'https' %>://$host/$1 permanent;
 
+    <% unless ENV['SKIP_HTTPS'] == 'true' %>
+    # Enforce HTTPS
+      if ($http_x_forwarded_proto != "https") {
+      return 301 https://$host$request_uri;
+    }
+    <% end %>
+
+    # Apply our redirects before rewriting
+    if ($redirected_url != "none") {
+      rewrite ^ $redirected_url permanent;
+    }
+
     # Strip /docs from the requests (we build with --prefix-paths and our files are in public/)
     rewrite ^/docs/(.*)$ /$1 last;
     rewrite ^/docs$ / last;
@@ -120,18 +132,6 @@ http {
 
     location ~ \.html$ {
       try_files $uri =404;
-    }
-
-    <% unless ENV['SKIP_HTTPS'] == 'true' %>
-    # Enforce HTTPS
-    if ($http_x_forwarded_proto != "https") {
-      return 301 https://$host$request_uri;
-    }
-    <% end %>
-
-    # Apply our redirects
-    if ($redirected_url != "none") {
-      rewrite ^ $redirected_url permanent;
     }
 
     # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404


### PR DESCRIPTION
## Description

We had a combination of issues with our nginx config and the changes from setting `pathPrefix` that broke the redirects specified using the `redirect_from` frontmatter.

Our nginx redirects list, generated from the `redirect_from` frontmatter, was missing `/docs` on the destination, like this:

~~~
...
/docs/control-api /account/control-api;
/docs/rest/authentication /auth/;
...
~~~

This made it impossible for nginx to match the directs (the matching happens after the URLs get rewritten). This PR fixes it so the redirects config looks like:

~~~
...
/docs/rest/history /docs/storage-history/history;
/docs/rest/versions/v1.1/history /docs/storage-history/history;
...
~~~

It also fixes issues in the ordering of the directives in the nginx config file that resulted in us serving up the "Gatsby placeholder redirect HTML file" - which is a 200 status code - instead of the 301 redirect from our redirects map. This was because the `try_files` directive matched the `.html` file _before_ we checked the results from the redirect map. 

## Review

Fetching `/how-ably-works` on the review app should redirect to `/key-concepts`, not 404 or 200.

* https://ably-docs-fix-website-r-g46vtu.herokuapp.com/docs/how-ably-works
* https://ably-docs-fix-website-r-g46vtu.herokuapp.com/how-ably-works

~~~
$ curl -I https://ably-docs-fix-website-r-g46vtu.herokuapp.com/docs/how-ably-works
HTTP/1.1 301 Moved Permanently
...
Location: http://ably-docs-fix-website-r-g46vtu.herokuapp.com/docs/key-concepts
...
~~~