### PR TITLE
[EDU-1587] Move Live Cursors payload to subscribe section

### DIFF
--- a/content/spaces/cursors.textile
+++ b/content/spaces/cursors.textile
@@ -45,6 +45,22 @@ window.addEventListener('mousemove', ({ clientX, clientY }) => {
 });
 ```
 
+h2(#subscribe). Subscribe to cursor events
+
+Subscribe to cursor events by registering a listener. Cursor events are emitted whenever a member moves their cursor by calling @set()@. Use the "@subscribe()@":https://sdk.ably.com/builds/ably/spaces/main/typedoc/classes/Cursors.html#subscribe method on the @cursors@ object of a space to receive updates.
+
+<aside data-type='note'>
+<p>The rate at which cursor events are published is controlled by the @outboundBatchInterval@ property set in the "cursor options":#options of a space.</p>
+</aside>
+
+The following is an example of subscribing to cursor events:
+
+```[javascript]
+space.cursors.subscribe('update', (cursorUpdate) => {
+  console.log(cursorUpdate);
+});
+```
+
 The following is an example payload of a cursor event. Cursor events are uniquely identifiable by the @connectionId@ of a cursor.
 
 ```[json]
@@ -72,22 +88,6 @@ The following are the properties of a cursor event payload:
 | position.x | The position of the member's cursor on the X-axis. | Number |
 | position.y | The position of the member's cursor on the Y-axis. | Number |
 | data | An optional arbitrary JSON-serializable object containing additional information about the cursor. | Object |
-
-h2(#subscribe). Subscribe to cursor events
-
-Subscribe to cursor events by registering a listener. Cursor events are emitted whenever a member moves their cursor by calling @set()@. Use the "@subscribe()@":https://sdk.ably.com/builds/ably/spaces/main/typedoc/classes/Cursors.html#subscribe method on the @cursors@ object of a space to receive updates.
-
-<aside data-type='note'>
-<p>The rate at which cursor events are published is controlled by the @outboundBatchInterval@ property set in the "cursor options":#options of a space.</p>
-</aside>
-
-The following is an example of subscribing to cursor events:
-
-```[javascript]
-space.cursors.subscribe('update', (cursorUpdate) => {
-  console.log(cursorUpdate);
-});
-```
 
 h3(#unsubscribe). Unsubscribe from cursor events
 


### PR DESCRIPTION
## Description

This PR moves the live cursors payload example to the subscribe section. This is to keep it consistent with the other features and because it makes more sense to view the payload as part of a subscription. 
