### PR TITLE
fix: JWT shouldn't be JSON-encoded and set correct content-type

### DIFF
--- a/content/tutorials/jwt-authentication.textile
+++ b/content/tutorials/jwt-authentication.textile
@@ -179,10 +179,10 @@ app.get("/auth", (req, res) => {
     if (err) return console.trace();
 
     res.header("Cache-Control", "private, no-cache, no-store, must-revalidate");
-    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Content-Type", "application/jwt");
 
     console.log("Sending signed JWT token back to client", tokenId);
-    res.send(JSON.stringify(tokenId));
+    res.send(tokenId);
   });
 });
 ```
@@ -224,7 +224,7 @@ Paste this "CSS code":https://github.com/ably/tutorials/blob/jwt-authentication-
 ```[html]
 <html>
   <head>
-    <script src="https://cdn.ably.com/lib/ably.min-1.js" type="text/javascript"></script>
+    <script src="https://cdn.ably.com/lib/ably.min-2.js" type="text/javascript"></script>
     <link rel="stylesheet" href="css/style.css">
   </head>
 
@@ -313,7 +313,7 @@ You will see an alert with the message "Client successfully connected to Ably us
 
 h2(#running-locally). Download tutorial source code
 
-In this section you'll learn how to download the tutorial solution code and run it locally. 
+In this section you'll learn how to download the tutorial solution code and run it locally.
 
 Perform the following steps:
 


### PR DESCRIPTION
## Description

This PR updates the JWT authentication tutorial:

* There isn't a need to JSON-encode the JWT
* The content-type shouldn't be `application/json`
* Updated minimum ably-js version to v2+
