### PR TITLE
History: document how to retrieve persist-last message with the rest api

### DIFF
--- a/content/storage-history/history.textile
+++ b/content/storage-history/history.textile
@@ -793,7 +793,4 @@ It is important to note that this is not necessarily the order that messages wer
 
 Ably preserves ordering for a specific publisher on a specific channel but, for example, if two publishers in regions A and B publish _message-one_ and _message-two_ simultaneously, then it is very possible that a subscriber in region A will receive _message-one_ before _message-two_, but that a subscriber in region B will receive _message-two_ before _message-one_.
 
-There are instances where messages will not be in canonical global order:
-
-* Recent messages (less than two minutes old) are retrieved from live ephemeral storage and are still ordered by region. They only appear in the canonical global order if you enable "message persistence":/storage-history/storage, which also prevents duplication and missing messages.
-* You choose to retrieve historical messages only up to the point at which a client attaches to a channel. You would typically use this approach to bring a subscriber up to date as part of connection state recovery.
+There are some instances where messages will not be in canonical global order. If you are using continuous history (that is, either a REST history call with @untilAttach=true@, or rewind on a realtime connection), then recent messages (less than two minutes old) are retrieved from live ephemeral storage and are still ordered by region, in order to correctly mesh with the live stream of messages in that region. Older messages retrieved from persisted history (if that is enabled) will be in canonical global order, and Ably will ensure that the transition between the two happens with no duplicates or missed messages.

--- a/content/storage-history/history.textile
+++ b/content/storage-history/history.textile
@@ -39,7 +39,6 @@ You can retrieve previously published messages using the history feature or usin
 * You can define a custom start and end time to retrieve messages from using history. Rewind returns either a given number of messages, or messages up to a point in time in the past.
 * History is available when using the realtime and REST interfaces of an SDK. Rewind is only available using the realtime interface.
 * Only history can return previously published presence events.
-* Rewind is the only way to return the last message published to a channel that has been "persisted for up to 365 days":/storage-history/storage#persist-last-message.
 
 h2(#retrieve-channel). Retrieve channel history
 
@@ -310,6 +309,8 @@ The following query parameters can be included in the @options@ object when maki
 | direction | @forwards@ or @backwards@ |
 | limit | maximum number of messages to retrieve, up to 1,000 |
 | untilAttach | when true, ensures message history is up until the point of the channel being attached. See "continuous history":#continuous-history for more info. Requires the @direction@ to be @backwards@ (the default). If the channel is not attached, or if @direction@ is set to @forwards@, this option will result in an error.|
+
+It is possible to use the history API to retrieve the last message published to a channel that has been "persisted for up to a year with the persist-last feature":/storage-history/storage#persist-last-message, if enabled, even if there is no history available from normal persisted history (if there have been no messages published on the channel for longer than the history retention period). To do this, make a history query with @limit=1@ and no @start@ or @end@ time.
 
 h3(#continuous-history). Continuous history
 

--- a/content/storage-history/storage.textile
+++ b/content/storage-history/storage.textile
@@ -38,7 +38,7 @@ h2(#persist-last-message). Persist last message - 365 days
 
 You can persist just the last message sent to a channel for one year by setting a "channel rule":/channels#rules. Note that this does not apply to "presence messages":/presence-occupancy/presence.
 
-Messages persisted for a year can only be retrieved using the "rewind channel option":/channels/options/rewind. They cannot be retrieved using the history feature.
+Messages persisted for a year can be retrieved using the "rewind channel option":/channels/options/rewind, or from the REST history API using "certain parameters":/storage-history/history#channel-parameters.
 
 The following diagram illustrates persisting the last message sent on a channel:
 


### PR DESCRIPTION
REA-1622

as well as persist-last retrieval, also fixed the section about exceptions to canonical global order, which was confused (enabling persistence doesn't change the order you get for messages from live history, which is always global unless you're using untilAttach. also you don't need to enable persistence to "prevent duplication and missing messages", none of our history apis return duplicate or missing messages given any settings. or if they ever do, that's a bug)