### PR TITLE
Auth docs: tweak js code sample

### DIFF
--- a/content/auth/token.textile
+++ b/content/auth/token.textile
@@ -139,12 +139,14 @@ You can specify an authentication callback function when you create the Ably cli
 ```[realtime_javascript]
 const ablyClient = new Realtime({
     authCallback: async (tokenParams, callback) => {
+        let tokenRequest;
         try {
-            const tokenRequest = await createTokenRequest() // Make a network request to your server
-            callback(null, tokenRequest)
-        } catch (error) {
-            callback(error, null)
+            tokenRequest = await obtainTokenRequest(); // Make a network request to your server
+        } catch (err) {
+            callback(err, null);
+            return;
         }
+        callback(null, tokenRequest);
     }
 });
 ```
@@ -152,12 +154,14 @@ const ablyClient = new Realtime({
 ```[realtime_nodejs]
 const ablyClient = new Realtime({
     authCallback: async (tokenParams, callback) => {
+        let tokenRequest;
         try {
-            const tokenRequest = await createTokenRequest() // Make a network request to your server
-            callback(null, tokenRequest)
-        } catch (error) {
-            callback(error, null)
+            tokenRequest = await obtainTokenRequest(); // Make a network request to your server
+        } catch (err) {
+            callback(err, null);
+            return;
         }
+        callback(null, tokenRequest);
     }
 });
 ```


### PR DESCRIPTION
- semicolons - no ASI in sample javascript code please!
- calling the callback inside the try/catch is an antipattern

page to review: token auth

really I would like an authcallback that returns a promise, but until that's implemented, the code snippet for doing this as-is was annoying me