### PR TITLE
chat: update room status and connection status

### DIFF
--- a/content/chat/connect.textile
+++ b/content/chat/connect.textile
@@ -22,13 +22,20 @@ A connection can have any of the following statuses:
 | failed | This status is entered if the SDK encounters a failure condition that it cannot recover from. This may be a fatal connection error received from the Ably service, such as an attempt to connect with an incorrect API key, or some local terminal error, such as that the token in use has expired and the SDK does not have any way to renew it. |
 
 blang[javascript].
+<<<<<<< HEAD
   Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#current property to check which status a connection is currently in:
+=======
+  Use the "@status@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Connection.html#status property to check which status a connection is currently in:
+>>>>>>> 0d6cc60d6 (chat: update room status and connection status)
 
 blang[react].
   Use the "@currentStatus@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseChatConnectionResponse.html#currentStatus property returned in the response of the "@useChatConnection@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useChatConnection.html hook to check which status a connection is currently in:
 
 ```[javascript]
-const connectionStatus = chatClient.connection.status.current;
+const connectionStatus = chatClient.connection.status;
+
+// The error related to the current status
+const error = chatClient.connection.error;
 ```
 
 ```[react]
@@ -64,13 +71,17 @@ blang[react].
 blang[javascript].
 
 blang[javascript].
+<<<<<<< HEAD
   Use the "@connection.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#onChange method to register a listener for status change updates:
+=======
+  Use the "@connection.onStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Connection.html#onStatusChange method to register a listener for status change updates:
+>>>>>>> 0d6cc60d6 (chat: update room status and connection status)
 
 blang[react].
   Listeners can also be registered to monitor the changes in connection status. Any hooks that take an optional listener to monitor their events, such as typing indicator events in the @useTyping@ hook, can also register a status change listener. Changing the value provided for a listener will cause the previously registered listener instance to stop receiving events. All messages will be received by exactly one listener.
 
 ```[javascript]
-const { off } = chatClient.connection.status.onStatusChange((change) => console.log(change));
+const { off } = chatClient.connection.onStatusChange((change) => console.log(change));
 ```
 
 ```[react]
@@ -93,10 +104,10 @@ blang[javascript].
   off();
   ```
 
-  Use the "@connection.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#offAll method to remove all connection status listeners:
+  Use the "@connection.offAllStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Connection.html#offAllStatusChange method to remove all connection status listeners:
 
   ```[javascript]
-  chatClient.connection.status.offAll();
+  chatClient.connection.offAllStatusChange();
   ```
 
 blang[react].

--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -179,13 +179,16 @@ A room can have any of the following statuses:
 | failed | An indefinite failure condition. This status is entered if an error has been received from Ably, such as an attempt to attach without the necessary access rights. |
 
 blang[javascript].
-  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#current property to check which status a room is currently in:
+  Use the "@status@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#status property to check which status a room is currently in:
 
 blang[react].
   Use the @roomStatus@ property to view the current "@Room@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html status changes. The @roomError@ property is its associated error. Any hooks that take an optional listener have these properties available in their response, such as @useMessages@ or @useTyping@. It is more common that you will monitor the room status in the specific feature hooks rather than needing to use @useRoom@. These events are related to the room instance of the nearest "@ChatRoomProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.ChatRoomProvider.html. For example, with the @useMessages@ hook:
 
 ```[javascript]
-const currentStatus = room.status.current
+const currentStatus = room.status;
+
+// The error related to the current room status
+const currentError = room.error;
 ```
 
 ```[react]
@@ -210,7 +213,7 @@ const MyComponent = () => {
 blang[javascript].
   You can also subscribe to room status updates by registering a listener. An event will be emitted whenever the status of the room changes.
 
-  Use the "@room.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#onChange method in a room to register a listener for status change updates:
+  Use the "@room.onStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#onStatusChange method in a room to register a listener for status change updates:
 
   ```[javascript]
   const { off } = room.onStatusChange((change) =>
@@ -223,10 +226,10 @@ blang[javascript].
   off();
   ```
 
-  Use the "@room.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#offAll method to remove all room status listeners in a room:
+  Use the "@room.offAllStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#offAllStatusChange method to remove all room status listeners in a room:
 
   ```[javascript]
-  room.status.offAll();
+  room.offAllStatusChange();
   ```
 
 blang[react].


### PR DESCRIPTION
## Description

per CHADR-062, we renamed some types and restructured the room status / connection handlers.

This change makes these effective in the docs.

## Review

Instructions on how to review the PR. 

`/chat/connections`
`/chat/rooms`
