### PR TITLE
Refactoring the scroll event handling and simplifying the scroll-to-top functionality

### DIFF
--- a/src/components/Redoc/GoTopButton.tsx
+++ b/src/components/Redoc/GoTopButton.tsx
@@ -3,22 +3,24 @@ import Icon from '@ably/ui/core/Icon';
 
 export const GoTopButton = () => {
   const [showGoTop, setShowGoTop] = useState(false);
-
-  const handleVisibleButton = () => {
-    setShowGoTop(window.scrollY > 20);
-  };
+  const scrollOffset = 20;
 
   const handleScrollUp = () => {
-    window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   useEffect(() => {
+    const handleVisibleButton = () => {
+      setShowGoTop(window.scrollY > scrollOffset);
+    };
+
     window.addEventListener('scroll', handleVisibleButton);
+    return () => window.removeEventListener('scroll', handleVisibleButton);
   }, []);
 
   return (
     <div className={showGoTop ? 'block' : 'hidden'} onClick={handleScrollUp}>
-      <div className="rounded text-white py-8 px-8 bg-cool-black bottom-0 left-0 fixed m-16 z-20 cursor-pointer">
+      <div className="rounded text-white py-8 px-8 bg-cool-black fixed bottom-0 left-0 m-16 z-20 cursor-pointer">
         <Icon
           name="icon-gui-link-arrow"
           size="1.5rem"


### PR DESCRIPTION

* Moved the `handleVisibleButton` function inside the `useEffect` hook and added cleanup to remove the event listener when the component unmounts. (`src/components/Redoc/GoTopButton.tsx`)

### Code Simplification:
* Introduced a `scrollOffset` constant to replace the hardcoded value in the `handleVisibleButton` function. (`src/components/Redoc/GoTopButton.tsx`)
* Simplified the `handleScrollUp` function by removing the unnecessary `left` parameter from `window.scrollTo`. (`src/components/Redoc/GoTopButton.tsx`)

### Style Adjustments:
* Adjusted the order of CSS classes in the `div` element to improve readability. (`src/components/Redoc/GoTopButton.tsx`)