### PR TITLE
Added examples directory to be ignored in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   coveragePathIgnorePatterns: ['src/styles/svg'],
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
+  modulePathIgnorePatterns: ['<rootDir>/examples/'],
   // NOTE: This is a workaround for compilation issues with .d.ts files
   transformIgnorePatterns: [
     `node_modules/(?!(gatsby|gatsby-script|use-keyboard-shortcut|react-medium-image-zoom|@react-hook/media-query|@mdx-js/react|@ably/ui/core)/)`,


### PR DESCRIPTION
Tests is having issues due to there being multiple instances of React (examples has many).
