### PR TITLE
chat: fix `ChatClient` import statement

### DIFF
--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -57,12 +57,12 @@ Import the SDKs into your project:
 
 ```[javascript]
 import * as Ably from 'ably';
-import ChatClient from '@ably/chat';
+import { ChatClient } from '@ably/chat';
 ```
 
 ```[react]
 import * as Ably from 'ably';
-import ChatClient from '@ably/chat';
+import { ChatClient } from '@ably/chat';
 import { ChatClientProvider } from '@ably/chat/react';
 ```
 


### PR DESCRIPTION
tiny but important mistake in the chat code examples, see https://github.com/ably/ably-chat-js/pull/414. 