### PR TITLE
Chat: Clarify the message listener input.

### DIFF
--- a/content/chat/rooms/messages.textile
+++ b/content/chat/rooms/messages.textile
@@ -15,13 +15,13 @@ blang[javascript].
   Subscribe to receive messages in a room by registering a listener. Use the "@messages.subscribe()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#subscribe method in a room to receive all messages that are sent to it:
 
 blang[react].
-    Subscribe to messages with the "@useMessages@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useMessages.html hook. Supply a listener and the hook will automatically subscribe to messages sent to the room. As long as a defined value is provided, the subscription will persist across renders. If the listener value is undefined, the subscription will be removed until it becomes defined again.
+    Subscribe to messages with the "@useMessages@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useMessages.html hook. Supply a listener and the hook will automatically subscribe to message events sent to the room. As long as a defined value is provided, the subscription will persist across renders. If the listener value is undefined, the subscription will be removed until it becomes defined again.
 
     Providing a listener will also enable you to retrieve messages that have been "previously sent to the room.":/chat/rooms/history
 
 ```[javascript]
-const {unsubscribe} = room.messages.subscribe((message) => {
-  console.log(message);
+const {unsubscribe} = room.messages.subscribe((event) => {
+  console.log(event.message);
 });
 ```
 
@@ -31,8 +31,8 @@ import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   useMessages({
-    listener: (message) => {
-      console.log('Received message: ', message);
+    listener: (event) => {
+      console.log('Received message: ', event.message);
     },
   });
 
@@ -76,7 +76,7 @@ blang[javascript].
 
   ```[javascript]
   // Initial subscription
-  const { unsubscribe } = room.messages.subscribe((message) => console.log(message));
+  const { unsubscribe } = room.messages.subscribe((event) => console.log(event.message));
 
   // To remove the listener
   unsubscribe();


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

In chat, the object passed to a listener is called the MessageEventPayload, this contains both a type (describes the event, message.created..) and a message (contains the actual chat message).
We should be clear here in the docs too.

* [messages](http://localhost:8000/chat/rooms/messages)
