### PR TITLE
Chat: Update chat docs to replace 'direction' with 'orderBy'

### DIFF
--- a/content/chat/rooms/history.textile
+++ b/content/chat/rooms/history.textile
@@ -18,7 +18,7 @@ blang[react].
     Use the "@get()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#get method available from the response of the @useMessages@ hook to retrieve messages that have bene previously sent to a room.
 
 ```[javascript]
-const historicalMessages = await room.messages.get({ direction: 'backwards', limit: 50 });
+const historicalMessages = await room.messages.get({ orderBy: 'newestFirst', limit: 50 });
 console.log(historicalMessages.items);
 
 if (historicalMessages.hasNext()) {
@@ -37,7 +37,7 @@ const MyComponent = () => {
 
   const handleGetMessages = () => {
     // fetch the last 3 messages, oldest to newest
-    get({ limit: 3, direction: 'forwards' })
+    get({ limit: 3, orderBy: 'oldestFirst' })
       .then((result) =>
         console.log('Previous messages: ', result.items));
   };
@@ -55,7 +55,7 @@ The following optional parameters can be passed when retrieving previously sent 
 |_. Parameter |_. Description |
 | start | Earliest time to retrieve messages from, as a unix timestamp in milliseconds. Messages with a timestamp equal to, or greater than, this value will be returned. |
 | end | Latest time to retrieve messages from, as a unix timestamp in milliseconds. Messages with a timestamp less than this value will be returned. |
-| direction | The direction in which to retrieve messages from; either @forwards@ or @backwards@. |
+| orderBy | The order in which to retrieve messages from; either @oldestFirst@ or @newestFirst@. |
 | limit | Maximum number of messages to be retrieved, up to 1,000. |
 
 h2(#subscribe). Retrieve messages sent prior to subscribing


### PR DESCRIPTION
> _NOTE TO REVIEWERS_ - please **do not review PRs in the `DRAFT` state**, as the PR may change substantially before it is ready to review. Thanks.

## Description

Replaced all references to the deprecated 'direction' parameter with the new 'orderBy' parameter in message history examples.

## Review

Instructions on how to review the PR. 

* [history](http://localhost:8000/chat/rooms/history)
