### PR TITLE
EDU-1580: Adds Python to lang selector

### DIFF
--- a/content/metadata-stats/metadata/subscribe.textile
+++ b/content/metadata-stats/metadata/subscribe.textile
@@ -3,6 +3,7 @@ title: Metadata subscriptions
 meta_description: "Retrieve metadata updates in realtime by subscribing to metachannels."
 languages:
   - javascript
+  - python
 redirect_from:
   - /realtime/metachannels
 ---


### PR DESCRIPTION
This PR:

- Adds Python to the language selector of the page /metadata-stats/metadata/subscribe


[EDU-1580](https://ably.atlassian.net/browse/EDU-1580)

[EDU-1580]: https://ably.atlassian.net/browse/EDU-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ