### PR TITLE
chore: roundtrip latency copy update

### DIFF
--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -284,9 +284,9 @@ AblyCompare:
           pusher: "*No.*"
         extra: 'Encoding messages in binary format is faster as it reduces bandwidth for sending and receiving messages, and streamlines the processing time for clients and servers when encoding and decoding messages.<br/><br/>"Learn about our binary protocol":https://faqs.ably.com/do-you-binary-encode-your-messages-for-greater-efficiency'
       roundtrip:
-        description: "Global median round trip latencies of sub 65ms"
+        description: "Global median round trip latencies of sub 50ms"
         compare:
-          ably: "*Yes.*<br/><br/>Ably’s round trip latencies, measured as the time taken to publish a message on one connection and receive a message on another connection, dependably range from 5ms to 200ms, with a median global latency of 91ms."
+          ably: "*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection."
           pubnub: >
             *Unknown.* <br/><br/>PubNub advertises sub-250ms worldwide latencies. <br/><br/> _(source "PA4":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ufhpqr4p9f31)_
           pusher: "*Unknown.*<br/><br/>Pusher does not share latencies."

--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -1,68 +1,68 @@
 Reliability:
   reliability:
-    description: "Reliability"
+    description: 'Reliability'
     sections:
       response_time:
-        description: "Latency of response times"
+        description: 'Latency of response times'
         compare:
-          fanout: "No data available."
-          push-technology: "Varies between 100ms-250ms+. Check status site for current latencies."
+          fanout: 'No data available.'
+          push-technology: 'Varies between 100ms-250ms+. Check status site for current latencies.'
           pubnub: 'Global average of 250ms. End-to-end within 100ms. "See support article":https://support.pubnub.com/support/solutions/articles/14000043680.'
-          pusher: "No data available."
-          realtime: "No data available."
+          pusher: 'No data available.'
+          realtime: 'No data available.'
       sla:
-        description: "Uptime SLA"
+        description: 'Uptime SLA'
         compare:
-          fanout: "99.999% uptime SLAs."
-          push-technology: "Unclear. SLAs offered but no mention of uptime guarantees."
-          pubnub: "99.999% uptime SLA for premium plans."
-          pusher: "99.9% uptime SLAs for Enterprise plans."
-          realtime: "100% SLA uptime guarantee for enterprise customers."
+          fanout: '99.999% uptime SLAs.'
+          push-technology: 'Unclear. SLAs offered but no mention of uptime guarantees.'
+          pubnub: '99.999% uptime SLA for premium plans.'
+          pusher: '99.9% uptime SLAs for Enterprise plans.'
+          realtime: '100% SLA uptime guarantee for enterprise customers.'
       datacenters:
-        description: "How many globally distributed datacenters?"
+        description: 'How many globally distributed datacenters?'
         compare:
-          fanout: "Four globally-distributed datacenters<br/><br/> The datacenter network comprises three Point of Presence locations in addition to a single Central location."
+          fanout: 'Four globally-distributed datacenters<br/><br/> The datacenter network comprises three Point of Presence locations in addition to a single Central location.'
           push-technology: 'According to the "status site":https://www.pushtechnology.com/status/ Push Technology has at least 3 datacenters across Europe, US, Australia.'
           pubnub: '"16+ datacenters and 175+ edge PoPs":https://ably.com/network?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages across Europe, USA, and Asia Pacific. <br/><br/> This equates to four Amazon geographical regions and ten EC2 availability zones with AWS.'
           pusher: 'Six datacenters across six Amazon geographical regions in Europe, USA, Asia Pacific.  <br/><br/> However, you must choose a "single datacenter":https://pusher.com/docs/channels/miscellaneous/clusters to host your app.'
-          realtime: "3-6 datacenters across Europe, US East, US West"
+          realtime: '3-6 datacenters across Europe, US East, US West'
       latency_routing:
-        description: "Latency based routing that ensures users connect to the closest datacenter"
+        description: 'Latency based routing that ensures users connect to the closest datacenter'
         compare:
-          fanout: "Supports latency based routing."
-          pubnub: "Supports latency based routing."
-          pusher: "Supports latency based routing."
+          fanout: 'Supports latency based routing.'
+          pubnub: 'Supports latency based routing.'
+          pusher: 'Supports latency based routing.'
       mesh_architecture:
         description: '"Mesh architecture":https://faqs.ably.com/do-you-have-any-single-point-of-congestion-that-limits-your-global-performance with no central point of failure'
         compare:
-          fanout: "Unknown."
-          push-technology: "Unknown."
-          pubnub: "Yes."
-          pusher: "No."
-          realtime: "Unknown."
+          fanout: 'Unknown.'
+          push-technology: 'Unknown.'
+          pubnub: 'Yes.'
+          pusher: 'No.'
+          realtime: 'Unknown.'
       replicated:
-        description: "Data replicated in multiple regions"
+        description: 'Data replicated in multiple regions'
         compare:
-          fanout: "Unknown."
+          fanout: 'Unknown.'
           push-technology: 'Supported on "specific plans":https://docs.pushtechnology.com/cloud/6.2.1/manual/html/cloud/plan/cloud_ha.html'
-          pubnub: "Partial. <br/><br/> Full data replication is guaranteed only for Enterprise customers."
-          pusher: "No. <br/><br/> Application data is stored in a single datacenter, making it more susceptible to data loss."
-          realtime: "No support."
+          pubnub: 'Partial. <br/><br/> Full data replication is guaranteed only for Enterprise customers.'
+          pusher: 'No. <br/><br/> Application data is stored in a single datacenter, making it more susceptible to data loss.'
+          realtime: 'No support.'
       qos:
         description: '"Quality of Service":https://faqs.ably.com/message-durability-and-qos-quality-of-service and message delivery guarantee (never lose data during brief disconnections)'
         compare:
-          fanout: "Shaky. <br/><br/> With Fanout, if a message is published whilst a client is briefly disconnected (if they are going through a tunnel, for example), then the message may never arrive to that client."
-          push-technology: "No support."
-          pubnub: "Partial. <br/><br/> PubNub imposes a message queue limit of 100 messages. Message recovery cannot be guaranteed and subscribed clients are at risk of missing messages if disconnected."
-          pusher: "No. <br/><br/> If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message will never arrive to that client."
-          realtime: "Limited support."
+          fanout: 'Shaky. <br/><br/> With Fanout, if a message is published whilst a client is briefly disconnected (if they are going through a tunnel, for example), then the message may never arrive to that client.'
+          push-technology: 'No support.'
+          pubnub: 'Partial. <br/><br/> PubNub imposes a message queue limit of 100 messages. Message recovery cannot be guaranteed and subscribed clients are at risk of missing messages if disconnected.'
+          pusher: 'No. <br/><br/> If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message will never arrive to that client.'
+          realtime: 'Limited support.'
 
 Interoperability:
   interoperability:
-    description: "Interoperability"
+    description: 'Interoperability'
     sections:
       sdks:
-        description: "Support for native client libraries/SDKs"
+        description: 'Support for native client libraries/SDKs'
         compare:
           fanout: '"6 SDKs":https://docs.fanout.io/docs/libraries.'
           push-technology: 'Limited with only "six SDKs":https://download.pushtechnology.com/cloud/latest/sdks.html covering the most popular platforms/languages (JavaScript, Apple, Android, .Net, C, Java).'
@@ -72,550 +72,550 @@ Interoperability:
       opensource:
         description: 'Support for open source and proprietary protocols (e.g. "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages, AMQP, STOMP)'
         compare:
-          fanout: "Limited."
-          push-technology: "No support."
+          fanout: 'Limited.'
+          push-technology: 'No support.'
           pubnub: 'Partial. <br/><br/> PubNub supports "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages but requires additional configuration opposed to native out-of-the-box support.'
-          pusher: "No support."
-          realtime: "No support."
+          pusher: 'No support.'
+          realtime: 'No support.'
       lockin:
         description: Migration and lock-in
         compare:
-          fanout: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          push-technology: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          pubnub: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          pusher: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          realtime: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
+          fanout: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          push-technology: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          pubnub: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          pusher: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          realtime: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
       adapters:
         description: 'Coverage of various languages, frameworks, protocols and transports, including "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages'
         compare:
-          fanout: "Limited. Fanout supports a few server environments; Python, Ruby, Php, Node, Golang, and .NET. <br/><br/> HTTP stream is offered for languages they do not support."
+          fanout: 'Limited. Fanout supports a few server environments; Python, Ruby, Php, Node, Golang, and .NET. <br/><br/> HTTP stream is offered for languages they do not support.'
           push-technology: 'Supports Kafka. See "GitHub":https://github.com/pushtechnology/diffusion-kafka-connect.'
           pubnub: >
             Partial. No support for third party queuing, streaming, or compute platforms. <br/><br/> "PubNub Functions":https://www.pubnub.com/products/functions provides a proprietary method of executing code. Unfortunately this limits you to PubNub’s functionality, their JavaScript API, and means you’re required to reproduce existing code already in your systems.
           pusher: No support.
-          realtime: "No support."
+          realtime: 'No support.'
 
 Features:
   features:
-    description: "Features"
+    description: 'Features'
     sections:
       realtime:
-        description: "Realtime data streaming"
-        extra: ""
+        description: 'Realtime data streaming'
+        extra: ''
         compare:
-          fanout: "Yes."
-          push-technology: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'Yes.'
+          push-technology: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       queues:
-        description: "Message and worker queues"
-        extra: "Message queues that provide a reliable and straightforward mechanism to consume, process, store, augment or reroute data efficiently from a realtime platform."
+        description: 'Message and worker queues'
+        extra: 'Message queues that provide a reliable and straightforward mechanism to consume, process, store, augment or reroute data efficiently from a realtime platform.'
         compare:
-          fanout: "No. <br/><br/>Fanout does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers."
-          push-technology: "No."
-          pubnub: "No. <br/><br/> PubNub does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers. However, PubNub Functions appears to be an alternative function-as-a-service approach."
-          pusher: "No. <br/><br/> Pusher does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers."
-          realtime: "No."
+          fanout: 'No. <br/><br/>Fanout does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers.'
+          push-technology: 'No.'
+          pubnub: 'No. <br/><br/> PubNub does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers. However, PubNub Functions appears to be an alternative function-as-a-service approach.'
+          pusher: 'No. <br/><br/> Pusher does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers.'
+          realtime: 'No.'
       webhooks:
         description: Webhooks
         extra: '"Webhooks":/general/events?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages provide a means to get messages, channel lifecycle and present events pushed to your servers over HTTP.'
         compare:
-          fanout: "Yes."
-          push-technology: "No."
-          pubnub: "Partial. <br/><br/> PubNub supports Webhooks if manually requested through support. However they are limited to presence events and do not cover channel lifecycle events."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'Yes.'
+          push-technology: 'No.'
+          pubnub: 'Partial. <br/><br/> PubNub supports Webhooks if manually requested through support. However they are limited to presence events and do not cover channel lifecycle events.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       serverless_functions:
         description: Serverless cloud function invocation
-        extra: "Trigger serverless functions on third platforms like Amazon Lambda, Microsoft Azure or Google Function."
+        extra: 'Trigger serverless functions on third platforms like Amazon Lambda, Microsoft Azure or Google Function.'
         compare:
-          fanout: "Limited."
-          push-technology: "No."
-          pubnub: "Partial. <br/><br/> PubNub allows you to run code on their own platform using their proprietary PubNub Functions. The code you can run is limited to the available Javascript API."
-          pusher: "No."
-          realtime: "Partial. Recommends using a generic Webhook to deliver to an API Gateway that then triggers a function."
+          fanout: 'Limited.'
+          push-technology: 'No.'
+          pubnub: 'Partial. <br/><br/> PubNub allows you to run code on their own platform using their proprietary PubNub Functions. The code you can run is limited to the available Javascript API.'
+          pusher: 'No.'
+          realtime: 'Partial. Recommends using a generic Webhook to deliver to an API Gateway that then triggers a function.'
       presence:
-        description: "Presence"
-        extra: "Subscribe to events when users or devices enter or leave channels/topics."
+        description: 'Presence'
+        extra: 'Subscribe to events when users or devices enter or leave channels/topics.'
         compare:
-          fanout: "No."
-          push-technology: "No."
-          pubnub: "Yes. <br/><br/> PubNub supports a default announcement of 20 members and a self-configurable maximum of 100 members per channel."
-          pusher: "Yes. <br/><br/> Pusher supports a maximum of 100 members per channel."
-          realtime: "Yes."
+          fanout: 'No.'
+          push-technology: 'No.'
+          pubnub: 'Yes. <br/><br/> PubNub supports a default announcement of 20 members and a self-configurable maximum of 100 members per channel.'
+          pusher: 'Yes. <br/><br/> Pusher supports a maximum of 100 members per channel.'
+          realtime: 'Yes.'
       history:
-        description: "Message history"
-        extra: "Dictates whether clients can access historical activity, catching up on missed messages."
+        description: 'Message history'
+        extra: 'Dictates whether clients can access historical activity, catching up on missed messages.'
         compare:
-          fanout: "No."
-          push-technology: "Partial. A fixed number of messages can be retained for a small amount of time. A NoSQL cloud database with built-in real-time notifications keeps data synchronized between users."
-          pubnub: "Yes."
-          pusher: "No."
-          realtime: "Partial. Up to 128 messages can be retained for up to 60 seconds. Although this is disabled by default."
+          fanout: 'No.'
+          push-technology: 'Partial. A fixed number of messages can be retained for a small amount of time. A NoSQL cloud database with built-in real-time notifications keeps data synchronized between users.'
+          pubnub: 'Yes.'
+          pusher: 'No.'
+          realtime: 'Partial. Up to 128 messages can be retained for up to 60 seconds. Although this is disabled by default.'
       firehose:
         description: Realtime data firehose
         extra: Stream your realtime data published within a realtime platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka.
         compare:
-          fanout: "No."
-          push-technology: "No."
-          pubnub: "No."
-          pusher: "No."
-          realtime: "No."
+          fanout: 'No.'
+          push-technology: 'No.'
+          pubnub: 'No.'
+          pusher: 'No.'
+          realtime: 'No.'
       push:
         description: Native push notifications
         extra: '"Send notifications and updates":https://ably.com/push-notifications?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages to users even when they are offline.'
         compare:
-          fanout: "No."
-          push-technology: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'No.'
+          push-technology: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       cname:
         description: Custom domain endpoint (CNAME)
         extra: 'Custom domains allowing you to connect using a CNAME such as "realtime.your-company.com".'
         compare:
-          fanout: "Yes."
-          pubnub: "No. <br/><br/> PubNub only provides support for custom CNAME for non-TLS connections as they do not serve up custom certificates for customers."
-          pusher: "No."
+          fanout: 'Yes.'
+          pubnub: 'No. <br/><br/> PubNub only provides support for custom CNAME for non-TLS connections as they do not serve up custom certificates for customers.'
+          pusher: 'No.'
       announcement:
         description: Announcement channels
-        extra: "Stay updated on what’s happening on the client’s end, connection, disconnection etc."
+        extra: 'Stay updated on what’s happening on the client’s end, connection, disconnection etc.'
         compare:
-          push-technology: "Yes."
-          realtime: "Yes."
+          push-technology: 'Yes.'
+          realtime: 'Yes.'
       ordering:
-        description: "Reliable message ordering"
-        extra: "Ensures messages are delivered to persistently connected subscribers in the order they were published on each channel/topic."
+        description: 'Reliable message ordering'
+        extra: 'Ensures messages are delivered to persistently connected subscribers in the order they were published on each channel/topic.'
         compare:
-          push-technology: "No."
-          realtime: "No."
+          push-technology: 'No.'
+          realtime: 'No.'
       conflation:
-        description: "Conflation"
-        extra: "Ability to reduce the amount of information sent to clients by combining or discarding updates."
+        description: 'Conflation'
+        extra: 'Ability to reduce the amount of information sent to clients by combining or discarding updates.'
         compare:
-          push-technology: "Yes."
-          realtime: "No."
+          push-technology: 'Yes.'
+          realtime: 'No.'
 
 Security:
   security:
-    description: "Security"
+    description: 'Security'
     sections:
       tls:
-        description: "TLS connection"
+        description: 'TLS connection'
         extra: '"TLS connections":https://faqs.ably.com/are-messages-sent-to-and-received-from-ably-securely-using-tls ensure all data in transit is encrypted.'
         compare:
-          fanout: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
+          fanout: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
       token:
-        description: "Token-based authentication"
+        description: 'Token-based authentication'
         extra: '"Token-based authentication":/core-features/authentication?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages ensures private keys are never shared and instead short-lived tokens are used to authenticate.'
         compare:
-          fanout: "Yes."
+          fanout: 'Yes.'
           pubnub: >
             No. <br/><br/> PubNub offers an authentication scheme called PAM that allows granular permissions to be configured per client. These permissions are stored on PubNub's servers however which means it is your responsibility to keep a client's permissions in sync with PubNub at all times.
           pusher: 'Yes. <br/><br/> Pusher requires a separate authentication request for every channel. The recent "Authorized Connections":https://pusher.com/docs/client_api_guide/client_authorized_connections feature, introduced in December 2018, improved this by adding more granular channel permissions.'
       jwt:
-        description: "JSON Web Token (JWT)"
+        description: 'JSON Web Token (JWT)'
         extra: '"JWT":/core-features/authentication#token-authentication?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages allows for easy integration with existing authentication systems, along with ensuring private keys are never shared.'
         compare:
-          fanout: "Yes. <br/><br/> Fanout uses Runscope JWT authentication."
-          pubnub: "No."
-          pusher: "Partial. <br/><br/> Pusher only supports JWT in certain products."
+          fanout: 'Yes. <br/><br/> Fanout uses Runscope JWT authentication.'
+          pubnub: 'No.'
+          pusher: 'Partial. <br/><br/> Pusher only supports JWT in certain products.'
       key_permissions:
-        description: "Configurable private key permissions"
+        description: 'Configurable private key permissions'
         extra: 'API keys with "configurable permissions":https://faqs.ably.com/setting-up-and-managing-api-keys including restrictions on channels or operations.'
         compare:
-          fanout: "No."
-          pubnub: "No."
-          pusher: "No."
+          fanout: 'No.'
+          pubnub: 'No.'
+          pusher: 'No.'
       channel_permissions:
-        description: "Configurable channel permissions"
+        description: 'Configurable channel permissions'
         extra: 'The "flexibility to maintain control of your channels":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, such as requiring SSL/TLS or only identified authenticated clients on a channel.'
         compare:
-          fanout: "No."
-          pubnub: "Yes."
+          fanout: 'No.'
+          pubnub: 'Yes.'
           pusher: >
             *Partial.*<br/><br/> Pusher provides a 'private-' and ‘presence-’ namespace for channels that require authentication. No other channel configuration is available.
       encrypted:
-        description: "Encrypted message payloads"
+        description: 'Encrypted message payloads'
         extra: 'AES "encryption":https://faqs.ably.com/cross-platform-symmetric-encryption-offered-by-the-libraries using the provided private key before publishing to a network. As a result, messages are practically impossible to intercept and view. For sensitive data this ensures your payloads are always secure and opaque.'
         compare:
-          fanout: "No."
-          pusher: "Yes. <br/><br/> PubNub include AES encryption in its client library SDKs."
-          pubnub: "No."
+          fanout: 'No.'
+          pusher: 'Yes. <br/><br/> PubNub include AES encryption in its client library SDKs.'
+          pubnub: 'No.'
 
 AblyCompare:
   performance:
-    description: "Performance and availability"
+    description: 'Performance and availability'
     sections:
       datacenters:
-        description: "Global datacenters"
+        description: 'Global datacenters'
         compare:
-          ably: "*15*<br/><br/>Ably has 15 datacenters spread across four continents so your users are never far from the Ably network. We ensure complete availability by routing to the next-closest alternative datacenter when necessary."
-          pusher: "*One per app.*<br/><br/>Pusher requires you to choose a single datacenter for an app to reside in. All realtime traffic must therefore be routed through a single datacenter, regardless of a user’s location. This has implications for performance, reliability, and availability."
+          ably: '*15*<br/><br/>Ably has 15 datacenters spread across four continents so your users are never far from the Ably network. We ensure complete availability by routing to the next-closest alternative datacenter when necessary.'
+          pusher: '*One per app.*<br/><br/>Pusher requires you to choose a single datacenter for an app to reside in. All realtime traffic must therefore be routed through a single datacenter, regardless of a user’s location. This has implications for performance, reliability, and availability.'
           pubnub: >
             *15* <br/><br/> _(source "PA1":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.mjx7qefdflb8)_
         extra: >
           A global physical data center presence means you can bring your users closer to your data. This reduces latency while ensuring high availability.<br/><br/>"Find out more about Ably's network":https://ably.com/network
       pops:
-        description: "Edge acceleration Points of Presence (PoPs)"
+        description: 'Edge acceleration Points of Presence (PoPs)'
         compare:
-          ably: "*205*<br/><br/>Ably’s edge acceleration PoPs extend our network coverage to clients connecting from locations further afield from core routing data centers, reducing volatility and latency when connecting into the Ably network."
-          pusher: "*Unknown.*"
-          pubnub: "*Unknown.*"
+          ably: '*205*<br/><br/>Ably’s edge acceleration PoPs extend our network coverage to clients connecting from locations further afield from core routing data centers, reducing volatility and latency when connecting into the Ably network.'
+          pusher: '*Unknown.*'
+          pubnub: '*Unknown.*'
         extra: 'Acceleration Points of Presence (PoPs) ensure more stable connections and low latency for clients connecting into a network, improving their experience.<br/><br/>"Find out more about Ably’s PoPs and their 205+ locations":https://ably.com/network'
       latencyrouting:
-        description: "Latency based routing"
+        description: 'Latency based routing'
         compare:
-          ably: "*Yes.*<br/><br/>Ably offers latency based routing that ensures users anywhere in the world connect to the closest datacenter or edge acceleration PoP available to them - ‘closest’ meaning the datacenter with the lowest latency."
+          ably: '*Yes.*<br/><br/>Ably offers latency based routing that ensures users anywhere in the world connect to the closest datacenter or edge acceleration PoP available to them - ‘closest’ meaning the datacenter with the lowest latency.'
           pubnub: >
             *Yes.* <br/><br/> _(source "PA2":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.91xvl0dxjogi)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: >
           Physical proximity doesn’t always equal lowest latency. With latency based DNS routing clients are connected based on latency, not location.<br/><br/>"Learn more about Ably's latency based DNS routing":https://faqs.ably.com/routing-around-network-and-dns-issues
       binary:
-        description: "Binary encoded messages"
+        description: 'Binary encoded messages'
         compare:
-          ably: "*Yes.*"
+          ably: '*Yes.*'
           pubnub: >
             *No.* <br/><br/> _(source "PA3":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.jg9jdlbmx5yd)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Encoding messages in binary format is faster as it reduces bandwidth for sending and receiving messages, and streamlines the processing time for clients and servers when encoding and decoding messages.<br/><br/>"Learn about our binary protocol":https://faqs.ably.com/do-you-binary-encode-your-messages-for-greater-efficiency'
       roundtrip:
-        description: "Global median round trip latencies of sub 50ms"
+        description: 'Global median round trip latencies of sub 50ms'
         compare:
-          ably: "*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection."
+          ably: '*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection.'
           pubnub: >
             *Unknown.* <br/><br/>PubNub advertises sub-250ms worldwide latencies. <br/><br/> _(source "PA4":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ufhpqr4p9f31)_
-          pusher: "*Unknown.*<br/><br/>Pusher does not share latencies."
+          pusher: '*Unknown.*<br/><br/>Pusher does not share latencies.'
         extra: 'Predictably low latency means you can build knowing concrete parameters of performance, designing a better system and end-user experience around that.<br/><br/>"View third-party benchmarking stats":https://faqs.ably.com/round-trip-latency-and-performance'
   redundancy:
-    description: "Redundancy, reliability, integrity of data"
+    description: 'Redundancy, reliability, integrity of data'
     sections:
       mesh:
-        description: "Realtime service mesh architecture with no single point of congestion"
+        description: 'Realtime service mesh architecture with no single point of congestion'
         compare:
-          ably: "*Yes.*<br/><br/>Ably’s realtime service mesh ensures no single point of congestion or failure, designed to always route messages with the least number of network hops."
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. Any latency issues that occur in that datacenter will affect all apps hosted there."
+          ably: '*Yes.*<br/><br/>Ably’s realtime service mesh ensures no single point of congestion or failure, designed to always route messages with the least number of network hops.'
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. Any latency issues that occur in that datacenter will affect all apps hosted there.'
         extra: >
           Having no single point of congestion enables the lowest latency and highest availability.<br/><br/>"Learn about Ably's mesh architecture":https://faqs.ably.com/do-you-have-any-single-point-of-congestion-that-limits-your-global-performance
       centralfailure:
-        description: "No central point of failure"
+        description: 'No central point of failure'
         compare:
           ably: '*Yes.*<br/><br/>The "Ably global platform":https://ably.com/platform is a distributed system designed with no single point of failure. All customers benefit from running their apps in all of our datacenters providing resilience, reliability, and global low latencies.'
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. If that datacenter goes offline then all apps hosted there are affected."
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. If that datacenter goes offline then all apps hosted there are affected.'
         extra: 'Data replication in multiple regions protects against single points of failure and ensures resilience and reliability of service.<br/><br/>"Learn about how we mitigate against a single point of failure":https://faqs.ably.com/message-durability-and-qos-quality-of-service'
       healing:
-        description: "Self-healing clusters"
+        description: 'Self-healing clusters'
         compare:
-          ably: "*Yes.*<br/><br/>The Ably service uses a consensus algorithm to communicate between servers, meaning any issues are isolated, intelligently fixed and replaced, and traffic routed to healthy servers."
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>The Ably service uses a consensus algorithm to communicate between servers, meaning any issues are isolated, intelligently fixed and replaced, and traffic routed to healthy servers.'
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*'
         extra: 'Automatic traffic rerouting, server isolation, and repair limit the risk of network problems, ensuring a better quality of service for you and your end-users.<br/><br/>"Learn more about our self-healing clusters":https://faqs.ably.com/self-healing-cluster'
       autonomous:
-        description: "Autonomous datacenters"
+        description: 'Autonomous datacenters'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's datacenters are designed to operate as part of our global cluster when available, but operate autonomously when necessary.
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*"
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*'
         extra: >
           Datacenters that operate as part of a global cluster, but also autonomously when needed, provide high availability of service.<br/><br/>"Find out where Ably's servers are located":https://ably.com/network
       replication:
-        description: "Data replicated in multiple regions"
+        description: 'Data replicated in multiple regions'
         compare:
-          ably: "*Yes.*"
+          ably: '*Yes.*'
           pubnub: >
             *Yes.*<br/><br/> _(source "PA5":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.wqteamvn2cnz)_
-          pusher: "*No.*<br/><br/>Data stored in a single datacenter is more susceptible to loss."
+          pusher: '*No.*<br/><br/>Data stored in a single datacenter is more susceptible to loss.'
         extra: >
           This ensures that an outage in any datacenter or region cannot result in data loss.<br/><br/>"Find out about Ably's message delivery guarantee":https://faqs.ably.com/message-durability-and-qos-quality-of-service
       qos:
-        description: "QoS & message delivery guarantee<br/><br/>(Unique to Ably)"
+        description: 'QoS & message delivery guarantee<br/><br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides guaranteed message delivery and continuity across disconnections. Publishers only receive an ACK when data is persisted in two locations, and subscribers never lose data during brief disconnections as we maintain connection state for each client on our servers."
-          pubnub: "*Unknown.*"
-          pusher: "*No.*<br/><br/>If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message published over Pusher will never arrive to that client."
+          ably: '*Yes.*<br/><br/>Ably provides guaranteed message delivery and continuity across disconnections. Publishers only receive an ACK when data is persisted in two locations, and subscribers never lose data during brief disconnections as we maintain connection state for each client on our servers.'
+          pubnub: '*Unknown.*'
+          pusher: '*No.*<br/><br/>If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message published over Pusher will never arrive to that client.'
         extra: >
           Upon a disconnection, retaining all messages on channels a client was subscribed to, and sending when the client reconnects and resumes its state, ensures messages are never lost and your end-users always receive messages.<br/><br/>"Find out about Ably's QoS and message delivery guarantee":https://faqs.ably.com/message-durability-and-qos-quality-of-service
       connectionrecovery:
-        description: "Continuity and connection state recovery<br/><br/>(Unique to Ably)"
+        description: 'Continuity and connection state recovery<br/><br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides continuity for clients that become disconnected for reasons such as going through a tunnel or changing networks. We store the connection state for each client on our servers so that clients that reconnect within two minutes can resume their connection and receive all messages published whilst they were disconnected."
+          ably: '*Yes.*<br/><br/>Ably provides continuity for clients that become disconnected for reasons such as going through a tunnel or changing networks. We store the connection state for each client on our servers so that clients that reconnect within two minutes can resume their connection and receive all messages published whilst they were disconnected.'
           pubnub: >
             *Partial* <br/><br/>From PubNub:<br />“The default message queue size is 100 messages. Consequently, publishing past 100 messages inevitably results in older messages overflowing the queue and getting discarded.” <br/><br/> _(source "PA6":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.95ye4ptvifhx)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Storing connection state means clients can resume from where they left off, providing a better quality of service as nothing is ever lost.<br/><br/>"Find out more about connection state recovery":https://faqs.ably.com/connection-state-recovery'
       uptimeguarantee:
-        description: "Uptime guarantee<br/><br/>"
+        description: 'Uptime guarantee<br/><br/>'
         compare:
           ably: '*Yes.*<br/><br/>Ably offers varying levels of uptime guarantees depending on your needs. For all of our enterprise customers we provide a 99.999% uptime SLA. If we are unable to meet your SLA goal, "we offer refunds":https://faqs.ably.com/ablys-uptime-guarantee.'
-          pubnub: "*Yes.*"
+          pubnub: '*Yes.*'
           pusher: >
             *No.*<br/><br/>Pusher doesn’t offer an SLA unless you are an Enterprise customer.
         extra: 'Confidence in a service to offer refunds on any downtime. That is what an uptime guarantee means, and it shows a provider values you and your end-users’ experience.<br/><br/>"Learn what we mean with our uptime guarantee":https://faqs.ably.com/ablys-uptime-guarantee'
   core:
-    description: "Core features"
+    description: 'Core features'
     sections:
       presence:
-        description: "Channel presence"
+        description: 'Channel presence'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports a configurable number of presence members and supports 200 members by default, with many more upon request. We also support member state updates such as GPS device location."
+          ably: '*Yes.*<br/><br/>Ably supports a configurable number of presence members and supports 200 members by default, with many more upon request. We also support member state updates such as GPS device location.'
           pubnub: >
             *Yes.* <br/><br/>PubNub supports presence with a default max limit of 100 announce members per channel. <br/><br/> _(source "PA7":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ssz0v2cxjy8u)_
-          pusher: "*Yes.*<br/><br/>Pusher supports presence with 100 members maximum per channel."
+          pusher: '*Yes.*<br/><br/>Pusher supports presence with 100 members maximum per channel.'
         extra: 'Presence allows you to subscribe to events when users or devices enter or leave channels. This is a useful feature for collaborative apps, games and chat rooms.<br/><br/>"Find out more about Presence":/realtime/presence'
       history:
-        description: "Message history (persisted data)"
+        description: 'Message history (persisted data)'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's message history feature provides a means for clients or servers to retrieve messages that were previously published on a channel.
-          pubnub: "*Yes.*"
-          pusher: "*No.*<br/><br/>Pusher does not support message history."
+          pubnub: '*Yes.*'
+          pusher: '*No.*<br/><br/>Pusher does not support message history.'
         extra: 'Clients connecting to a channel can view messages previously published on that channel. This includes instant message rewind upon connection.<br/><br/>"Find out more about our History API":/realtime/history'
       ordering:
-        description: "Reliable message ordering<br/>(Unique to Ably)"
+        description: 'Reliable message ordering<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably ensures that messages are delivered to persistently connected subscribers in the order they were published on each channel using the First-in-First-Out (FIFO) pattern."
+          ably: '*Yes.*<br/><br/>Ably ensures that messages are delivered to persistently connected subscribers in the order they were published on each channel using the First-in-First-Out (FIFO) pattern.'
           pubnub: >
             *No.* <br/><br/> _(source "PA8":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.s5n1v4t4pp8r)_
-          pusher: "*No.*<br/><br/>Pusher does not support reliable message ordering."
+          pusher: '*No.*<br/><br/>Pusher does not support reliable message ordering.'
         extra: 'For many realtime features, like chat or live collaboration, the ordering of messages is paramount to the end-user experience.<br/><br/>"Find out more about reliable ordering":https://faqs.ably.com/reliable-message-ordering-for-connected-clients'
       idempotent:
-        description: "Idempotent message publishing"
+        description: 'Idempotent message publishing'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports idempotent publishing across all our native client library SDKs."
+          ably: '*Yes.*<br/><br/>Ably supports idempotent publishing across all our native client library SDKs.'
           pubnub: >
             *Unlikely.* <br/><br/>PubNub’s "recommended design pattern":https://support.pubnub.com/hc/en-us/articles/360051496012-How-do-I-handle-publish-timeouts- for publish timeouts is to try the publish again which can result in duplicate publishes.  For this reason, and the lack of any documentation that exists, we believe it’s unlikely idempotency is supported. <br/><br/> _(source "PA9":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.w170mu1nm7vo)_
-          pusher: "*No.*<br/><br/>Pusher does not support idempotent publishing."
+          pusher: '*No.*<br/><br/>Pusher does not support idempotent publishing.'
         extra: 'Idempotent REST publishing assures published messages are only processed once, even if client or connectivity failures cause a publish to be reattempted.<br/><br/>"Learn more about idempotent publishing with Ably":https://ably.com/topic/idempotency'
       deltas:
-        description: "Delta Message Compression"
+        description: 'Delta Message Compression'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports message delta compression on a per channel basis."
+          ably: '*Yes.*<br/><br/>Ably supports message delta compression on a per channel basis.'
           pubnub: >
             *No.*<br/><br/>PubNub does not support message delta compression according to their documentation and SDKs.
-          pusher: "*No.*<br/><br/>Pusher does not support message delta compression."
+          pusher: '*No.*<br/><br/>Pusher does not support message delta compression.'
         extra: 'Delta compression reduces the bandwidth costs required to transmit realtime messages by sending only changes to a stream instead of the entire payload each time.<br/><br/>"Learn more about Delta Message Compression":/realtime/channels/channel-parameters/deltas'
       pushnotifications:
-        description: "Push notifications"
+        description: 'Push notifications'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides a unified API to deliver push notifications, including native iOS and Android push notifications."
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*<br/><br/>Pusher provides push notifications through its “Beams” product."
+          ably: '*Yes.*<br/><br/>Ably provides a unified API to deliver push notifications, including native iOS and Android push notifications.'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*<br/><br/>Pusher provides push notifications through its “Beams” product.'
         extra: 'Send native push notifications to all your end-users.<br/><br/>"Find out more about Push Notifications":/general/push'
       queues:
-        description: "Message and worker queues<br/>(Unique to Ably)"
+        description: 'Message and worker queues<br/>(Unique to Ably)'
         compare:
           ably: >
             *Yes.*<br/><br/>Data published into Ably's realtime system can be moved into traditional message queues for realtime or batch processing. We also support AWS SQS, RabbitMQ, and AMQP. Ably handles all the complexity of doing so.
           pubnub: >
             *Partial.* <br/><br/>PubNub does not offer any native message queue service or mechanism to distribute data using once-only pattern to your server workers. However, it does integrate with services such as Amazon SQS which do provide this. <br/><br/> _(source "PA10":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.x0ofj3jcov16)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Queuing helps scale the consumption of realtime messages.<br/><br/>"Find out more about our Queues":/general/queues'
       webhooks:
-        description: "Webhooks"
+        description: 'Webhooks'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's Webhooks provide a means to get messages, channel lifecycle and presence events pushed to your servers over HTTP.
           pubnub: >
             *Partial.* <br/><br/>PubNub supports Webhooks for presence natively, and recommends the use of Blocks for triggering Webhooks for message events. <br/><br/> _(source "PA11":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.grb44677a49g)_
-          pusher: "*Yes.*"
+          pusher: '*Yes.*'
         extra: 'Publish messages and channel lifecycle and presence events to your own servers over HTTP so you can trigger events in your existing systems and execute on business logic.<br/><br/>"Find out more about Webhooks":/general/events'
       functions:
-        description: "Serverless cloud function invocation<br/>(Unique to Ably)"
+        description: 'Serverless cloud function invocation<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can trigger serverless functions on any third party cloud providers such as Amazon Lambda, Microsoft Azure or Google Function."
+          ably: '*Yes.*<br/><br/>Ably can trigger serverless functions on any third party cloud providers such as Amazon Lambda, Microsoft Azure or Google Function.'
           pubnub: >
             *Partial.* <br/><br/>PubNub allows you to run code on its own platform using proprietary PubNub Functions in the form of “Blocks”. The code you can run in Blocks is limited to the Javascript API available in PubNub’s system. <br/><br/> _(source "PA13":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.6hpsmlo4hpnx)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Trigger events in other cloud systems in response to realtime messages so you can execute on business logic. For example, on-the-fly translation.<br/><br/>"Find out more about Reactor Events":/general/events'
       integrations:
-        description: "Third-party services integration"
+        description: 'Third-party services integration'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can link to third-party services such as Cloudflare Functions, Zapier, IFTTT, and Tray.io."
+          ably: '*Yes.*<br/><br/>Ably can link to third-party services such as Cloudflare Functions, Zapier, IFTTT, and Tray.io.'
           pubnub: >
             *Yes.*<br/><br/>PubNub’s Functions offers some pre-built Blocks from third-party services.
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Similar to Ably, third-party platforms such as Cloudflare and Zapier do a lot of the background heavy lifting to provide increased automation and functionality while reducing operational overhead. Being able to easily link your realtime operations to these existing services means creating even richer, more powerful realtime experiences.<br/><br/>"Learn more about third-party integrations":https://ably.com/integrations'
       firehose:
-        description: "Realtime data firehose<br/>(Unique to Ably)"
+        description: 'Realtime data firehose<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Stream your realtime data published within the Ably platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka, AWS SQS, and RabbitMQ."
+          ably: '*Yes.*<br/><br/>Stream your realtime data published within the Ably platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka, AWS SQS, and RabbitMQ.'
           pubnub: >
             *Partial.* <br/><br/>PubNub provides bridges for Kafka and NATS; however, the bridge is designed to stream data out of Kafka or NATs to PubNub.  The Ably Firehose is designed to solve a different problem, streaming data from your clients connected to Ably into your streaming or queueing services. <br/><br/> _(source "PA14":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.twdrgpsj83ge)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Linking systems together is a common requirement as services are responsible for different things. Easily being able to do takes unnecessary engineering strain off you.<br/><br/>"Find out more about our Reactor Firehose":/general/firehose'
       cname:
-        description: "Custom domain endpoint (CNAME)"
+        description: 'Custom domain endpoint (CNAME)'
         compare:
           ably: '*Yes.*<br/><br/>Ably supports custom domains for our Enterprise customers allowing them to connect to Ably using a CNAME such as "realtime.your-company.com".'
           pubnub: >
             *No.*<br/><br/>PubNub only provides support for custom CNAME for non-TLS connections as it does not serve up custom certificates for customers.
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Comply with security policies and firewall restrictions with custom CNAMEs.<br/><br/>"Find out more about our custom domains":https://faqs.ably.com/do-you-support-custom-cname-endpoints'
   distribute:
-    description: "Distribute data streams to third party developers (Unique to Ably)"
+    description: 'Distribute data streams to third party developers (Unique to Ably)'
     sections:
       streamer:
-        description: "Optionally deploy, manage, and distribute data streams to third party developers"
+        description: 'Optionally deploy, manage, and distribute data streams to third party developers'
         compare:
-          ably: "*Yes.*<br/><br/>Deploy data streams to Ably’s managed infrastructure, manage and control who can access those data streams, and distribute them to third party developers as realtime APIs - so they can consume and integrate them into their own apps."
-          pubnub: "*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Deploy data streams to Ably’s managed infrastructure, manage and control who can access those data streams, and distribute them to third party developers as realtime APIs - so they can consume and integrate them into their own apps.'
+          pubnub: '*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer.'
+          pusher: '*No.*'
         extra: 'As realtime API adoption increases so does complexity, cost, and friction of integration for developers wanting to consume realtime data. Being able to easily distribute data streams future-proofs product development requirements and eases API programme creation.<br/><br/>"Learn more about API Streamer":https://ably.com/api-streamer'
       management:
-        description: "Complete management layer"
+        description: 'Complete management layer'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer."
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer.'
+          pusher: '*No.*'
         extra: 'This management layer drastically reduces the complexity, cost, and friction of creating self-service realtime API programs that are easy for developers to integrate with. Ably is first to offer this to market.<br/><br/>"Learn more about creating realtime API programs built on Ably’s network":https://ably.com/api-streamer'
   libraries:
-    description: "Client libraries and protocol support"
+    description: 'Client libraries and protocol support'
     sections:
       native:
-        description: "Native client libraries for every popular platform"
+        description: 'Native client libraries for every popular platform'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides 40+ client library SDKs for a considerable range of popular platforms."
-          pubnub: "*Yes.*<br/><br/>PubNub offers a range of client libraries"
-          pusher: "*Yes.*<br/><br/>Pusher offers 40+ SDKs."
+          ably: '*Yes.*<br/><br/>Ably provides 40+ client library SDKs for a considerable range of popular platforms.'
+          pubnub: '*Yes.*<br/><br/>PubNub offers a range of client libraries'
+          pusher: '*Yes.*<br/><br/>Pusher offers 40+ SDKs.'
         extra: >
           You should be able to integrate with the technologies and platforms you’re already building with.<br/><br/>"View our client library SDKs":https://ably.com/download
       websocket:
-        description: "1st class WebSocket support"
+        description: '1st class WebSocket support'
         compare:
           ably: '*Yes.*<br/><br/>The Ably protocol is WebSocket-based with first-class "WebSocket":https://ably.com/topic/websockets support.'
           pubnub: >
             *No.* <br/><br/>PubNub uses HTTP as the transport for their client libraries. A WebSocket compliant interface is provided in some libraries, however this is just a wrapper around an underlying HTTP transport. <br/><br/> _(source "CL1":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.9pjhvqc01dow)_
-          pusher: "*Yes.*"
+          pusher: '*Yes.*'
         extra: 'WebSocket is a widely-supported, bi-directional, feature-rich transport suitable for a range of realtime uses.<br/><br/>"View our supported transports":https://faqs.ably.com/which-transports-are-supported'
       fallback:
-        description: "Fallback to Comet (XHR) and Long Polling for older browsers"
+        description: 'Fallback to Comet (XHR) and Long Polling for older browsers'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*'
         extra: 'Whilst most modern devices support "WebSockets":https://ably.com/topic/websockets, there are situations where the device or the network environment requires use of HTTP transports.<br/><br/>"View our supported transports":https://faqs.ably.com/which-transports-are-supported'
       competitorsupport:
-        description: "Support for proprietary protocols of other realtime platforms<br/>(Unique to Ably)"
+        description: 'Support for proprietary protocols of other realtime platforms<br/>(Unique to Ably)'
         compare:
           ably: >
             *Yes.*<br/><br/>The Ably platform is designed to be protocol-agnostic and ensure protocol interoperability. We support other proprietary realtime protocols and ensure interoperability with Ably's protocol and the other protocols we offer.
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'It should be easy to migrate from, or to, one realtime provider to another.<br/><br/>"Learn more about our Protocol Adapters":https://ably.com/protocols'
       mqtt:
-        description: "MQTT support"
+        description: 'MQTT support'
         compare:
           ably: '*Yes.*<br/><br/>The Ably platform is designed to be protocol-agnostic and ensure protocol interoperability. Ably supports "MQTT":https://ably.com/topic/mqtt'
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'MQTT provides a lightweight messaging protocol for small sensors and mobile devices, optimized for low-bandwidth or unreliable networks. MQTT libraries already exist for almost every IoT device around.<br/><br/>"Find out which protocols we support":https://ably.com/protocols'
       sse:
-        description: "Server-Sent Events (HTTP Streaming) protocol support"
+        description: 'Server-Sent Events (HTTP Streaming) protocol support'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: '"Server-Sent Events":https://ably.com/topic/server-sent-events is a lightweight, subscribe-only protocol for when your end-users need only to receive new event data.<br/><br/>"Find out which protocols we support":https://ably.com/protocols'
       amqp:
-        description: "AMQP and STOMP"
+        description: 'AMQP and STOMP'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'AMQP and STOMP protocols are for provisioning queues and configuring routing, among other things.<br/><br/>"Learn more about AMQP and STOMP at Ably":/general/queues'
       whitelabel:
-        description: "White-label browser library"
+        description: 'White-label browser library'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can provide a white-labelled browser Javascript library with a namespace of your choosing and no reference to Ably in the code."
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Ably can provide a white-labelled browser Javascript library with a namespace of your choosing and no reference to Ably in the code.'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'Keep your code clean with white-label libraries.<br/><br/>"Find out about our white-label libraries":https://faqs.ably.com/do-you-support-white-label-browser-libraries'
   security:
-    description: "Security"
+    description: 'Security'
     sections:
       tls:
-        description: "TLS connection"
+        description: 'TLS connection'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*'
         extra: 'TLS connections ensure all data in transit is encrypted.<br/><br/>"Find out more about SSL/TLS":https://faqs.ably.com/are-messages-sent-to-and-received-from-ably-securely-using-tls'
       tokens:
-        description: "Token based authentication"
+        description: 'Token based authentication'
         compare:
-          ably: "*Yes.*<br/><br/>Ably allows configurable policies and an identity to be embedded in a token ensuring you have complete control over what actions your users can perform such as limiting which channels they can subscribe or publish to."
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*<br/><br/>Pusher requires a separate authentication request for every channel. And there is no means to specify granular permissions for a channel."
+          ably: '*Yes.*<br/><br/>Ably allows configurable policies and an identity to be embedded in a token ensuring you have complete control over what actions your users can perform such as limiting which channels they can subscribe or publish to.'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*<br/><br/>Pusher requires a separate authentication request for every channel. And there is no means to specify granular permissions for a channel.'
         extra: >
           Token based authentication ensures your private key is never shared and instead a short-lived token is used to authenticate.<br/><br/>"Find out more about Ably's authentication":/core-features/authentication#token-authentication
       jwt:
-        description: "JSON Web Token support"
+        description: 'JSON Web Token support'
         compare:
-          ably: "*Yes.*<br/><br/>Ably allows for not only Ably Tokens to be embedded within JWTs, but also for JWTs to be signed by Ably API keys and used themselves for authentication."
+          ably: '*Yes.*<br/><br/>Ably allows for not only Ably Tokens to be embedded within JWTs, but also for JWTs to be signed by Ably API keys and used themselves for authentication.'
           pubnub: >
             *No.* <br/><br/> _(source "CL2":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.lftajqade1el)_
-          pusher: "*Partial.*<br/><br/>Pusher only supports JWT in certain products."
+          pusher: '*Partial.*<br/><br/>Pusher only supports JWT in certain products.'
         extra: 'Using JWT allows for easy integration with your existing authentication systems, along with ensuring your private key is never shared.<br/><br/>"Find out more about using JWT with Ably":/core-features/authentication#ably-jwt-process'
       keypermissions:
-        description: "Configurable private key permissions"
+        description: 'Configurable private key permissions'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides support for private API keys with configurable permissions including restrictions on channels or operations."
-          pubnub: "*No.*<br/><br/>PubNub does not provide configurable private key permissions. It uses a different model where each client’s access is configured with the PubNub Access Manager (PAM)."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Ably provides support for private API keys with configurable permissions including restrictions on channels or operations.'
+          pubnub: '*No.*<br/><br/>PubNub does not provide configurable private key permissions. It uses a different model where each client’s access is configured with the PubNub Access Manager (PAM).'
+          pusher: '*No.*'
         extra: 'API keys are a standard method for securing access to an application.<br/><br/>"Find out more about API keys":https://faqs.ably.com/setting-up-and-managing-api-keys'
       channelpermissions:
-        description: "Configurable channel permissions"
+        description: 'Configurable channel permissions'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably’s channel rules provide you with the flexibility you need to build rich and secure realtime apps.
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'Maintain control of your channels, such as requiring SSL/TLS or only identified authenticated clients on a channel.<br/><br/>"Find out more about channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app'
       encryption:
-        description: "Encryption for message payloads"
+        description: 'Encryption for message payloads'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports AES encryption."
-          pubnub: "*Yes.*<br/><br/>PubNub provides AES encryption."
+          ably: '*Yes.*<br/><br/>Ably supports AES encryption.'
+          pubnub: '*Yes.*<br/><br/>PubNub provides AES encryption.'
           pusher: >
             *Beta*<br/><br/>End-to-end encryption for Pusher’s channels product is currently in beta.
         extra: >
           Encryption allows messages to be encrypted using the provided private key before they are published. As a result, messages are practically impossible to intercept and view for anyone. For very sensitive data, this ensures you can safely use us knowing your payloads are always secure and opaque.<br/><br/>"Find out more about Ably's encryption":https://faqs.ably.com/cross-platform-symmetric-encryption-offered-by-the-libraries
   compliance:
-    description: "Compliance"
+    description: 'Compliance'
     sections:
       gdpr:
-        description: "EU GDPR compliant"
+        description: 'EU GDPR compliant'
         compare:
-          ably: "*Yes.*<br/><br/>Procedures and processes in place for EU GDPR regulation."
-          pubnub: "*Yes.*"
-          pusher: "“Pusher is committed to complying with the requirements of the GDPR long-term.”"
+          ably: '*Yes.*<br/><br/>Procedures and processes in place for EU GDPR regulation.'
+          pubnub: '*Yes.*'
+          pusher: '“Pusher is committed to complying with the requirements of the GDPR long-term.”'
         extra: 'EU GDPR is regulation introduced to protect consumers and their data.<br/><br/>"Learn more about GDPR":https://en.wikipedia.org/wiki/General_Data_Protection_Regulation'
       soc:
-        description: "SOC 2 Type 2 compliant"
+        description: 'SOC 2 Type 2 compliant'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'SOC 2 Type 2 is a standard designed to help measure how well service organizations conduct and regulate information. The purpose of SOC standards is to provide confidence and peace of mind for organizations when they engage third-party cloud vendors.<br/><br/>"Learn more about SOC 2 Type 2":https://en.wikipedia.org/wiki/SSAE_16'
       hipaa:
-        description: "HIPAA compliant"
+        description: 'HIPAA compliant'
         compare:
-          ably: "*Yes.*<br/><br/>Ably has many customers in the healthcare industry that we provide Business Associate Agreements to."
-          pubnub: "*Yes.*"
-          pusher: "*No.*<br/><br/>Pusher does not currently sign Business Associate Agreements with customers."
+          ably: '*Yes.*<br/><br/>Ably has many customers in the healthcare industry that we provide Business Associate Agreements to.'
+          pubnub: '*Yes.*'
+          pusher: '*No.*<br/><br/>Pusher does not currently sign Business Associate Agreements with customers.'
         extra: 'HIPAA stipulates how Personally Identifiable Information in healthcare in the USA should be protected.<br/><br/>"Learn more about HIPAA":https://en.wikipedia.org/wiki/Health_Insurance_Portability_and_Accountability_Act'
   value:
-    description: "Value"
+    description: 'Value'
     sections:
       usagepricing:
-        description: "Transparent usage based pricing"
+        description: 'Transparent usage based pricing'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's pricing is simple and transparent. You pay for the messages, peak active channels and peak connections you use for the month. You can either pay for what you've used at the end of the month, or reserve capacity in advance each month and benefit from a discount.
@@ -626,10 +626,10 @@ AblyCompare:
         extra: >
           Pricing should be clear, flexible, and scalable when it comes to realtime messaging.<br/><br/>"Calculate your usage with Ably's pricing calculator":https://ably.com/pricing/calculator
   other:
-    description: "Other important stuff"
+    description: 'Other important stuff'
     sections:
       theme_tune:
-        description: "Theme tune"
+        description: 'Theme tune'
         compare:
           ably: >
             *No.*

--- a/data/yaml/compare.yaml
+++ b/data/yaml/compare.yaml
@@ -284,9 +284,9 @@ AblyCompare:
           pusher: "*No.*"
         extra: 'Encoding messages in binary format is faster as it reduces bandwidth for sending and receiving messages, and streamlines the processing time for clients and servers when encoding and decoding messages.<br/><br/>"Learn about our binary protocol":https://faqs.ably.com/do-you-binary-encode-your-messages-for-greater-efficiency'
       roundtrip:
-        description: "Global median round trip latencies of sub 65ms"
+        description: "Global median round trip latencies of sub 50ms"
         compare:
-          ably: "*Yes.*<br/><br/>Ably’s round trip latencies, measured as the time taken to publish a message on one connection and receive a message on another connection, dependably range from 5ms to 200ms, with a median global latency of 91ms."
+          ably: "*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection."
           pubnub: >
             *Unknown.* <br/><br/>PubNub advertises sub-250ms worldwide latencies. <br/><br/> _(source "PA4":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ufhpqr4p9f31)_
           pusher: "*Unknown.*<br/><br/>Pusher does not share latencies."

--- a/data/yaml/compare.yaml
+++ b/data/yaml/compare.yaml
@@ -1,68 +1,68 @@
 Reliability:
   reliability:
-    description: "Reliability"
+    description: 'Reliability'
     sections:
       response_time:
-        description: "Latency of response times"
+        description: 'Latency of response times'
         compare:
-          fanout: "No data available."
-          push-technology: "Varies between 100ms-250ms+. Check status site for current latencies."
+          fanout: 'No data available.'
+          push-technology: 'Varies between 100ms-250ms+. Check status site for current latencies.'
           pubnub: 'Global average of 250ms. End-to-end within 100ms. "See support article":https://support.pubnub.com/support/solutions/articles/14000043680.'
-          pusher: "No data available."
-          realtime: "No data available."
+          pusher: 'No data available.'
+          realtime: 'No data available.'
       sla:
-        description: "Uptime SLA"
+        description: 'Uptime SLA'
         compare:
-          fanout: "99.999% uptime SLAs."
-          push-technology: "Unclear. SLAs offered but no mention of uptime guarantees."
-          pubnub: "99.999% uptime SLA for premium plans."
-          pusher: "99.9% uptime SLAs for Enterprise plans."
-          realtime: "100% SLA uptime guarantee for enterprise customers."
+          fanout: '99.999% uptime SLAs.'
+          push-technology: 'Unclear. SLAs offered but no mention of uptime guarantees.'
+          pubnub: '99.999% uptime SLA for premium plans.'
+          pusher: '99.9% uptime SLAs for Enterprise plans.'
+          realtime: '100% SLA uptime guarantee for enterprise customers.'
       datacenters:
-        description: "How many globally distributed datacenters?"
+        description: 'How many globally distributed datacenters?'
         compare:
-          fanout: "Four globally-distributed datacenters<br/><br/> The datacenter network comprises three Point of Presence locations in addition to a single Central location."
+          fanout: 'Four globally-distributed datacenters<br/><br/> The datacenter network comprises three Point of Presence locations in addition to a single Central location.'
           push-technology: 'According to the "status site":https://www.pushtechnology.com/status/ Push Technology has at least 3 datacenters across Europe, US, Australia.'
           pubnub: '"16+ datacenters and 175+ edge PoPs":https://ably.com/network?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages across Europe, USA, and Asia Pacific. <br/><br/> This equates to four Amazon geographical regions and ten EC2 availability zones with AWS.'
           pusher: 'Six datacenters across six Amazon geographical regions in Europe, USA, Asia Pacific.  <br/><br/> However, you must choose a "single datacenter":https://pusher.com/docs/channels/miscellaneous/clusters to host your app.'
-          realtime: "3-6 datacenters across Europe, US East, US West"
+          realtime: '3-6 datacenters across Europe, US East, US West'
       latency_routing:
-        description: "Latency based routing that ensures users connect to the closest datacenter"
+        description: 'Latency based routing that ensures users connect to the closest datacenter'
         compare:
-          fanout: "Supports latency based routing."
-          pubnub: "Supports latency based routing."
-          pusher: "Supports latency based routing."
+          fanout: 'Supports latency based routing.'
+          pubnub: 'Supports latency based routing.'
+          pusher: 'Supports latency based routing.'
       mesh_architecture:
         description: '"Mesh architecture":https://faqs.ably.com/do-you-have-any-single-point-of-congestion-that-limits-your-global-performance with no central point of failure'
         compare:
-          fanout: "Unknown."
-          push-technology: "Unknown."
-          pubnub: "Yes."
-          pusher: "No."
-          realtime: "Unknown."
+          fanout: 'Unknown.'
+          push-technology: 'Unknown.'
+          pubnub: 'Yes.'
+          pusher: 'No.'
+          realtime: 'Unknown.'
       replicated:
-        description: "Data replicated in multiple regions"
+        description: 'Data replicated in multiple regions'
         compare:
-          fanout: "Unknown."
+          fanout: 'Unknown.'
           push-technology: 'Supported on "specific plans":https://docs.pushtechnology.com/cloud/6.2.1/manual/html/cloud/plan/cloud_ha.html'
-          pubnub: "Partial. <br/><br/> Full data replication is guaranteed only for Enterprise customers."
-          pusher: "No. <br/><br/> Application data is stored in a single datacenter, making it more susceptible to data loss."
-          realtime: "No support."
+          pubnub: 'Partial. <br/><br/> Full data replication is guaranteed only for Enterprise customers.'
+          pusher: 'No. <br/><br/> Application data is stored in a single datacenter, making it more susceptible to data loss.'
+          realtime: 'No support.'
       qos:
         description: '"Quality of Service":https://faqs.ably.com/message-durability-and-qos-quality-of-service and message delivery guarantee (never lose data during brief disconnections)'
         compare:
-          fanout: "Shaky. <br/><br/> With Fanout, if a message is published whilst a client is briefly disconnected (if they are going through a tunnel, for example), then the message may never arrive to that client."
-          push-technology: "No support."
-          pubnub: "Partial. <br/><br/> PubNub imposes a message queue limit of 100 messages. Message recovery cannot be guaranteed and subscribed clients are at risk of missing messages if disconnected."
-          pusher: "No. <br/><br/> If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message will never arrive to that client."
-          realtime: "Limited support."
+          fanout: 'Shaky. <br/><br/> With Fanout, if a message is published whilst a client is briefly disconnected (if they are going through a tunnel, for example), then the message may never arrive to that client.'
+          push-technology: 'No support.'
+          pubnub: 'Partial. <br/><br/> PubNub imposes a message queue limit of 100 messages. Message recovery cannot be guaranteed and subscribed clients are at risk of missing messages if disconnected.'
+          pusher: 'No. <br/><br/> If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message will never arrive to that client.'
+          realtime: 'Limited support.'
 
 Interoperability:
   interoperability:
-    description: "Interoperability"
+    description: 'Interoperability'
     sections:
       sdks:
-        description: "Support for native client libraries/SDKs"
+        description: 'Support for native client libraries/SDKs'
         compare:
           fanout: '"6 SDKs":https://docs.fanout.io/docs/libraries.'
           push-technology: 'Limited with only "six SDKs":https://download.pushtechnology.com/cloud/latest/sdks.html covering the most popular platforms/languages (JavaScript, Apple, Android, .Net, C, Java).'
@@ -72,550 +72,550 @@ Interoperability:
       opensource:
         description: 'Support for open source and proprietary protocols (e.g. "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages, AMQP, STOMP)'
         compare:
-          fanout: "Limited."
-          push-technology: "No support."
+          fanout: 'Limited.'
+          push-technology: 'No support.'
           pubnub: 'Partial. <br/><br/> PubNub supports "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages but requires additional configuration opposed to native out-of-the-box support.'
-          pusher: "No support."
-          realtime: "No support."
+          pusher: 'No support.'
+          realtime: 'No support.'
       lockin:
         description: Migration and lock-in
         compare:
-          fanout: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          push-technology: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          pubnub: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          pusher: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
-          realtime: "Does not support proprietary realtime vendor protocols, making it harder to migrate in and away."
+          fanout: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          push-technology: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          pubnub: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          pusher: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
+          realtime: 'Does not support proprietary realtime vendor protocols, making it harder to migrate in and away.'
       adapters:
         description: 'Coverage of various languages, frameworks, protocols and transports, including "MQTT":https://ably.com/topic/mqtt?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages'
         compare:
-          fanout: "Limited. Fanout supports a few server environments; Python, Ruby, Php, Node, Golang, and .NET. <br/><br/> HTTP stream is offered for languages they do not support."
+          fanout: 'Limited. Fanout supports a few server environments; Python, Ruby, Php, Node, Golang, and .NET. <br/><br/> HTTP stream is offered for languages they do not support.'
           push-technology: 'Supports Kafka. See "GitHub":https://github.com/pushtechnology/diffusion-kafka-connect.'
           pubnub: >
             Partial. No support for third party queuing, streaming, or compute platforms. <br/><br/> "PubNub Functions":https://www.pubnub.com/products/functions provides a proprietary method of executing code. Unfortunately this limits you to PubNub’s functionality, their JavaScript API, and means you’re required to reproduce existing code already in your systems.
           pusher: No support.
-          realtime: "No support."
+          realtime: 'No support.'
 
 Features:
   features:
-    description: "Features"
+    description: 'Features'
     sections:
       realtime:
-        description: "Realtime data streaming"
-        extra: ""
+        description: 'Realtime data streaming'
+        extra: ''
         compare:
-          fanout: "Yes."
-          push-technology: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'Yes.'
+          push-technology: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       queues:
-        description: "Message and worker queues"
-        extra: "Message queues that provide a reliable and straightforward mechanism to consume, process, store, augment or reroute data efficiently from a realtime platform."
+        description: 'Message and worker queues'
+        extra: 'Message queues that provide a reliable and straightforward mechanism to consume, process, store, augment or reroute data efficiently from a realtime platform.'
         compare:
-          fanout: "No. <br/><br/>Fanout does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers."
-          push-technology: "No."
-          pubnub: "No. <br/><br/> PubNub does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers. However, PubNub Functions appears to be an alternative function-as-a-service approach."
-          pusher: "No. <br/><br/> Pusher does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers."
-          realtime: "No."
+          fanout: 'No. <br/><br/>Fanout does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers.'
+          push-technology: 'No.'
+          pubnub: 'No. <br/><br/> PubNub does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers. However, PubNub Functions appears to be an alternative function-as-a-service approach.'
+          pusher: 'No. <br/><br/> Pusher does not offer any message queuing features or ways to distribute data using once-only pattern to your server workers.'
+          realtime: 'No.'
       webhooks:
         description: Webhooks
         extra: '"Webhooks":/general/events?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages provide a means to get messages, channel lifecycle and present events pushed to your servers over HTTP.'
         compare:
-          fanout: "Yes."
-          push-technology: "No."
-          pubnub: "Partial. <br/><br/> PubNub supports Webhooks if manually requested through support. However they are limited to presence events and do not cover channel lifecycle events."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'Yes.'
+          push-technology: 'No.'
+          pubnub: 'Partial. <br/><br/> PubNub supports Webhooks if manually requested through support. However they are limited to presence events and do not cover channel lifecycle events.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       serverless_functions:
         description: Serverless cloud function invocation
-        extra: "Trigger serverless functions on third platforms like Amazon Lambda, Microsoft Azure or Google Function."
+        extra: 'Trigger serverless functions on third platforms like Amazon Lambda, Microsoft Azure or Google Function.'
         compare:
-          fanout: "Limited."
-          push-technology: "No."
-          pubnub: "Partial. <br/><br/> PubNub allows you to run code on their own platform using their proprietary PubNub Functions. The code you can run is limited to the available Javascript API."
-          pusher: "No."
-          realtime: "Partial. Recommends using a generic Webhook to deliver to an API Gateway that then triggers a function."
+          fanout: 'Limited.'
+          push-technology: 'No.'
+          pubnub: 'Partial. <br/><br/> PubNub allows you to run code on their own platform using their proprietary PubNub Functions. The code you can run is limited to the available Javascript API.'
+          pusher: 'No.'
+          realtime: 'Partial. Recommends using a generic Webhook to deliver to an API Gateway that then triggers a function.'
       presence:
-        description: "Presence"
-        extra: "Subscribe to events when users or devices enter or leave channels/topics."
+        description: 'Presence'
+        extra: 'Subscribe to events when users or devices enter or leave channels/topics.'
         compare:
-          fanout: "No."
-          push-technology: "No."
-          pubnub: "Yes. <br/><br/> PubNub supports a default announcement of 20 members and a self-configurable maximum of 100 members per channel."
-          pusher: "Yes. <br/><br/> Pusher supports a maximum of 100 members per channel."
-          realtime: "Yes."
+          fanout: 'No.'
+          push-technology: 'No.'
+          pubnub: 'Yes. <br/><br/> PubNub supports a default announcement of 20 members and a self-configurable maximum of 100 members per channel.'
+          pusher: 'Yes. <br/><br/> Pusher supports a maximum of 100 members per channel.'
+          realtime: 'Yes.'
       history:
-        description: "Message history"
-        extra: "Dictates whether clients can access historical activity, catching up on missed messages."
+        description: 'Message history'
+        extra: 'Dictates whether clients can access historical activity, catching up on missed messages.'
         compare:
-          fanout: "No."
-          push-technology: "Partial. A fixed number of messages can be retained for a small amount of time. A NoSQL cloud database with built-in real-time notifications keeps data synchronized between users."
-          pubnub: "Yes."
-          pusher: "No."
-          realtime: "Partial. Up to 128 messages can be retained for up to 60 seconds. Although this is disabled by default."
+          fanout: 'No.'
+          push-technology: 'Partial. A fixed number of messages can be retained for a small amount of time. A NoSQL cloud database with built-in real-time notifications keeps data synchronized between users.'
+          pubnub: 'Yes.'
+          pusher: 'No.'
+          realtime: 'Partial. Up to 128 messages can be retained for up to 60 seconds. Although this is disabled by default.'
       firehose:
         description: Realtime data firehose
         extra: Stream your realtime data published within a realtime platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka.
         compare:
-          fanout: "No."
-          push-technology: "No."
-          pubnub: "No."
-          pusher: "No."
-          realtime: "No."
+          fanout: 'No.'
+          push-technology: 'No.'
+          pubnub: 'No.'
+          pusher: 'No.'
+          realtime: 'No.'
       push:
         description: Native push notifications
         extra: '"Send notifications and updates":https://ably.com/push-notifications?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages to users even when they are offline.'
         compare:
-          fanout: "No."
-          push-technology: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
-          realtime: "Yes."
+          fanout: 'No.'
+          push-technology: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
+          realtime: 'Yes.'
       cname:
         description: Custom domain endpoint (CNAME)
         extra: 'Custom domains allowing you to connect using a CNAME such as "realtime.your-company.com".'
         compare:
-          fanout: "Yes."
-          pubnub: "No. <br/><br/> PubNub only provides support for custom CNAME for non-TLS connections as they do not serve up custom certificates for customers."
-          pusher: "No."
+          fanout: 'Yes.'
+          pubnub: 'No. <br/><br/> PubNub only provides support for custom CNAME for non-TLS connections as they do not serve up custom certificates for customers.'
+          pusher: 'No.'
       announcement:
         description: Announcement channels
-        extra: "Stay updated on what’s happening on the client’s end, connection, disconnection etc."
+        extra: 'Stay updated on what’s happening on the client’s end, connection, disconnection etc.'
         compare:
-          push-technology: "Yes."
-          realtime: "Yes."
+          push-technology: 'Yes.'
+          realtime: 'Yes.'
       ordering:
-        description: "Reliable message ordering"
-        extra: "Ensures messages are delivered to persistently connected subscribers in the order they were published on each channel/topic."
+        description: 'Reliable message ordering'
+        extra: 'Ensures messages are delivered to persistently connected subscribers in the order they were published on each channel/topic.'
         compare:
-          push-technology: "No."
-          realtime: "No."
+          push-technology: 'No.'
+          realtime: 'No.'
       conflation:
-        description: "Conflation"
-        extra: "Ability to reduce the amount of information sent to clients by combining or discarding updates."
+        description: 'Conflation'
+        extra: 'Ability to reduce the amount of information sent to clients by combining or discarding updates.'
         compare:
-          push-technology: "Yes."
-          realtime: "No."
+          push-technology: 'Yes.'
+          realtime: 'No.'
 
 Security:
   security:
-    description: "Security"
+    description: 'Security'
     sections:
       tls:
-        description: "TLS connection"
+        description: 'TLS connection'
         extra: '"TLS connections":https://faqs.ably.com/are-messages-sent-to-and-received-from-ably-securely-using-tls ensure all data in transit is encrypted.'
         compare:
-          fanout: "Yes."
-          pubnub: "Yes."
-          pusher: "Yes."
+          fanout: 'Yes.'
+          pubnub: 'Yes.'
+          pusher: 'Yes.'
       token:
-        description: "Token-based authentication"
+        description: 'Token-based authentication'
         extra: '"Token-based authentication":/core-features/authentication?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages ensures private keys are never shared and instead short-lived tokens are used to authenticate.'
         compare:
-          fanout: "Yes."
+          fanout: 'Yes.'
           pubnub: >
             No. <br/><br/> PubNub offers an authentication scheme called PAM that allows granular permissions to be configured per client. These permissions are stored on PubNub's servers however which means it is your responsibility to keep a client's permissions in sync with PubNub at all times.
           pusher: 'Yes. <br/><br/> Pusher requires a separate authentication request for every channel. The recent "Authorized Connections":https://pusher.com/docs/client_api_guide/client_authorized_connections feature, introduced in December 2018, improved this by adding more granular channel permissions.'
       jwt:
-        description: "JSON Web Token (JWT)"
+        description: 'JSON Web Token (JWT)'
         extra: '"JWT":/core-features/authentication#token-authentication?utm_source={{COMPANY_ID_0}}_v_{{COMPANY_ID_1}}&utm_medium=compare_pages allows for easy integration with existing authentication systems, along with ensuring private keys are never shared.'
         compare:
-          fanout: "Yes. <br/><br/> Fanout uses Runscope JWT authentication."
-          pubnub: "No."
-          pusher: "Partial. <br/><br/> Pusher only supports JWT in certain products."
+          fanout: 'Yes. <br/><br/> Fanout uses Runscope JWT authentication.'
+          pubnub: 'No.'
+          pusher: 'Partial. <br/><br/> Pusher only supports JWT in certain products.'
       key_permissions:
-        description: "Configurable private key permissions"
+        description: 'Configurable private key permissions'
         extra: 'API keys with "configurable permissions":https://faqs.ably.com/setting-up-and-managing-api-keys including restrictions on channels or operations.'
         compare:
-          fanout: "No."
-          pubnub: "No."
-          pusher: "No."
+          fanout: 'No.'
+          pubnub: 'No.'
+          pusher: 'No.'
       channel_permissions:
-        description: "Configurable channel permissions"
+        description: 'Configurable channel permissions'
         extra: 'The "flexibility to maintain control of your channels":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app, such as requiring SSL/TLS or only identified authenticated clients on a channel.'
         compare:
-          fanout: "No."
-          pubnub: "Yes."
+          fanout: 'No.'
+          pubnub: 'Yes.'
           pusher: >
             *Partial.*<br/><br/> Pusher provides a 'private-' and ‘presence-’ namespace for channels that require authentication. No other channel configuration is available.
       encrypted:
-        description: "Encrypted message payloads"
+        description: 'Encrypted message payloads'
         extra: 'AES "encryption":https://faqs.ably.com/cross-platform-symmetric-encryption-offered-by-the-libraries using the provided private key before publishing to a network. As a result, messages are practically impossible to intercept and view. For sensitive data this ensures your payloads are always secure and opaque.'
         compare:
-          fanout: "No."
-          pusher: "Yes. <br/><br/> PubNub include AES encryption in its client library SDKs."
-          pubnub: "No."
+          fanout: 'No.'
+          pusher: 'Yes. <br/><br/> PubNub include AES encryption in its client library SDKs.'
+          pubnub: 'No.'
 
 AblyCompare:
   performance:
-    description: "Performance and availability"
+    description: 'Performance and availability'
     sections:
       datacenters:
-        description: "Global datacenters"
+        description: 'Global datacenters'
         compare:
-          ably: "*15*<br/><br/>Ably has 15 datacenters spread across four continents so your users are never far from the Ably network. We ensure complete availability by routing to the next-closest alternative datacenter when necessary."
-          pusher: "*One per app.*<br/><br/>Pusher requires you to choose a single datacenter for an app to reside in. All realtime traffic must therefore be routed through a single datacenter, regardless of a user’s location. This has implications for performance, reliability, and availability."
+          ably: '*15*<br/><br/>Ably has 15 datacenters spread across four continents so your users are never far from the Ably network. We ensure complete availability by routing to the next-closest alternative datacenter when necessary.'
+          pusher: '*One per app.*<br/><br/>Pusher requires you to choose a single datacenter for an app to reside in. All realtime traffic must therefore be routed through a single datacenter, regardless of a user’s location. This has implications for performance, reliability, and availability.'
           pubnub: >
             *15* <br/><br/> _(source "PA1":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.mjx7qefdflb8)_
         extra: >
           A global physical data center presence means you can bring your users closer to your data. This reduces latency while ensuring high availability.<br/><br/>"Find out more about Ably's network":https://ably.com/network
       pops:
-        description: "Edge acceleration Points of Presence (PoPs)"
+        description: 'Edge acceleration Points of Presence (PoPs)'
         compare:
-          ably: "*205*<br/><br/>Ably’s edge acceleration PoPs extend our network coverage to clients connecting from locations further afield from core routing data centers, reducing volatility and latency when connecting into the Ably network."
-          pusher: "*Unknown.*"
-          pubnub: "*Unknown.*"
+          ably: '*205*<br/><br/>Ably’s edge acceleration PoPs extend our network coverage to clients connecting from locations further afield from core routing data centers, reducing volatility and latency when connecting into the Ably network.'
+          pusher: '*Unknown.*'
+          pubnub: '*Unknown.*'
         extra: 'Acceleration Points of Presence (PoPs) ensure more stable connections and low latency for clients connecting into a network, improving their experience.<br/><br/>"Find out more about Ably’s PoPs and their 205+ locations":https://ably.com/network'
       latencyrouting:
-        description: "Latency based routing"
+        description: 'Latency based routing'
         compare:
-          ably: "*Yes.*<br/><br/>Ably offers latency based routing that ensures users anywhere in the world connect to the closest datacenter or edge acceleration PoP available to them - ‘closest’ meaning the datacenter with the lowest latency."
+          ably: '*Yes.*<br/><br/>Ably offers latency based routing that ensures users anywhere in the world connect to the closest datacenter or edge acceleration PoP available to them - ‘closest’ meaning the datacenter with the lowest latency.'
           pubnub: >
             *Yes.* <br/><br/> _(source "PA2":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.91xvl0dxjogi)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: >
           Physical proximity doesn’t always equal lowest latency. With latency based DNS routing clients are connected based on latency, not location.<br/><br/>"Learn more about Ably's latency based DNS routing":https://faqs.ably.com/routing-around-network-and-dns-issues
       binary:
-        description: "Binary encoded messages"
+        description: 'Binary encoded messages'
         compare:
-          ably: "*Yes.*"
+          ably: '*Yes.*'
           pubnub: >
             *No.* <br/><br/> _(source "PA3":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.jg9jdlbmx5yd)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Encoding messages in binary format is faster as it reduces bandwidth for sending and receiving messages, and streamlines the processing time for clients and servers when encoding and decoding messages.<br/><br/>"Learn about our binary protocol":https://faqs.ably.com/do-you-binary-encode-your-messages-for-greater-efficiency'
       roundtrip:
-        description: "Global median round trip latencies of sub 50ms"
+        description: 'Global median round trip latencies of sub 50ms'
         compare:
-          ably: "*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection."
+          ably: '*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection.'
           pubnub: >
             *Unknown.* <br/><br/>PubNub advertises sub-250ms worldwide latencies. <br/><br/> _(source "PA4":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ufhpqr4p9f31)_
-          pusher: "*Unknown.*<br/><br/>Pusher does not share latencies."
+          pusher: '*Unknown.*<br/><br/>Pusher does not share latencies.'
         extra: 'Predictably low latency means you can build knowing concrete parameters of performance, designing a better system and end-user experience around that.<br/><br/>"View third-party benchmarking stats":https://faqs.ably.com/round-trip-latency-and-performance'
   redundancy:
-    description: "Redundancy, reliability, integrity of data"
+    description: 'Redundancy, reliability, integrity of data'
     sections:
       mesh:
-        description: "Realtime service mesh architecture with no single point of congestion"
+        description: 'Realtime service mesh architecture with no single point of congestion'
         compare:
-          ably: "*Yes.*<br/><br/>Ably’s realtime service mesh ensures no single point of congestion or failure, designed to always route messages with the least number of network hops."
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. Any latency issues that occur in that datacenter will affect all apps hosted there."
+          ably: '*Yes.*<br/><br/>Ably’s realtime service mesh ensures no single point of congestion or failure, designed to always route messages with the least number of network hops.'
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. Any latency issues that occur in that datacenter will affect all apps hosted there.'
         extra: >
           Having no single point of congestion enables the lowest latency and highest availability.<br/><br/>"Learn about Ably's mesh architecture":https://faqs.ably.com/do-you-have-any-single-point-of-congestion-that-limits-your-global-performance
       centralfailure:
-        description: "No central point of failure"
+        description: 'No central point of failure'
         compare:
           ably: '*Yes.*<br/><br/>The "Ably global platform":https://ably.com/platform is a distributed system designed with no single point of failure. All customers benefit from running their apps in all of our datacenters providing resilience, reliability, and global low latencies.'
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. If that datacenter goes offline then all apps hosted there are affected."
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*<br/><br/>Pusher apps are located in a single datacenter rather than distributed across multiple datacenters. If that datacenter goes offline then all apps hosted there are affected.'
         extra: 'Data replication in multiple regions protects against single points of failure and ensures resilience and reliability of service.<br/><br/>"Learn about how we mitigate against a single point of failure":https://faqs.ably.com/message-durability-and-qos-quality-of-service'
       healing:
-        description: "Self-healing clusters"
+        description: 'Self-healing clusters'
         compare:
-          ably: "*Yes.*<br/><br/>The Ably service uses a consensus algorithm to communicate between servers, meaning any issues are isolated, intelligently fixed and replaced, and traffic routed to healthy servers."
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>The Ably service uses a consensus algorithm to communicate between servers, meaning any issues are isolated, intelligently fixed and replaced, and traffic routed to healthy servers.'
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*'
         extra: 'Automatic traffic rerouting, server isolation, and repair limit the risk of network problems, ensuring a better quality of service for you and your end-users.<br/><br/>"Learn more about our self-healing clusters":https://faqs.ably.com/self-healing-cluster'
       autonomous:
-        description: "Autonomous datacenters"
+        description: 'Autonomous datacenters'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's datacenters are designed to operate as part of our global cluster when available, but operate autonomously when necessary.
-          pubnub: "*Yes.*<br/><br/>PubNub is also a distributed platform."
-          pusher: "*No.*"
+          pubnub: '*Yes.*<br/><br/>PubNub is also a distributed platform.'
+          pusher: '*No.*'
         extra: >
           Datacenters that operate as part of a global cluster, but also autonomously when needed, provide high availability of service.<br/><br/>"Find out where Ably's servers are located":https://ably.com/network
       replication:
-        description: "Data replicated in multiple regions"
+        description: 'Data replicated in multiple regions'
         compare:
-          ably: "*Yes.*"
+          ably: '*Yes.*'
           pubnub: >
             *Yes.*<br/><br/> _(source "PA5":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.wqteamvn2cnz)_
-          pusher: "*No.*<br/><br/>Data stored in a single datacenter is more susceptible to loss."
+          pusher: '*No.*<br/><br/>Data stored in a single datacenter is more susceptible to loss.'
         extra: >
           This ensures that an outage in any datacenter or region cannot result in data loss.<br/><br/>"Find out about Ably's message delivery guarantee":https://faqs.ably.com/message-durability-and-qos-quality-of-service
       qos:
-        description: "QoS & message delivery guarantee<br/><br/>(Unique to Ably)"
+        description: 'QoS & message delivery guarantee<br/><br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides guaranteed message delivery and continuity across disconnections. Publishers only receive an ACK when data is persisted in two locations, and subscribers never lose data during brief disconnections as we maintain connection state for each client on our servers."
-          pubnub: "*Unknown.*"
-          pusher: "*No.*<br/><br/>If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message published over Pusher will never arrive to that client."
+          ably: '*Yes.*<br/><br/>Ably provides guaranteed message delivery and continuity across disconnections. Publishers only receive an ACK when data is persisted in two locations, and subscribers never lose data during brief disconnections as we maintain connection state for each client on our servers.'
+          pubnub: '*Unknown.*'
+          pusher: '*No.*<br/><br/>If a message is published whilst a client is briefly disconnected (such as going through a tunnel or changing networks), then the message published over Pusher will never arrive to that client.'
         extra: >
           Upon a disconnection, retaining all messages on channels a client was subscribed to, and sending when the client reconnects and resumes its state, ensures messages are never lost and your end-users always receive messages.<br/><br/>"Find out about Ably's QoS and message delivery guarantee":https://faqs.ably.com/message-durability-and-qos-quality-of-service
       connectionrecovery:
-        description: "Continuity and connection state recovery<br/><br/>(Unique to Ably)"
+        description: 'Continuity and connection state recovery<br/><br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides continuity for clients that become disconnected for reasons such as going through a tunnel or changing networks. We store the connection state for each client on our servers so that clients that reconnect within two minutes can resume their connection and receive all messages published whilst they were disconnected."
+          ably: '*Yes.*<br/><br/>Ably provides continuity for clients that become disconnected for reasons such as going through a tunnel or changing networks. We store the connection state for each client on our servers so that clients that reconnect within two minutes can resume their connection and receive all messages published whilst they were disconnected.'
           pubnub: >
             *Partial* <br/><br/>From PubNub:<br />“The default message queue size is 100 messages. Consequently, publishing past 100 messages inevitably results in older messages overflowing the queue and getting discarded.” <br/><br/> _(source "PA6":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.95ye4ptvifhx)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Storing connection state means clients can resume from where they left off, providing a better quality of service as nothing is ever lost.<br/><br/>"Find out more about connection state recovery":https://faqs.ably.com/connection-state-recovery'
       uptimeguarantee:
-        description: "Uptime guarantee<br/><br/>"
+        description: 'Uptime guarantee<br/><br/>'
         compare:
           ably: '*Yes.*<br/><br/>Ably offers varying levels of uptime guarantees depending on your needs. For all of our enterprise customers we provide a 99.999% uptime SLA. If we are unable to meet your SLA goal, "we offer refunds":https://faqs.ably.com/ablys-uptime-guarantee.'
-          pubnub: "*Yes.*"
+          pubnub: '*Yes.*'
           pusher: >
             *No.*<br/><br/>Pusher doesn’t offer an SLA unless you are an Enterprise customer.
         extra: 'Confidence in a service to offer refunds on any downtime. That is what an uptime guarantee means, and it shows a provider values you and your end-users’ experience.<br/><br/>"Learn what we mean with our uptime guarantee":https://faqs.ably.com/ablys-uptime-guarantee'
   core:
-    description: "Core features"
+    description: 'Core features'
     sections:
       presence:
-        description: "Channel presence"
+        description: 'Channel presence'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports a configurable number of presence members and supports 200 members by default, with many more upon request. We also support member state updates such as GPS device location."
+          ably: '*Yes.*<br/><br/>Ably supports a configurable number of presence members and supports 200 members by default, with many more upon request. We also support member state updates such as GPS device location.'
           pubnub: >
             *Yes.* <br/><br/>PubNub supports presence with a default max limit of 100 announce members per channel. <br/><br/> _(source "PA7":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ssz0v2cxjy8u)_
-          pusher: "*Yes.*<br/><br/>Pusher supports presence with 100 members maximum per channel."
+          pusher: '*Yes.*<br/><br/>Pusher supports presence with 100 members maximum per channel.'
         extra: 'Presence allows you to subscribe to events when users or devices enter or leave channels. This is a useful feature for collaborative apps, games and chat rooms.<br/><br/>"Find out more about Presence":/realtime/presence'
       history:
-        description: "Message history (persisted data)"
+        description: 'Message history (persisted data)'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's message history feature provides a means for clients or servers to retrieve messages that were previously published on a channel.
-          pubnub: "*Yes.*"
-          pusher: "*No.*<br/><br/>Pusher does not support message history."
+          pubnub: '*Yes.*'
+          pusher: '*No.*<br/><br/>Pusher does not support message history.'
         extra: 'Clients connecting to a channel can view messages previously published on that channel. This includes instant message rewind upon connection.<br/><br/>"Find out more about our History API":/realtime/history'
       ordering:
-        description: "Reliable message ordering<br/>(Unique to Ably)"
+        description: 'Reliable message ordering<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably ensures that messages are delivered to persistently connected subscribers in the order they were published on each channel using the First-in-First-Out (FIFO) pattern."
+          ably: '*Yes.*<br/><br/>Ably ensures that messages are delivered to persistently connected subscribers in the order they were published on each channel using the First-in-First-Out (FIFO) pattern.'
           pubnub: >
             *No.* <br/><br/> _(source "PA8":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.s5n1v4t4pp8r)_
-          pusher: "*No.*<br/><br/>Pusher does not support reliable message ordering."
+          pusher: '*No.*<br/><br/>Pusher does not support reliable message ordering.'
         extra: 'For many realtime features, like chat or live collaboration, the ordering of messages is paramount to the end-user experience.<br/><br/>"Find out more about reliable ordering":https://faqs.ably.com/reliable-message-ordering-for-connected-clients'
       idempotent:
-        description: "Idempotent message publishing"
+        description: 'Idempotent message publishing'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports idempotent publishing across all our native client library SDKs."
+          ably: '*Yes.*<br/><br/>Ably supports idempotent publishing across all our native client library SDKs.'
           pubnub: >
             *Unlikely.* <br/><br/>PubNub’s "recommended design pattern":https://support.pubnub.com/hc/en-us/articles/360051496012-How-do-I-handle-publish-timeouts- for publish timeouts is to try the publish again which can result in duplicate publishes.  For this reason, and the lack of any documentation that exists, we believe it’s unlikely idempotency is supported. <br/><br/> _(source "PA9":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.w170mu1nm7vo)_
-          pusher: "*No.*<br/><br/>Pusher does not support idempotent publishing."
+          pusher: '*No.*<br/><br/>Pusher does not support idempotent publishing.'
         extra: 'Idempotent REST publishing assures published messages are only processed once, even if client or connectivity failures cause a publish to be reattempted.<br/><br/>"Learn more about idempotent publishing with Ably":https://ably.com/topic/idempotency'
       deltas:
-        description: "Delta Message Compression"
+        description: 'Delta Message Compression'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports message delta compression on a per channel basis."
+          ably: '*Yes.*<br/><br/>Ably supports message delta compression on a per channel basis.'
           pubnub: >
             *No.*<br/><br/>PubNub does not support message delta compression according to their documentation and SDKs.
-          pusher: "*No.*<br/><br/>Pusher does not support message delta compression."
+          pusher: '*No.*<br/><br/>Pusher does not support message delta compression.'
         extra: 'Delta compression reduces the bandwidth costs required to transmit realtime messages by sending only changes to a stream instead of the entire payload each time.<br/><br/>"Learn more about Delta Message Compression":/realtime/channels/channel-parameters/deltas'
       pushnotifications:
-        description: "Push notifications"
+        description: 'Push notifications'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides a unified API to deliver push notifications, including native iOS and Android push notifications."
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*<br/><br/>Pusher provides push notifications through its “Beams” product."
+          ably: '*Yes.*<br/><br/>Ably provides a unified API to deliver push notifications, including native iOS and Android push notifications.'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*<br/><br/>Pusher provides push notifications through its “Beams” product.'
         extra: 'Send native push notifications to all your end-users.<br/><br/>"Find out more about Push Notifications":/general/push'
       queues:
-        description: "Message and worker queues<br/>(Unique to Ably)"
+        description: 'Message and worker queues<br/>(Unique to Ably)'
         compare:
           ably: >
             *Yes.*<br/><br/>Data published into Ably's realtime system can be moved into traditional message queues for realtime or batch processing. We also support AWS SQS, RabbitMQ, and AMQP. Ably handles all the complexity of doing so.
           pubnub: >
             *Partial.* <br/><br/>PubNub does not offer any native message queue service or mechanism to distribute data using once-only pattern to your server workers. However, it does integrate with services such as Amazon SQS which do provide this. <br/><br/> _(source "PA10":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.x0ofj3jcov16)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Queuing helps scale the consumption of realtime messages.<br/><br/>"Find out more about our Queues":/general/queues'
       webhooks:
-        description: "Webhooks"
+        description: 'Webhooks'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's Webhooks provide a means to get messages, channel lifecycle and presence events pushed to your servers over HTTP.
           pubnub: >
             *Partial.* <br/><br/>PubNub supports Webhooks for presence natively, and recommends the use of Blocks for triggering Webhooks for message events. <br/><br/> _(source "PA11":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.grb44677a49g)_
-          pusher: "*Yes.*"
+          pusher: '*Yes.*'
         extra: 'Publish messages and channel lifecycle and presence events to your own servers over HTTP so you can trigger events in your existing systems and execute on business logic.<br/><br/>"Find out more about Webhooks":/general/events'
       functions:
-        description: "Serverless cloud function invocation<br/>(Unique to Ably)"
+        description: 'Serverless cloud function invocation<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can trigger serverless functions on any third party cloud providers such as Amazon Lambda, Microsoft Azure or Google Function."
+          ably: '*Yes.*<br/><br/>Ably can trigger serverless functions on any third party cloud providers such as Amazon Lambda, Microsoft Azure or Google Function.'
           pubnub: >
             *Partial.* <br/><br/>PubNub allows you to run code on its own platform using proprietary PubNub Functions in the form of “Blocks”. The code you can run in Blocks is limited to the Javascript API available in PubNub’s system. <br/><br/> _(source "PA13":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.6hpsmlo4hpnx)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Trigger events in other cloud systems in response to realtime messages so you can execute on business logic. For example, on-the-fly translation.<br/><br/>"Find out more about Reactor Events":/general/events'
       integrations:
-        description: "Third-party services integration"
+        description: 'Third-party services integration'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can link to third-party services such as Cloudflare Functions, Zapier, IFTTT, and Tray.io."
+          ably: '*Yes.*<br/><br/>Ably can link to third-party services such as Cloudflare Functions, Zapier, IFTTT, and Tray.io.'
           pubnub: >
             *Yes.*<br/><br/>PubNub’s Functions offers some pre-built Blocks from third-party services.
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Similar to Ably, third-party platforms such as Cloudflare and Zapier do a lot of the background heavy lifting to provide increased automation and functionality while reducing operational overhead. Being able to easily link your realtime operations to these existing services means creating even richer, more powerful realtime experiences.<br/><br/>"Learn more about third-party integrations":https://ably.com/integrations'
       firehose:
-        description: "Realtime data firehose<br/>(Unique to Ably)"
+        description: 'Realtime data firehose<br/>(Unique to Ably)'
         compare:
-          ably: "*Yes.*<br/><br/>Stream your realtime data published within the Ably platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka, AWS SQS, and RabbitMQ."
+          ably: '*Yes.*<br/><br/>Stream your realtime data published within the Ably platform directly to another streaming or queueing service such as Amazon Kinesis, Apache Storm or Kafka, AWS SQS, and RabbitMQ.'
           pubnub: >
             *Partial.* <br/><br/>PubNub provides bridges for Kafka and NATS; however, the bridge is designed to stream data out of Kafka or NATs to PubNub.  The Ably Firehose is designed to solve a different problem, streaming data from your clients connected to Ably into your streaming or queueing services. <br/><br/> _(source "PA14":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.twdrgpsj83ge)_
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Linking systems together is a common requirement as services are responsible for different things. Easily being able to do takes unnecessary engineering strain off you.<br/><br/>"Find out more about our Reactor Firehose":/general/firehose'
       cname:
-        description: "Custom domain endpoint (CNAME)"
+        description: 'Custom domain endpoint (CNAME)'
         compare:
           ably: '*Yes.*<br/><br/>Ably supports custom domains for our Enterprise customers allowing them to connect to Ably using a CNAME such as "realtime.your-company.com".'
           pubnub: >
             *No.*<br/><br/>PubNub only provides support for custom CNAME for non-TLS connections as it does not serve up custom certificates for customers.
-          pusher: "*No.*"
+          pusher: '*No.*'
         extra: 'Comply with security policies and firewall restrictions with custom CNAMEs.<br/><br/>"Find out more about our custom domains":https://faqs.ably.com/do-you-support-custom-cname-endpoints'
   distribute:
-    description: "Distribute data streams to third party developers (Unique to Ably)"
+    description: 'Distribute data streams to third party developers (Unique to Ably)'
     sections:
       streamer:
-        description: "Optionally deploy, manage, and distribute data streams to third party developers"
+        description: 'Optionally deploy, manage, and distribute data streams to third party developers'
         compare:
-          ably: "*Yes.*<br/><br/>Deploy data streams to Ably’s managed infrastructure, manage and control who can access those data streams, and distribute them to third party developers as realtime APIs - so they can consume and integrate them into their own apps."
-          pubnub: "*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Deploy data streams to Ably’s managed infrastructure, manage and control who can access those data streams, and distribute them to third party developers as realtime APIs - so they can consume and integrate them into their own apps.'
+          pubnub: '*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer.'
+          pusher: '*No.*'
         extra: 'As realtime API adoption increases so does complexity, cost, and friction of integration for developers wanting to consume realtime data. Being able to easily distribute data streams future-proofs product development requirements and eases API programme creation.<br/><br/>"Learn more about API Streamer":https://ably.com/api-streamer'
       management:
-        description: "Complete management layer"
+        description: 'Complete management layer'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer."
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*Unknown.*<br/><br/>We have not identified any documentation that indicates PubNub provides functionality comparable to API Streamer.'
+          pusher: '*No.*'
         extra: 'This management layer drastically reduces the complexity, cost, and friction of creating self-service realtime API programs that are easy for developers to integrate with. Ably is first to offer this to market.<br/><br/>"Learn more about creating realtime API programs built on Ably’s network":https://ably.com/api-streamer'
   libraries:
-    description: "Client libraries and protocol support"
+    description: 'Client libraries and protocol support'
     sections:
       native:
-        description: "Native client libraries for every popular platform"
+        description: 'Native client libraries for every popular platform'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides 40+ client library SDKs for a considerable range of popular platforms."
-          pubnub: "*Yes.*<br/><br/>PubNub offers a range of client libraries"
-          pusher: "*Yes.*<br/><br/>Pusher offers 40+ SDKs."
+          ably: '*Yes.*<br/><br/>Ably provides 40+ client library SDKs for a considerable range of popular platforms.'
+          pubnub: '*Yes.*<br/><br/>PubNub offers a range of client libraries'
+          pusher: '*Yes.*<br/><br/>Pusher offers 40+ SDKs.'
         extra: >
           You should be able to integrate with the technologies and platforms you’re already building with.<br/><br/>"View our client library SDKs":https://ably.com/download
       websocket:
-        description: "1st class WebSocket support"
+        description: '1st class WebSocket support'
         compare:
           ably: '*Yes.*<br/><br/>The Ably protocol is WebSocket-based with first-class "WebSocket":https://ably.com/topic/websockets support.'
           pubnub: >
             *No.* <br/><br/>PubNub uses HTTP as the transport for their client libraries. A WebSocket compliant interface is provided in some libraries, however this is just a wrapper around an underlying HTTP transport. <br/><br/> _(source "CL1":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.9pjhvqc01dow)_
-          pusher: "*Yes.*"
+          pusher: '*Yes.*'
         extra: 'WebSocket is a widely-supported, bi-directional, feature-rich transport suitable for a range of realtime uses.<br/><br/>"View our supported transports":https://faqs.ably.com/which-transports-are-supported'
       fallback:
-        description: "Fallback to Comet (XHR) and Long Polling for older browsers"
+        description: 'Fallback to Comet (XHR) and Long Polling for older browsers'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*'
         extra: 'Whilst most modern devices support "WebSockets":https://ably.com/topic/websockets, there are situations where the device or the network environment requires use of HTTP transports.<br/><br/>"View our supported transports":https://faqs.ably.com/which-transports-are-supported'
       competitorsupport:
-        description: "Support for proprietary protocols of other realtime platforms<br/>(Unique to Ably)"
+        description: 'Support for proprietary protocols of other realtime platforms<br/>(Unique to Ably)'
         compare:
           ably: >
             *Yes.*<br/><br/>The Ably platform is designed to be protocol-agnostic and ensure protocol interoperability. We support other proprietary realtime protocols and ensure interoperability with Ably's protocol and the other protocols we offer.
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'It should be easy to migrate from, or to, one realtime provider to another.<br/><br/>"Learn more about our Protocol Adapters":https://ably.com/protocols'
       mqtt:
-        description: "MQTT support"
+        description: 'MQTT support'
         compare:
           ably: '*Yes.*<br/><br/>The Ably platform is designed to be protocol-agnostic and ensure protocol interoperability. Ably supports "MQTT":https://ably.com/topic/mqtt'
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'MQTT provides a lightweight messaging protocol for small sensors and mobile devices, optimized for low-bandwidth or unreliable networks. MQTT libraries already exist for almost every IoT device around.<br/><br/>"Find out which protocols we support":https://ably.com/protocols'
       sse:
-        description: "Server-Sent Events (HTTP Streaming) protocol support"
+        description: 'Server-Sent Events (HTTP Streaming) protocol support'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: '"Server-Sent Events":https://ably.com/topic/server-sent-events is a lightweight, subscribe-only protocol for when your end-users need only to receive new event data.<br/><br/>"Find out which protocols we support":https://ably.com/protocols'
       amqp:
-        description: "AMQP and STOMP"
+        description: 'AMQP and STOMP'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'AMQP and STOMP protocols are for provisioning queues and configuring routing, among other things.<br/><br/>"Learn more about AMQP and STOMP at Ably":/general/queues'
       whitelabel:
-        description: "White-label browser library"
+        description: 'White-label browser library'
         compare:
-          ably: "*Yes.*<br/><br/>Ably can provide a white-labelled browser Javascript library with a namespace of your choosing and no reference to Ably in the code."
-          pubnub: "*No.*"
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Ably can provide a white-labelled browser Javascript library with a namespace of your choosing and no reference to Ably in the code.'
+          pubnub: '*No.*'
+          pusher: '*No.*'
         extra: 'Keep your code clean with white-label libraries.<br/><br/>"Find out about our white-label libraries":https://faqs.ably.com/do-you-support-white-label-browser-libraries'
   security:
-    description: "Security"
+    description: 'Security'
     sections:
       tls:
-        description: "TLS connection"
+        description: 'TLS connection'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*'
         extra: 'TLS connections ensure all data in transit is encrypted.<br/><br/>"Find out more about SSL/TLS":https://faqs.ably.com/are-messages-sent-to-and-received-from-ably-securely-using-tls'
       tokens:
-        description: "Token based authentication"
+        description: 'Token based authentication'
         compare:
-          ably: "*Yes.*<br/><br/>Ably allows configurable policies and an identity to be embedded in a token ensuring you have complete control over what actions your users can perform such as limiting which channels they can subscribe or publish to."
-          pubnub: "*Yes.*"
-          pusher: "*Yes.*<br/><br/>Pusher requires a separate authentication request for every channel. And there is no means to specify granular permissions for a channel."
+          ably: '*Yes.*<br/><br/>Ably allows configurable policies and an identity to be embedded in a token ensuring you have complete control over what actions your users can perform such as limiting which channels they can subscribe or publish to.'
+          pubnub: '*Yes.*'
+          pusher: '*Yes.*<br/><br/>Pusher requires a separate authentication request for every channel. And there is no means to specify granular permissions for a channel.'
         extra: >
           Token based authentication ensures your private key is never shared and instead a short-lived token is used to authenticate.<br/><br/>"Find out more about Ably's authentication":/core-features/authentication#token-authentication
       jwt:
-        description: "JSON Web Token support"
+        description: 'JSON Web Token support'
         compare:
-          ably: "*Yes.*<br/><br/>Ably allows for not only Ably Tokens to be embedded within JWTs, but also for JWTs to be signed by Ably API keys and used themselves for authentication."
+          ably: '*Yes.*<br/><br/>Ably allows for not only Ably Tokens to be embedded within JWTs, but also for JWTs to be signed by Ably API keys and used themselves for authentication.'
           pubnub: >
             *No.* <br/><br/> _(source "CL2":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.lftajqade1el)_
-          pusher: "*Partial.*<br/><br/>Pusher only supports JWT in certain products."
+          pusher: '*Partial.*<br/><br/>Pusher only supports JWT in certain products.'
         extra: 'Using JWT allows for easy integration with your existing authentication systems, along with ensuring your private key is never shared.<br/><br/>"Find out more about using JWT with Ably":/core-features/authentication#ably-jwt-process'
       keypermissions:
-        description: "Configurable private key permissions"
+        description: 'Configurable private key permissions'
         compare:
-          ably: "*Yes.*<br/><br/>Ably provides support for private API keys with configurable permissions including restrictions on channels or operations."
-          pubnub: "*No.*<br/><br/>PubNub does not provide configurable private key permissions. It uses a different model where each client’s access is configured with the PubNub Access Manager (PAM)."
-          pusher: "*No.*"
+          ably: '*Yes.*<br/><br/>Ably provides support for private API keys with configurable permissions including restrictions on channels or operations.'
+          pubnub: '*No.*<br/><br/>PubNub does not provide configurable private key permissions. It uses a different model where each client’s access is configured with the PubNub Access Manager (PAM).'
+          pusher: '*No.*'
         extra: 'API keys are a standard method for securing access to an application.<br/><br/>"Find out more about API keys":https://faqs.ably.com/setting-up-and-managing-api-keys'
       channelpermissions:
-        description: "Configurable channel permissions"
+        description: 'Configurable channel permissions'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably’s channel rules provide you with the flexibility you need to build rich and secure realtime apps.
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'Maintain control of your channels, such as requiring SSL/TLS or only identified authenticated clients on a channel.<br/><br/>"Find out more about channel rules":https://faqs.ably.com/what-are-channel-rules-and-how-can-i-use-them-in-my-app'
       encryption:
-        description: "Encryption for message payloads"
+        description: 'Encryption for message payloads'
         compare:
-          ably: "*Yes.*<br/><br/>Ably supports AES encryption."
-          pubnub: "*Yes.*<br/><br/>PubNub provides AES encryption."
+          ably: '*Yes.*<br/><br/>Ably supports AES encryption.'
+          pubnub: '*Yes.*<br/><br/>PubNub provides AES encryption.'
           pusher: >
             *Beta*<br/><br/>End-to-end encryption for Pusher’s channels product is currently in beta.
         extra: >
           Encryption allows messages to be encrypted using the provided private key before they are published. As a result, messages are practically impossible to intercept and view for anyone. For very sensitive data, this ensures you can safely use us knowing your payloads are always secure and opaque.<br/><br/>"Find out more about Ably's encryption":https://faqs.ably.com/cross-platform-symmetric-encryption-offered-by-the-libraries
   compliance:
-    description: "Compliance"
+    description: 'Compliance'
     sections:
       gdpr:
-        description: "EU GDPR compliant"
+        description: 'EU GDPR compliant'
         compare:
-          ably: "*Yes.*<br/><br/>Procedures and processes in place for EU GDPR regulation."
-          pubnub: "*Yes.*"
-          pusher: "“Pusher is committed to complying with the requirements of the GDPR long-term.”"
+          ably: '*Yes.*<br/><br/>Procedures and processes in place for EU GDPR regulation.'
+          pubnub: '*Yes.*'
+          pusher: '“Pusher is committed to complying with the requirements of the GDPR long-term.”'
         extra: 'EU GDPR is regulation introduced to protect consumers and their data.<br/><br/>"Learn more about GDPR":https://en.wikipedia.org/wiki/General_Data_Protection_Regulation'
       soc:
-        description: "SOC 2 Type 2 compliant"
+        description: 'SOC 2 Type 2 compliant'
         compare:
-          ably: "*Yes.*"
-          pubnub: "*Yes.*"
-          pusher: "*No.*"
+          ably: '*Yes.*'
+          pubnub: '*Yes.*'
+          pusher: '*No.*'
         extra: 'SOC 2 Type 2 is a standard designed to help measure how well service organizations conduct and regulate information. The purpose of SOC standards is to provide confidence and peace of mind for organizations when they engage third-party cloud vendors.<br/><br/>"Learn more about SOC 2 Type 2":https://en.wikipedia.org/wiki/SSAE_16'
       hipaa:
-        description: "HIPAA compliant"
+        description: 'HIPAA compliant'
         compare:
-          ably: "*Yes.*<br/><br/>Ably has many customers in the healthcare industry that we provide Business Associate Agreements to."
-          pubnub: "*Yes.*"
-          pusher: "*No.*<br/><br/>Pusher does not currently sign Business Associate Agreements with customers."
+          ably: '*Yes.*<br/><br/>Ably has many customers in the healthcare industry that we provide Business Associate Agreements to.'
+          pubnub: '*Yes.*'
+          pusher: '*No.*<br/><br/>Pusher does not currently sign Business Associate Agreements with customers.'
         extra: 'HIPAA stipulates how Personally Identifiable Information in healthcare in the USA should be protected.<br/><br/>"Learn more about HIPAA":https://en.wikipedia.org/wiki/Health_Insurance_Portability_and_Accountability_Act'
   value:
-    description: "Value"
+    description: 'Value'
     sections:
       usagepricing:
-        description: "Transparent usage based pricing"
+        description: 'Transparent usage based pricing'
         compare:
           ably: >
             *Yes.*<br/><br/>Ably's pricing is simple and transparent. You pay for the messages, peak active channels and peak connections you use for the month. You can either pay for what you've used at the end of the month, or reserve capacity in advance each month and benefit from a discount.
@@ -626,10 +626,10 @@ AblyCompare:
         extra: >
           Pricing should be clear, flexible, and scalable when it comes to realtime messaging.<br/><br/>"Calculate your usage with Ably's pricing calculator":https://ably.com/pricing/calculator
   other:
-    description: "Other important stuff"
+    description: 'Other important stuff'
     sections:
       theme_tune:
-        description: "Theme tune"
+        description: 'Theme tune'
         compare:
           ably: >
             *No.*


### PR DESCRIPTION
## Description

Updates the copy for Ably in the roundtrip latency section of the current comparison pages - I wasn't sure which config file applied so I applied the change equally to both.

First commit does the change, the second one applies default `prettier` styling to the rest of the YAML files - as my IDE wanted to do this (keeping it as feasibly other IDEs with `prettier` format on save would want to as well)

## Review

Test `/compare/ably-vs-pubnub`, check the "Global median round trip latencies..." section has been updated.
