### PR TITLE
[CHAT-398] currentlyTyping is a set not an array

### DIFF
--- a/content/chat/rooms/typing.textile
+++ b/content/chat/rooms/typing.textile
@@ -28,19 +28,19 @@ The following is the structure of a typing event:
 
 ```[json]
 {
-  "currentlyTyping": [
+  "currentlyTyping": {
     "clemons",
     "zoranges",
-  ],
+  },
 }
 ```
 
 The following are the properties of a typing event:
 
 |_. Property |_. Description |_. Type |
-| currentlyTyping | An array of all users currently typing. | Array |
+| currentlyTyping | A set of all users currently typing. | Set |
 
-You can use the length of the @currentlyTyping@ array to decide whether to display individual user names, or that multiple people are typing in your user interface.
+You can use the size of the @currentlyTyping@ set to decide whether to display individual user names, or that multiple people are typing in your user interface.
 
 h3(#unsubscribe). Unsubscribe from typing events
 
@@ -82,7 +82,7 @@ await room.typing.stop();
 
 h2(#retrieve). Retrieve a list of users that are currently typing
 
-Use the "@typing.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#get method to retrieve an array of @clientId@s for all users that are currently typing in the room:
+Use the "@typing.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#get method to retrieve a set of @clientId@s for all users that are currently typing in the room:
 
 ```[javascript]
 const currentlyTypingClientIds = await room.typing.get();


### PR DESCRIPTION
## Description

This PR updates `currentlyTyping` to correctly be a set, rather than an array. 


