### PR TITLE
[EDU-1585] Add a loop to Python quickstart

### DIFF
--- a/content/getting-started/quickstart.textile
+++ b/content/getting-started/quickstart.textile
@@ -373,6 +373,12 @@ async def main():
     await ably.connection.once_async('connected')
     print('Connected to Ably')
 
+# Optionally add this loop to stop the process from closing whilst testing if you are running this example outside of any framework
+
+loop = asyncio.get_event_loop()
+loop.create_task(main())
+loop.run_forever()
+
 asyncio.run(main())
 ```
 


### PR DESCRIPTION
## Description

This PR adds an optional loop into the Python quickstart that devs can use to stop the process from exiting in case they're running it outside of a framework.
