### PR TITLE
[WEB-3567] Increase CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
   install-dependencies:
     executor:
       name: default
-    resource_class: medium+
     steps:
       - checkout
       - restore-yarn-cache
@@ -87,7 +86,6 @@ jobs:
   test:
     executor:
       name: default
-    resource_class: medium
     steps:
       - checkout
       - attach_workspace:
@@ -110,7 +108,7 @@ jobs:
   build:
     executor:
       name: default
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.0.2
+  node: circleci/node@5.2.0
 
 parameters:
   content-update:
@@ -15,29 +15,6 @@ executors:
       - image: cimg/node:18.12.0
 
 commands:
-  restore-yarn-cache:
-    steps:
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - yarn-packages-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-packages-v2-{{ .Branch }}-
-            - yarn-packages-v2-
-
-  save-yarn-cache:
-    steps:
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-
-  yarn-install:
-    steps:
-      - run:
-          name: Dependencies
-          command: yarn install --frozen-lockfile
-
   build-nginx:
     steps:
       - run:
@@ -69,13 +46,12 @@ jobs:
       name: default
     steps:
       - checkout
-      - restore-yarn-cache
-      - yarn-install
+      - node/install-packages:
+          pkg-manager: yarn
       - persist_to_workspace:
           root: .
           paths:
             - node_modules
-      - save-yarn-cache
 
   install-nginx:
     executor:


### PR DESCRIPTION
## Description

Now that we're doing full blown image processing during the build step on CI, we're starting to see an increase in build failures due to running out of memory. This then prevents Heroku from deploying `main` automatically due to false negatives.

This PR bumps the resource class for build from `medium+` to `large`, while dropping the explicit `resource_class` keys from other steps.

It also hands over installation of NPM packages to the circleci/node orb, which should do a better job with caching of dependencies than we can

## Review

Look at this build in CI and notice that:

* The yarn caches are actually used and restored
* The `build` step never fails due to running out of memory
