### PR TITLE
EDU-888: Adds dotnet code examples

### DIFF
--- a/content/push/device.textile
+++ b/content/push/device.textile
@@ -6,6 +6,7 @@ languages:
   - android
   - swift
   - objc
+  - csharp
 redirect_from:
   - /realtime/push/activate-subscribe
   - /general/versions/v1.1/push/activate-subscribe
@@ -102,7 +103,7 @@ func getAblyRealtime() -> ARTRealtime {
     // Create options for Ably client configuration.
     ARTClientOptions *options = [[ARTClientOptions alloc] init];
     // Set up options such as API key or authentication URL here.
-    
+
     // Initialize and return a new instance of Ably realtime client with the configured options.
     return [[ARTRealtime alloc] initWithOptions:options];
 }
@@ -153,6 +154,10 @@ ARTRealtime *ably = [self getAblyRealtime];
 [ably.push activate];
 ```
 
+```[csharp]
+ActivatePush = new Command(() => Ably.Push.Activate());
+```
+
 h4. Test your push notification activation
 
 * Use the Ably "dashboard":https://ably.com/accounts or "API":/api/realtime-sdk/push-admin to send a test push notification to a registered device.
@@ -179,7 +184,7 @@ The following diagram demonstrates the process for activating devices from a ser
 <p>Utilize the "push notifications admin API":/api/realtime-sdk/push-admin on your server to register devices.</p>
 </aside>
 
-h4. Activate Android device via server
+h4. Activate Android devices via server
 
 Your application must interact with the Ably SDK to configure server-side registration for push notifications, utilizing the "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager for communication.
 
@@ -190,9 +195,9 @@ ably.push.activate(context, true);
 ably.push.deactivate(context, true);
 ```
 
-Upon activation or deactivation, the Ably SDK broadcasts signals indicating whether to register or deregister the device from your server. It uses @io.ably.broadcast.PUSH_REGISTER_DEVICE@ for registration and @io.ably.broadcast.PUSH_DEREGISTER_DEVICE@ for deregistration. To handle these broadcasts, implement a listener in your app's @AndroidManifest.xml@ and respond by sending back @PUSH_DEVICE_REGISTERED@ or @PUSH_DEVICE_DEREGISTERED@ as appropriate. 
-    
-The following examples set up the server-side activation: 
+Upon activation or deactivation, the Ably SDK broadcasts signals indicating whether to register or deregister the device from your server. It uses @io.ably.broadcast.PUSH_REGISTER_DEVICE@ for registration and @io.ably.broadcast.PUSH_DEREGISTER_DEVICE@ for deregistration. To handle these broadcasts, implement a listener in your app's @AndroidManifest.xml@ and respond by sending back @PUSH_DEVICE_REGISTERED@ or @PUSH_DEVICE_DEREGISTERED@ as appropriate.
+
+The following examples set up the server-side activation:
 
 ```[xml]
 <receiver android:name=".MyAblyBroadcastReceiver">
@@ -240,11 +245,11 @@ The following examples set up the server-side activation:
         }
     }
 ```
-    
-h4. Activate iOS device via server
+
+h4. Activate iOS devices via server
 
 When setting up server-side registration for push notifications on iOS, your application must interact with the Ably SDK to handle device registration and deregistration securely and effectively. Implement the following optional methods from @ARTPushRegistererDelegate@ in your @UIApplicationDelegate@ to customize the registration process:
-    
+
 ```[swift]
 func ablyPushCustomRegister(_ error: ARTErrorInfo?, deviceDetails: ARTDeviceDetails, callback: @escaping (ARTDeviceIdentityTokenDetails?, ARTErrorInfo?) -> Void) {
     if let e = error {
@@ -299,6 +304,59 @@ func ablypushCustomDeregister(_ error: ARTErrorInfo?, deviceId: String, callback
 
 ```
 
+h4. Activate Android and iOS devices via server using .NET
+
+Initialize the specific mobile device. You can achieve this by using either @AppleMobileDevice.Initialize@ or @AndroidMobileDevice.Initialize@. To initialize, you need to pass a valid @Ably.ClientOptions@, which will be used to initialize the Ably realtime client, and an instance of @PushCallbacks@, which you can use to receive notifications when the device is activated, deactivated, or when sync registration fails.
+
+The @Initialize@ method will create an instance of @IRealtimeClient@, which can be used to activate push notifications for the device by calling @client.Push.Activate()@. Activation is not guaranteed to happen immediately. The developer will be notified through the @ActivatedCallback@, which was passed to the @Initialize@ method when setting up push notifications.
+
+```[csharp]
+public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+{
+    Xamarin.Forms.Forms.Init();
+    InitialiseAbly();
+    //...
+
+    return base.FinishedLaunching(app, options);
+}
+
+private void InitialiseAbly()
+{
+    var clientId = ""; // Set a clientId or generate one. It can be later used to send push notifications to the device.
+    var callbacks = new PushCallbacks
+    {
+        ActivatedCallback = error => { /* handle notification */ },
+        DeactivatedCallback = error => { /* handle notification */ },
+        SyncRegistrationFailedCallback = error => { /* handle notification */ },
+    };
+
+    #if __IOS__
+        _realtime = AppleMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
+    #elif __ANDROID__
+        _realtime = AndroidMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
+    #endif
+
+    _realtime.Connect();
+}
+
+private ClientOptions GetAblyOptions(string clientId)
+{
+    var options = new ClientOptions
+    {
+        Key = "{{API_KEY_NAME}}",
+        ClientId = string.IsNullOrWhiteSpace(clientId) ? Guid.NewGuid().ToString("D") : clientId,
+    };
+
+    _realtime = new AblyRealtime(options);
+    // If you are going to use the AblyRealtime client in the app feel free to call Connect here
+    // If not then skip it and add `AutoConnect = false,` to the ClientOptions.
+    _realtime.Connect();
+
+    return options;
+}
+
+```
+
 h4. Test your push notification activation
 
 * Use the Ably "dashboard":https://ably.com/accounts or "API":https://ably.com/docs/api/realtime-sdk/push-admin to send a test push notification to a registered device.
@@ -312,7 +370,7 @@ When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactiva
 <p>The activation, deactivation, and update processes may fail. You should handle the outcomes of these operations appropriately within your push notification lifecycle methods.</p>
 </aside>
 
-- Android := 
+- Android :=
 * To activate implement @io.ably.broadcast.PUSH_ACTIVATE@ in a broadcast intent.
 
 * To deactivate implement @io.ably.broadcast.PUSH_DEACTIVATE@ in a broadcast intent.
@@ -320,7 +378,7 @@ When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactiva
 * To update implement @io.ably.broadcast.PUSH_UPDATE_FAILED@ in a broadcast intent. =:
 
 
-- Swift := 
+- Swift :=
 * To activate implement @func didActivateAblyPush(_ error: ARTErrorInfo?)@
 
 * To deactivate implement @func didDeactivateAblyPush(_ error: ARTErrorInfo?)@
@@ -328,7 +386,7 @@ When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactiva
 * To update implement @func didAblyPushRegistrationFail(_ error: ARTErrorInfo?)@ =:
 
 
-- ObjC := 
+- ObjC :=
 * To activate implement @(void)didActivateAblyPush:(nullable ARTErrorInfo *)error;@
 
 * To deactivate implement @(void)didDeactivateAblyPush:(nullable ARTErrorInfo *)error;@

--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -12,7 +12,6 @@ languages:
   - python
   - php
   - csharp
-  - flutter
 redirect_from:
   - /realtime/push/publish
   - /general/versions/v1.1/push/publish
@@ -254,13 +253,58 @@ var channel = rest.channels.get('pushenabled:foo');
 channel.publish({'name': 'example', 'data': 'data', 'extras': extras});
 ```
 
+```[csharp]
+using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
+
+namespace IO.Ably.Push
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // Assuming you have a method to create or get an AblyRest client
+            var ablyRest = GetAblyRestClient();
+
+            // Create recipient JObject
+            var recipient = new JObject
+            {
+                { "deviceId", "xxxxxxxxxxx" }
+            };
+
+            // Create data JObject with notification details
+            var data = new JObject
+            {
+                ["notification"] = new JObject
+                {
+                    { "title", "Hello from Ably!" },
+                    { "body", "Example push notification from Ably." }
+                }
+            };
+
+            // Publish the push notification
+            await ablyRest.Push.Admin.PublishAsync(recipient, data);
+        }
+
+        static AblyRest GetAblyRestClient()
+        {
+            // Here you should provide the API key or the necessary configuration
+            // to authenticate and create an instance of AblyRest.
+            var clientOptions = new ClientOptions("your-ably-api-key");
+            return new AblyRest(clientOptions);
+        }
+    }
+```
+
+
+
 h3(#client-id). Publish directly using @clientId@
 
 When you need to deliver push notifications to specific users rather than a single device, you can use the @clientId@ to target all devices associated with a particular user. This process is particularly useful for applications where users may have multiple devices, and you want to ensure that all devices receive the notifications seamlessly.
 
 A @clientId@ is set during the device "activation":device#device process.
 
-The following example publishes a push notification using the @clientId@: 
+The following example publishes a push notification using the @clientId@:
 
 ```[jsall]
 var recipient = {
@@ -362,6 +406,18 @@ $data = [ 'push' =>
           ]
         ];
 $rest->push->admin->publish( $recipient, $data );
+```
+
+```[csharp]
+var recipient = new { clientId = "bob" };
+var notification = new {
+    notification = new {
+        title = "Hello from Ably!",
+        body = "Example push notification from Ably."
+    }
+};
+
+rest.Push.Admin.Publish(recipient, notification);
 ```
 
 h3(#recipient). Publish directly using recipient attributes
@@ -494,20 +550,6 @@ var data = new {
 rest.push.admin.publish(recipient, data);
 ```
 
-```[flutter]
-    'deviceId': 'xxxxxxxxxxx',
-};
-var data = {
-    'notification': {
-        'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.',
-    },
-};
-
-rest.push.admin.publish(recipient, data);
-
-```
-
 h2(#via-channels). Publish via channels
 
 Publishing via channels is modeled on Ably's "channel":#channels infrastructure, facilitating the delivery of push notifications across a network of subscribed devices. This process publishes messages through predefined channels, which devices must "subscribe":#sub-channels to in order to   receive updates. This process ensures registered devices in the specified channels recieve the correct push notifications. Publishing via channels is particularly useful for publishing notifications to multiple groups with varying privileges.
@@ -552,6 +594,12 @@ realtime.channels.get("pushenabled:foo").push.subscribeDevice { error
 }];
 ```
 
+```[csharp]
+var channel = realtime.Channels.Get("channelName")
+//Subscribe the device to the push channel, using the device ID
+channel.Push.SubscribeDevice()
+```
+
 The following example shows how to subscribe for push notifications using @clientId@ by calling the @push.subscribeClient()@ method:
 
 ```[android]
@@ -580,6 +628,12 @@ realtime.channels.get("pushenabled:foo").push.subscribeClient { error
 [[realtime.channels get:@"pushenabled:foo"].push subscribeClient:^(ARTErrorInfo *error) {
     // Check error.
 }];
+```
+
+```[csharp]
+var channel = realtime.Channels.Get("channelName")
+//Subscribe the device to the push channel, using the client ID
+channel.Push.SubscribeClient()
 ```
 
 h3(#publish-channels-process). Publish via channels process
@@ -708,4 +762,20 @@ $msg->extras = [
 ];
 $channel = $rest->channels->get('pushenabled:foo');
 $channel->publish($msg);
+```
+
+```[csharp]
+var extrasText = @"{
+    ""push"": {
+      ""notification"": {
+        ""title"": ""Hello from Ably."",
+        ""body"": ""Example push notification from Ably."",
+        ""sound"": ""default"",
+    },
+  },
+}
+";
+
+var extras = new MessageExtras(JToken.Parse(extrasText));
+var message = new Message("messageName", "data", messageExtras: extras);
 ```


### PR DESCRIPTION
This PR:

- Adds .NET code examples to the required areas of the recently updated Push notification docs.
- Removes the leftover Flutter code example (to be updated in a separate Flutter code example update PR).

[EDU-888: Add dotNet to push notifications](https://ably.atlassian.net/browse/EDU-888)