### PR TITLE
chat: point docs to umd Chat bundle

### DIFF
--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -65,7 +65,12 @@ Reference the Pub/Sub SDK and the Chat SDK within your HTML file:
 
 ```[html]
 <script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
-<script src="https://cdn.ably.com/lib/ably-chat-0.js"></script>
+<script src="https://cdn.ably.com/lib/ably-chat.umd.cjs-0.js"></script>
+<script>
+  const realtime = new Ably.Realtime({ key: '{{API_KEY}}', clientId: '<clientId>'});
+  const chatClient = new AblyChat.ChatClient(realtime);
+  
+</script>
 ```
 
 h2(#instantiate). Instantiate a client


### PR DESCRIPTION
## Description

A PR description indicating the purpose of the PR.

Related to https://github.com/ably/ably-chat-js/pull/333

Currently, only the UMD variant of Chat works with ably-js, so we need to point to that.

Also expands the example of how to use the CDN-served library.

## Review

See Chat Setup page
