### PR TITLE
EDU-1660: Adds CDN activation copy

### DIFF
--- a/content/push/configure/web.textile
+++ b/content/push/configure/web.textile
@@ -83,11 +83,40 @@ The following diagram demonstrates the direct activation process:
   <img src="@content/diagrams/push-direct-activation-web-push.png" style="width: 100%" alt="push notifications in Ably">
 </a>
 
+h4(#package-man). Activate via package manager
+
+If you have installed the Ably SDK using a package manager (such as npm), you can use the @activate@ method to enable push notifications. You can then initialize the push plugin with the Ably client instance.
+
 The following example initializes an instance of the Ably realtime service and then activates the push notifications feature _for that instance_:
 
 ```[javascript]
-await ably.push.activate();
+await client.push.activate();
 ```
+
+h4(#no-package-man). Activate via Content Delivery Network (CDN)
+
+If you can't use a package manager, you can activate it via CDN by directly loading the push plugin in your HTML using a @<script>@ tag.
+
+The following example is loading the Ably push notifications library from a CDN:
+
+```[html]
+<script src="https://cdn.ably.com/lib/push.umd.min-2.js"></script>
+```
+
+When loaded, the push plugin becomes available on the global object via the @AblyPushPlugin@ property. You can then initialize the push plugin with the Ably client instance.
+
+The following example initializes an instance of the Ably realtime service and then activates the push notifications feature _for that instance_:
+
+```[javascript]
+const client = new Ably.Realtime({
+  ...options,
+  plugins: { Push: AblyPushPlugin },
+});
+```
+
+<aside data-type='note'>
+<p>This plugin must be passed to the Ably instance for it to be utilized.</p>
+</aside>
 
 h4. Test your push notification activation
 


### PR DESCRIPTION
This PR:

- Updates the Web Push Activation section:
  - Adds instructions for activating via CDN as an alternative to a package manager.
  - Refines and rephrases the existing instructions for direct activation of web push.
  
  [EDU-1660](https://ably.atlassian.net/browse/EDU-1660)

[EDU-1660]: https://ably.atlassian.net/browse/EDU-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ