### PR TITLE
Edu 1667 orgs and SCIM page

### DIFF
--- a/content/account/organizations.textile
+++ b/content/account/organizations.textile
@@ -1,0 +1,81 @@
+---
+title: Organizations
+meta_description: "Manage Ably organizations, provision users, configure SSO with SCIM, and handle account roles."
+meta_keywords: "Ably organizations, user provisioning, SSO, SCIM, access management, Ably dashboard, account roles"
+---
+
+Use organizations to manage multiple Ably accounts by centralizing user access and roles under a single organizational structure. Organizations streamline user provisioning through "Single Sign-On (SSO)":/account/sso configuration and utilize SCIM System for Cross-domain Identity Management for group-based access control.
+
+Organizations enable the "primary":#primary account to assign and adjust the roles of users and groups across all accounts.
+
+You can separate accounts within an organization to create isolated environments, such as production, staging, and development. Assign each environment a "package":/pricing#packages that meets its specific needs. For example, production may need high capacity with an *Enterprise* package, staging might use a *Standard* package, and development a *Free* package.
+
+<aside data-type='note'>
+<p>An "Enterprise":/pricing/enterprise account is required to use organizations. "Contact us":https://ably.com/contact to enable organizations for your account.</p>
+</aside>
+
+h2(#primary). Primary account
+
+The primary account is an organization's main account and holds the following privileges:
+
+* The highest level of access to the organization.
+* Ownership of all all accounts within the organization.
+* The default account used for provisioning.
+
+h2(#accounts). Create accounts in an organization
+
+Create accounts in an organization:
+
+* Open the *Account* navigation dropdown.
+** Click *Organization Accounts.*
+** Click *New account*.
+** Add an account name and *Create account*.
+
+h2(#scim). Provision users via SCIM
+
+<aside data-type='note'>
+<p>Google Workspace _alone_ does not natively support SCIM.</p>
+</aside>
+
+Manage access to multiple Ably accounts through a single identity provider. To enable this, configure both "SSO":/account/sso with your chosen identity provider and "SCIM":#SCIM. Once configured, Ably automatically provisions and deprovisions users with access to the Ably app in your identity provider, either individually or through assigned groups. New users are added to Ably's default provisioning account with the role of *Developer*.
+
+Ably only recognizes one registered email domain per organization, unrecognized email domains will result in rejected provisioning attempts.
+
+Users provisioned through SCIM cannot modify their name or email address within Ably. All personal information updates must be made through your identity provider, and changes will sync to Ably on the next SCIM update cycle.
+
+The following steps outline the process for provisioning users through SCIM:
+
+* Configure "SSO":/account/sso by enabling and setting up SSO between Ably and your identity provider.
+
+* Copy Ably SCIM configuration values:
+** Open the *Account* navigation dropdown in the Ably dashboard.
+** Select *Organization Settings* from the menu.
+** Navigate to the *Users & Groups Provisioning (SCIM)* section and copy:
+** *Service Provider Configuration Endpoint.*
+** *SCIM Username.*
+** *SCIM Password.*
+* In your identity providers provisioning app, paste the following values from Ably:
+** *Service Provider Configuration Endpoint.*
+** *SCIM Username.*
+** *SCIM Password.*
+* Ensure that any additional setup required by your identity provider is completed to finalize the SCIM configuration.
+
+
+h2(#manage). Manage roles
+
+Manage user and group "roles":/account/users#roles across accounts within your organization. User and group roles include those assigned directly to the user and through the groups the user belongs to. Use the *Organization Users* page as a central point of control, rather than managing access individually within each account.
+
+h3(#group). Group roles
+
+When organizations and your identity provider are configured, the groups you create in the identity provider are synchronized with Ably. This allows you to manage group-based access centrally. Assign roles to these groups and all users in a group will inherit those roles.
+
+To manage group roles in Ably:
+* Open the *Account* navigation dropdown.
+** Click *Organization Users*.
+** Under *Ably Realtime identity provider groups*, click *Manage account access*.
+** Select the group whose access you want to manage.
+** Specify the required *Roles* for the group -- and all users in this group inherit these roles automatically.
+
+<aside data-type='note'>
+<p>When modifying an individual user's roles, any rights assigned via groups will be greyed out and cannot be changed directly.</p>
+</aside>

--- a/content/account/sso.textile
+++ b/content/account/sso.textile
@@ -6,10 +6,6 @@ meta_keywords: "sso, saml, strict mode, single sign-on"
 
 Single sign-on (SSO) enables your users to authenticate via any SAML-compatible identity provider.
 
-<aside date-type='note'>
-<p>User provisioning and deprovisioning via SCIM is not supported.</p>
-</aside>
-
 h2(#configure). Configure
 
 Single sign-on is restricted to Enterprise customers only and must be enabled on a per-account basis by "contacting Ably":https://ably.com/contact. Only "account owners":/account/users can configure SSO for an account.
@@ -80,6 +76,10 @@ Use the "Google Workspace guide":https://support.google.com/a/answer/6087519?hl=
 5. Ably requires users' full names, so ensure *first_name* and *last_name* are populated.
 6. Assign users to the newly created Google Workspace application.
 7. Test the SSO connection from Google Workspace.
+
+<aside data-type='note'>
+<p>Google Workspace _alone_ does not natively support SCIM.</p>
+</aside>
 
 h2(#strict). Strict mode
 

--- a/data/yaml/page-furniture/sidebar.yaml
+++ b/data/yaml/page-furniture/sidebar.yaml
@@ -162,6 +162,14 @@ items:
         items:
           - label: 'Account overview'
             link: /account
+          - label: 'User management'
+            link: /account/users
+          - label: 'Organizations'
+            link: /account/organizations
+          - label: 'Single sign-on (SSO)'
+            link: /account/sso
+          - label: 'Two-factor authentication (2FA)'
+            link: /account/2fa
           - label: 'App management'
             link: ''
             items:
@@ -179,12 +187,6 @@ items:
                 link: /account/app/console
               - label: 'Settings'
                 link: /account/app/settings
-          - label: 'Single sign-on (SSO)'
-            link: /account/sso
-          - label: 'Two-factor authentication (2FA)'
-            link: /account/2fa
-          - label: 'User management'
-            link: /account/users
           - label: 'Programmatic management with Control API'
             link: /account/control-api
       - label: 'Pricing'


### PR DESCRIPTION
This PR:

- Adds Ably Organizations page
  - Includes SSO and SCIM setup
 - @denissellu left a [comment](https://ably.atlassian.net/wiki/spaces/PLG/pages/3059777557/Docs+draft+for+Orgs+and+SCIM?focusedCommentId=3350134809) on the original doc. I have not been able to weave this into the content due to lack of clarification (my side).   
   - "Should we already list the endpoints we support somewhere, api/Users api/Groups?"

 
[EDU-1667](https://ably.atlassian.net/browse/EDU-1667)

[EDU-1667]: https://ably.atlassian.net/browse/EDU-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ