### PR TITLE
Chat fixes

### DIFF
--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -28,7 +28,7 @@ blang[react].
   </aside>
 
 ```[javascript]
-const room = chatClient.rooms.get('basketball-stream');
+const room = chatClient.rooms.get('basketball-stream', RoomOptionsDefaults);
 ```
 
 ```[react]
@@ -66,6 +66,10 @@ blang[javascript].
   When you create or retrieve a room using @rooms.get()@, you need to choose which additional chat features you want enabled for that room. This is configured by passing a "@RoomOptions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomOptions.html object as the second argument. In addition to setting which features are enabled, @RoomOptions@ also configures the properties of the associated features, such as the timeout period for typing indicators.
 
   ```[javascript]
+  const presence = {enter: false};
+  const reactions = {};
+  const occupancy = {};
+  const typing = {timeoutMs: 5000};
   const room = chatClient.rooms.get('basketball-stream', {presence, reactions, typing, occupancy});
   ```
 

--- a/content/chat/rooms/messages.textile
+++ b/content/chat/rooms/messages.textile
@@ -106,7 +106,7 @@ blang[react].
   Use the "@send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#send method available from the response of the @useMessages@ hook to to send a message to the room:
 
 ```[javascript]
-await room.messages.send('hello');
+await room.messages.send({text: 'hello'});
 ```
 
 ```[react]


### PR DESCRIPTION
## Description

This change fixes two issues with the chat docs:

- Rooms page missing `RoomOptions` values in 1 example
- Messages page passing the message text incorrectly.

## Review

- Chat Rooms
- Chat Messages