### PR TITLE
[WEB-3677] Implement UI to support version notices

### DIFF
--- a/src/components/blocks/dividers/Aside.tsx
+++ b/src/components/blocks/dividers/Aside.tsx
@@ -6,6 +6,8 @@ import HtmlDataTypes from '../../../../data/types/html';
 import {
   inlineGridParagraph,
   inlineContentContainer,
+  versioningContainer,
+  versioningTitleElement,
   pitfallElement,
   leftSideElement,
   furtherReadingElement,
@@ -14,12 +16,20 @@ import {
 } from './dividers.module.css';
 
 const Aside = ({ data, attribs }: HtmlComponentProps<'div'>) => {
+  const isVersioningInfo: boolean =
+    attribs && (attribs[`data-type`] === 'new' || attribs[`data-type`] === 'updated') ? true : false;
+
+  const versioningColors: { [key: string]: { bg: string; text: string } } = {
+    new: { bg: '#FFF0BA', text: '#AC8600' },
+    updated: { bg: '#FFB8F1', text: '#9C007E' },
+  };
+
   let paddingBottom: string | false = false;
-  if (isArray(data) && data[data.length - 1].name === HtmlDataTypes.ul) {
+  if ((isArray(data) && data[data.length - 1].name === HtmlDataTypes.ul) || isVersioningInfo) {
     paddingBottom = '0';
   }
   return (
-    <aside className={`${inlineGridParagraph} ${attribs?.className}`}>
+    <aside className={`${!isVersioningInfo && inlineGridParagraph} ${attribs?.className}`}>
       {attribs && attribs[`data-type`] === `important` ? (
         <>
           <span className={`${leftSideElement} ${pitfallElement}`}>&nbsp;</span>
@@ -36,6 +46,18 @@ const Aside = ({ data, attribs }: HtmlComponentProps<'div'>) => {
             <span className="mb-48">Further Reading</span>
           </strong>
         </>
+      ) : attribs && isVersioningInfo ? (
+        <>
+          <span
+            className={versioningTitleElement}
+            style={{
+              backgroundColor: versioningColors[attribs[`data-type`]].bg,
+              color: versioningColors[attribs[`data-type`]].text,
+            }}
+          >
+            {attribs[`data-type`]}
+          </span>
+        </>
       ) : (
         <>
           <span className={`${leftSideElement} ${noteElement}`}>&nbsp;</span>
@@ -46,7 +68,13 @@ const Aside = ({ data, attribs }: HtmlComponentProps<'div'>) => {
         </>
       )}
 
-      <div className={inlineContentContainer} style={{ paddingBottom: paddingBottom || '24px' }}>
+      <div
+        className={isVersioningInfo ? versioningContainer : inlineContentContainer}
+        style={{
+          paddingBottom: paddingBottom || '24px',
+          borderLeftColor: attribs && isVersioningInfo ? versioningColors[attribs[`data-type`]].bg : '',
+        }}
+      >
         <Html data={data} />
       </div>
     </aside>

--- a/src/components/blocks/dividers/dividers.module.css
+++ b/src/components/blocks/dividers/dividers.module.css
@@ -57,3 +57,32 @@ aside.inline-grid-paragraph {
   padding: 0;
   width: 100%;
 }
+
+span.versioningTitleElement {
+  display: inline-flex;
+  font-size: 10px;
+  line-height: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  padding: var(--spacing-4) var(--spacing-8);
+  border-radius: 0 var(--spacing-4) var(--spacing-4) 0;
+}
+
+div.versioningContainer {
+  padding-top: var(--spacing-8);
+  padding-left: var(--spacing-8);
+  border-left: solid 1px;
+  color: #89929F;
+}
+
+div.versioningContainer * {
+  font-size: var(--fs-p3);
+  line-height: var(--lh-normal);
+}
+
+div.versioningContainer code {
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  color: #89929F;
+}


### PR DESCRIPTION
## Description

https://ably.atlassian.net/browse/WEB-3677

Versioning styles `new` and `updated` added to `<aside>` component, according to the [designs on figma](https://www.figma.com/file/hptKqjNIu6G1KXf3IMOWlK/Versioning-Info-UI)


## Review

To add the versioning notices on the docs pages:

`new`:
```
<aside data-type='new'>
  <p>[text here...]</p>
</aside>
```

`updated`:
```
<aside data-type='updated'>
  <p>[text here...]</p>
</aside>
```
