### PR TITLE
[WEB-3920] Add Inkeep search widget

### DIFF
--- a/src/components/Header/SearchBar/InkeepSearchBar.tsx
+++ b/src/components/Header/SearchBar/InkeepSearchBar.tsx
@@ -1,0 +1,11 @@
+import { CSSProperties } from 'react';
+
+export const InkeepSearchBar = ({
+  className,
+  extraInputStyle,
+}: {
+  className: string;
+  extraInputStyle: CSSProperties;
+}) => {
+  return <div id="inkeep-search" className={className} style={extraInputStyle}></div>;
+};

--- a/src/components/Header/SearchBar/SearchBar.module.css
+++ b/src/components/Header/SearchBar/SearchBar.module.css
@@ -3,3 +3,7 @@
   min-width: 176px;
   padding-left: 50px;
 }
+
+.searchInputNoPadding {
+  padding-left: 0;
+}

--- a/src/components/Header/SearchBar/SearchBar.test.tsx
+++ b/src/components/Header/SearchBar/SearchBar.test.tsx
@@ -5,13 +5,15 @@ import userEvent from '@testing-library/user-event';
 import { DisplayMode, SearchBar } from '.';
 
 describe('<SearchBar />', () => {
+  const externalScriptsData = {
+    addsearchSiteKey: 'shh-do-not-tell-to-anyone',
+  };
+
   beforeEach(() => {
     useStaticQuery.mockReturnValue({
       site: {
         siteMetadata: {
-          externalScriptsData: {
-            addsearchSiteKey: 'shh-do-not-tell-to-anyone',
-          },
+          externalScriptsData,
         },
       },
     });
@@ -45,5 +47,16 @@ describe('<SearchBar />', () => {
 
     await user.click(screen.getByText('click me'));
     expect(screen.queryByLabelText('suggestions')).not.toBeInTheDocument();
+  });
+
+  describe('when Inkeep is enabled', () => {
+    beforeEach(() => {
+      externalScriptsData.inkeepEnabled = true;
+    });
+
+    it('should render the component', () => {
+      render(<SearchBar displayMode={DisplayMode.FULL_SCREEN} />);
+      expect(document.querySelector('#inkeep-search')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Header/SearchBar/SearchBar.tsx
+++ b/src/components/Header/SearchBar/SearchBar.tsx
@@ -9,9 +9,10 @@ import { useSearch } from 'src/hooks';
 import { isMac } from 'src/utilities';
 
 import { SuggestionBox } from './SuggestionBox';
+import { InkeepSearchBar } from './InkeepSearchBar';
 import { KeyIcon } from './KeyIcon';
 
-import { searchInput } from './SearchBar.module.css';
+import { searchInput, searchInputNoPadding } from './SearchBar.module.css';
 
 export enum DisplayMode {
   FULL_SCREEN = 'FULL_SCREEN',
@@ -44,6 +45,7 @@ export const SearchBar = ({
         siteMetadata {
           externalScriptsData {
             addsearchSiteKey
+            inkeepEnabled
           }
         }
       }
@@ -103,30 +105,36 @@ export const SearchBar = ({
           'mx-24 mt-24 md:m-0': displayLocation !== 'homepage',
         })}
       >
-        <input
-          type="text"
-          ref={textInput}
-          placeholder="Search"
-          className={cn(searchInput)}
-          value={query}
-          onChange={handleSearch}
-          style={{ ...extraInputStyle }}
-        />
-        <Icon name="icon-gui-search" size="24px" additionalCSS="absolute left-16 top-12" />
-        {!isInFocus && (
-          <div className="absolute right-16 top-12 hidden lg:flex items-center justify-end">
-            <KeyIcon className="mr-4">{keyIcon}</KeyIcon>
-            <KeyIcon className="pt-2">K</KeyIcon>
-          </div>
+        {externalScriptsData.inkeepEnabled ? (
+          <InkeepSearchBar className={`${searchInput} ${searchInputNoPadding}`} extraInputStyle={extraInputStyle} />
+        ) : (
+          <>
+            <input
+              type="text"
+              ref={textInput}
+              placeholder="Search"
+              className={cn(searchInput)}
+              value={query}
+              onChange={handleSearch}
+              style={{ ...extraInputStyle }}
+            />
+            <Icon name="icon-gui-search" size="24px" additionalCSS="absolute left-16 top-12" />
+            {!isInFocus && (
+              <div className="absolute right-16 top-12 hidden lg:flex items-center justify-end">
+                <KeyIcon className="mr-4">{keyIcon}</KeyIcon>
+                <KeyIcon className="pt-2">K</KeyIcon>
+              </div>
+            )}
+            <SuggestionBox
+              results={results}
+              error={error}
+              query={query}
+              isActive={isInFocus}
+              displayLocation={String(displayLocation)}
+            />
+          </>
         )}
       </div>
-      <SuggestionBox
-        results={results}
-        error={error}
-        query={query}
-        isActive={isInFocus}
-        displayLocation={String(displayLocation)}
-      />
     </div>
   );
 };

--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -25,44 +25,77 @@ const openHubSpotConversations = () => {
   });
 };
 
+const aiChatSettings = {
+  aiChatSettings: {
+    actionButtonLabels: {
+      getHelpButtonLabel: 'More Help',
+    },
+    chatSubjectName: 'Ably',
+    botAvatarSrcUrl: 'https://storage.googleapis.com/organization-image-assets/ably-botAvatarSrcUrl-1721406747144.png',
+    getHelpCallToActions: [
+      {
+        name: 'Chat with support',
+        url: 'https://ably.com/support',
+        icon: {
+          builtIn: 'IoHelpBuoyOutline',
+        },
+        type: 'INVOKE_CALLBACK',
+        callback: () => {
+          openHubSpotConversations();
+        },
+        shouldCloseModal: true,
+      },
+    ],
+    quickQuestions: [
+      'How do I get presence data for a specific member?',
+      "What's the difference between detach and unsubscribe?",
+      "Can I limit users' access to message interactions?",
+    ],
+  },
+};
+
 export const inkeepOnLoad = (apiKey, integrationId, organizationId) => {
-  window.inkeepWidget = Inkeep().embed({
+  window.inkeepBase = Inkeep({
+    apiKey,
+    integrationId,
+    organizationId,
+    theme: {
+      components: {
+        SearchBarTrigger: {
+          defaultProps: {
+            size: 'expand',
+            variant: 'emphasize',
+          },
+        },
+      },
+    },
+  });
+
+  window.inkeepWidget = inkeepBase.embed({
     componentType: 'ChatButton',
     properties: {
       chatButtonType: 'PILL',
       chatButtonText: 'Ask Ably',
-      baseSettings: {
-        apiKey,
-        integrationId,
-        organizationId,
+      ...aiChatSettings,
+    },
+  });
+
+  loadInkeepSearch();
+};
+
+const loadInkeepSearch = () => {
+  const searchBar = document.getElementById('inkeep-search');
+  if (!searchBar) {
+    return;
+  }
+  window.inkeepBase.embed({
+    componentType: 'SearchBar',
+    targetElement: searchBar,
+    properties: {
+      searchSettings: {
+        placeholder: 'Search',
       },
-      aiChatSettings: {
-        actionButtonLabels: {
-          getHelpButtonLabel: 'More Help',
-        },
-        chatSubjectName: 'Ably',
-        botAvatarSrcUrl:
-          'https://storage.googleapis.com/organization-image-assets/ably-botAvatarSrcUrl-1721406747144.png',
-        getHelpCallToActions: [
-          {
-            name: 'Chat with support',
-            url: 'https://ably.com/support',
-            icon: {
-              builtIn: 'IoHelpBuoyOutline',
-            },
-            type: 'INVOKE_CALLBACK',
-            callback: () => {
-              openHubSpotConversations();
-            },
-            shouldCloseModal: true,
-          },
-        ],
-        quickQuestions: [
-          'How do I get presence data for a specific member?',
-          "What's the difference between detach and unsubscribe?",
-          "Can I limit users' access to message interactions?",
-        ],
-      },
+      ...aiChatSettings,
     },
   });
 };


### PR DESCRIPTION
## Description

If Inkeep is enabled show the Inkeep search widget instead of the existing search. 
___

_Notes_: 
* Current behaviour of adding the search query to the URL query parameter is not added, whilst awaiting for feedback from Inkeep
* No independent feature flag has been added as no there's no current business requirement to be able to turn on/off search independently from Inkeep chat.

* WEB-3920

## Review

* [Preview App](https://ably-docs-web-3920-add--75xwwf.herokuapp.com/docs/) can be used to interact with the Inkeep search widget
  * [Homepage](https://ably-docs-web-3920-add--75xwwf.herokuapp.com/docs/)
  * [Example page with search in header](https://ably-docs-web-3920-add--75xwwf.herokuapp.com/docs/products/channels) 
* Locally, set the `INKEEP_...` variables to enable Inkeep and the search widget