### PR TITLE
EDU-1573: Adds installation section

### DIFF
--- a/content/push/device.textile
+++ b/content/push/device.textile
@@ -17,7 +17,7 @@ redirect_from:
 
 To push notifications with Ably, you must first configure the device using its platform-specific notification service (APNs for iOS or FCM for Android) and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
 
-h3(#configure). Configure devices
+h2(#configure). Configure devices
 
 Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure on the device's operating system or platform, such as iOS with "APNs":https://developer.apple.com/notifications/ or Android with "FCM":https://firebase.google.com/docs/cloud-messaging, as well as on the Ably platform.
 
@@ -25,16 +25,16 @@ Configuration is the first step in setting up push notifications with Ably. This
   <img src="@content/diagrams/push-process-2.png" style="width: 100%" alt="Push Notifications in Ably">
 </a>
 
-h3. Configure an Android device
+h3. Configure FCM for Android devices
 
 * Go to the "Firebase Console.":https://firebase.google.com/
 * Click *add project* and follow the steps to *create and manage service account keys*.
-* Download your Service account key file containing your *PEM cert* and *PEM private key*.
+* Download your service account *JSON file*.
 * In your Ably "dashboard":https://ably.com/accounts, navigate to the *Notifications* tab under your app settings.
 * Go to *push notifications setup*, click *configure push*.
-* Under the *setting up Firebase cloud messaging*, add your *PEM cert* and *PEM private key*. Then, click *save*.
+* Add your service account *JSON file* to the *setting up Firebase cloud messaging* section.
 
-h3. Configure an iOS device
+h3. Configure APNs for iOS devices
 
 * Go to the "Apple Developer Program.":https://developer.apple.com/programs/
 * Use the Apple developer portal to create a *push notification* service certificate for your app.
@@ -53,88 +53,84 @@ h3. Configure an iOS device
 ** Copy everything between and including @-----BEGIN CERTIFICATE-----@ and @-----END CERTIFICATE-----@, and paste it into the *PEM cert* text box of the Apple push notification service section of your Ably notifications app "dashboard":https://ably.com/accounts.
 ** Similarly, copy everything between and including @-----BEGIN PRIVATE KEY-----@ and @-----END PRIVATE KEY-----@, and paste it into the *PEM private key* text box of the same section. Then, click *save*.
 
-h3. Integrate Ably into your app
+h3. Install and set up your Ably SDK
 
-The following steps guide you through the "Ably SDK":https://ably.com/docs/sdks integration process:
-
-```[kotlin]
-class AblyPushNotificationService : FirebaseMessagingService() {
-
-    // This method is overridden to handle any messages received while the app is in the foreground or background.
-    override fun onMessageReceived(message: RemoteMessage) {
-        // Process the incoming message here
-    }
-
-    // This method is overridden to handle token refresh, ensuring that Ably is always updated with the latest token.
-    override fun onNewToken(token: String) {
-        super.onNewToken(token)
-        // Update Ably's server with the new token
-        ActivationContext.getActivationContext(this).onNewRegistrationToken(RegistrationToken.Type.FCM, token)
-    }
-}
-```
+Use the following code to install and set up your Ably SDK:
 
 ```[java]
-// Define the custom action for push notifications
-public class AblyPushNotificationService extends FirebaseMessagingService {
+// Add the Ably SDK into your build.gradle dependencies and ensure there's a reference to Maven in the repositories section:
 
-    // This method is overridden to handle any messages received while the app is in the foreground or background.
-    @Override
-    public void onMessageReceived(@NonNull RemoteMessage message) {
-        // Process the incoming message here
-    }
+dependencies {
+  implementation 'io.ably:ably-android:1.2.0'
+}
 
-    // This method is overridden to handle token refresh, ensuring that Ably is always updated with the latest token.
-    @Override
-    public void onNewToken(@NonNull String token) {
-        super.onNewToken(token);
-        // Update Ably's server with the new token
-        ActivationContext.getActivationContext(this).onNewRegistrationToken(RegistrationToken.Type.FCM, token);
-    }
+repositories {
+  mavenCentral()
 }
 ```
 
 ```[swift]
-// Extend your UIApplicationDelegate to handle remote notification registration lifecycle events.
-func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    // This method is called when APNs has successfully registered the device for push notifications
-    ARTPush.didRegisterForRemoteNotifications(withDeviceToken: deviceToken, realtime: self.getAblyRealtime())
-}
+// Add the Ably SDK to your Podfile:
 
-func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    // This method is called when APNs failed to register the device for push notifications
-    ARTPush.didFailToRegisterForRemoteNotificationsWithError(error, realtime: self.getAblyRealtime())
-}
+pod 'Ably'
 
-// Helper function to configure and return an instance of ARTRealtime
-func getAblyRealtime() -> ARTRealtime {
-    let options = ARTClientOptions()
-    return ARTRealtime(options: options)
-}
+// Install the SDK with:
+
+pod install
+
+// Import the SDK into your files with:
+
+import Ably
 ```
 
 ```[objc]
-// Extend your UIApplicationDelegate to handle remote notification registration lifecycle events.
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    // This method is called when APNs has successfully registered the device for push notifications
-    [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken realtime:[self getAblyRealtime]];
-}
+// Add the Ably SDK to your Podfile:
 
-// This method is called when the device fails to register for remote notifications.
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-    // Call Ably's method to handle the registration failure, passing the error and Ably's realtime client.
-    [ARTPush didFailToRegisterForRemoteNotificationsWithError:error realtime:[self getAblyRealtime]];
-}
+pod 'Ably'
 
-// Helper method to create and return an Ably realtime client.
-- (ARTRealtime *)getAblyRealtime {
-    // Create options for Ably client configuration.
-    ARTClientOptions *options = [[ARTClientOptions alloc] init];
-    // Set up options such as API key or authentication URL here.
+// Install the SDK with:
 
-    // Initialize and return a new instance of Ably realtime client with the configured options.
-    return [[ARTRealtime alloc] initWithOptions:options];
-}
+pod install
+
+// Import the SDK into your files with:
+
+#import "Ably.h"
+```
+
+```[csharp]
+// For Android, install .NET SDK from the package manager console:
+
+PM> Install-Package ably.io.push.android
+
+// For Android, install the .NET package into your project directory using the .NET CLI:
+
+dotnet add package ably.io.push.ios
+
+// For iOS, install .NET SDK from the package manager console:
+
+PM> Install-Package ably.io.push.ios
+
+// For iOS, install the .NET package into your project directory using the .NET CLI:
+
+dotnet add package ably.io.push.ios
+
+// Then, add the SDK to your .cs file:
+
+using IO.Ably;
+using IO.Ably.Realtime;
+```
+
+```[flutter]
+// Update your @pubspec.yaml with the package and version:
+
+dependencies:
+  # ...
+  ably_flutter: [version]
+  # ...
+
+// Import the package into your Dart file:
+
+import 'package:ably_flutter/ably_flutter.dart' as ably;
 ```
 
 h2. Activate devices


### PR DESCRIPTION

This PR

Adds the following sections:
- Install Ably into your app
- Setup your SDK

Improves the wording of the following sections:
- Configure FCM for Android devices
- Configure APNs for iOS devices

Removes the following section:
- Integrate Ably into your app
- -  The information was misleading. It has been put to one side as potential content for an 'advanced user' section

[EDU-1573: Add installation section extend integrate ably section](https://ably.atlassian.net/browse/EDU-1573)