### PR TITLE
Fix missed 24-72 hours in storage

### DIFF
--- a/content/storage-history/storage.textile
+++ b/content/storage-history/storage.textile
@@ -3,7 +3,7 @@ title:  Message Storage
 meta_description: "Explore the different ways Ably can handle Message Storage"
 ---
 
-Ably stores all messages for two minutes by default. This can be increased to 24 hours, or 72 hours depending on your account package. It is also possible to persist the last message sent to a channel for a year. Ably "integrations":/general/integrations can also be used to send messages outside of Ably for long-term storage.
+Ably stores all messages for two minutes by default. This can be increased up to a year, or longer, depending on your account package. It is also possible to persist the last message sent to a channel for a year. Ably "integrations":/general/integrations can also be used to send messages outside of Ably for long-term storage.
 
 h2(#default-persistence). Default message storage - two minutes
 


### PR DESCRIPTION
## Description

This PR fixes a missed reference to storage time being limited to 24-72 hours that was originally updated in https://github.com/ably/docs/pull/2248. 
