### PR TITLE
EDU-1561: Adds 'push meta channel' info under a new 'error handling' section

### DIFF
--- a/content/metadata-stats/metadata/subscribe.textile
+++ b/content/metadata-stats/metadata/subscribe.textile
@@ -109,11 +109,16 @@ channel.Subscribe(context.Background(), "channel.closed", func(msg *ably.Message
 
 h2(#log). Log events
 
-The @[meta]log@ and @[meta]log:push@ metachannels publish events that aren't otherwise available to clients. For example, if Ably receives an error response when delivering a webhook to your endpoint, Ably sends an event to @[meta]log@ with information about the error.
+The @[meta]log@ and "@[meta]log:push@":/push#Error metachannels publish events that aren't otherwise available to clients.
 
 Errors where the client can be directly notified are **not** published to the metachannels. For example, if a client attempts to publish a message but exceeds a channel rate limit, the client will be notified by an error callback passed to the "publish()":/api/realtime-sdk/channels#publish method.
 
-@[meta]log@ publishes errors related to all resources other than Push Notifications, which are published to @[meta]log:push@.
+The following example subscribes to the @[meta]log@ channel:
+
+```[javascript]
+const channel = realtime.channels.get('[meta]log');
+channel.subscribe(msg => console.log(msg));
+```
 
 h2(#stats). App statistics events
 

--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -1,7 +1,7 @@
 ---
 title: Configure and activate devices
 meta_description: "Learn how to set up and manage device activations for push notifications with Ably, including platform installation, device registration, and handling lifecycle events."
-meta_keywords: "Push, push notifications, Apple push notification service, Google firebase cloud messaging service, Web Push, activate, subscribe"
+meta_keywords: "Push, push notifications, Apple push notification service, Google firebase cloud messaging service, activate, subscribe"
 languages:
   - kotlin
   - java

--- a/content/push/index.textile
+++ b/content/push/index.textile
@@ -1,6 +1,6 @@
 ---
 title: Push notifications
-meta_description: "Ably delivers push notifications to user devices."
+meta_description: "Ably delivers push notifications to user devices or browsers."
 meta_keywords: "Push, push notifications, Apple push notification service, Google Firebase cloud messaging service, APNs, FCM, Web Push"
 redirect_from:
   - /general/push
@@ -79,3 +79,15 @@ Each push target device or browser is associated with a unique @deviceId@ and au
 * By employing a standard "Ably key":/auth/basic or "Token":/auth/token, with a @deviceIdentityToken@, a credential generated during registration to assert the device's or browser's identity, included in the request header.
 
 The service credential management is handled by the "Ably SDK":https://ably.com/docs/sdks, removing the need for the client application to manage device credentials unless accessing the "push admin API":/api/realtime-sdk/push-admin directly via HTTP.
+
+
+h4(#Error). Error handling
+
+Metachannels, such as @[meta]log:push@, publish events and errors that aren't otherwise available to clients. It's important to note that client-returned errors will not be published to this channel.
+
+The following example subscribes to the @[meta]log:push@ channel:
+
+```[javascript]
+const channel = realtime.channels.get('[meta]log:push');
+channel.subscribe(msg => console.log(msg));
+```


### PR DESCRIPTION
This PR:

- Adds 'push meta channel' info under a new 'error handling' section
- Updates and improves /metadata/subscribe [meta]log content 

[EDU-1561: Add mention of push meta channel](https://ably.atlassian.net/browse/EDU-1561)