### PR TITLE
Change python example for Channel options without Ably SDK support

### DIFF
--- a/content/channels/options/index.textile
+++ b/content/channels/options/index.textile
@@ -523,9 +523,8 @@ Channel channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
 ```
 
 ```[realtime_python]
-ably_rest = AblyRealtime(key='{{API_KEY}}')
-
-channel = ably_rest.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}`')
+realtime = AblyRealtime(key='{{API_KEY}}')
+channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}`')
 ```
 
 ```[realtime_go]


### PR DESCRIPTION
Change from 'ably_rest' to 'realtime', to fit in with other examples, and reflect that it is a realtime client not a rest client in the example.