### PR TITLE
Integrations: Add note around webhook data envelope support

### DIFF
--- a/content/general/webhooks.textile
+++ b/content/general/webhooks.textile
@@ -143,6 +143,10 @@ When you configure a rule using "single requests":#batching, you are given the o
 
 However, if you don't need anything besides the payload of each message, or the endpoint expects a very restricted data structure, you may choose not to envelope messages and instead have only the message payload (@data@ element) published. This has the advantage of requiring one less parsing step, however decoding of the raw payload in the published message will be your responsibility.
 
+<aside data-type='note'>
+<p>When utilizing webhook-based integrations, such as Zapier or Google Functions, only data from the @channel.message@ and @channel.presence@ sources can be received as raw payloads. @channel.lifecycle@ and @channel.occupancy@ events will always be enveloped.</p>
+</aside>
+
 Check out examples of "enveloped":#envelope-examples and "non-enveloped":#no-envelope-examples examples down below.
 
 h3(#channel-filter). Channel filter


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

When creating a new Webhook integration rule, it wasn't obvious that only message and presence events can be sent as raw payload in webhooks. Trying to do the same with occupancy or lifecycle events would generate an error when trying to create the rule. I have added a small section to the docs to make this clearer, in the hopes we will avoid future confusion.

* [REA-2071](https://ably.atlassian.net/browse/REA-2071)

## Review

Instructions on how to review the PR. 

* [Page to review](https://ably.com/docs/general/webhooks?)


[REA-2071]: https://ably.atlassian.net/browse/REA-2071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ