### PR TITLE
EDU-196: Adds device registration instructions

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -583,7 +583,14 @@ h2(#push). Push
 
 h3(#post-device-registration). Register a device for receiving push notifications
 
-Register a device's details, including the information necessary to deliver push notifications to it.
+Before registering a device to receive push notifications, ensure it has a @deviceId@ and a @deviceSecret@. If these are missing, follow these steps to generate them:
+
+1. Generate the @deviceId@ using a UUID (universally unique identifier) or GUID (globally unique identifier).
+2. Generate the @deviceSecret@ using secure random data. The @deviceSecret@ should have sufficient entropy to allow for the creation of a digest using the SHA-256 algorithm. Encode the resultant hash in Base64.
+
+After generating these, update your local @DeviceDetails@ object with the new @deviceId@ and @deviceSecret@. If you ever lose either, you must generate a new pair.
+
+The following API endpoint provided is used to register a device for receiving push notifications:
 
 h6. POST rest.ably.io/push/deviceRegistrations
 


### PR DESCRIPTION
This PR:

- Improves the "Register a device for receiving push notifications" section of: docs/api/rest-api#push

[EDU-196: EDU-196: Adds device registration instructions](https://ably.atlassian.net/browse/EDU-196)