### PR TITLE
Fix broken links in navigation bar, where an extra /docs is added in Ably Accounts and Apps

### DIFF
--- a/data/yaml/page-furniture/sidebar.yaml
+++ b/data/yaml/page-furniture/sidebar.yaml
@@ -154,11 +154,11 @@ items:
         link: ''
         items:
           - label: 'User management'
-            link: /docs/account/users
+            link: /account/users
           - label: 'Single sign-on (SSO)'
-            link: /docs/account/sso
+            link: /account/sso
           - label: 'Two-factor authentication (2FA)'
-            link: /docs/account/2fa
+            link: /account/2fa
           - label: 'Programmatic management with Control API'
             link: /account/control-api
       - label: 'Asset Tracking'


### PR DESCRIPTION
## Description

Three links in the nav were broken because they had an extra /docs/ to the path.

* [Jira ticket](https://ably.atlassian.net/browse/EDU-1504).

## Review

By clicking any of the three links in the nav below to ensure they don't return a 404.

<img width="252" alt="Screenshot 2024-03-13 at 09 47 41" src="https://github.com/ably/docs/assets/2411269/a3aa2706-b2ed-4190-b676-3173d5acafd7">

