### PR TITLE
Fix broken link, textile was including the : in the URL

### DIFF
--- a/content/partials/types/_push_device.textile
+++ b/content/partials/types/_push_device.textile
@@ -1,6 +1,6 @@
 h2(#push-object). Push Device object
 
-This object is accessible through @client.push@ and provides to "push-compatible devices":/push:
+This object is accessible through @client.push@ and provides to "push-compatible devices":/push :
 
 h3. Methods
 


### PR DESCRIPTION

## Description

Broken link introduced in a release 2 days ago, this PR fixes it. 

