### PR TITLE
[EDU-1698] - Fix Ably JWT generation with Python

### DIFF
--- a/content/auth/token.textile
+++ b/content/auth/token.textile
@@ -695,29 +695,31 @@ The following is an example of creating an Ably JWT:
 ```
 
 ```[python]
+import jwt
 import time
-import hashlib
-import base64
-import json
 
-header = {
-    "typ": "JWT",
-    "alg": "HS256",
-    "kid": "{{API_KEY_NAME}}"
-}
-claims = {
-    "iat": int(time.time()),  # current time in seconds
-    "exp": int(time.time()) + 3600,  # time of expiration in seconds
-    "x-ably-capability": "{\"*\":[\"*\"]}"
-}
+def createAblyJwt(ably_api_key: str):
+    # Split the API key into key ID and secret
+    parts = ably_api_key.split(":")
+    kid = parts[0]
 
-base64_header = base64.urlsafe_b64encode(bytes(json.dumps(header), 'utf-8')).decode('utf-8')
-base64_claims = base64.urlsafe_b64encode(bytes(json.dumps(claims), 'utf-8')).decode('utf-8')
+    # Prepare JWT headers
+    headers = {
+        "typ": "JWT",
+        "alg": "HS256",
+        "kid": kid
+    }
 
-signature = hashlib.sha256((base64_header + "." + base64_claims + "{{API_KEY_SECRET}}").encode('utf-8')).digest()
-signature_base64 = base64.urlsafe_b64encode(signature).decode('utf-8')
+    # Prepare JWT claims
+    claims = {
+        "iat": int(time.time()),  # Issued at time
+        "exp": int(time.time()) + 120,  # Expiration time (2 minutes from now)
+        "x-ably-capability": "{\"*\":[\"*\"]}"  # Full capability
+    }
 
-ably_jwt = base64_header + "." + base64_claims + "." + signature_base64
+    # Encode the JWT
+    jwtToken = jwt.encode(headers=headers, payload=claims, key=parts[1])
+    return jwtToken
 ```
 
 ```[java]


### PR DESCRIPTION
The example in production was incorrect and causing the following error `signature verification failed`

* [Jira ticket](https://ably.atlassian.net/browse/EDU-1698).

## Review

Instructions on how to review the PR. 

* [Page to review](https://ably-docs-edu-1698-pyth-u9veih.herokuapp.com/docs/auth/token?lang=python#standard)
