### PR TITLE
Correct technical errors in restrictions for channel names and namespaces

### DIFF
--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -42,9 +42,18 @@ Channels are used to separate "messages":/channels/messages into different topic
 
 Clients can subscribe to channels and publish messages using the realtime interface of an Ably SDK. Clients can only publish messages when using the REST interface.
 
+<aside data-type='note'>
+<ul><li>Channel names are case sensitive</li>
+<li>They can't start with @[@ or @:@</li>
+<li>They can't be empty</li>
+<li>They can't contain newline characters</li></ul>
+<p>While Ably doesn't limit the length of channel names, we recommend you keep them under 2048 characters, since some older browsers have trouble with long URLs.</p>
+</aside>
+
+
 h2(#namespaces). Channel namespaces
 
-Channel namespaces enable channels to be grouped together based on a prefix that is included as part of the channel name. A colon @:@ is used to delimit a channel namespace, and a namespace is the first segment of a channel name up until the first colon. If a channel name does not contain a colon, the namespace is the entire channel name.
+Channel namespaces enable channels to be grouped together based on a prefix that is included as part of the channel name. A colon @:@ is used to delimit a channel namespace, that is, a namespace is the first segment of a channel name up until the first colon. If a channel name does not contain a colon, the namespace is the entire channel name.
 
 The following are examples of channels that are all part of the 'customer' namespace:
 
@@ -55,12 +64,7 @@ The following are examples of channels that are all part of the 'customer' names
 Namespaces can be used to apply operations to all channels within the namespace, such as "capabilities":/auth/capabilities, "channel rules":#rules and "integration rules":/general/integrations. Namespaces are not required to refer to a set of channels within a capability. A resource specifier, such as @foo:*@, a glob expression, will match a channel named @foo:bar@, even without a @foo@ namespace.
 
 <aside data-type='note'>
-<p>Restrictions for channel names and namespaces:</p>
-<ul><li>Avoid starting names with @[@ or @:@.</li>
-<li>Ensure names aren't empty.</li>
-<li>Exclude whitespace and wildcards, such as @*@.</li>
-<li>Use the correct case, whether it be uppercase or lowercase.</li></ul>
-<p>While Ably doesn't limit channel name and namespace length, be aware that the name appears in REST request URLs. Most browsers cap URLs at 2048 characters.</p>
+In addition to the restrictions on channel names above, a namespace cannot contain the wildcard character @*@.
 </aside>
 
 h2(#create). Create or retrieve a channel


### PR DESCRIPTION
Several issues:
- when porting this over from faqs, it was put into the namespace section, which doesn't really make sense, the restrictions on channel names apply whether you're doing anything with namespaces or not. It also conflated restrictions for channel names and namespaces, which is wrong -- in particular, wildcards are fine in channel names.
- https://github.com/ably/docs/commit/54364428a5eed8384703b7cb9b33f4e607644866 , which claimed to just change the style to an active voice, apparently decided all whitespace was now banned, not just newlines (???)
- That commit also decided that "most" browsers have trouble with 2k long urls, which is just wrong.
- "wildcards such as `*`" is a very confusing way of phrasing it. The wildcard is `*`, that wording sounds like it's implying that `*` is one of many.
- An injunction to "Use the correct case, whether uppercase or lowercase" doesn't make sense as a "restriction". Which is the "correct" case, upper or lower?
