### PR TITLE
[EDU-1506] Remove `/docs` from all links

### DIFF
--- a/content/root/platform-customization.textile
+++ b/content/root/platform-customization.textile
@@ -57,7 +57,7 @@ Note that this does not prevent customers outside of your chosen region from con
 
 If you are interested in applying processing or storage constraints to regions other than Europe or the US, then please speak to your customer success manager.
 
-To implement regional restrictions at the application level, you must specify the required environment after configuring your account for regional routing and storage. Specify the required environment: @eu@ or environment: @us@ in the Ably client options ( "Rest SDK":/docs/api/rest-sdk#client-options and "Realtime SDK":/docs/api/realtime-sdk#client-options ) when you are initiating the connection, from both the publisher's and subscriber's side.
+To implement regional restrictions at the application level, you must specify the required environment after configuring your account for regional routing and storage. Specify the required environment: @eu@ or environment: @us@ in the Ably client options ( "Rest SDK":/api/rest-sdk#client-options and "Realtime SDK":/api/realtime-sdk#client-options ) when you are initiating the connection, from both the publisher's and subscriber's side.
 
 *Note*: This approach does not apply regional restrictions when you are using a persistent history feature. For implementing geolocation restrictions on history, you would need to set a placement constraint to ensure data stays in the EU or any designated region.
 
@@ -76,7 +76,7 @@ When you request a custom environment, you have the following options:
 
 h3(#option-1). Option 1: The custom domain is an Ably subdomain
 
-For "example,":#modify @example-rest.ably.io@ and @example-realtime.ably.io@. 
+For "example,":#modify @example-rest.ably.io@ and @example-realtime.ably.io@.
 
 These use Ably's existing wildcard certificate, which supports @*.ably.io@ and @*.ably-realtime.com@.
 

--- a/data/yaml/page-furniture/apiSidebar.yaml
+++ b/data/yaml/page-furniture/apiSidebar.yaml
@@ -4,64 +4,64 @@ items:
     link: ""
     items:
       - label: "Overview"
-        link: "/docs/api"
+        link: "/api"
       - label: "Realtime SDK"
         link: ""
         items:
           - label: "Constructor"
-            link: /docs/api/realtime-sdk
+            link: /api/realtime-sdk
           - label: "Connection"
-            link: /docs/api/realtime-sdk/connection
+            link: /api/realtime-sdk/connection
           - label: "Channels"
-            link: /docs/api/realtime-sdk/channels
+            link: /api/realtime-sdk/channels
           - label: "Channel Metadata"
-            link: /docs/api/realtime-sdk/channel-metadata
+            link: /api/realtime-sdk/channel-metadata
           - label: "Messages"
-            link: /docs/api/realtime-sdk/messages
+            link: /api/realtime-sdk/messages
           - label: "Presence"
-            link: /docs/api/realtime-sdk/presence
+            link: /api/realtime-sdk/presence
           - label: "Authentication"
-            link: /docs/api/realtime-sdk/authentication
+            link: /api/realtime-sdk/authentication
           - label: "History"
-            link: /docs/api/realtime-sdk/history
+            link: /api/realtime-sdk/history
           - label: "Push Notifications - Admin"
-            link: /docs/api/realtime-sdk/push-admin
+            link: /api/realtime-sdk/push-admin
           - label: "Push Notifications - Devices"
-            link: /docs/api/realtime-sdk/push
+            link: /api/realtime-sdk/push
           - label: "Encryption"
-            link: /docs/api/realtime-sdk/encryption
+            link: /api/realtime-sdk/encryption
           - label: "Statistics"
-            link: /docs/api/realtime-sdk/statistics
+            link: /api/realtime-sdk/statistics
           - label: "Types"
-            link: /docs/api/realtime-sdk/types
+            link: /api/realtime-sdk/types
       - label: "REST SDK"
         link: ""
         items:
           - label: "Constructor"
-            link: /docs/api/rest-sdk
+            link: /api/rest-sdk
           - label: "Channels"
-            link: /docs/api/rest-sdk/channels
+            link: /api/rest-sdk/channels
           - label: "Channel Status"
-            link: /docs/api/rest-sdk/channel-status
+            link: /api/rest-sdk/channel-status
           - label: "Messages"
-            link: /docs/api/rest-sdk/messages
+            link: /api/rest-sdk/messages
           - label: "Presence"
-            link: /docs/api/rest-sdk/presence
+            link: /api/rest-sdk/presence
           - label: "Authentication"
-            link: /docs/api/rest-sdk/authentication
+            link: /api/rest-sdk/authentication
           - label: "History"
-            link: /docs/api/rest-sdk/history
+            link: /api/rest-sdk/history
           - label: "Push Notifications - Admin"
-            link: /docs/api/rest-sdk/push-admin
+            link: /api/rest-sdk/push-admin
           - label: "Encryption"
-            link: /docs/api/rest-sdk/encryption
+            link: /api/rest-sdk/encryption
           - label: "Statistics"
-            link: /docs/api/rest-sdk/statistics
+            link: /api/rest-sdk/statistics
           - label: "Types"
-            link: /docs/api/rest-sdk/types
+            link: /api/rest-sdk/types
       - label: "REST API"
-        link: /docs/api/rest-api
+        link: /api/rest-api
       - label: "SSE API"
-        link: /docs/api/sse
+        link: /api/sse
       - label: "Control API"
-        link: /docs/api/control-api
+        link: /api/control-api


### PR DESCRIPTION
## Description

This PR removes the last use of `/docs/` in local links as these will no longer function correctly with the updates from https://github.com/ably/docs/pull/2145


