### PR TITLE
EDU-1606: Fixes various typos and grammar errors

### DIFF
--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -17,11 +17,11 @@ redirect_from:
   - /general/push/activate-subscribe
 ---
 
-To push notifications with Ably, you must first configure the device using its platform-specific notification service (APNs for iOS or FCM for Android) and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
+To send push notifications with Ably, you must first configure the device using its platform-specific notification service ("FCM":https://firebase.google.com/docs/cloud-messaging or "APNs":https://developer.apple.com/notifications/) and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
 
 h2(#configure). Configure devices
 
-Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure on the device's operating system or platform, such as iOS with "APNs":https://developer.apple.com/notifications/ or Android with "FCM":https://firebase.google.com/docs/cloud-messaging, as well as on the Ably platform.
+Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure on the device's operating system or platform, as well as on the Ably platform.
 
 <a href="@content/diagrams/push-process-configure-highlighted.png" target="_blank">
   <img src="@content/diagrams/push-process-configure-highlighted.png" style="width: 100%" alt="Push Notifications in Ably">
@@ -154,7 +154,7 @@ self.addEventListener("push", async (event) => {
 
 h2. Activate devices
 
-To receive push notifications using Ably, each device must first register with the platform-specific push notification service — APNs and FCM, or for web push, the service worker registration's push manager. Ably's SDK facilitates this registration process and provides a unified API to manage it across different platforms.
+To receive push notifications using Ably, each device must first register with it's platform-specific push notification service (FCM or APNs). Ably's SDK facilitates this registration process and provides a unified API to manage it across different platforms.
 
 <a href="@content/diagrams/push-process-activate-highlighted.png" target="_blank">
   <img src="@content/diagrams/push-process-activate-highlighted.png" style="width: 100%" alt="Push Notifications in Ably">
@@ -226,7 +226,7 @@ In specific scenarios, especially where strict control over device capabilities 
 
 The following steps explain the server assisted activation process:
 
-# The device initiates the activation process by registering with its respective platform service (APNs or FCM) to obtain a unique device identifier, such as a registration token or device token.
+# The device initiates the activation process by registering with its platform service to obtain a unique device identifier, such as a registration token for FCM or device token for APNs.
 # Instead of registering itself with Ably, the device sends its platform-specific identifier to your server. Your server then uses this identifier to register the device with Ably using Ably's Push Admin API.
 # The server stores and manages the device tokens. It is responsible for updating these tokens in Ably's system whenever they change, which can be triggered by the device sending a new token to the server following the platform service's renewal.
 
@@ -466,7 +466,7 @@ h4. Test your push notification activation
 
 h3. Device activation lifecycle
 
-When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactivate()@":/api/realtime-sdk/push#deactivate methods are called, the device registers with FCM or APNs. In addition, whenever there is an update to the push token (either the APNs device token or the FCM registration token), the Ably SDK attempts to update this token on Ably’s servers.
+When the "@push.activate()@":/api/realtime-sdk/push#activate and "@push.deactivate()@":/api/realtime-sdk/push#deactivate methods are called, the device registers with FCM or APNs. In addition, whenever there is an update to the push token (registration token for FCM or device token for APNs), the Ably SDK attempts to update this token on Ably's servers.
 
 <aside data-type='note'>
 <p>The activation, deactivation, and update processes may fail. You should handle the outcomes of these operations appropriately within your push notification lifecycle methods.</p>

--- a/content/push/configure/web.textile
+++ b/content/push/configure/web.textile
@@ -6,7 +6,7 @@ languages:
   - javascript
 ---
 
-To push notifications with Ably, you must first configure the browser using "Web Push":https://www.w3.org/TR/push-api/ and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
+To send push notifications with Ably, you must first configure browsers using "Web Push":https://www.w3.org/TR/push-api/ and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
 
 h2(#configure). Configure web browsers
 
@@ -15,6 +15,8 @@ Configuration is the first step in setting up push notifications with Ably. This
 <a href="@content/diagrams/push-process-configure-highlighted-web-push.png" target="_blank">
   <img src="@content/diagrams/push-process-configure-highlighted-web-push.png" style="width: 100%" alt="Push Notifications in Ably">
 </a>
+
+The following steps configure a web browser for push notifications using the Ably JavaScript SDK:
 
 * Generate a VAPID (Voluntary Application Server Identification) Key:
 ** When you first activate a web browser using the Ably JavaScript "SDK":https://ably.com/docs/getting-started/setup, Ably automatically creates a VAPID key pair for your application.
@@ -38,7 +40,7 @@ self.addEventListener("push", (event) => {
 
 h3. Install and set up your Ably SDK
 
-Use the following code to install and set up your Ably SDK:
+The following example installs and sets up the Ably SDK:
 
 ```[javascript]
 import Ably from "ably";
@@ -51,7 +53,7 @@ const client = new Ably.Realtime({
 })
 ```
 
-h2. Activate browers
+h2. Activate browsers
 
 To receive push notifications using Ably, each browser must first register with the service worker registration's push manager for web push notifications. Ably's SDK facilitates this registration process and provides a unified API to manage it.
 
@@ -64,8 +66,8 @@ h3(#browser). Activate directly
 Activating a browser for push notifications is typically done directly on the browser itself. Use the "@push.activate()@":/api/realtime-sdk/push#activate method to activate push notifications from a browser. The following steps describe the direct activation process:
 
 # Authenticate the Ably client.
-# Generate a unique identifier for the browser and saves it locally.
-# Activate push notifications for the browers with the service worker registration's push manager, obtaining a unique identifier.
+# Generate a unique identifier for the browser and save it locally.
+# Activate push notifications for the browsers with the service worker registration's push manager, obtaining a unique identifier.
 # Register the browser with Ably, providing its unique identifier (@deviceId@), browser details, and push recipient information.
 # Store the browser's identity token from Ably's response locally for authentication in subsequent updates.
 
@@ -96,7 +98,7 @@ The following steps explain the server-assisted activation process:
 
 # The browser initiates activation by registering with Web Push to obtain a unique identifier, such as VAPID key.
 # Instead of registering with Ably, the browser sends identifier to your server. Your server then uses this identifier to register the browser with Ably using Ably's Push Admin API.
-# The server stores and manages the identifier. It is responsible for updating the identifier in Ably's system whenever there are changes, which can be triggered by the browser sending a updates to the server following the Web Push service's renewal.
+# The server stores and manages the identifier. It is responsible for updating the identifier in Ably's system whenever there are changes, which can be triggered by the browser sending updates to the server following the Web Push service's renewal.
 
 The following diagram demonstrates the process for activating browsers from a server:
 
@@ -108,11 +110,11 @@ The following diagram demonstrates the process for activating browsers from a se
 <p>Utilize the "push notifications admin API":/api/realtime-sdk/push-admin on your server to register browsers.</p>
 </aside>
 
-h4. Activate browers via server
+h4. Activate browsers via server
 
-The following example shows how to activate and deactivate Web Push notifications using a @registerCallback@ and @deregisterCallback@ with the @activate@ method.
+The following examples show how to *activate* and *deactivate* Web Push notifications using a @registerCallback@ and @deregisterCallback@ with the @activate@ method.
 
-To activate a device:
+To activate:
 
 ```[javascript]
 ably.push.activate(async (deviceDetails, callback) => {
@@ -121,7 +123,7 @@ ably.push.activate(async (deviceDetails, callback) => {
 });
 ```
 
-To deavtivate a device:
+To deactivate:
 
 ```[javascript]
 ably.push.deactivate(async (deviceDetails, callback) => {

--- a/content/push/index.textile
+++ b/content/push/index.textile
@@ -15,13 +15,13 @@ redirect_from:
   - /general/smart-notifications
 ---
 
-Push notifications notify user devices or browsers whether or not an application is open and running. They deliver information, such as app updates, social media alerts, or promotional offers, directly to the user's screen. Ably sends push notifications to devices using Google's Firebase Cloud Messaging service ("FCM":https://firebase.google.com/docs/cloud-messaging), Apple's Push Notification Service ("APNs":https://developer.apple.com/notifications/), and the "Web Push API":https://developer.mozilla.org/en-US/docs/Web/API/Push_API. Push notifications don't require a device or browser to stay connected to Ably. Instead, a device' or browser's operating system or web browser maintains its own battery-efficient transport to receive notifications.
+Push notifications notify user devices or browsers regardless of whether an application is open and running. They deliver information, such as app updates, social media alerts, or promotional offers, directly to the user's screen. Ably sends push notifications to devices using "FCM":https://firebase.google.com/docs/cloud-messaging, "APNs":https://developer.apple.com/notifications/, or to browsers using "Web Push":https://developer.mozilla.org/en-US/docs/Web/API/Push_API. Push notifications don't require a device or browser to stay connected to Ably. Instead, a device's or browser's operating system or web browser maintains its own battery-efficient transport to receive notifications.
 
-You can publish push notifications to user device' or browser's "directly":/push/publish/#direct-publishing or "via channels":#via-channels.
+You can publish push notifications to user devices or browsers "directly":/push/publish/#direct-publishing or "via channels":#via-channels.
 
 *Publishing directly* sends push notifications to specific devices or browsers identified by unique identifiers, such as a @deviceId@ or a @clientId@. This approach is akin to sending a personal message or alerts directly to an individual user's device or browser, bypassing the need for channel subscriptions. It excels in targeted and personalized communications, such as alerts specific to a user's actions, account notifications, or customized updates.
 
-*Publishing via channels* uses a "Pub/Sub":/docs/channels/messages model. Messages are sent to channels to which multiple devices or browser can subscribe. When a message is published to a channel, all devices or browser subscribed to that channel receive the notification. This approach is particularly powerful for simultaneously publishing messages to multiple users.
+*Publishing via channels* uses a "Pub/Sub":/docs/channels/messages model. Messages are sent to channels to which multiple devices or browsers can subscribe. When a message is published to a channel, all devices or browsers subscribed to that channel receive the notification. This approach is particularly powerful for simultaneously publishing messages to multiple users.
 
 h2. Push notification process
 
@@ -35,22 +35,22 @@ The following diagram demonstrates the push notification process:
 
 h3. Configure
 
-"Configuring":/push/configure/device#configure push notifications sets your device' or browser's push notification service to operate with the Ably "platform":https://ably.com/docs/. This process includes inputting the necessary credentials into your Ably "dashboard":https://ably.com/accounts.
+"Configuring":/push/configure/device#configure push notifications sets your device's or browser's push notification service to operate with the Ably "platform":https://ably.com/docs/. This process includes inputting the necessary credentials into your Ably "dashboard":https://ably.com/accounts.
 
 h3. Activate
 
-Activate a device or browser for push notifications "directly":/push/configure/device#device or "via a server:":/push/configure/device#server
+Activate devices or browsers for push notifications "directly":/push/configure/device#device or "via a server:":/push/configure/device#server
 
-* Activating *directly* enables the device or browser to recieve push notifications. This process involves obtaining a unique identifier for the device or browser, which serves as a push recipient. Direct activation is typically used when the application can directly handle device or browser registration without intermediaries, providing a straightforward approach to activation.
+* Activating *directly* enables devices or browsers to receive push notifications. This process involves obtaining a device or browser unique identifier, which serves as a push recipient. Direct activation is typically used when the application can directly handle device or browser registration without intermediaries, providing a straightforward approach to activation.
 
-* Activating *via server* delegates the activation process to your server rather than handling it directly on the device or browser. This approach is often preferred to minimize the capabilities assigned to an untrusted device or browser, enhancing security and control. By managing device or browser registrations server-side, you can also centralize activation logistics and handle sensitive operations away from the client.
+* Activating *via server* delegates the activation process to your server rather than handling it directly on devices or browsers. This approach is often preferred to minimize the capabilities assigned to untrusted devices or browsers, enhancing security and control. By managing device or browser registrations server-side, you can also centralize activation logistics and handle sensitive operations away from the client.
 
 h3. Publish
 
 Publish push notifications using Ably via "channels":push/publish#channel-pub or "directly:":/push/publish#direct-publishing
 
 
-* Publishing directly allows for the delivery of push notifications straight to individual devices or browsers. This process is beneficial for targeting specific devices or browsers with unique "@deviceIds@":/push/publish#device-id, "@clientIds@":push/publish#client-id associated with one or more devices or browsers, or "@recipient@":#recipient details particular to the push notification service. Direct publishing is akin to sending a personal, targeted message to a user's device or browser.
+* Publishing directly allows for the delivery of push notifications straight to individual devices or browsers. This process is beneficial for targeting a specific device or browser using a unique "@deviceId@":/push/publish#device-id, "@clientId@":push/publish#client-id, or "@recipient@":#recipient. Direct publishing is akin to sending a personal, targeted message to a user's device or browser.
 
 * Publishing via channels operates similarly to Ably's "Pub/Sub":/docs/channels/messages messaging model, broadcasting notifications to all channel subscribers. This process leverages Ably "channels":/channels to distribute push notifications efficiently to all devices or browsers subscribed to those channels. It is ideal for scenarios where the same information, such as alerts or updates, needs to be sent to multiple users.
 
@@ -58,9 +58,9 @@ h4. Subscribe
 
 If you publish via channels, devices or browsers must subscribe to those channels to receive notifications. This process offers flexibility in managing and delivering notifications. Subscriptions can be made using the @deviceId@ or @clientId@:
 
-* The "@deviceId@":/push/publish#sub-deviceID process subscribes a device or browsers directly to a channel using its unique @deviceId@, assigned by Ably, for push notifications upon device activation. This process links the subscription to the device or browser.
+* The "@deviceId@":/push/publish#sub-deviceID process subscribes devices or browsers directly to a channel using its unique @deviceId@, assigned by Ably, for push notifications upon device activation.
 
-* The "@clientId@":/push/publish#sub-clientID process subscribes all devices or browsers or browsers tied to a particular @clientId@ to a channel in one action, for example the same user's laptop and mobile phone. This approach is useful for subscribing multiple devices or browsers simultaneously.
+* The "@clientId@":/push/publish#sub-clientID process subscribes all devices or browsers tied to a particular @clientId@ to a channel in one action, for example the same user's laptop and mobile phone. This approach is useful for subscribing multiple devices or browsers simultaneously.
 
 h2(#push-admin). Push admin API
 
@@ -74,8 +74,8 @@ Using the push Admin API requires explicit capabilities within a client's creden
 
 Each push target device or browser is associated with a unique @deviceId@ and authentication credentials. Authentication can be achieved in two ways when using the push Admin API:
 
-* By utilizing an Ably token containing the device' or browser's @deviceId@.
+* By utilizing an Ably token containing the device's or browser's @deviceId@.
 
-* By employing a standard "Ably key":/auth/basic or "Token":/auth/token, with a @deviceIdentityToken@, a credential generated during registration to assert the device' or browser's identity, included in the request header.
+* By employing a standard "Ably key":/auth/basic or "Token":/auth/token, with a @deviceIdentityToken@, a credential generated during registration to assert the device's or browser's identity, included in the request header.
 
-The sevice credential management is handled by the "Ably SDK":https://ably.com/docs/sdks, removing the need for the client application to manage device credentials unless accessing the "push admin API":/api/realtime-sdk/push-admin directly via HTTP.
+The service credential management is handled by the "Ably SDK":https://ably.com/docs/sdks, removing the need for the client application to manage device credentials unless accessing the "push admin API":/api/realtime-sdk/push-admin directly via HTTP.

--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -22,7 +22,7 @@ redirect_from:
   - /push/admin
   - /general/versions/v1.1/push/admin
 ---
-Publishing sends push notifications to all specified devices either directly or via channels. This process is facilitated by Ably's realtime messaging infrastructure, which ensures that messages and notifications are delivered instantaneously.
+Publishing sends push notifications to all specified devices or browsers either directly or via channels. This process is facilitated by Ably's realtime messaging infrastructure, which ensures that messages and notifications are delivered instantaneously.
 
 <a href="@content/diagrams/push-process-publish-subscribe-highlighted.png" target="_blank">
   <img src="@content/diagrams/push-process-publish-subscribe-highlighted.png" style="width: 100%" alt="Push Notifications in Ably">
@@ -31,15 +31,15 @@ Publishing sends push notifications to all specified devices either directly or 
 Publish push notifications directly or via channels:
 
 - "Publish directly":#direct-publishing :=
-* *Description:* Messages are sent directly to specified devices without the need for channel subscriptions.
+* *Description:* Messages are sent directly to specified devices or browsers without the need for channel subscriptions.
 
-* *Requirement:* Relies on "@deviceIds@":#device-id, "@clientIds@":#client-id and "recipient attributes":#recipient to target messages directly to devices. =:
+* *Requirement:* Relies on "@deviceIds@":#device-id, "@clientIds@":#client-id and "recipient attributes":#recipient to target messages directly to devices or browsers. =:
 
 
 - "Publish via channels":#via-channels :=
-* *Description:* Messages are sent to multiple devices through specified channels.
+* *Description:* Messages are sent to multiple devices or browsers through specified channels.
 
-* *Requirement:* Devices must be "subscribed":#sub-channels to these channels to receive notifications. =:
+* *Requirement:* Devices or browsers must be "subscribed":#sub-channels to these channels to receive notifications. =:
 
 h2(#payload). Push notification payload structure
 
@@ -115,7 +115,9 @@ You can also override generic values for a field or add specific fields not supp
 
 h3(#apns-headers). APNs Headers
 
-To enable background notifications on iOS, you must include specific headers in the notification. You can specify these headers by adding an @apns-headers@ object, which should contain all the desired APNs headers, as part of the @apns@ object. The following example shows how a background notification would appear:
+To enable background notifications on iOS, you must include specific headers in the notification. You can specify these headers by adding an @apns-headers@ object, which should contain all the desired APNs headers, as part of the @apns@ object.
+
+The following example shows a background notification:
 
 ```[json]
 {
@@ -137,9 +139,9 @@ To enable background notifications on iOS, you must include specific headers in 
 
 h2(#direct-publishing). Publish directly
 
-Direct publishing sends push notifications directly to individual devices via the  "Ably SDK"::https://ably.com/docs/sdks, bypassing the intermediary of channels. This approach delivers personalized or precise notifications customized for individual users. Direct publishing proves beneficial during the transition phase to Ably's platform and when the objective is to engage existing push notification devices.
+Direct publishing sends push notifications directly to individual devices or browsers via the "Ably SDK":https://ably.com/docs/sdks, bypassing the intermediary of channels. This approach delivers personalized or precise notifications customized for individual users. Direct publishing proves beneficial during the transition phase to Ably's platform and when the objective is to engage existing push notification devices or browsers.
 
-Notifications are targeted explicitly towards devices identified by:
+Push notifications are targeted explicitly towards devices identified by:
 
 * "@deviceId@":#device-id
 * "@clientId@":#client-id
@@ -147,9 +149,9 @@ Notifications are targeted explicitly towards devices identified by:
 
 h3(#device-id). Publish directly using @deviceId@
 
-For applications requiring direct targeting of individual devices, using the @deviceId@ allows for precise control over where each push notification is sent. This approach is ideal when notifications are intended for a specific device, such as alerting users about actions required on a particular device or sending device-specific updates.
+For applications requiring direct targeting of individual devices or browsers, using the @deviceId@ allows for precise control over where each push notification is sent. This approach is ideal when notifications are intended for a specific device or browser, such as alerting users about actions required on a particular device or browser or sending device-specific or server-specific updates.
 
-A @deviceId@ is set during the device "activation":device#device process.
+A @deviceId@ is set during the device or browser "activation":device#device process.
 
 The following example publishes a push notification using the @deviceId@:
 
@@ -250,9 +252,9 @@ await ablyRest.Push.Admin.PublishAsync(recipient, data);
 
 h3(#client-id). Publish directly using @clientId@
 
-When you need to deliver push notifications to specific users rather than a single device, you can use the @clientId@ to target all devices associated with a particular user. This process is particularly useful for applications where users may have multiple devices, and you want to ensure that all devices receive the notifications seamlessly.
+When you need to deliver push notifications to a specific user rather than a single device, you can use the @clientId@ to target all devices associated with a particular user. This process is particularly useful for applications where users may have multiple devices or browsers, and you want to ensure that all devices or browsers receive the notifications seamlessly.
 
-A @clientId@ is set during the device "activation":device#device process.
+A @clientId@ is set during the device or browser "activation":device#device process.
 
 The following example publishes a push notification using the @clientId@:
 
@@ -347,7 +349,7 @@ h3(#recipient). Publish directly using recipient attributes
 
 Direct publishing using recipient attributes allows for a highly tailored approach to sending notifications based on specific criteria such as device tokens or transport types. This method is particularly effective when engaging users across different platforms or devices with customized messages.
 
-Recipient attributes are set during the device "activation":device#device process.
+Recipient attributes are set during the device or browser "activation":device#device process.
 
 The following example publishes a push notification using the recipient attributes:
 
@@ -442,7 +444,7 @@ rest.Push.Admin.Publish(recipient, notification);
 
 h2(#via-channels). Publish via channels
 
-Publishing via channels is modeled on Ably's "channel":#channels infrastructure, facilitating the delivery of push notifications across a network of subscribed devices. This process publishes messages through predefined channels, which devices must "subscribe":#sub-channels to in order to   receive updates. This process ensures registered devices in the specified channels recieve the correct push notifications. Publishing via channels is particularly useful for publishing notifications to multiple groups with varying privileges.
+Publishing via channels is modeled on Ably's "channel":#channels infrastructure, facilitating the delivery of push notifications across a network of subscribed devices or browsers. This process publishes messages through predefined channels, which devices or browsers must "subscribe":#sub-channels to in order to   receive updates. This process ensures registered devices or browsers in the specified channels receive the correct push notifications. Publishing via channels is particularly useful for publishing notifications to multiple groups with varying privileges.
 
 It's important to distinguish — subscribing to push notifications differs from subscribing to ordinary messages, as it requires a specific action to receive updates.
 
@@ -456,7 +458,7 @@ Subscribe to Ably "channels":/channels only if you are publishing push notificat
 
 The following example shows how to subscribe for push notifications using @deviceId@ by calling the @push.subscribeDevice()@ method:
 
-```[android]
+```[java]
 realtime.channels.get("pushenabled:foo").push.subscribeDevice(context);
 
 // or
@@ -501,7 +503,7 @@ await channel.subscribeDevice();
 
 The following example shows how to subscribe for push notifications using @clientId@ by calling the @push.subscribeClient()@ method:
 
-```[android]
+```[java]
 realtime.channels.get("pushenabled:foo").push.subscribeClient();
 
 // or
@@ -552,8 +554,8 @@ Note that the device will receive a push notification published on a channel onl
 
 * The published message includes the extra push notification payload.
 * You explicitly configure a channel rule to enable push notifications on that channel.
-* The device subscribes to the channel.
-* The push notification payload is compatible with the device.
+* The device or browser subscribes to the channel.
+* The push notification payload is compatible with the device or browser.
 
 Add push notifications as special payloads in a standard Ably message's @extras@ field. Ensure this field includes a @push@ attribute object specifying the push payload details:
 


### PR DESCRIPTION
This PR:

- Fixes various typos and grammar errors throughout the push documentation, ensuring improved readability and accuracy.

[EDU-1606](https://ably.atlassian.net/browse/EDU-1606)

[EDU-1606]: https://ably.atlassian.net/browse/EDU-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ