### PR TITLE
[FIX] Control API Stats response copy

### DIFF
--- a/content/account/control-api.textile
+++ b/content/account/control-api.textile
@@ -194,12 +194,6 @@ Sample response, with @entries@ trimmed for readability:
       "messages.all.all.data": 349,
       "connections.all.peak": 502,
       "channels.peak": 37
-    },
-    "self": {
-      "href": "/metrics/account%VgQpOZ/by/minute/intervals/2024-10-17%3A08%3A45"
-    },
-    "meta": {
-      "href": "/metrics/account%VgQpOZ/by/minute/intervals/2024-10-17%3A08%3A45/meta"
     }
   },
   {
@@ -212,12 +206,6 @@ Sample response, with @entries@ trimmed for readability:
       "messages.all.all.data": 279,
       "connections.all.peak": 472,
       "channels.peak": 36
-    },
-    "self": {
-      "href": "/metrics/account%VgQpOZ/by/minute/intervals/2024-10-17%3A08%3A44"
-    },
-    "meta": {
-      "href": "/metrics/account%VgQpOZ/by/minute/intervals/2024-10-17%3A08%3A44/meta"
     }
   }
 ]
@@ -330,12 +318,6 @@ Sample response, with @entries@ trimmed for readability:
       "messages.all.all.data": 30879,
       "connections.all.peak": 510,
       "channels.peak": 68
-    },
-    "self": {
-      "href": "/metrics/app%pR4La5/by/hour/intervals/2024-10-17%3A15"
-    },
-    "meta": {
-      "href": "/metrics/app%pR4La5/by/hour/intervals/2024-10-17%3A15/meta"
     }
   }
 ]

--- a/content/account/control-api.textile
+++ b/content/account/control-api.textile
@@ -188,7 +188,7 @@ Sample response, with @entries@ trimmed for readability:
     "intervalId": "2024-10-17:08:45",
     "unit": "minute",
     "accountId": "VgQpOZ",
-    "schema": "https://schemas.ably.com/json/account-stats-0.0.5.json",
+    "schema": "https://schemas.ably.com/json/account-stats-0.0.4.json",
     "entries": {
       "messages.all.all.count": 125,
       "messages.all.all.data": 349,
@@ -206,7 +206,7 @@ Sample response, with @entries@ trimmed for readability:
     "intervalId": "2024-10-17:08:44",
     "unit": "minute",
     "accountId": "VgQpOZ",
-    "schema": "https://schemas.ably.com/json/account-stats-0.0.5.json",
+    "schema": "https://schemas.ably.com/json/account-stats-0.0.4.json",
     "entries": {
       "messages.all.all.count": 92,
       "messages.all.all.data": 279,

--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -5113,22 +5113,6 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           example: { "messages.all.all.count": 10293,
       "connections.all.peak": 510,
       "channels.peak": 68 }
-        self:
-          type: object
-          description: A link to the statistics resource for this interval.
-          properties:
-            href:
-              type: string
-              description: URL to retrieve the statistics of this interval.
-              example: "/metrics/account%3ADhSspB/by/hour/intervals/2024-08-04%3A20"
-        meta:
-          type: object
-          description: A link to the metadata for the statistics of this interval.
-          properties:
-            href:
-              type: string
-              description: URL to retrieve the metadata for the statistics of this interval.
-              example: "/metrics/account%3ADhSspB/by/hour/intervals/2024-08-04%3A20/meta"
     app_stats_response:
       type: object
       additionalProperties: false
@@ -5156,22 +5140,6 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           example: { "messages.all.all.count": 723,
       "connections.all.peak": 201,
       "channels.peak": 27 }
-        self:
-          type: object
-          description: A link to the statistics resource for this interval.
-          properties:
-            href:
-              type: string
-              description: URL to retrieve the statistics of this interval.
-              example: "/metrics/app%3AMKEFrw/by/hour/intervals/2024-08-04%3A20"
-        meta:
-          type: object
-          description: A link to the metadata for the statistics of this interval.
-          properties:
-            href:
-              type: string
-              description: URL to retrieve the metadata for the statistics of this interval.
-              example: "/metrics/app%3AMKEFrw/by/hour/intervals/2024-08-04%3A20/meta"
     error:
       type: object
       additionalProperties: false

--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -5105,7 +5105,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         schema:
           type: string
           description: The schema URL defining the structure of the statistics.
-          example: "https://schemas.ably.com/json/account-stats-0.0.5.json"
+          example: "https://schemas.ably.com/json/account-stats-0.0.4.json"
         entries:
           type: object
           description: Contains the actual statistics entries for this interval. View the `schema` for descriptions of each entry.


### PR DESCRIPTION
## Description

This PR updates the schema version for the Control API stats, as well as removes the `self` and `meta` keys from the response.
