### PR TITLE
[FIX] Typography tweaks

### DIFF
--- a/src/components/blocks/list/Li.tsx
+++ b/src/components/blocks/list/Li.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
 
 const StyledLi: FC<{ children: React.ReactNode }> = ({ children, ...props }) => (
-  <li {...props} className="ui-text-p2">
+  <li {...props} className="text-p2">
     {children}
   </li>
 );

--- a/src/components/blocks/list/Ol.tsx
+++ b/src/components/blocks/list/Ol.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
 
-const Ol: FC = (props) => <ol {...props} className="ui-text-p2 pl-16 pb-32 list-decimal -mt-16" />;
+const Ol: FC = (props) => <ol {...props} className="text-p2 pl-16 pb-32 list-decimal -mt-16" />;
 
 export default GenericHtmlBlock(Ol);

--- a/src/components/blocks/list/Ul.tsx
+++ b/src/components/blocks/list/Ul.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import GenericHtmlBlock from '../Html/GenericHtmlBlock';
 
-const Ul: FC<{ className: string }> = (props) => <ul {...props} className="ui-text-p2 pl-16 pb-32 list-disc" />;
+const Ul: FC<{ className: string }> = (props) => <ul {...props} className="text-p2 pl-16 pb-32 list-disc" />;
 
 export default GenericHtmlBlock(Ul);

--- a/src/components/blocks/list/list.module.css
+++ b/src/components/blocks/list/list.module.css
@@ -4,7 +4,9 @@ All styles to be migrated to Tailwind classes when convenient */
 .list-dt {
   font-weight: 500;
   margin: 0 0 10px;
-  @media (min-width: 40em) {
+}
+@media (min-width: 40em) {
+  .list-dt {
     min-width: 120px;
   }
 }
@@ -17,66 +19,67 @@ All styles to be migrated to Tailwind classes when convenient */
   margin-bottom: 20px;
   font-size: 16px;
   overflow-x: scroll;
-
-  /**
-    * This :only-child directive is present to ensure that multiple lines are not shown in the situation
-    * where there is a <dl> inside a <div> that is selected based on language type in between two other divs, i.e.
-    * <dl>
-    *   <dt></dt>
-    *   <dd></dd>
-    * </dl>
-    * <div>
-    *   <dl>
-    *     <dt></dt>
-    *     <dd></dd>
-    *   </dl>
-    * </div>
-    * <dl>
-    *   <dt></dt>
-    *   <dd></dd>
-    * </dl>
-    */
-  :only-child {
-    margin-bottom: -1px;
-    margin-top: -21px;
-  }
-
-  div {
-    display: contents;
-  }
-  dt,
-  dd {
-    border-bottom: 1px solid #e1e1e1;
-    height: 100%;
-    padding: 15px 20px 15px 0;
-    line-height: 1.5;
-  }
-  dt {
-    grid-column: 1;
-  }
-  dd > em:not(.italics):first-of-type {
-    background: #e1e1e1;
-    border-radius: 5px;
-    padding: 2px 5px;
-    display: block;
-    width: fit-content;
-    block-size: fit-content;
-    margin-bottom: 7px;
-    ::before {
-      content: '(default: ';
-    }
-    ::after {
-      content: ')';
-    }
-  }
-  dd > em.italics:last-of-type {
-    float: right;
-    display: block;
-    text-align: right;
-    font-size: 12px;
-    margin-top: 12px;
-  }
 }
+
+/**
+ * This :only-child directive is present to ensure that multiple lines are not shown in the situation
+ * where there is a <dl> inside a <div> that is selected based on language type in between two other divs, i.e.
+ * <dl>
+ *   <dt></dt>
+ *   <dd></dd>
+ * </dl>
+ * <div>
+ *   <dl>
+ *     <dt></dt>
+ *     <dd></dd>
+ *   </dl>
+ * </div>
+ * <dl>
+ *   <dt></dt>
+ *   <dd></dd>
+ * </dl>
+ */
+.list-dl:only-child {
+  margin-bottom: -1px;
+  margin-top: -21px;
+}
+
+.list-dl div {
+  display: contents;
+}
+.list-dl dt,
+.list-dl dd {
+  border-bottom: 1px solid #e1e1e1;
+  height: 100%;
+  padding: 15px 20px 15px 0;
+  line-height: 1.5;
+}
+.list-dl dt {
+  grid-column: 1;
+}
+.list-dl dd > em:not(.italics):first-of-type {
+  background: #e1e1e1;
+  border-radius: 5px;
+  padding: 2px 5px;
+  display: block;
+  width: fit-content;
+  block-size: fit-content;
+  margin: 7px 0;
+}
+.list-dl dd > em:not(.italics):first-of-type::before {
+  content: '(default: ';
+}
+.list-dl dd > em:not(.italics):first-of-type::after {
+  content: ')';
+}
+.list-dl dd > em.italics:last-of-type {
+  float: right;
+  display: block;
+  text-align: right;
+  font-size: 12px;
+  margin-top: 12px;
+}
+
 
 div.definition-list-row-styles {
   display: block;
@@ -84,7 +87,9 @@ div.definition-list-row-styles {
   border-bottom: 1px solid #e1e1e1;
   overflow: auto;
   padding: 15px 0;
-  @media (min-width: 40em) {
+}
+@media (min-width: 40em) {
+  div.definition-list-row-styles {
     display: flex;
     padding: 0;
     width: 100%;


### PR DESCRIPTION
## Description

Two small typography updates

1. Fix regressions in `dl`/`dt`/`dd` styling from #2147
2. for `ol`/`ul`/`li` in textile docs, use `text-p2` instead of `ui-text-p2` for now (affected by #2136)

## Review

Both changes can be seen in on this page, compare with screenshots below:

### Lists before [live](https://ably.com/docs/channels#connection-state)

![Monosnap Channels 2024-03-13 06-32-12](https://github.com/ably/docs/assets/8756/8fed61cf-9cfe-426e-818f-1724c679452e)

### Lists after [preview](https://ably-docs-fix-typograph-8ybee7.herokuapp.com/docs/channels#connection-state)

![Monosnap Channels 2024-03-13 06-34-17](https://github.com/ably/docs/assets/8756/d2385ec6-bde5-4180-828e-a0c152702858)

### Definitions before [live](https://ably.com/docs/api/rest-sdk#time)

![Monosnap Constructor 2024-03-13 06-36-20](https://github.com/ably/docs/assets/8756/09452552-d49d-4d1c-a95a-5b0c534a76db)


### Definitions after [preview](https://ably-docs-fix-typograph-8ybee7.herokuapp.com/docs/api/rest-sdk#time)

![Monosnap Constructor 2024-03-13 06-36-54](https://github.com/ably/docs/assets/8756/6fb2f6f2-7e6e-4bf5-a994-0644ee16ad06)

