### PR TITLE
[WEB-4120] Fix shortcut and gasby env loading

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,3 +1,9 @@
+import dotenv from 'dotenv';
+
+dotenv.config({
+  path: `.env.${process.env.NODE_ENV}`,
+});
+
 const stripTrailingSlash = (str: string) => (str.endsWith('/') ? str.slice(0, -1) : str);
 
 const mainWebsite = stripTrailingSlash(process.env.GATSBY_ABLY_MAIN_WEBSITE ?? 'http://localhost:3000');

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,9 +1,3 @@
-import dotenv from 'dotenv';
-
-dotenv.config({
-  path: `.env.${process.env.NODE_ENV}`,
-});
-
 export { createPages } from './data/createPages';
 export { onCreateNode, createSchemaCustomization } from './data/onCreateNode';
 export { onCreateWebpackConfig } from './gatsby-overwrite-config';

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "babel-jest": "^29.3.1",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-gatsby": "^3.3.0",
+    "dotenv": "^16.4.5",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-flowtype": "^8.0.3",

--- a/src/components/Header/SearchBar/SearchBar.tsx
+++ b/src/components/Header/SearchBar/SearchBar.tsx
@@ -80,7 +80,7 @@ export const SearchBar = ({
   useOnClickOutside(handleFocusEvent, searchDisplayRef);
   useKeyPress(['Escape'], handleFocusEvent);
   useKeyboardShortcut(['Meta', 'K'], focusOnSearchInput, {
-    overrideSystem: true,
+    overrideSystem: !externalScriptsData.inkeepEnabled,
     repeatOnHold: false,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6495,7 +6495,7 @@ dotenv-expand@^5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv@^16.0.3:
+dotenv@^16.0.3, dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

See WEB-4120
This pull request includes several changes to improve environment variable management and update dependencies. The most important changes include moving the dotenv configuration to `gatsby-config.ts`, updating the `package.json` dependencies, and modifying the behavior of the search bar component.

Environment variable management:

* [`gatsby-config.ts`](diffhunk://#diff-26b5c624a22b9f24d3e683f7ee5b69788ee6b166a655b7423b6a4c5a1ef6f0a1R1-R6): Added dotenv configuration to load environment variables based on the current environment.
* [`gatsby-node.ts`](diffhunk://#diff-f5fdf00d27b2934559500edae0b37a71958a34e4584f097afeb95260144a761fL1-L6): Removed dotenv configuration as it is now handled in `gatsby-config.ts`.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R111): Added the `dotenv` package to manage environment variables.

Component behavior modification:

* [`src/components/Header/SearchBar/SearchBar.tsx`](diffhunk://#diff-698828f4a6004b94b157fe2051fec3a1787cf887d508f10d2a44624f1cb8d7aeL83-R83): Modified the `useKeyboardShortcut` hook to disable system override based on the `externalScriptsData.inkeepEnabled` flag.
