### PR TITLE
EDU-1578: Corrects code examples

### DIFF
--- a/content/push/device.textile
+++ b/content/push/device.textile
@@ -6,6 +6,7 @@ languages:
   - android
   - swift
   - objc
+  - csharp
   - flutter
 redirect_from:
   - /realtime/push/activate-subscribe
@@ -40,14 +41,6 @@ h3. Configure an iOS device
 * In your Ably "dashboard":https://ably.com/accounts, navigate to the *notifications tab* under your app settings.
 * Go to *push notifications setup*, click *configure push*.
 * Add your *.p12* file.
-
-h4. Add Ably Flutter to your iOS project
-
-Include Ably Flutter in your project by adding it to your @pubspec.yaml@ or running:
-
-```[flutter]
-flutter pub add ably_flutter
-```
 
 h3. Integrate Ably into your app
 
@@ -160,6 +153,10 @@ ably.push.activate()
 ```[objc]
 ARTRealtime *ably = [self getAblyRealtime];
 [ably.push activate];
+```
+
+```[csharp]
+ActivatePush = new Command(() => Ably.Push.Activate());
 ```
 
 ```[flutter]
@@ -331,7 +328,7 @@ public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 
 private void InitialiseAbly()
 {
-    var clientId = ""; // Set a clientId or generate one. It can be later used to send push notifications to the device.
+    var clientId = ""; // Set or generate a clientId. Use the clientId to send push notifications to a device.
     var callbacks = new PushCallbacks
     {
         ActivatedCallback = error => { /* handle notification */ },
@@ -339,11 +336,10 @@ private void InitialiseAbly()
         SyncRegistrationFailedCallback = error => { /* handle notification */ },
     };
 
-    #if __IOS__
-        _realtime = AppleMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
-    #elif __ANDROID__
-        _realtime = AndroidMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
-    #endif
+    // IOS
+    _realtime = AppleMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
+    // ANDROID
+    _realtime = AndroidMobileDevice.Initialise(GetAblyOptions(clientId), callbacks);
 
     _realtime.Connect();
 }
@@ -352,7 +348,7 @@ private ClientOptions GetAblyOptions(string clientId)
 {
     var options = new ClientOptions
     {
-        Key = "{{API_KEY_NAME}}",
+        Key = "{{API_KEY}}",
         ClientId = string.IsNullOrWhiteSpace(clientId) ? Guid.NewGuid().ToString("D") : clientId,
     };
 
@@ -363,7 +359,6 @@ private ClientOptions GetAblyOptions(string clientId)
 
     return options;
 }
-
 ```
 
 h4. Test your push notification activation
@@ -380,79 +375,32 @@ When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactiva
 </aside>
 
 - Android :=
-* To activate implement @io.ably.broadcast.PUSH_ACTIVATE@ in a broadcast intent.
+* Handle the push activation: @io.ably.broadcast.PUSH_ACTIVATE@ in a broadcast intent.
 
-* To deactivate implement @io.ably.broadcast.PUSH_DEACTIVATE@ in a broadcast intent.
+* Handle the push deactivation: @io.ably.broadcast.PUSH_DEACTIVATE@ in a broadcast intent.
 
-* To update implement @io.ably.broadcast.PUSH_UPDATE_FAILED@ in a broadcast intent. =:
+* Handle push registration failure: @io.ably.broadcast.PUSH_UPDATE_FAILED@ in a broadcast intent. =:
 
 
 - Swift :=
-* To activate implement @func didActivateAblyPush(_ error: ARTErrorInfo?)@
+* Handle the push activation @func didActivateAblyPush(_ error: ARTErrorInfo?)@
 
-* To deactivate implement @func didDeactivateAblyPush(_ error: ARTErrorInfo?)@
+* Handle the push deactivation @func didDeactivateAblyPush(_ error: ARTErrorInfo?)@
 
-* To update implement @func didAblyPushRegistrationFail(_ error: ARTErrorInfo?)@ =:
+* Handle push registration failure @func didAblyPushRegistrationFail(_ error: ARTErrorInfo?)@ =:
 
 
 - ObjC :=
-* To activate implement @(void)didActivateAblyPush:(nullable ARTErrorInfo *)error;@
+* Handle the push activation: @(void)didActivateAblyPush:(nullable ARTErrorInfo *)error;@
 
-* To deactivate implement @(void)didDeactivateAblyPush:(nullable ARTErrorInfo *)error;@
+* To the handle push deactivation: @(void)didDeactivateAblyPush:(nullable ARTErrorInfo *)error;@
 
-* To update implement @(void)didAblyPushRegistrationFail:(nullable ARTErrorInfo *)error;=:ionFail:(nullable ARTErrorInfo *)error;@ =:
+* Handle push registration failure: @(void)didAblyPushRegistrationFail:(nullable ARTErrorInfo *)error;=:ionFail:(nullable ARTErrorInfo *)error;@ =:
 
 
-The following is an example of how to listen for a push activation event:
+- .NET :=
+* Handle the push activation: @private void HandlePushActivation(ARTErrorInfo error)@
 
-```[android]
-LocalBroadcastManager.getInstance(context.getApplicationContext()).registerReceiver(new BroadcastReceiver() {
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        ErrorInfo error = IntentUtils.getErrorInfo(intent);
-        if (error != null) {
-            // Handle error
-            return;
-        }
-        // Subscribe to channels / listen for push etc.
-    }
-}, new IntentFilter("io.ably.broadcast.PUSH_ACTIVATE"));
+* Handle the push deactivation: @private void HandlePushDeactivation(ARTErrorInfo error)@
 
-ably.push.activate(context);
-```
-
-```[swift]
-// Add the activate method from 'ARTPushRegistererDelegate' to your 'UIApplicationDelegate' class:
-func didActivateAblyPush(_ error: ARTErrorInfo?) {
-    if let error = error {
-        // Handle error
-        return
-    }
-    // Subscribe to channels / listen for push etc.
-}
-
-// Inside your AppDelegate, set the delegate on ARTClientOptions
-let options = ARTClientOptions()
-options.pushRegistererDelegate = self // Or another dedicated delegate class
-
-// Call activate, which will call the delegate method when done:
-ably.push.activate()
-```
-
-```[objc]
-// Add the activate method from 'ARTPushRegistererDelegate' to your 'UIApplicationDelegate' class:
-- (void)didActivateAblyPush:(nullable ARTErrorInfo *)error {
-    if (error) {
-        // Handle error
-        return;
-    }
-    // Subscribe to channels / listen for push etc.
-}
-
-// Inside your AppDelegate, set the delegate on ARTClientOptions
-ARTClientOptions *const options = [[ARTClientOptions alloc] init];
-options.pushRegistererDelegate = self; // Or another dedicated delegate class
-
-// Call activate, which will call the delegate method when done:
-[ably.push activate];
-```
+* Handle push registration failure: @(void)didAblyPushRegistrationFail:(nullable ARTErrorInfo *)error;=:ionFail:(nullable ARTErrorInfo *)error;@ =:

--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -11,6 +11,7 @@ languages:
   - ruby
   - python
   - php
+  - csharp
   - flutter
 redirect_from:
   - /realtime/push/publish
@@ -420,6 +421,21 @@ $recipient = [
 $rest->push->admin->publish( $recipient, $data );
 ```
 
+```[csharp]
+var recipient = new { transport_type: 'apns' };
+
+var notification = new
+{
+    notification = new
+    {
+        title = "Hello from Ably!",
+        body = "Example push notification from Ably."
+    }
+};
+
+rest.Push.Admin.Publish(recipient, notification);
+```
+
 h2(#via-channels). Publish via channels
 
 Publishing via channels is modeled on Ably's "channel":#channels infrastructure, facilitating the delivery of push notifications across a network of subscribed devices. This process publishes messages through predefined channels, which devices must "subscribe":#sub-channels to in order to   receive updates. This process ensures registered devices in the specified channels recieve the correct push notifications. Publishing via channels is particularly useful for publishing notifications to multiple groups with varying privileges.
@@ -464,6 +480,12 @@ realtime.channels.get("pushenabled:foo").push.subscribeDevice { error
 }];
 ```
 
+```[csharp]
+var channel = realtime.Channels.Get("channelName")
+//Subscribe the device to the push channel, using the device ID
+channel.Push.SubscribeDevice()
+```
+
 ```[flutter]
 await realtime.channels.get("pushenabled:foo").push.subscribeDevice();
 ```
@@ -496,6 +518,12 @@ realtime.channels.get("pushenabled:foo").push.subscribeClient { error
 [[realtime.channels get:@"pushenabled:foo"].push subscribeClient:^(ARTErrorInfo *error) {
     // Check error.
 }];
+```
+
+```[csharp]
+var channel = realtime.Channels.Get("channelName")
+//Subscribe the device to the push channel, using the client ID
+channel.Push.SubscribeClient()
 ```
 
 ```[flutter]
@@ -595,6 +623,22 @@ $msg->extras = [
 
 $channel = $rest->channels->get('pushenabled:foo');
 $channel->publish($msg);
+```
+
+```[csharp]
+var extrasText = @"{
+    ""push"": {
+      ""notification"": {
+        ""title"": ""Hello from Ably."",
+        ""body"": ""Example push notification from Ably."",
+        ""sound"": ""default"",
+    },
+  },
+}
+";
+
+var extras = new MessageExtras(JToken.Parse(extrasText));
+var message = new Message("messageName", "data", messageExtras: extras);
 ```
 
 ```[flutter]


### PR DESCRIPTION
This PR:
- Adds .Net code that was accidentally dropped when addressing merge conflicts in https://github.com/ably/docs/pull/2188
- Removes unneeded flutter content 
- Removes unneeded/duplicate code examples from the "Activation lifecycle section."

[EDU-1578](https://ably.atlassian.net/browse/EDU-1578)


[EDU-1578]: https://ably.atlassian.net/browse/EDU-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ