### PR TITLE
EDU-1638: Adds copy and links to inform user of Web Push availability

### DIFF
--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -19,6 +19,10 @@ redirect_from:
 
 To send push notifications with Ably, you must first configure the device using its platform-specific notification service ("FCM":https://firebase.google.com/docs/cloud-messaging or "APNs":https://developer.apple.com/notifications/) and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
 
+<aside data-type='note'>
+<p>To configure web browsers using Web Push, see "configure web browsers.":/push/configure/web</p>
+</aside>
+
 h2(#configure). Configure devices
 
 Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure on the device's operating system or platform, as well as on the Ably platform.

--- a/content/push/configure/web.textile
+++ b/content/push/configure/web.textile
@@ -8,6 +8,10 @@ languages:
 
 To send push notifications with Ably, you must first configure browsers using "Web Push":https://www.w3.org/TR/push-api/ and integrate it with Ably's infrastructure. You can then activate the push notifications service, either directly or via a server.
 
+<aside data-type='note'>
+<p>To configure devices using FCM or APNs, see "configure devices.":/push/configure/device</p>
+</aside>
+
 h2(#configure). Configure web browsers
 
 Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure for your application.

--- a/content/push/index.textile
+++ b/content/push/index.textile
@@ -15,7 +15,7 @@ redirect_from:
   - /general/smart-notifications
 ---
 
-Push notifications notify user devices or browsers regardless of whether an application is open and running. They deliver information, such as app updates, social media alerts, or promotional offers, directly to the user's screen. Ably sends push notifications to devices using "FCM":https://firebase.google.com/docs/cloud-messaging, "APNs":https://developer.apple.com/notifications/, or to browsers using "Web Push":https://developer.mozilla.org/en-US/docs/Web/API/Push_API. Push notifications don't require a device or browser to stay connected to Ably. Instead, a device's or browser's operating system or web browser maintains its own battery-efficient transport to receive notifications.
+Push notifications notify user devices or browsers regardless of whether an application is open and running. They deliver information, such as app updates, social media alerts, or promotional offers, directly to the user's screen. Ably sends push notifications to devices using "Firebase Cloud Messaging":https://firebase.google.com/docs/cloud-messaging or "Apple Push Notification Service":https://developer.apple.com/notifications/, and to browsers using "Web Push":https://developer.mozilla.org/en-US/docs/Web/API/Push_API. Push notifications don't require a device or browser to stay connected to Ably. Instead, a device's or browser's operating system or web browser maintains its own battery-efficient transport to receive notifications.
 
 You can publish push notifications to user devices or browsers "directly":/push/publish/#direct-publishing or "via channels":#via-channels.
 
@@ -35,7 +35,7 @@ The following diagram demonstrates the push notification process:
 
 h3. Configure
 
-"Configuring":/push/configure/device#configure push notifications sets your device's or browser's push notification service to operate with the Ably "platform":https://ably.com/docs/. This process includes inputting the necessary credentials into your Ably "dashboard":https://ably.com/accounts.
+Configuring push notifications sets your "device's":/push/configure/device or "browser's":/push/configure/web push notification service to operate with the Ably "platform":https://ably.com/docs/. This process includes inputting the necessary credentials into your Ably "dashboard":https://ably.com/accounts.
 
 h3. Activate
 
@@ -48,7 +48,6 @@ Activate devices or browsers for push notifications "directly":/push/configure/d
 h3. Publish
 
 Publish push notifications using Ably via "channels":push/publish#channel-pub or "directly:":/push/publish#direct-publishing
-
 
 * Publishing directly allows for the delivery of push notifications straight to individual devices or browsers. This process is beneficial for targeting a specific device or browser using a unique "@deviceId@":/push/publish#device-id, "@clientId@":push/publish#client-id, or "@recipient@":#recipient. Direct publishing is akin to sending a personal, targeted message to a user's device or browser.
 


### PR DESCRIPTION
This PR:

- Adds new copy and links to inform the user they can configure **web browsers** using web push -- while on the "configure **devices**" section.

- Adds new copy and links to inform the user they can configure **devices** using FCM and APNs -- while on the "configure **web browsers**" section.

[EDU-1638](https://ably.atlassian.net/browse/EDU-1638)



[EDU-1638]: https://ably.atlassian.net/browse/EDU-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ