### PR TITLE
[EDU-1533] Add note about JavaScript v2 to API references

### DIFF
--- a/content/api/index.textile
+++ b/content/api/index.textile
@@ -40,8 +40,7 @@ The API references generated from source code are structured by classes. The com
 The SDKs that have API references generated from source code are:
 
 * "Java":https://ably.com/docs/sdk/java/v1.2/
-* "JavaScript - callbacks":https://ably.com/docs/sdk/js/v1.2/callbacks
-* "JavaScript - promises":https://ably.com/docs/sdk/js/v1.2/promises
+* "JavaScript":https://ably.com/docs/sdk/js/v2.0
 * "Objective-C":https://ably.com/docs/sdk/cocoa/v1.2/
 * "Ruby":https://ably.com/docs/sdk/ruby/v1.2/
 * "Swift":https://ably.com/docs/sdk/cocoa/v1.2/

--- a/content/api/realtime-sdk.textile
+++ b/content/api/realtime-sdk.textile
@@ -57,6 +57,12 @@ inline-toc.
     - Params
     - HttpPaginatedResponse#http-paginated-response
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#constructor). Constructor
 
 The Ably Realtime library constructor is overloaded allowing it to be instantiated using a "@ClientOptions@":#client-options object, or more simply using a string containing an "API key":/auth/basic or "Token":/auth/token, as shown below:

--- a/content/api/realtime-sdk/authentication.textile
+++ b/content/api/realtime-sdk/authentication.textile
@@ -30,6 +30,12 @@ redirect_from:
   - /api/versions/v0.8/realtime-sdk/authentication
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 This is the Authentication API Reference.
 
 h2(#tokens). Tokens

--- a/content/api/realtime-sdk/channel-metadata.textile
+++ b/content/api/realtime-sdk/channel-metadata.textile
@@ -20,6 +20,12 @@ inline-toc.
     - ChannelStatus#channel-status
     - Occupancy#occupancy
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#types). Types
 
 The payload of metadata events for channels is the "@ChannelDetails@":#channel-details type which contains the @channelId@ and other static information about the channel, plus a @status@ containing a "@ChannelStatus@":#channel-status instance which contains information about the current state of the channel.

--- a/content/api/realtime-sdk/channels.textile
+++ b/content/api/realtime-sdk/channels.textile
@@ -69,6 +69,12 @@ inline-toc.
     - PaginatedResult#paginated-result
     - Param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#channels-object).
   default: Channels
 

--- a/content/api/realtime-sdk/connection.textile
+++ b/content/api/realtime-sdk/connection.textile
@@ -59,6 +59,12 @@ inline-toc.
     - ConnectionStateChange#connection-state-change
     - LastConnectionDetails#last-connection-details
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#properties).
   default: Connection Properties
   swift,objc: ARTConnection Properties

--- a/content/api/realtime-sdk/encryption.textile
+++ b/content/api/realtime-sdk/encryption.textile
@@ -33,6 +33,12 @@ inline-toc.
     - Channel Options
     - CipherParams#cipher-params
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 The <span lang="default">@Ably.Realtime.@</span><span lang="ruby">@Ably::Util::@</span><span lang="java">@io.ably.lib.util.@</span><span lang="swift,objc">@ART@</span>@Crypto@ object exposes the following public methods:
 
 h2(#methods). Methods

--- a/content/api/realtime-sdk/history.textile
+++ b/content/api/realtime-sdk/history.textile
@@ -36,6 +36,12 @@ inline-toc.
     - PaginatedResult#paginated-result
     - Param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2. Channel object
 
 The "Realtime @Channel@ object":/channels exposes the following public method to obtain "@Message@":#message history.

--- a/content/api/realtime-sdk/messages.textile
+++ b/content/api/realtime-sdk/messages.textile
@@ -45,6 +45,12 @@ inline-toc.
     - fromEncoded#message-from-encoded
     - fromEncodedArray#message-from-encoded-array
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#properties).
   default: Properties
   java:    Members

--- a/content/api/realtime-sdk/presence.textile
+++ b/content/api/realtime-sdk/presence.textile
@@ -56,6 +56,12 @@ inline-toc.
     - Param
     - PresenceListener#presence-listener
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#properties).
   default: Presence Properties
   objc,swift: ARTPresence Properties

--- a/content/api/realtime-sdk/push-admin.textile
+++ b/content/api/realtime-sdk/push-admin.textile
@@ -48,6 +48,12 @@ inline-toc.
     - PushChannelSubscription#push-channel-subscription
     - PaginatedResult#paginated-result
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 <%= partial partial_version('types/_push_admin') %>
 
 h2(#related-types). Related types

--- a/content/api/realtime-sdk/statistics.textile
+++ b/content/api/realtime-sdk/statistics.textile
@@ -23,6 +23,12 @@ redirect_from:
   - /api/versions/v0.8/realtime-sdk/statistics
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h6(#stats). stats
 
 bq(definition).

--- a/content/api/realtime-sdk/types.textile
+++ b/content/api/realtime-sdk/types.textile
@@ -24,6 +24,12 @@ redirect_from:
   - /realtime/versions/v0.8/types
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 The Ably client library defines both data types and option types. Data types are used to represent object such as messages. Option types are used in method arguments.
 
 Where client libraries support both Realtime and REST APIs, the types are shared between both clients.

--- a/content/api/rest-sdk.textile
+++ b/content/api/rest-sdk.textile
@@ -52,6 +52,12 @@ inline-toc.
     - HttpPaginatedResponse#http-paginated-response
     - Params#param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#constructor). Constructor
 
 The Ably REST library constructor is overloaded allowing it to be instantiated using a "@ClientOptions@":#client-options object, or more simply using a string containing an "API key":/auth/basic or "Token":/auth/token.

--- a/content/api/rest-sdk/authentication.textile
+++ b/content/api/rest-sdk/authentication.textile
@@ -33,6 +33,12 @@ redirect_from:
   - /api/versions/v0.8/rest-sdk/authentication
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 This is the Authentication API Reference.
 
 h2(#tokens). Tokens

--- a/content/api/rest-sdk/channel-status.textile
+++ b/content/api/rest-sdk/channel-status.textile
@@ -20,6 +20,12 @@ inline-toc.
     - ChannelStatus#channel-status
     - Occupancy#occupancy
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#types). Types
 
 The payload of metadata events for channels is the "@ChannelDetails@":#channel-details type which contains the @channelId@ (AKA the "channel's name":/api/realtime-sdk/channels#name) and other static information about the channel, plus a @status@ containing a "@ChannelStatus@":#channel-status instance which contains information about the current state of the channel.

--- a/content/api/rest-sdk/channels.textile
+++ b/content/api/rest-sdk/channels.textile
@@ -50,6 +50,12 @@ inline-toc.
     - PaginatedResult#paginated-result
     - Param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#channels-object).
   default: Channels
 

--- a/content/api/rest-sdk/encryption.textile
+++ b/content/api/rest-sdk/encryption.textile
@@ -36,6 +36,12 @@ inline-toc.
     - Channel Options
     - CipherParams#cipher-params
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 The <span lang="default">@Ably.Rest.Crypto@</span><span lang="ruby">@Ably::Util::Crypto@</span><span lang="php">@Ably\Utils\Crypto@</span><span lang="python">@ably.util.crypto@</span><span lang="java">@io.ably.lib.util.crypto@</span><span lang="swift,objc">@ARTCrypto@</span><span lang="csharp"> @IO.Ably.Encryption.Crypto@</span> object exposes the following public methods:
 
 h2(#methods). Methods

--- a/content/api/rest-sdk/history.textile
+++ b/content/api/rest-sdk/history.textile
@@ -39,6 +39,12 @@ inline-toc.
     - PaginatedResult#paginated-result
     - Param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2. Channel object
 
 The "Rest @Channel@ object":/channels exposes the following public method to obtain "@Message@":#message history.

--- a/content/api/rest-sdk/messages.textile
+++ b/content/api/rest-sdk/messages.textile
@@ -44,6 +44,12 @@ inline-toc.
     - fromEncoded#message-from-encoded
     - fromEncodedArray#message-from-encoded-array
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2(#properties).
   default: Properties
   java:    Members

--- a/content/api/rest-sdk/presence.textile
+++ b/content/api/rest-sdk/presence.textile
@@ -37,6 +37,12 @@ inline-toc.
     - PaginatedResult#paginated-result
     - Param
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h2. Methods
 
 h6(#get).

--- a/content/api/rest-sdk/push-admin.textile
+++ b/content/api/rest-sdk/push-admin.textile
@@ -51,6 +51,12 @@ inline-toc.
     - PushChannel#push-channel
     - PaginatedResult#paginated-result
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 <%= partial partial_version('types/_push_admin') %>
 
 h2(#related-types). Related types

--- a/content/api/rest-sdk/statistics.textile
+++ b/content/api/rest-sdk/statistics.textile
@@ -26,6 +26,12 @@ redirect_from:
   - /api/versions/v0.8/rest-sdk/statistics
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 h6(#stats).
   default: stats
   csharp,go: Stats

--- a/content/api/rest-sdk/types.textile
+++ b/content/api/rest-sdk/types.textile
@@ -23,6 +23,12 @@ redirect_from:
   - /rest/types
 ---
 
+blang[javascript,nodejs].
+
+  <aside data-type='note'>
+  <p>This API reference is for version 1.2 of the JavaScript SDK. Version 2.0 references are "available in TypeDoc.":https://ably.com/docs/sdk/js/v2.0/</p>
+  </aside>
+
 The Ably REST client library defines both data types and option types.  Data types are used to represent object such as messages; Option types are used in method arguments.
 
 Where client libraries support both Realtime and REST APIs, the types are shared between both clients.


### PR DESCRIPTION
## Description

This PR adds a note to the JavaScript API references that directs developers to the idiomatic API references for v2. This is temporary whilst we transition from manual to auto-generated API refs. 

## Review

Ensure that the notice only appears for JavaScript users.