### PR TITLE
[WEB-3951] Mark control-api as internal link

### DIFF
--- a/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
+++ b/src/components/blocks/external-references/AElementHelpers/check-link-is-internal.test.ts
@@ -5,29 +5,12 @@ describe('Check link is internal: unit tests', () => {
   it('Asserts that an internal link is internal', () => {
     expect(checkLinkIsInternal('/docs/api/sse')).toBe(true);
   });
-  it('Asserts that an control API link is not internal', () => {
-    expect(checkLinkIsInternal('/docs/api/control-api')).toBe(false);
-  });
 });
 
-const passingRelativeLinks = webPath()
-  .filter((webPath) => !!webPath)
-  .filter((webPath) => !webPath.includes('/api/control-api'));
-
+const passingRelativeLinks = webPath().filter((webPath) => !!webPath);
 const nonAblyAbsoluteLinks = webUrl()
   .filter((webUrl) => !webUrl.startsWith('https://ably.com'))
   .filter((webUrl) => !webUrl.startsWith('https://www.ably.com'));
-
-const controlAPIPath = tuple(
-  webPath(),
-  constantFrom(
-    'https://ably.com/docs/',
-    'http://ably.com/docs/',
-    'https://www.ably.com/docs/',
-    'http://www.ably.com/docs/',
-    '/',
-  ),
-).map(([webPath, validInternalPrefix]) => `${validInternalPrefix}api/control-api${webPath}`);
 
 describe('Check link is internal: Property tests', () => {
   it('Always identifies web paths as internal', () => {
@@ -47,12 +30,5 @@ describe('Check link is internal: Property tests', () => {
   it('Always identifies an empty link as not being internal', () => {
     expect(checkLinkIsInternal('')).toBe(false);
     expect(checkLinkIsInternal()).toBe(false);
-  });
-  it('Always identifies the control API link and children as not being internal', () => {
-    assert(
-      property(controlAPIPath, (link) => {
-        expect(checkLinkIsInternal(link)).toBe(false);
-      }),
-    );
   });
 });

--- a/src/utilities/link-checks.test.ts
+++ b/src/utilities/link-checks.test.ts
@@ -48,10 +48,6 @@ describe('checkLinkIsInternal', () => {
   });
 
   it('respects exclusion list for docs links', () => {
-    expect(checkLinkIsInternal('https://ably.com/docs/api/control-api')).toBeFalsy();
-    expect(checkLinkIsInternal('/api/control-api')).toBeFalsy();
-    expect(checkLinkIsInternal('/api/control-api/')).toBeFalsy();
-
     expect(checkLinkIsInternal('https://ably.com/docs/sdk/cocoa')).toBeFalsy();
     expect(checkLinkIsInternal('/docs/sdk/cocoa')).toBeFalsy();
 

--- a/src/utilities/link-checks.ts
+++ b/src/utilities/link-checks.ts
@@ -1,4 +1,4 @@
-const DOCS_URLS_BUT_EXTERNAL = [/.*\/api\/control-api.*/, /.*\/sdk\/.*/, /^\/tutorials\/?.*/];
+const DOCS_URLS_BUT_EXTERNAL = [/.*\/sdk\/.*/, /^\/tutorials\/?.*/];
 
 /**
  * This regex only matches old hard-coded docs links


### PR DESCRIPTION
## Description

Remove `control-api` as being an external link to allow the internal page to render. Fixes current 404's where `api/control-api`is not being redirected/rendered externally.

* WEB-3951

## Review

* [Review App](https://ably-docs-fix-control-a-j1bffi.herokuapp.com/)
