### PR TITLE
chore: update roundtrip latency copy for Ably

### DIFF
--- a/data/compare.yaml
+++ b/data/compare.yaml
@@ -284,9 +284,9 @@ AblyCompare:
           pusher: "*No.*"
         extra: 'Encoding messages in binary format is faster as it reduces bandwidth for sending and receiving messages, and streamlines the processing time for clients and servers when encoding and decoding messages.<br/><br/>"Learn about our binary protocol":https://faqs.ably.com/do-you-binary-encode-your-messages-for-greater-efficiency'
       roundtrip:
-        description: "Global median round trip latencies of sub 65ms"
+        description: "Global median round trip latencies of sub 50ms"
         compare:
-          ably: "*Yes.*<br/><br/>Ably’s round trip latencies, measured as the time taken to publish a message on one connection and receive a message on another connection, dependably range from 5ms to 200ms, with a median global latency of 91ms."
+          ably: "*Yes.*<br/><br/>Ably offers a global median latency of 50ms, with roundtrip latency measured as the time taken to publish a message on one connection and receive a message on another connection."
           pubnub: >
             *Unknown.* <br/><br/>PubNub advertises sub-250ms worldwide latencies. <br/><br/> _(source "PA4":https://docs.google.com/document/d/1MrFOBNhk5R5ttv-w5wVSU9EfCjqpVJaKDTaNgdta_l0/edit#heading=h.ufhpqr4p9f31)_
           pusher: "*Unknown.*<br/><br/>Pusher does not share latencies."


### PR DESCRIPTION
Supersedes https://github.com/ably/docs/pull/2179, same applies as in that PR - this just works off of `nanoc-toolchain` instead