### PR TITLE
chat: fix merge conflict marker in connections

### DIFF
--- a/content/chat/connect.textile
+++ b/content/chat/connect.textile
@@ -22,11 +22,7 @@ A connection can have any of the following statuses:
 | failed | This status is entered if the SDK encounters a failure condition that it cannot recover from. This may be a fatal connection error received from the Ably service, such as an attempt to connect with an incorrect API key, or some local terminal error, such as that the token in use has expired and the SDK does not have any way to renew it. |
 
 blang[javascript].
-<<<<<<< HEAD
-  Use the "@current@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#current property to check which status a connection is currently in:
-=======
-  Use the "@status@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Connection.html#status property to check which status a connection is currently in:
->>>>>>> 0d6cc60d6 (chat: update room status and connection status)
+  Use the "@status@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Connection.html#status property to check which status a connection is currently in:
 
 blang[react].
   Use the "@currentStatus@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseChatConnectionResponse.html#currentStatus property returned in the response of the "@useChatConnection@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useChatConnection.html hook to check which status a connection is currently in:
@@ -71,11 +67,7 @@ blang[react].
 blang[javascript].
 
 blang[javascript].
-<<<<<<< HEAD
-  Use the "@connection.status.onChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.ConnectionStatus.html#onChange method to register a listener for status change updates:
-=======
-  Use the "@connection.onStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_js.Connection.html#onStatusChange method to register a listener for status change updates:
->>>>>>> 0d6cc60d6 (chat: update room status and connection status)
+  Use the "@connection.onStatusChange()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Connection.html#onStatusChange method to register a listener for status change updates:
 
 blang[react].
   Listeners can also be registered to monitor the changes in connection status. Any hooks that take an optional listener to monitor their events, such as typing indicator events in the @useTyping@ hook, can also register a status change listener. Changing the value provided for a listener will cause the previously registered listener instance to stop receiving events. All messages will be received by exactly one listener.


### PR DESCRIPTION
## Description

This was missed somehow - removes the marker and fixes the conflict.

## Review

chat/connection is the page
