### PR TITLE
[WEB-3642] Canonical URL fixes

### DIFF
--- a/src/hooks/use-site-metadata.test.ts
+++ b/src/hooks/use-site-metadata.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import { useStaticQuery } from 'gatsby';
+import { useSiteMetadata } from './use-site-metadata';
+
+describe('useSiteMedata', () => {
+  beforeEach(() => {
+    useStaticQuery.mockReturnValue({
+      site: {
+        siteMetadata: {
+          siteUrl: 'http://example.com',
+        },
+      },
+    });
+  });
+
+  it('contains the siteMetadata', () => {
+    const { result } = renderHook(() => useSiteMetadata());
+
+    expect(result.current.siteUrl).toBe('http://example.com');
+  });
+
+  it('contains a canonicalUrl helper', () => {
+    expect(__PATH_PREFIX__).toBe('/docs');
+
+    const { result } = renderHook(() => useSiteMetadata());
+    const {
+      current: { canonicalUrl },
+    } = result;
+
+    const url = canonicalUrl('/my-page');
+    expect(url).toBe('http://example.com/docs/my-page');
+  });
+});

--- a/src/hooks/use-site-metadata.ts
+++ b/src/hooks/use-site-metadata.ts
@@ -1,4 +1,10 @@
-import { graphql, useStaticQuery } from 'gatsby';
+import { graphql, withPrefix, useStaticQuery } from 'gatsby';
+
+const stripTrailingSlash = (str: string) => (str.endsWith('/') ? str.slice(0, -1) : str);
+
+const canonicalUrl = (siteUrl: string): ((path: string) => string) => {
+  return (path: string): string => stripTrailingSlash(`${siteUrl}${withPrefix(path)}`);
+};
 
 export const useSiteMetadata = () => {
   const data = useStaticQuery(graphql`
@@ -12,5 +18,10 @@ export const useSiteMetadata = () => {
     }
   `);
 
-  return data.site.siteMetadata;
+  const siteMetadata = data.site.siteMetadata;
+
+  return {
+    ...siteMetadata,
+    canonicalUrl: canonicalUrl(siteMetadata.siteUrl),
+  };
 };

--- a/src/pages/how-to/pub-sub.tsx
+++ b/src/pages/how-to/pub-sub.tsx
@@ -79,8 +79,8 @@ interface HowToFile {
 
 const PubSubHowTo = () => {
   const meta_description = `How to use basic publish and subscribe (pub/sub) functionality with Ably channels.`;
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/how-to/pub-sub')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/how-to/pub-sub');
 
   const data = useStaticQuery(graphql`
     query {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,8 +29,8 @@ const IndexPage = ({
   location: Location;
 }) => {
   const openGraphTitle = sections[0]?.title ?? 'Ably Realtime Docs';
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/');
 
   return (
     <>

--- a/src/pages/products/channels.tsx
+++ b/src/pages/products/channels.tsx
@@ -24,8 +24,8 @@ const IndexPage = ({
   data: { pageContentYaml: { sections: SectionProps[]; meta: MetaData }; allFile: { images: ImageProps[] } };
 }) => {
   const openGraphTitle = sections[0]?.title ?? 'Ably Realtime Docs';
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/products/channels')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/products/channels');
 
   return (
     <>

--- a/src/pages/products/livesync.tsx
+++ b/src/pages/products/livesync.tsx
@@ -23,8 +23,8 @@ const IndexPage = ({
   data: { pageContentYaml: { sections: SectionProps[]; meta: MetaData }; allFile: { images: ImageProps[] } };
 }) => {
   const openGraphTitle = sections[0]?.title ?? 'Ably Realtime Docs';
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/products/livesync')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/products/livesync');
 
   return (
     <>

--- a/src/pages/products/spaces.tsx
+++ b/src/pages/products/spaces.tsx
@@ -24,8 +24,8 @@ const IndexPage = ({
   data: { pageContentYaml: { sections: SectionProps[]; meta: MetaData }; allFile: { images: ImageProps[] } };
 }) => {
   const openGraphTitle = sections[0]?.title ?? 'Ably Realtime Docs';
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/products/spaces')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/products/spaces');
 
   return (
     <>

--- a/src/pages/sdks/index.tsx
+++ b/src/pages/sdks/index.tsx
@@ -7,8 +7,8 @@ import { Head } from 'src/components/Head';
 const SDKsIndexPage = ({ location: { search } }: { location: { search: string } }) => {
   const meta_title = 'SDKs';
   const meta_description = '';
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix('/sdks')}`;
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl('/sdks');
 
   const urlParams = new URLSearchParams(search);
   const tab = urlParams.get('tab') ?? '';

--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -56,8 +56,8 @@ const Template = ({
   const title = getMetaDataDetails(document, 'title') as string;
   const description = getMetaDataDetails(document, 'meta_description', META_DESCRIPTION_FALLBACK) as string;
   const menuLanguages = getMetaDataDetails(document, 'languages', languages) as string[];
-  const { siteUrl } = useSiteMetadata();
-  const canonical = `${siteUrl}/${withPrefix(slug)}`.replace(/\/+$/, '');
+  const { canonicalUrl } = useSiteMetadata();
+  const canonical = canonicalUrl(slug);
 
   // when we don't get a product, peek into the metadata of the page for a default value
   currentProduct ??= getMetaDataDetails(document, 'product', META_PRODUCT_FALLBACK) as ProductName;


### PR DESCRIPTION
## Description

While reviewing some site monitoring metrics after merging all the link/image updates I spotted issues with the canonical URLs on several pages.

Using [pup](https://github.com/EricChiang/pup) this is easy to see:

```
$ curl -s https://ably.com/docs/api/rest-sdk/authentication | pup "link[rel=canonical]"
<link data-react-helmet="true" rel="canonical" href="https://ably.com//docs/api/rest-sdk/authentication">
```

This PR unifies hows canonical URLs are generated by having a single utility function that is part of the `useSiteMetadata` hook.

## Review

Review a few canonical URLs to ensure no `//` are present

* https://ably-docs-web-3642-cano-bwdlyv.herokuapp.com/docs/api/rest-sdk/authentication

```
$ curl -s https://ably-docs-web-3642-cano-bwdlyv.herokuapp.com/docs/api/rest-sdk/authentication | pup "link[rel=canonical]"
<link data-react-helmet="true" rel="canonical" href="https://ably-dev.com/docs/api/rest-sdk/authentication">
```