### PR TITLE
Fix TypeDoc links after update

### DIFF
--- a/content/chat/connect.textile
+++ b/content/chat/connect.textile
@@ -22,10 +22,10 @@ A connection can have any of the following statuses:
 | failed | This status is entered if the SDK encounters a failure condition that it cannot recover from. This may be a fatal connection error received from the Ably service, such as an attempt to connect with an incorrect API key, or some local terminal error, such as that the token in use has expired and the SDK does not have any way to renew it. |
 
 blang[javascript].
-  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.ConnectionStatus.html#current property to check which status a connection is currently in:
+  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#current property to check which status a connection is currently in:
 
 blang[react].
-  Use the "@currentStatus@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseChatConnectionResponse.html#currentStatus property returned in the response of the "@useChatConnection@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useChatConnection.html hook to check which status a connection is currently in:
+  Use the "@currentStatus@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseChatConnectionResponse.html#currentStatus property returned in the response of the "@useChatConnection@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useChatConnection.html hook to check which status a connection is currently in:
 
 ```[javascript]
 const connectionStatus = chatClient.connection.status.current;
@@ -64,7 +64,7 @@ blang[react].
 blang[javascript].
 
 blang[javascript].
-  Use the "@connection.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.ConnectionStatus.html#onChange method to register a listener for status change updates:
+  Use the "@connection.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#onChange method to register a listener for status change updates:
 
 blang[react].
   Listeners can also be registered to monitor the changes in connection status. Any hooks that take an optional listener to monitor their events, such as typing indicator events in the @useTyping@ hook, can also register a status change listener. Changing the value provided for a listener will cause the previously registered listener instance to stop receiving events. All messages will be received by exactly one listener.
@@ -93,7 +93,7 @@ blang[javascript].
   off();
   ```
 
-  Use the "@connection.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.ConnectionStatus.html#offAll method to remove all connection status listeners:
+  Use the "@connection.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#offAll method to remove all connection status listeners:
 
   ```[javascript]
   chatClient.connection.status.offAll();
@@ -147,8 +147,8 @@ blang[javascript].
 
   The following discontinuity handlers are available:
 
-  * "Messages":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Messages.html#onDiscontinuity
-  * "Presence":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#onDiscontinuity
-  * "Occupancy":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Occupancy.html#onDiscontinuity
-  * "Typing indicators":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#onDiscontinuity
-  * "Room reactions":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomReactions.html#onDiscontinuity
+  * "Messages":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#onDiscontinuity
+  * "Presence":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#onDiscontinuity
+  * "Occupancy":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Occupancy.html#onDiscontinuity
+  * "Typing indicators":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#onDiscontinuity
+  * "Room reactions":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomReactions.html#onDiscontinuity

--- a/content/chat/rooms/history.textile
+++ b/content/chat/rooms/history.textile
@@ -12,10 +12,10 @@ The history feature enables users to retrieve messages that have been previously
 h2(#get). Retrieve previously sent messages
 
 blang[javascript].
-  Use the "@messages.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Messages.html#get method to retrieve messages that have been previously sent to a room:
+  Use the "@messages.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#get method to retrieve messages that have been previously sent to a room:
 
 blang[react].
-    Use the "@get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#get method available from the response of the @useMessages@ hook to retrieve messages that have been previously sent to a room.
+    Use the "@get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#get method available from the response of the @useMessages@ hook to retrieve messages that have been previously sent to a room.
 
 ```[javascript]
 const historicalMessages = await room.messages.get({ direction: 'backwards', limit: 50 });
@@ -63,10 +63,10 @@ h2(#subscribe). Retrieve messages sent prior to subscribing
 Users can also retrieve historical messages that were sent to a room before the point that they registered a listener by "subscribing":/chat/rooms/messages#subscribe. The order of messages returned is from most recent, to oldest. This is useful for providing conversational context when a user first joins a room, or when they subsequently rejoin it later on. It also ensures that the message history they see is continuous, without any overlap of messages being returned between their subscription and their history call.
 
 blang[javascript].
-  Use the "@getPreviousMessages()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.MessageSubscriptionResponse.html#getPreviousMessages function returned as part of a "message subscription":/chat/rooms/messages#subscribe response to only retrieve messages that were received before the listener was subscribed to the room:
+  Use the "@getPreviousMessages()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.MessageSubscriptionResponse.html#getPreviousMessages function returned as part of a "message subscription":/chat/rooms/messages#subscribe response to only retrieve messages that were received before the listener was subscribed to the room:
 
 blang[react].
-  Use the "@getPrevious()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#getPreviousMessages method available from the response of the @useMessages@ hook to only retrieve messages that were received before the listener subscribed to the room. As long as a defined value is provided for the listener, and there are no message discontinuities, @getPreviousMessages()@ will return messages from the same point across component renders. If the listener becomes undefined, the subscription to messages will be removed. If you subsequently redefine the listener then @getPreviousMessages()@ will return messages from the new point of subscription.
+  Use the "@getPrevious()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#getPreviousMessages method available from the response of the @useMessages@ hook to only retrieve messages that were received before the listener subscribed to the room. As long as a defined value is provided for the listener, and there are no message discontinuities, @getPreviousMessages()@ will return messages from the same point across component renders. If the listener becomes undefined, the subscription to messages will be removed. If you subsequently redefine the listener then @getPreviousMessages()@ will return messages from the new point of subscription.
 
 ```[javascript]
 const { getPreviousMessages } = room.messages.subscribe(() => {

--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -16,12 +16,12 @@ h2(#create). Create or retrieve a room
 Users send messages to a room and subscribe to the room in order to receive messages. Other features, such as indicating which users are online, or which users are typing are configured as part of a room's options.
 
 blang[javascript].
-  A @room@ is created, or an existing one is retrieved from the @rooms@ collection using the "@rooms.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Rooms.html#get method:
+  A @room@ is created, or an existing one is retrieved from the @rooms@ collection using the "@rooms.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Rooms.html#get method:
 
 blang[react].
-  The "@ChatRoomProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.ChatRoomProvider.html provides access to a specific chat room to all child components in the component tree.
+  The "@ChatRoomProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.ChatRoomProvider.html provides access to a specific chat room to all child components in the component tree.
 
-  Pass in the ID of the room to use, and select which which additional chat features you want enabled for that room. This is configured by passing a "@RoomOptions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomOptions.html object to the provider.
+  Pass in the ID of the room to use, and select which which additional chat features you want enabled for that room. This is configured by passing a "@RoomOptions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomOptions.html object to the provider.
 
   <aside data-type='note'>
   <p>All components that utilize chat feature hooks must be children of a @ChatRoomProvider@. This includes @useRoom@, "@useMessages@":/chat/rooms/messages, "@useOccupancy@":/chat/rooms/occupancy, "@usePresence@":/chat/rooms/presence, "@usePresenceListener@":/chat/rooms/presence, "@useRoomReactions@":/chat/rooms/reactions and "@useTyping@":/chat/rooms/typing.</p>
@@ -63,7 +63,7 @@ blang[react].
 blang[javascript].
 
 blang[javascript].
-  When you create or retrieve a room using @rooms.get()@, you need to choose which additional chat features you want enabled for that room. This is configured by passing a "@RoomOptions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomOptions.html object as the second argument. In addition to setting which features are enabled, @RoomOptions@ also configures the properties of the associated features, such as the timeout period for typing indicators.
+  When you create or retrieve a room using @rooms.get()@, you need to choose which additional chat features you want enabled for that room. This is configured by passing a "@RoomOptions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomOptions.html object as the second argument. In addition to setting which features are enabled, @RoomOptions@ also configures the properties of the associated features, such as the timeout period for typing indicators.
 
   ```[javascript]
   const presence = {enter: false};
@@ -102,14 +102,14 @@ Releasing a room allows the underlying resources to be garbage collected or rele
 Releasing a room may be optional for many applications. If you have multiple transient rooms, such as in the case of a 1:1 support chat, then it is may be more beneficial.
 
 blang[javascript].
-  Once "@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Rooms.html#release has been called, the room will be unusable and a new instance will need to be created using "@rooms.get()@":#create if you want to reuse it.
+  Once "@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Rooms.html#release has been called, the room will be unusable and a new instance will need to be created using "@rooms.get()@":#create if you want to reuse it.
 
   ```[javascript]
   await rooms.release('basketball-stream');
   ```
 
 blang[react].
-  By default the @ChatRoomProvider@ will automatically call "@release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html#release on the room when it unmounts. Set the "@release@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.ChatRoomProviderProps.html#release property to @false@ to change this behavior and have the room only "detach":#detach when the component unmounts. You can manually control this attachment behavior using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useRoom.html hook.
+  By default the @ChatRoomProvider@ will automatically call "@release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#release on the room when it unmounts. Set the "@release@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.ChatRoomProviderProps.html#release property to @false@ to change this behavior and have the room only "detach":#detach when the component unmounts. You can manually control this attachment behavior using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useRoom.html hook.
 
 h2(#attach). Attach to a room
 
@@ -118,10 +118,10 @@ As soon as a client is attached to a room, Ably will begin streaming messages an
 blang[javascript].
   Once a reference to a room has been created using @rooms.get()@, clients attach to it in order to ensure it is created in the Ably system.
 
-  Use the "@attach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html#attach method on a room to attach to it:
+  Use the "@attach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#attach method on a room to attach to it:
 
 blang[react].
-  By default the @ChatRoomProvider@ will automatically call "@attach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html#attach on the room when it first mounts. Set the "@attach@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.ChatRoomProviderProps.html#attach property to @false@ to manually control the attachment using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useRoom.html hook instead.
+  By default the @ChatRoomProvider@ will automatically call "@attach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#attach on the room when it first mounts. Set the "@attach@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.ChatRoomProviderProps.html#attach property to @false@ to manually control the attachment using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useRoom.html hook instead.
 
   Note that automatically "detaching":#detach from a room will only happen if @attach@ is also set to @true@.
 
@@ -145,14 +145,14 @@ const MyComponent = () => {
 h3(#detach). Detach from a room
 
 blang[javascript].
-  Use the "@detach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html#detach method on a room to detach from it and stop receiving messages and events:
+  Use the "@detach()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#detach method on a room to detach from it and stop receiving messages and events:
 
   ```[javascript]
   await room.detach();
   ```
 
 blang[react].
-  By default the @ChatRoomProvider@ will automatically call "@release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html#release on the room when it unmounts. Set the "@release@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.ChatRoomProviderProps.html#release property to @false@ to change this behavior and have the room only "detach":#detach when the component unmounts. You can manually control this attachment behavior using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useRoom.html hook.
+  By default the @ChatRoomProvider@ will automatically call "@release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html#release on the room when it unmounts. Set the "@release@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.ChatRoomProviderProps.html#release property to @false@ to change this behavior and have the room only "detach":#detach when the component unmounts. You can manually control this attachment behavior using the "@useRoom@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useRoom.html hook.
 
   Note that automatically detaching from a room will only happen if "@attach@":#attach is also set to @true@.
 
@@ -175,10 +175,10 @@ A room can have any of the following statuses:
 | failed | An indefinite failure condition. This status is entered if an error has been received from Ably, such as an attempt to attach without the necessary access rights. |
 
 blang[javascript].
-  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomStatus.html#current property to check which status a room is currently in:
+  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#current property to check which status a room is currently in:
 
 blang[react].
-  Use the @roomStatus@ property to view the current "@Room@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Room.html status changes. The @roomError@ property is its associated error. Any hooks that take an optional listener have these properties available in their response, such as @useMessages@ or @useTyping@. It is more common that you will monitor the room status in the specific feature hooks rather than needing to use @useRoom@. These events are related to the room instance of the nearest "@ChatRoomProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.ChatRoomProvider.html. For example, with the @useMessages@ hook:
+  Use the @roomStatus@ property to view the current "@Room@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Room.html status changes. The @roomError@ property is its associated error. Any hooks that take an optional listener have these properties available in their response, such as @useMessages@ or @useTyping@. It is more common that you will monitor the room status in the specific feature hooks rather than needing to use @useRoom@. These events are related to the room instance of the nearest "@ChatRoomProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.ChatRoomProvider.html. For example, with the @useMessages@ hook:
 
 ```[javascript]
 const currentStatus = room.status.current
@@ -206,7 +206,7 @@ const MyComponent = () => {
 blang[javascript].
   You can also subscribe to room status updates by registering a listener. An event will be emitted whenever the status of the room changes.
 
-  Use the "@room.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomStatus.html#onChange method in a room to register a listener for status change updates:
+  Use the "@room.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#onChange method in a room to register a listener for status change updates:
 
   ```[javascript]
   const { off } = room.onStatusChange((change) =>
@@ -219,7 +219,7 @@ blang[javascript].
   off();
   ```
 
-  Use the "@room.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomStatus.html#offAll method to remove all room status listeners in a room:
+  Use the "@room.status.offAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomStatus.html#offAll method to remove all room status listeners in a room:
 
   ```[javascript]
   room.status.offAll();

--- a/content/chat/rooms/messages.textile
+++ b/content/chat/rooms/messages.textile
@@ -12,10 +12,10 @@ You can send and receive messages in a chat room with any number of participants
 h2(#subscribe). Subscribe to messages
 
 blang[javascript].
-  Subscribe to receive messages in a room by registering a listener. Use the "@messages.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Messages.html#subscribe method in a room to receive all messages that are sent to it:
+  Subscribe to receive messages in a room by registering a listener. Use the "@messages.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#subscribe method in a room to receive all messages that are sent to it:
 
 blang[react].
-    Subscribe to messages with the "@useMessages@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useMessages.html hook. Supply a listener and the hook will automatically subscribe to messages sent to the room. As long as a defined value is provided, the subscription will persist across renders. If the listener value is undefined, the subscription will be removed until it becomes defined again.
+    Subscribe to messages with the "@useMessages@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useMessages.html hook. Supply a listener and the hook will automatically subscribe to messages sent to the room. As long as a defined value is provided, the subscription will persist across renders. If the listener value is undefined, the subscription will be removed until it becomes defined again.
 
     Providing a listener will also enable you to retrieve messages that have been "previously sent to the room.":/chat/rooms/history
 
@@ -72,7 +72,7 @@ h3(#unsubscribe). Unsubscribe from messages
 blang[javascript].
   Unsubscribe from messages to remove previously registered listeners.
 
-  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.MessageSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
+  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.MessageSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
 
   ```[javascript]
   // Initial subscription
@@ -82,7 +82,7 @@ blang[javascript].
   unsubscribe();
   ```
 
-  Use the "@messages.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Messages.html#unsubscribeAll method to deregister all chat message listeners in a room:
+  Use the "@messages.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#unsubscribeAll method to deregister all chat message listeners in a room:
 
   ```[javascript]
   await room.messages.unsubscribeAll();
@@ -100,10 +100,10 @@ blang[react].
 h2(#send). Send a message
 
 blang[javascript].
-  Use the "@messages.send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Messages.html#send method to send a message in a chat room. All users that are "subscribed":#subscribe to messages on that room will receive it:
+  Use the "@messages.send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#send method to send a message in a chat room. All users that are "subscribed":#subscribe to messages on that room will receive it:
 
 blang[react].
-  Use the "@send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#send method available from the response of the @useMessages@ hook to to send a message to the room:
+  Use the "@send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#send method available from the response of the @useMessages@ hook to to send a message to the room:
 
 ```[javascript]
 await room.messages.send({text: 'hello'});

--- a/content/chat/rooms/occupancy.textile
+++ b/content/chat/rooms/occupancy.textile
@@ -16,10 +16,10 @@ Occupancy enables you to view the number of users currently online in a room. Th
 h2(#subscribe). Subscribe to room occupancy
 
 blang[javascript].
-  Subscribe to a room's occupancy by registering a listener. Occupancy events are emitted whenever the number of online users within a room changes. Use the "@occupancy.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Occupancy.html#subscribe method in a room to receive updates:
+  Subscribe to a room's occupancy by registering a listener. Occupancy events are emitted whenever the number of online users within a room changes. Use the "@occupancy.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Occupancy.html#subscribe method in a room to receive updates:
 
 blang[react].
-  Subscribe to a room's occupancy with the "@useOccupancy@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useOccupancy.html hook.
+  Subscribe to a room's occupancy with the "@useOccupancy@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useOccupancy.html hook.
 
 ```[javascript]
 const {unsubscribe} = room.occupancy.subscribe((event) => {
@@ -76,7 +76,7 @@ h3(#unsubscribe). Unsubscribe from room occupancy
 blang[javascript].
   Unsubscribe from room occupancy to remove previously registered listeners.
 
-  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.OccupancySubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
+  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.OccupancySubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
 
   ```[javascript]
   // Initial subscription
@@ -88,7 +88,7 @@ blang[javascript].
   unsubscribe();
   ```
 
-  Use the "@occupancy.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Occupancy.html#unsubscribeAll method to remove all occupancy listeners in a room:
+  Use the "@occupancy.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Occupancy.html#unsubscribeAll method to remove all occupancy listeners in a room:
 
   ```[javascript]
   await room.occupancy.unsubscribeAll();
@@ -102,14 +102,14 @@ h2(#retrieve). Retrieve room occupancy
 blang[javascript].
   The occupancy of a room can be retrieved in one-off calls instead of subscribing to updates.
 
-  Use the "@occupancy.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Occupancy.html#get method to retrieve the occupancy of a room:
+  Use the "@occupancy.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Occupancy.html#get method to retrieve the occupancy of a room:
 
   ```[javascript]
   const occupancy = await room.occupancy.get();
   ```
 
 blang[react].
-  Use the "@connections@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseOccupancyResponse.html#connections and "@presenceMembers@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseOccupancyResponse.html#presenceMembers properties available from the response of the @useOccupancy@ hook to view the occupancy of a room.
+  Use the "@connections@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseOccupancyResponse.html#connections and "@presenceMembers@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseOccupancyResponse.html#presenceMembers properties available from the response of the @useOccupancy@ hook to view the occupancy of a room.
 
 The following is the structure of an occupancy event:
 

--- a/content/chat/rooms/presence.textile
+++ b/content/chat/rooms/presence.textile
@@ -16,10 +16,10 @@ Subscribe to the online status of room members using the presence feature. Prese
 h2(#subscribe). Subscribe to presence
 
 blang[javascript].
-  Subscribe to users' presence status by registering a listener. Presence events are emitted whenever a member enters or leaves the presence set, or updates their user data. Use the "@presence.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#subscribe method in a room to receive updates:
+  Subscribe to users' presence status by registering a listener. Presence events are emitted whenever a member enters or leaves the presence set, or updates their user data. Use the "@presence.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#subscribe method in a room to receive updates:
 
 blang[react].
-  Subscribe to users' presence status with the "@usePresenceListener@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.usePresenceListener.html hook. Supply an optional listener to receive presence status updates, or use the "@presenceData@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UsePresenceListenerResponse.html#presenceData property returned by the hook.
+  Subscribe to users' presence status with the "@usePresenceListener@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.usePresenceListener.html hook. Supply an optional listener to receive presence status updates, or use the "@presenceData@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UsePresenceListenerResponse.html#presenceData property returned by the hook.
 
   To enter the presence set of a room, use the "@usePresence@":#set hook instead.
 
@@ -100,7 +100,7 @@ h3(#unsubscribe). Unsubscribe from presence
 blang[javascript].
   Unsubscribe from online presence to remove previously registered listeners.
 
-  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.PresenceSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
+  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.PresenceSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
 
   ```[javascript]
   // Initial subscription
@@ -112,7 +112,7 @@ blang[javascript].
   unsubscribe();
   ```
 
-  Use the "@presence.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#unsubscribeAll method to remove all presence listeners in a room:
+  Use the "@presence.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#unsubscribeAll method to remove all presence listeners in a room:
 
   ```[javascript]
   await room.presence.unsubscribeAll();
@@ -130,10 +130,10 @@ Users can enter and leave the presence set of a room to indicate when they are o
 </aside>
 
 blang[javascript].
-  Use the "@presence.enter()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#enter method to indicate when a user joins a room. This will send a presence event to all users subscribed to presence indicating that a new member has joined the chat. You can also set an optional data field with information such as the status of a user:
+  Use the "@presence.enter()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#enter method to indicate when a user joins a room. This will send a presence event to all users subscribed to presence indicating that a new member has joined the chat. You can also set an optional data field with information such as the status of a user:
 
 blang[react].
-  Indicate when a user joins a room with the "@usePresence@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.usePresence.html hook. Users will automatically be entered into the presence set when the component mounts.
+  Indicate when a user joins a room with the "@usePresence@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.usePresence.html hook. Users will automatically be entered into the presence set when the component mounts.
 
   To subscribe to the presence updates of a room, use the "@usePresenceListener@":#subscribe hook instead.
 
@@ -160,10 +160,10 @@ const MyComponent = () => {
 ```
 
 blang[javascript].
-  Use the "@presence.update()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#update method when a user wants to update their data, such as an update to their status, or to indicate that they're raising their hand. Updates will send a presence event ao all users subscribed to presence:
+  Use the "@presence.update()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#update method when a user wants to update their data, such as an update to their status, or to indicate that they're raising their hand. Updates will send a presence event ao all users subscribed to presence:
 
 blang[react].
-  Use the "@update()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UsePresenceResponse.html#update property available from the response of the @usePresence@ hook to update a user's data, such as setting their status to 'Away from keyboard'.
+  Use the "@update()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UsePresenceResponse.html#update property available from the response of the @usePresence@ hook to update a user's data, such as setting their status to 'Away from keyboard'.
 
 ```[javascript]
 await room.presence.update({ status: 'busy' });
@@ -192,10 +192,10 @@ const MyComponent = () => {
 ```
 
 blang[javascript].
-  Use the "@presence.leave()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#leave method to explicitly remove a user from the presence set. This will send a presence event to all users subscribed to presence. You can also set an optional data field such as setting a status of 'Back later'.
+  Use the "@presence.leave()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#leave method to explicitly remove a user from the presence set. This will send a presence event to all users subscribed to presence. You can also set an optional data field such as setting a status of 'Back later'.
 
 blang[react].
-  Indicate when a user leaves a room with the "@usePresence@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.usePresence.html hook. Users will automatically be removed from the presence set when the component unmounts.
+  Indicate when a user leaves a room with the "@usePresence@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.usePresence.html hook. Users will automatically be removed from the presence set when the component unmounts.
 
 ```[javascript]
 await room.presence.leave({ status: 'Be back later!' });
@@ -240,7 +240,7 @@ h2(#retrieve). Retrieve the presence set
 blang[javascript].
   The online presence of users can be retrieved in one-off calls. This can be used to check the status of an individual user, or return the entire presence set as an array.
 
-  Use the "@presence.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#get method to retrieve an array of all users currently entered into the presence set, or individual users:
+  Use the "@presence.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#get method to retrieve an array of all users currently entered into the presence set, or individual users:
 
   ```[javascript]
   // Retrieve all users entered into presence as an array:
@@ -250,14 +250,14 @@ blang[javascript].
   const presentMember = await room.presence.get({ clientId: 'clemons123' });
   ```
 
-  Alternatively, use the "@presence.isUserPresent()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Presence.html#isUserPresent method and pass in a user's @clientId@ to check whether they are online or not. This will return a boolean:
+  Alternatively, use the "@presence.isUserPresent()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Presence.html#isUserPresent method and pass in a user's @clientId@ to check whether they are online or not. This will return a boolean:
 
   ```[javascript]
   const isPresent = await room.presence.isUserPresent('clemons123');
   ```
 
 blang[react].
-  Use the "@presenceData@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UsePresenceListener.html#presenceData property available from the response of the @usePresence@ hook to view a list of all member's presence status in the room.
+  Use the "@presenceData@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UsePresenceListener.html#presenceData property available from the response of the @usePresence@ hook to view a list of all member's presence status in the room.
 
 h3(#member-structure). Presence member structure
 

--- a/content/chat/rooms/reactions.textile
+++ b/content/chat/rooms/reactions.textile
@@ -18,10 +18,10 @@ Room reactions are ephemeral and not stored or aggregated by Ably. The intention
 h2(#subscribe). Subscribe to room reactions
 
 blang[javascript].
-  Subscribe to room reactions by registering a listener. These events are emitted whenever a user sends a reaction, such as by hitting a 'like' button or clicking a heart emoji. Use the "@reactions.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomReactions.html#subscribe method in a room to receive reactions:
+  Subscribe to room reactions by registering a listener. These events are emitted whenever a user sends a reaction, such as by hitting a 'like' button or clicking a heart emoji. Use the "@reactions.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomReactions.html#subscribe method in a room to receive reactions:
 
 blang[react].
-  Subscribe to room reactions with the "@useRoomReactions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useRoomReactions.html hook. Supply an optional listener to receive the room reactions.
+  Subscribe to room reactions with the "@useRoomReactions@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useRoomReactions.html hook. Supply an optional listener to receive the room reactions.
 
 ```[javascript]
 const {unsubscribe} = room.reactions.subscribe((reaction) => {
@@ -74,7 +74,7 @@ h3(#unsubscribe). Unsubscribe from room reactions
 blang[javascript].
   Unsubscribe from receiving room reactions to remove previously registered listeners.
 
-  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomReactionsSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
+  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomReactionsSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
 
   ```[javascript]
   // Initial subscription
@@ -86,7 +86,7 @@ blang[javascript].
   unsubscribe();
   ```
 
-  Use the "@reactions.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomReactions.html#unsubscribeAll method to remove all reaction listeners in a room:
+  Use the "@reactions.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomReactions.html#unsubscribeAll method to remove all reaction listeners in a room:
 
   ```[javascript]
   await room.reactions.unsubscribeAll();
@@ -98,10 +98,10 @@ blang[react].
 h2(#send). Send a room reaction
 
 blang[javascript].
-  Use the "@reactions.send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.RoomReactions.html#send method to send a room-level reaction. The most common way of using this method is to trigger it whenever a user clicks an emoji button in a room:
+  Use the "@reactions.send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.RoomReactions.html#send method to send a room-level reaction. The most common way of using this method is to trigger it whenever a user clicks an emoji button in a room:
 
 blang[react].
-  Use the "@send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseRoomReactionsResponse.html#send method available from the response of the @useRoomReactions@ hook to emit an event when a user reacts, for example when they click an emoji button:
+  Use the "@send()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseRoomReactionsResponse.html#send method available from the response of the @useRoomReactions@ hook to emit an event when a user reacts, for example when they click an emoji button:
 
 ```[javascript]
 await room.reactions.send({type: "like"});

--- a/content/chat/rooms/typing.textile
+++ b/content/chat/rooms/typing.textile
@@ -16,10 +16,10 @@ Typing indicators enable you to display which users are currently writing a mess
 h2(#subscribe). Subscribe to typing events
 
 blang[javascript].
-  Subscribe to typing events by registering a listener. Typing events can be emitted when a user starts typing, and when they stop typing. Use the "@typing.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#subscribe method in a room to subscribe to receive these updates:
+  Subscribe to typing events by registering a listener. Typing events can be emitted when a user starts typing, and when they stop typing. Use the "@typing.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#subscribe method in a room to subscribe to receive these updates:
 
 blang[react].
-  Subscribe to typing events with the "@useTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.useTyping.html hook. Supply an optional listener to receive the typing events, or use the "@currentlyTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseTypingResponse.html#currentlyTyping property returned by the hook to access the list of those users that are currently typing.
+  Subscribe to typing events with the "@useTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useTyping.html hook. Supply an optional listener to receive the typing events, or use the "@currentlyTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseTypingResponse.html#currentlyTyping property returned by the hook to access the list of those users that are currently typing.
 
 ```[javascript]
 const {unsubscribe} = room.typing.subscribe((event) => {
@@ -71,7 +71,7 @@ h3(#unsubscribe). Unsubscribe from typing events
 blang[javascript].
   Unsubscribe from typing events to remove previously registered listeners.
 
-  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.TypingSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
+  Use the "@unsubscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.TypingSubscriptionResponse.html#unsubscribe function returned in the @subscribe()@ response to remove a listener:
 
   ```[javascript]
   // Initial subscription
@@ -83,7 +83,7 @@ blang[javascript].
   unsubscribe();
   ```
 
-  Use the "@typing.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#unsubscribeAll method to remove all typing listeners in a room:
+  Use the "@typing.unsubscribeAll()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#unsubscribeAll method to remove all typing listeners in a room:
 
   ```[javascript]
   await room.typing.unsubscribeAll();
@@ -95,10 +95,10 @@ blang[react].
 h2(#set). Set typing status
 
 blang[javascript].
-  Use the "@typing.start()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#start method to emit a typing event with @isTyping@ set to @true@.
+  Use the "@typing.start()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#start method to emit a typing event with @isTyping@ set to @true@.
 
 blang[react].
-  Use the "@start()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseTypingResponse.html#start method available from the response of the @useTyping@ hook to emit an event when a user has started typing.
+  Use the "@start()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseTypingResponse.html#start method available from the response of the @useTyping@ hook to emit an event when a user has started typing.
 
 There is a timeout associated with start events. A stop event will be automatically emitted after it expires if one isn't received before the timeout. The length of this timeout is customizable using the @timeoutMs@ parameter that can be configured in the @RoomOptions@ that you set when you "create a room":/chat/rooms#create. The default is 10000ms.
 
@@ -126,10 +126,10 @@ const MyComponent = () => {
 ```
 
 blang[javascript].
-  Use the "@stop()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#stop method to emit a typing event with @isTyping@ set to @false@.
+  Use the "@stop()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#stop method to emit a typing event with @isTyping@ set to @false@.
 
 blang[react].
-  Use the "@stop()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseTypingResponse.html#stop method available from the response of the @useTyping@ hook to emit an event when a user has stopped typing.
+  Use the "@stop()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseTypingResponse.html#stop method available from the response of the @useTyping@ hook to emit an event when a user has stopped typing.
 
 ```[javascript]
 await room.typing.stop();
@@ -156,11 +156,11 @@ const MyComponent = () => {
 h2(#retrieve). Retrieve a list of users that are currently typing
 
 blang[javascript].
-  Use the "@typing.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Typing.html#get method to retrieve a set of @clientId@s for all users that are currently typing in the room:
+  Use the "@typing.get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Typing.html#get method to retrieve a set of @clientId@s for all users that are currently typing in the room:
 
   ```[javascript]
   const currentlyTypingClientIds = await room.typing.get();
   ```
 
 blang[react].
-  Use the "@currentlyTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseTypingResponse.html#currentlyTyping property available from the response of the @useTyping@ hook to view a list of all users that are currently typing in the room.
+  Use the "@currentlyTyping@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseTypingResponse.html#currentlyTyping property available from the response of the @useTyping@ hook to view a list of all users that are currently typing in the room.

--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -116,7 +116,7 @@ h2(#instantiate). Instantiate a client
 Instantiate a realtime client using the Pub/Sub SDK and pass the generated client into the Chat constructor.
 
 blang[react].
-  Pass the @ChatClient@ into the "@ChatClientProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat_react.ChatClientProvider.html. The @ChatClient@ instance will be available to all child components in your React component tree.
+  Pass the @ChatClient@ into the "@ChatClientProvider@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.ChatClientProvider.html. The @ChatClient@ instance will be available to all child components in your React component tree.
 
 blang[javascript].
 


### PR DESCRIPTION
## Description

This PR fixes the TypeDoc links in Ably Chat after an update has changed the link format from `chat_js` to `chat-js` and `chat_react` to `chat-react`.
