### PR TITLE
EDU-1438: Adds new Java code example to the 'Publish directly using cl…

### DIFF
--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -260,7 +260,7 @@ When you need to deliver push notifications to specific users rather than a sing
 
 A @clientId@ is set during the device "activation":device#device process.
 
-The following example publishes a push notification using the @clientId@: 
+The following example publishes a push notification using the @clientId@:
 
 ```[jsall]
 var recipient = {
@@ -325,17 +325,18 @@ rest.push.admin.publish(recipient, data: data)
 ```
 
 ```[java]
-Message message = new Message("example", "rest data");
-message.extras = io.ably.lib.util.JsonUtils.object()
-    .add("push", io.ably.lib.util.JsonUtils.object()
-        .add("notification", io.ably.lib.util.JsonUtils.object()
-            .add("title", "Hello from Ably!")
-            .add("body", "Example push notification from Ably."))
-        .add("data", io.ably.lib.util.JsonUtils.object()
-            .add("foo", "bar")
-            .add("baz", "qux")));
+JsonObject payload = JsonUtils.object()
+    .add("notification", JsonUtils.object()
+        .add("title", "Hello from Ably!")
+        .add("body", "Example push notification from Ably.")
+    )
+    .add("data", JsonUtils.object()
+        .add("foo", "bar")
+        .add("baz", "qux")
+    )
+    .toJson();
 
-rest.push.admin.publish(arrayOf(Param("clientId", clientId)), message);
+rest.push.admin.publish(new Param[]{new Param("clientId", "xxxxxxxxxxxx")}, payload);
 ```
 
 ```[python]


### PR DESCRIPTION
This PR:

- Adds new Java code example to the 'Publish directly using clientId section'.
- The original code in the documentation did not function correctly and was identified by the engineering team.

[EDU-1438: Publishing Push notifications, Java example causes error](https://ably.atlassian.net/browse/EDU-1438)