### PR TITLE
[WEB-3834] Fix the heroku buildpack nginx script to a commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
               mkdir build-nginx
               cd build-nginx
               sudo apt install --no-install-recommends -y libssl-dev
-              wget https://raw.githubusercontent.com/heroku/heroku-buildpack-nginx/main/scripts/build_nginx
+              wget https://raw.githubusercontent.com/heroku/heroku-buildpack-nginx/ad3be4d23676ef6382720892257c3c01078b1bf7/scripts/build_nginx
               sed -i.pak 's/https:\/\/ftp.exim.org/ftp:\/\/ftp.exim.org/' build_nginx
               chmod +x ./build_nginx
               ./build_nginx .


### PR DESCRIPTION
This pull request updates the `install-nginx` build script to fetch the `build_nginx` script from a specific commit, this will make sure that we use a known and stable version of the `build_nginx` script, and not be at the mercy of any update