### PR TITLE
Fix Python rewind example errors

### DIFF
--- a/content/channels/options/index.textile
+++ b/content/channels/options/index.textile
@@ -523,9 +523,9 @@ Channel channel = realtime.channels.get("[?rewind=1]{{RANDOM_CHANNEL_NAME}}");
 ```
 
 ```[realtime_python]
-ably_rest = AblyRealtime(key='{{API_KEY}}')
+realtime = AblyRealtime(key='{{API_KEY}}')
 
-channel = ably_rest.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}`')
+channel = realtime.channels.get('[?rewind=1]{{RANDOM_CHANNEL_NAME}}')
 ```
 
 ```[realtime_go]


### PR DESCRIPTION
## Description

This PR fixes two mistakes with the Python rewind example:

* Erroneous backtick
* Should be using realtime, not REST
