### PR TITLE
Pubnub: tweak message continuity wording

### DIFF
--- a/content/protocols/pubnub.textile
+++ b/content/protocols/pubnub.textile
@@ -87,11 +87,11 @@ PubNub doesn't have the concept of a "message name":/api/realtime-sdk/messages#n
 
 Each UUID, for a given API key in a given region, is treated as a separate subscriber and will count as a separate connection to Ably. This is for presence purposes.
 
-PubNub message continuity is available for 5-20 minutes for up to 100 messages. To provide compatibility, the PubNub Adapter stays connected and attached to channels for 5 minutes after the last subscribe long poll it receives. If the client doesn't connect within 5 minutes, then the adapter will disconnect from Ably. Any subsequent subscribe poll requests will be treated as a new connection.
+The Pubnub adapter provides at least 2 minutes of message continuity over client disconnections. It does this by staying connected to Ably for 2 minutes after the end of the last subscribe long poll it receives. After that time, it will disconnect from Ably (and any presence members entered by that connection will leave). Any further subscribe polls will be treated as a new connection.
 
-Be aware that using many UUIDs, for example using the @unique_uuid@ option to generate a new UUID on page refresh, during development may result in connection counts increasing quickly as each connection will stay alive for 5 minutes.
+PubNub's message continuity only provides the last 100 messages in total, across all channels a client is subscribed to. Using the PubNub Adapter clients will receive the last 100 messages for each channel that they are subscribed to. Note that in Pubnub's protocol there is no way to signal whether this represents all of the messages that were missed or not. Use an Ably SDK if you need to know this information as it will notify clients of "continuity losses":/channels#non-fatal-errors.
 
-PubNub's message continuity only provides the last 100 messages in total, across all channels a client is subscribed to. Using the PubNub Adapter clients will receive the last 100 messages for each channel that they are subscribed to. However, neither mechanism offers the ability to know whether this represents all of the messages that were missed or not. Use an Ably SDK if you need to know this information as it will notify clients and enable them to retrieve messages from "history":/storage-history/history.
+Be aware that using many UUIDs, for example using the @unique_uuid@ option to generate a new UUID on page refresh, during development may result in connection counts increasing quickly as each connection will stay alive for at least 2 minutes.
 
 Ably allows commas in channel names, however PubNub uses them as delimiters and does not. Therefore, PubNub clients cannot access any Ably channels with commas in their names.
 


### PR DESCRIPTION
- we no longer stay connected for 5 minutes, only 2
- we have never provided 5-20 minutes. The original docs said: "In Pubnub’s model, message continuity is available for ‘5-20 minutes’ and up to 100 messages". At some point this was changed to "PubNub message continuity is available for 5-20 minutes for up to 100 messages". The former version makes it clear that this is talking about pubnub itself. The latter sounds like it could be talking about the pubnub adapter.