### PR TITLE
Revert "fix: client-lib-development-guide redirects need pathPrefix set"

### DIFF
--- a/config/client-lib-development-guide-redirects.conf
+++ b/config/client-lib-development-guide-redirects.conf
@@ -2,12 +2,12 @@
 # on docs.ably.com, but have moved to sdk.ably.com and are no longer available
 # in the Gatsby toolchain.
 
-/docs/client-lib-development-guide/comet https://sdk.ably.com/builds/ably/specification/main/comet/;
-/docs/client-lib-development-guide/encryption https://sdk.ably.com/builds/ably/specification/main/encryption/;
-/docs/client-lib-development-guide/feature-prioritisation https://sdk.ably.com/builds/ably/specification/main/feature-prioritisation/;
-/docs/client-lib-development-guide/features https://sdk.ably.com/builds/ably/specification/main/features/;
-/docs/client-lib-development-guide/protocol https://sdk.ably.com/builds/ably/specification/main/protocol/;
-/docs/client-lib-development-guide/test-api https://sdk.ably.com/builds/ably/specification/main/test-api/;
-/docs/client-lib-development-guide/versioning https://sdk.ably.com/builds/ably/specification/main/versioning/;
-/docs/client-lib-development-guide/websocket https://sdk.ably.com/builds/ably/specification/main/websocket/;
-/docs/client-lib-development-guide https://sdk.ably.com/builds/ably/specification/main/;
+/client-lib-development-guide/comet https://sdk.ably.com/builds/ably/specification/main/comet/;
+/client-lib-development-guide/encryption https://sdk.ably.com/builds/ably/specification/main/encryption/;
+/client-lib-development-guide/feature-prioritisation https://sdk.ably.com/builds/ably/specification/main/feature-prioritisation/;
+/client-lib-development-guide/features https://sdk.ably.com/builds/ably/specification/main/features/;
+/client-lib-development-guide/protocol https://sdk.ably.com/builds/ably/specification/main/protocol/;
+/client-lib-development-guide/test-api https://sdk.ably.com/builds/ably/specification/main/test-api/;
+/client-lib-development-guide/versioning https://sdk.ably.com/builds/ably/specification/main/versioning/;
+/client-lib-development-guide/websocket https://sdk.ably.com/builds/ably/specification/main/websocket/;
+/client-lib-development-guide https://sdk.ably.com/builds/ably/specification/main/;


### PR DESCRIPTION
## Description

This reverts commit 5f11627ad4d3e4a8bdc9e521cdc749d5e5b86dd5 from #2149 which mistakenly updated the client-lib-development-guide redirects, assuming they were served up on `ably.com/docs`, but this is not the case, they were served up on `docs.ably.com`

## Review

Hit `/client-lib-development-guide` on the review app and you'll get redirected to `sdk.ably.com`

* https://ably-docs-fix-client-li-jtovd1.herokuapp.com/client-lib-development-guide

~~~
$ curl -I https://ably-docs-fix-client-li-jtovd1.herokuapp.com/client-lib-development-guide
HTTP/1.1 301 Moved Permanently
...
Location: https://sdk.ably.com/builds/ably/specification/main/
...
~~~
