### PR TITLE
EDU-1579: Adds extra required steps from FAQ

### DIFF
--- a/content/push/device.textile
+++ b/content/push/device.textile
@@ -29,19 +29,29 @@ h3. Configure an Android device
 
 * Go to the "Firebase Console.":https://firebase.google.com/
 * Click *add project* and follow the steps to *create and manage service account keys*.
-* Download your Service account key file containing your Privacy Enhanced Mail (PEM) cert and PEM private key.
-* In your Ably "dashboard":https://ably.com/accounts, navigate to the *notifications tab* under your app settings.
+* Download your Service account key file containing your *PEM cert* and *PEM private key*.
+* In your Ably "dashboard":https://ably.com/accounts, navigate to the *Notifications* tab under your app settings.
 * Go to *push notifications setup*, click *configure push*.
-* Add your *PEM cert* and *PEM private key*.
+* Under the *setting up Firebase cloud messaging*, add your *PEM cert* and *PEM private key*. Then, click *save*.
 
 h3. Configure an iOS device
 
 * Go to the "Apple Developer Program.":https://developer.apple.com/programs/
-* Use the Apple Developer portal to create a *push notification* service certificate for your app.
-* Export the certificate as a *.p12* file.
-* In your Ably "dashboard":https://ably.com/accounts, navigate to the *notifications tab* under your app settings.
-* Go to *push notifications setup*, click *configure push*.
-* Add your *.p12* file.
+* Use the Apple developer portal to create a *push notification* service certificate for your app.
+* Export the certificate as a *.p12 file*.
+* Next, you can either import the *.p12 cert* or create a *PEM file* and copy it into your Ably dashboard:
+
+* Import the *.p12 file*:
+** In your Ably "dashboard":https://ably.com/accounts, navigate to the *Notifications* tab under your app settings.
+** Go to *push notifications setup*, click *configure push* and scroll to the *setting up Apple push notification service* section.
+** Select the *.p12 file* you exported and enter the password you created during the export process.
+** Click *save*. You should receive confirmation that the certificate has been successfully imported.
+** To further confirm the import, refresh the page and check if the *PEM cert* and *private key* text boxes are now populated with the imported key details.
+* Create a *PEM file* from the *.p12 file*:
+** Using "OpenSSL":/https://www.openssl.org/, convert the recently exported *.p12 file* (@io.ably.test.p12@) to a *PEM file* with the following command: @$ openssl pkcs12 -in ./io.ably.test.p12 -out ./io.ably.test.pem -nodes -clcerts@.
+** Open the *PEM file* in your text editor.
+** Copy everything between and including @-----BEGIN CERTIFICATE-----@ and @-----END CERTIFICATE-----@, and paste it into the *PEM cert* text box of the Apple push notification service section of your Ably notifications app "dashboard":https://ably.com/accounts.
+** Similarly, copy everything between and including @-----BEGIN PRIVATE KEY-----@ and @-----END PRIVATE KEY-----@, and paste it into the *PEM private key* text box of the same section. Then, click *save*.
 
 h3. Integrate Ably into your app
 
@@ -255,7 +265,7 @@ class MyAblyBroadcastReceiver : BroadcastReceiver() {
                 val response = Intent("io.ably.broadcast.PUSH_DEVICE_REGISTERED")
 
                 try {
-                    val deviceIdentityToken: String = registerThroughYourServer(device, 
+                    val deviceIdentityToken: String = registerThroughYourServer(device,
                     isNew)
 
                     response.putExtra("deviceIdentityToken", deviceIdentityToken)


### PR DESCRIPTION
This PR:
 - Adds additional steps to doc from the Push FAQ.
 - The user must make amendments to the PEM cert to align with the Ably config
 
[EDU-1579](https://ably.atlassian.net/browse/EDU-1579)

[EDU-1579]: https://ably.atlassian.net/browse/EDU-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ