### PR TITLE
[EDU-1639] Update CDN versions to minimum of v2

### DIFF
--- a/content/getting-started/quickstart.textile
+++ b/content/getting-started/quickstart.textile
@@ -62,7 +62,7 @@ blang[javascript].
   To get started with your project, reference the SDK within the @<head>@ of an HTML page:
 
   ```[html]
-  <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
+  <script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
   ```
 
   The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.

--- a/content/getting-started/setup.textile
+++ b/content/getting-started/setup.textile
@@ -50,10 +50,10 @@ Ably SDKs provide a consistent and idiomatic API across a variety of "supported 
 blang[javascript].
   The JavaScript SDK is available via CDN. To get started with your project, reference the SDK within the @<head>@ of an HTML page. The SDK is also available as an "NPM module":https://www.npmjs.com/package/ably.
 
-  When including the SDK from CDN, Ably recommends that you lock into major version @1@ of the library. This means that you will automatically receive minor updates and patches, but you will never receive breaking changes. For example, if you lock into major version @1@ using "@https://cdn.ably.com/lib/ably.min-1.js@", you will receive all minor updates and patch fixes automatically. Additionally, the @.min@ suffix can be dropped if you want the non-minified version for debugging.
+  When including the SDK from CDN, Ably recommends that you lock into major version @1@ of the library. This means that you will automatically receive minor updates and patches, but you will never receive breaking changes. For example, if you lock into major version @2@ using "@https://cdn.ably.com/lib/ably.min-2.js@", you will receive all minor updates and patch fixes automatically. Additionally, the @.min@ suffix can be dropped if you want the non-minified version for debugging.
 
   ```[html]
-  <script lang="text/javascript" src="https://cdn.ably.com/lib/ably.min-1.js"></script>
+  <script lang="text/javascript" src="https://cdn.ably.com/lib/ably.min-2.js"></script>
   ```
 
 blang[nodejs].


### PR DESCRIPTION
## Description

This PR updates the minimum version listed in the CDN imports to v2.

Resolves #2239. 