### PR TITLE
[WEB-3904]: Prefix meta title with product frontmatter

### DIFF
--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -10,10 +10,10 @@ export const Head = ({
   title: string;
   canonical: string;
   description: string;
-  metaTitle: string;
+  metaTitle?: string;
 }) => (
   <Helmet>
-    <title>{metaTitle}</title>
+    <title>{metaTitle || title}</title>
     <meta property="og:title" content={title} />
     <meta property="twitter:title" content={title} />
     <link rel="canonical" href={canonical} />

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 
-export const Head = ({ title, canonical, description }: { title: string; canonical: string; description: string }) => (
+export const Head = ({
+  title,
+  canonical,
+  description,
+  metaTitle,
+}: {
+  title: string;
+  canonical: string;
+  description: string;
+  metaTitle: string;
+}) => (
   <Helmet>
-    <title>{title}</title>
+    <title>{metaTitle}</title>
     <meta property="og:title" content={title} />
     <meta property="twitter:title" content={title} />
     <link rel="canonical" href={canonical} />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -27,6 +27,7 @@ const getSidebarName = (currentProduct: string): SidebarName => {
   switch (currentProduct) {
     case 'home':
     case 'channels':
+    case 'pub_sub':
     case 'SDKs':
       return 'channels';
     case 'api-reference':

--- a/src/components/common/meta-title.test.ts
+++ b/src/components/common/meta-title.test.ts
@@ -1,0 +1,28 @@
+import { getMetaTitle } from './meta-title';
+
+describe('getMetaTitle', () => {
+  it('Returns the meta title for each product', () => {
+    const pageMappings = [
+      ['channels', 'Channels', 'Intro'],
+      ['spaces', 'Spaces', 'Setup'],
+      ['livesync', 'LiveSync', 'Begin'],
+      ['chat', 'Chat', 'Emojis'],
+      ['asset-tracking', 'Asset Tracking', 'Examples'],
+      ['api-reference', 'API References', 'Setup'],
+      ['pub_sub', 'Pub/Sub', 'Authentication'],
+    ];
+
+    pageMappings.forEach((product) => {
+      const [productName, productTitle, pageTitle] = product;
+      const metaTitle = getMetaTitle(pageTitle, productName);
+
+      expect(metaTitle).toBe(`${productTitle} | ${pageTitle}`);
+    });
+  });
+
+  it('Returns a default product for uknown product names', () => {
+    const metaTitle = getMetaTitle('Getting Started', 'unknown');
+
+    expect(metaTitle).toBe('Ably Realtime | Getting Started');
+  });
+});

--- a/src/components/common/meta-title.ts
+++ b/src/components/common/meta-title.ts
@@ -1,0 +1,16 @@
+import { ProductName, ProductTitle } from '../../templates/template-data';
+
+export const getMetaTitle = (title: string, product: ProductName): string => {
+  const productTitle = ({
+    channels: 'Channels',
+    spaces: 'Spaces',
+    livesync: 'LiveSync',
+    chat: 'Chat',
+    'asset-tracking': 'Asset Tracking',
+    'api-reference': 'API References',
+    pub_sub: 'Pub/Sub',
+    home: 'Home',
+  }[product] || 'Ably Realtime') as ProductTitle;
+
+  return `${productTitle} | ${title}`;
+};

--- a/src/pages/sdks/index.tsx
+++ b/src/pages/sdks/index.tsx
@@ -15,7 +15,7 @@ const SDKsIndexPage = ({ location: { search } }: { location: { search: string } 
 
   return (
     <>
-      <Head title={title} metaTitle={title} description={meta_description} canonical={canonical} />
+      <Head title={title} description={meta_description} canonical={canonical} />
       <Layout noSidebar currentProduct="SDKs">
         <SDKsContent tab={tab} />
       </Layout>

--- a/src/pages/sdks/index.tsx
+++ b/src/pages/sdks/index.tsx
@@ -5,7 +5,7 @@ import { useSiteMetadata } from 'src/hooks/use-site-metadata';
 import { Head } from 'src/components/Head';
 
 const SDKsIndexPage = ({ location: { search } }: { location: { search: string } }) => {
-  const meta_title = 'SDKs';
+  const title = 'SDKs';
   const meta_description = '';
   const { canonicalUrl } = useSiteMetadata();
   const canonical = canonicalUrl('/sdks');
@@ -15,7 +15,7 @@ const SDKsIndexPage = ({ location: { search } }: { location: { search: string } 
 
   return (
     <>
-      <Head title={meta_title} description={meta_description} canonical={canonical} />
+      <Head title={title} metaTitle={title} description={meta_description} canonical={canonical} />
       <Layout noSidebar currentProduct="SDKs">
         <SDKsContent tab={tab} />
       </Layout>

--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../data/createPages/constants';
 import { AblyDocument, AblyDocumentMeta, AblyTemplateData, ProductName } from './template-data';
 import { useSiteMetadata } from 'src/hooks/use-site-metadata';
+import { getMetaTitle } from 'src/components/common/meta-title';
 
 const getMetaDataDetails = (
   document: AblyDocument,
@@ -34,7 +35,7 @@ const getMetaDataDetails = (
 
 const META_DESCRIPTION_FALLBACK = `Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime. Organizations like Toyota, Bloomberg, HubSpot, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale.`;
 const NO_LANGUAGE = 'none';
-const META_PRODUCT_FALLBACK = 'channels';
+const META_PRODUCT_FALLBACK = 'pub_sub';
 
 interface ITemplate extends AblyTemplateData {
   showProductNavigation: boolean;
@@ -61,6 +62,7 @@ const Template = ({
 
   // when we don't get a product, peek into the metadata of the page for a default value
   currentProduct ??= getMetaDataDetails(document, 'product', META_PRODUCT_FALLBACK) as ProductName;
+  const metaTitle = getMetaTitle(title, currentProduct) as string;
 
   const filteredLanguages = useMemo(
     () =>
@@ -147,7 +149,7 @@ const Template = ({
   return (
     <>
       <PathnameContext.Provider value={pathname}>
-        <Head title={title} canonical={canonical} description={description} />
+        <Head title={title} metaTitle={metaTitle} canonical={canonical} description={description} />
 
         <SidebarProvider>
           <Layout showProductNavigation={showProductNavigation} currentProduct={currentProduct}>

--- a/src/templates/template-data.d.ts
+++ b/src/templates/template-data.d.ts
@@ -37,6 +37,16 @@ export type AblyPageContext = {
 
 export type ProductName = 'channels' | 'spaces' | 'livesync' | 'chat' | 'asset-tracking' | 'api-reference' | 'home';
 
+export type ProductTitle =
+  | 'Channels'
+  | 'Spaces'
+  | 'LiveSync'
+  | 'Chat'
+  | 'Asset Tracking'
+  | 'API References'
+  | 'Home'
+  | 'Pub/Sub';
+
 export type AblyTemplateData = {
   data: AblyDocumentData;
   location: Location;


### PR DESCRIPTION
## Description

Using the `product` frontmatter data or the template's `currentProduct`, we now prefix the page meta title with the page category, i.e `Pub/Sub` , `API References`. For pages without `product` data, we default to `pub_sub`. 

![Screenshot from 2024-08-20 17-30-27](https://github.com/user-attachments/assets/4e80aa7c-42e7-4f55-a4ba-0373116e472b)

* WEB-3904

## Review

Visit the [review app](https://ably-docs-web-3904-add--8ocjfx.herokuapp.com/) and browse through the pages and check that the titles are showing the prefix as expected. 