### PR TITLE
Fix: prefix meta titles with 'Ably' for product names

### DIFF
--- a/data/yaml/page-content/asset-tracking.yaml
+++ b/data/yaml/page-content/asset-tracking.yaml
@@ -1,6 +1,6 @@
 name: asset-tracking
 meta:
-  title: Asset Tracking | Ably Realtime
+  title: Ably Asset Tracking | Ably Realtime
   description: Asset Tracking enables you to track the location of your assets in realtime.
   image: https://files.ably.io/website/images/meta-tags/ably-generic%402x.jpg
   twitter: '@ablyrealtime'

--- a/data/yaml/page-content/channels.yaml
+++ b/data/yaml/page-content/channels.yaml
@@ -1,6 +1,6 @@
 name: Channels
 meta:
-  title: Pub/Sub | Ably Realtime
+  title: Ably Pub/Sub | Ably Realtime
   description: Pub/Sub is Ably’s cloud-based pub/sub (publish/subscribe) platform-as-a-service (PaaS) product.
   image: https://files.ably.io/website/images/meta-tags/ably-generic%402x.jpg
   twitter: "@ablyrealtime"

--- a/data/yaml/page-content/chat.yaml
+++ b/data/yaml/page-content/chat.yaml
@@ -1,6 +1,6 @@
 name: chat
 meta:
-  title: Chat | Ably Realtime
+  title: Ably Chat | Ably Realtime
   description: Chat enables you to build large-scale realtime chat.
   image: https://files.ably.io/website/images/meta-tags/ably-generic%402x.jpg
   twitter: '@ablyrealtime'

--- a/data/yaml/page-content/livesync.yaml
+++ b/data/yaml/page-content/livesync.yaml
@@ -1,6 +1,6 @@
 name: LiveSync
 meta:
-  title: LiveSync | Ably Realtime
+  title: Ably LiveSync | Ably Realtime
   description: LiveSync enables you to synchronize changes in your database to frontend clients at scale.
   image: https://files.ably.io/website/images/meta-tags/ably-generic%402x.jpg
   twitter: '@ablyrealtime'

--- a/data/yaml/page-content/spaces.yaml
+++ b/data/yaml/page-content/spaces.yaml
@@ -1,6 +1,6 @@
 name: Spaces
 meta:
-  title: Spaces | Ably Realtime
+  title: Ably Spaces | Ably Realtime
   description: Spaces enables you to build collaborative environments in your application.
   image: https://files.ably.io/website/images/meta-tags/ably-generic%402x.jpg
   twitter: '@ablyrealtime'

--- a/src/components/common/meta-title.test.ts
+++ b/src/components/common/meta-title.test.ts
@@ -4,12 +4,12 @@ describe('getMetaTitle', () => {
   it('Returns the meta title for each product', () => {
     const pageMappings = [
       ['channels', 'Channels', 'Intro'],
-      ['spaces', 'Spaces', 'Setup'],
-      ['livesync', 'LiveSync', 'Begin'],
-      ['chat', 'Chat', 'Emojis'],
-      ['asset-tracking', 'Asset Tracking', 'Examples'],
+      ['spaces', 'Ably Spaces', 'Setup'],
+      ['livesync', 'Ably LiveSync', 'Begin'],
+      ['chat', 'Ably Chat', 'Emojis'],
+      ['asset-tracking', 'Ably Asset Tracking', 'Examples'],
       ['api-reference', 'API References', 'Setup'],
-      ['pub_sub', 'Pub/Sub', 'Authentication'],
+      ['pub_sub', 'Ably Pub/Sub', 'Authentication'],
     ];
 
     pageMappings.forEach((product) => {
@@ -20,7 +20,7 @@ describe('getMetaTitle', () => {
     });
   });
 
-  it('Returns a default product for uknown product names', () => {
+  it('Returns a default product for unknown product names', () => {
     const metaTitle = getMetaTitle('Getting Started', 'unknown');
 
     expect(metaTitle).toBe('Ably Realtime | Getting Started');

--- a/src/components/common/meta-title.ts
+++ b/src/components/common/meta-title.ts
@@ -3,12 +3,12 @@ import { ProductName, ProductTitle } from '../../templates/template-data';
 export const getMetaTitle = (title: string, product: ProductName): string => {
   const productTitle = ({
     channels: 'Channels',
-    spaces: 'Spaces',
-    livesync: 'LiveSync',
-    chat: 'Chat',
-    'asset-tracking': 'Asset Tracking',
+    spaces: 'Ably Spaces',
+    livesync: 'Ably LiveSync',
+    chat: 'Ably Chat',
+    'asset-tracking': 'Ably Asset Tracking',
     'api-reference': 'API References',
-    pub_sub: 'Pub/Sub',
+    pub_sub: 'Ably Pub/Sub',
     home: 'Home',
   }[product] || 'Ably Realtime') as ProductTitle;
 

--- a/src/templates/template-data.d.ts
+++ b/src/templates/template-data.d.ts
@@ -39,13 +39,13 @@ export type ProductName = 'channels' | 'spaces' | 'livesync' | 'chat' | 'asset-t
 
 export type ProductTitle =
   | 'Channels'
-  | 'Spaces'
-  | 'LiveSync'
-  | 'Chat'
-  | 'Asset Tracking'
+  | 'Ably Spaces'
+  | 'Ably LiveSync'
+  | 'Ably Chat'
+  | 'Ably Asset Tracking'
   | 'API References'
   | 'Home'
-  | 'Pub/Sub';
+  | 'Ably Pub/Sub';
 
 export type AblyTemplateData = {
   data: AblyDocumentData;


### PR DESCRIPTION
## Description

This PR updates the meta title for pages to correctly include 'Ably' in product names.

