### PR TITLE
History: reduce max normal retention period from 365 to 30 days

### DIFF
--- a/content/pricing/limits.textile
+++ b/content/pricing/limits.textile
@@ -69,7 +69,8 @@ Message limits relate to the number, rate and bandwidth of messages consumed acr
 | *Message bandwidth (monthly, GiB)*<p>_the maximum amount of data that can be transferred through messages each month, in GiB_</p> | 28.6 | 1,192 | 4,768  | Unlimited |
 | *Max message size (KiB)*<p>_the maximum size of a single published message_</p> | 64 | 64 | 256 | 256 |
 | *Default history TTL (hours)*<p>_the default time that a message or presence message can be retrieved from history_</p> | 24 | 72 | 72 | 72 |
-| *Max history / storage TTL (days)*<p>_the maximum time that a message or presence message can be retrieved from history_</p> | 1 | 30 | 365 | 365 |
+| *Max history / storage TTL (days)*<p>_the maximum time that a message or presence message can be retrieved from history_</p> | 1 | 30 | 30 | 30 |
+| *Persist-last storage TTL (days)*<p>_the period that the most recent message on a channel is stored for if the persist-last feature is enabled_</p> | 1 | 30 | 365 | 365 |
 
 h2(#channel). Channel limits
 
@@ -77,7 +78,6 @@ Channel limits relate to the number, rate and membership of "channels":/channels
 
 |_. Channel limit |_. Free |_. Standard |_. Pro |_. Enterprise |
 | *Concurrent channels*<p>_the maximum number of channels that are active simultaneously at any point_</p> | 200 | 10,000 | 50,000 | Unlimited |
-| *Default last message on channel TTL (days)*<p>_the default period that the last message on a channel is stored for, when enabled_</p> | 1 | 30 | 365 | 365 |
 | *Channel creation rate (per second)*<p>_the maximum rate at which channels can be created across an account_</p> | 42 | 250 | 500 | Custom |
 | *Message publish rate per channel (per second)*<p>_the maximum rate at which messages can be published for each channel_</p> | 50 | 50 | 50 | 50 |
 | *Presence members per channel*<p>_the maximum number of clients that can be simultaneously present on a channel_</p> | 200 | 200 | 200 | 200 |

--- a/content/storage-history/storage.textile
+++ b/content/storage-history/storage.textile
@@ -19,10 +19,11 @@ h2(#all-message-persistence). Persist all messages
 
 If you need to retain messages for longer than the default two minutes you can enable persisted history by setting a "channel rule":/channels#rules. When persisted history is enabled for a channel any messages will be stored on disk. The time that messages will be stored for depends on your account package:
 
-|_. Package |_. Minimum |_. Maximum |
+|_. Package |_. Default |_. Maximum |
 | Free | 24 hours | 24 hours |
-| PAYG | 72 hours | 365 days |
-| Enterprise | 72 hours | Custom |
+| Standard | 72 hours | 30 days |
+| Pro | 72 hours | 30 days |
+| Enterprise | 72 hours | 30 days |
 
 There is a cost associated with storing messages for longer than the minimum time period. "Contact us":https://ably.com/support to discuss enabling long term storage.
 


### PR DESCRIPTION
We don't support a year of normal history, we've never supported a year of normal history. if you want a year, that's what persist-last is for

https://ably-real-time.slack.com/archives/C019XP5SYB0/p1731108835200039?thread_ts=1729587824.143959&cid=C019XP5SYB0