### PR TITLE
chat: update docs for async room get

### DIFF
--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -28,7 +28,7 @@ blang[react].
   </aside>
 
 ```[javascript]
-const room = chatClient.rooms.get('basketball-stream', RoomOptionsDefaults);
+const room = await chatClient.rooms.get('basketball-stream', RoomOptionsDefaults);
 ```
 
 ```[react]
@@ -70,20 +70,22 @@ blang[javascript].
   const reactions = {};
   const occupancy = {};
   const typing = {timeoutMs: 5000};
-  const room = chatClient.rooms.get('basketball-stream', {presence, reactions, typing, occupancy});
+  const room = await chatClient.rooms.get('basketball-stream', {presence, reactions, typing, occupancy});
   ```
 
   You can also use the @RoomOptionsDefaults@ property for each @RoomOption@ to configure whether the default settings should be used:
 
   ```[javascript]
-  const room = chatClient.rooms.get('basketball-stream', {presence: RoomOptionsDefaults.presence});
+  const room = await chatClient.rooms.get('basketball-stream', {presence: RoomOptionsDefaults.presence});
   ```
 
   Or configure each feature using your own values:
 
   ```[javascript]
-  const room = chatClient.rooms.get('basketball-stream', {typing: {timeoutMs: 5000}});
+  const room = await chatClient.rooms.get('basketball-stream', {typing: {timeoutMs: 5000}});
   ```
+
+  Note that any unresolved promises from @rooms.get()@ will be rejected when @rooms.release()@ is called.
 
 blang[react].
 
@@ -103,6 +105,8 @@ Releasing a room may be optional for many applications. If you have multiple tra
 
 blang[javascript].
   Once "@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Rooms.html#release has been called, the room will be unusable and a new instance will need to be created using "@rooms.get()@":#create if you want to reuse it.
+
+  Note that any unresolved promises from @rooms.get()@ will be rejected when @rooms.release()@ is called.
 
   ```[javascript]
   await rooms.release('basketball-stream');
@@ -165,7 +169,7 @@ Monitoring the status of a room enables you to track its lifecycle and react acc
 A room can have any of the following statuses:
 
 |_. Status |_. Description |
-| initializing | The library is initializing the room. |
+| initializing | The library is initializing the room. This status is only used for React when the room has not yet resolved. |
 | initialized | The room has been initialized, but no attach has been attempted yet. |
 | attaching | An attach has been initiated by sending a request to Ably. This is a transient status and will be followed either by a transition to attached, suspended, or failed. |
 | attached | An attach has succeeded. In the attached status a client can publish and subscribe to messages, and enter the presence set. |


### PR DESCRIPTION
## Description

Updates the chat docs to reflect the changes to async `rooms.get()`

[CHA-670]

## Review

`/chat/rooms`


[CHA-670]: https://ably.atlassian.net/browse/CHA-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ