### PR TITLE
[FIX] API reference docs links edge case

### DIFF
--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`<Pre /> should successfully render Code elements with language 1`] = `
               aria-live="polite"
               aria-relevant="additions text"
               class="css-1f43avz-a11yText-A11yText"
+              role="log"
             />
             <div
               class="ably-select__control css-1k9j1wp-control"
@@ -64,6 +65,7 @@ exports[`<Pre /> should successfully render Code elements with language 1`] = `
                   JavaScript v1.2
                 </div>
                 <input
+                  aria-activedescendant=""
                   aria-autocomplete="list"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -178,6 +180,7 @@ exports[`<Pre /> should successfully render code elements with  only Realtime la
               aria-live="polite"
               aria-relevant="additions text"
               class="css-1f43avz-a11yText-A11yText"
+              role="log"
             />
             <div
               class="ably-select__control css-1k9j1wp-control"
@@ -191,6 +194,7 @@ exports[`<Pre /> should successfully render code elements with  only Realtime la
                   JavaScript v1.2
                 </div>
                 <input
+                  aria-activedescendant=""
                   aria-autocomplete="list"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -305,6 +309,7 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
               aria-live="polite"
               aria-relevant="additions text"
               class="css-1f43avz-a11yText-A11yText"
+              role="log"
             />
             <div
               class="ably-select__control css-1k9j1wp-control"
@@ -318,6 +323,7 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
                   JavaScript v1.2
                 </div>
                 <input
+                  aria-activedescendant=""
                   aria-autocomplete="list"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -437,6 +443,7 @@ exports[`<Pre /> should successfully render code elements with both Rest and Rea
               aria-live="polite"
               aria-relevant="additions text"
               class="css-1f43avz-a11yText-A11yText"
+              role="log"
             />
             <div
               class="ably-select__control css-1k9j1wp-control"
@@ -450,6 +457,7 @@ exports[`<Pre /> should successfully render code elements with both Rest and Rea
                   JavaScript v1.2
                 </div>
                 <input
+                  aria-activedescendant=""
                   aria-autocomplete="list"
                   aria-expanded="false"
                   aria-haspopup="true"

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
             aria-live="polite"
             aria-relevant="additions text"
             class="css-1f43avz-a11yText-A11yText"
+            role="log"
           />
           <div
             class="ably-select__control css-1k9j1wp-control"
@@ -52,6 +53,7 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
                 JavaScript v1.2
               </div>
               <input
+                aria-activedescendant=""
                 aria-autocomplete="list"
                 aria-expanded="false"
                 aria-haspopup="true"

--- a/src/utilities/link-checks.test.ts
+++ b/src/utilities/link-checks.test.ts
@@ -28,6 +28,12 @@ describe('checkLinkIsInternal', () => {
 
   it('returns true for relative links', () => {
     expect(checkLinkIsInternal('/')).toBeTruthy();
+    expect(checkLinkIsInternal('/api')).toBeTruthy();
+    expect(checkLinkIsInternal('/api/realtime-sdk')).toBeTruthy();
+  });
+
+  it('returns true for relative links with anchors', () => {
+    expect(checkLinkIsInternal('/api/rest-sdk/authentication#token-request')).toBeTruthy();
   });
 
   it('returns false for ably.com links outside of docs', () => {

--- a/src/utilities/link-checks.ts
+++ b/src/utilities/link-checks.ts
@@ -1,4 +1,4 @@
-const DOCS_URLS_BUT_EXTERNAL = [/.*\/api\/control-api.*/, /sdk\/.*/];
+const DOCS_URLS_BUT_EXTERNAL = [/.*\/api\/control-api.*/, /.*\/sdk\/.*/];
 
 /**
  * This regex only matches old hard-coded docs links


### PR DESCRIPTION
## Description

A regex meant to prevent links to `/docs/sdk/*` from being considered as local links was too broad and captured links to `/api/rest-sdk` and `/api/realtime-sdk` as well. This fixes it and adds more test coverage.


## Review

Verify the following on the review app at [/api/rest-sdk#time](https://ably-docs-fix-api-docs--hnq9ez.herokuapp.com/api/rest-sdk#time)

![Monosnap Constructor 2024-03-12 16-50-22](https://github.com/ably/docs/assets/8756/ded91534-2ca0-4c03-a9c2-0acee2be3168)

* https://ably-docs-fix-api-docs--hnq9ez.herokuapp.com/api/rest-sdk#time
