### PR TITLE
[EDU-1702] Updates all product statuses to remove beta tags

### DIFF
--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -10,8 +10,7 @@ languages:
 Use these instructions to install, authenticate and instantiate the Chat SDK.
 
 <aside data-type='note'>
-<p>The Chat SDK is currently in private beta. "Request an invite":https://forms.gle/iEFxLJBNYSy8onmz5 to gain access. If you have any feedback or feature requests, "let us know.":https://forms.gle/SmCLNFoRrYmkbZSf8</p>
-<p>You can also follow updates in the "GitHub repository.":https://github.com/ably/ably-chat-js</p>
+<p>If you have any feedback or feature requests, "let us know.":https://forms.gle/SmCLNFoRrYmkbZSf8</p>
 </aside>
 
 h2(#authentication). Authentication

--- a/content/livesync/index.textile
+++ b/content/livesync/index.textile
@@ -34,7 +34,3 @@ LiveSync can benefit a wide range of applications where it's important to broadc
 h2(#pricing). Pricing
 
 LiveSync "pricing":https://ably.com/pricing is mainly based on message consumption (alongside concurrent connections and concurrent channels). This means that each update published from the database connector to Ably channels is counted as a single message. The message is received by every client subscribed to that channel, each of which counts as one additional message. If, for example, one update is published by the database connector and there are three clients subscribed, that one update will lead result in four messages in total.
-
-h2(#development-status). Development status
-
-LiveSync is in public beta so that you can explore its capabilities. Your "feedback":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform will help prioritize improvements and fixes for subsequent releases.

--- a/content/livesync/mongodb/index.textile
+++ b/content/livesync/mongodb/index.textile
@@ -23,6 +23,9 @@ The integration rule exists as a "database connector" component that is entirely
 
 When a change event is received over the Change Streams API it is published to an Ably channel. When you configure the integration rule, you can specify how change events are mapped to individual Ably channels. Clients can then subscribe to database changes by subscribing to Ably channels. Ably "Auth":/auth and "Capabilities":/auth/capabilities control which channels a client can interact with.
 
+h2(#development-status). Development status
+
+The MongoDB database connector is currently in beta status. Your "feedback":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform will help prioritize improvements and fixes for subsequent releases.
 
 h2(#integration-rule). Integration rule
 

--- a/content/livesync/postgres/index.textile
+++ b/content/livesync/postgres/index.textile
@@ -27,6 +27,10 @@ The Postgres database connector automatically retries failed publishes while mai
 
 The database connector can be "self-hosted":#self-host.
 
+h2(#development-status). Development status
+
+The Postgres database connector is currently in alpha status. Your "feedback":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform will help prioritize improvements and fixes for subsequent releases.
+
 h2(#integration-rule). Integration rule
 
 h3(#create). Creating the rule

--- a/content/pricing/faqs.textile
+++ b/content/pricing/faqs.textile
@@ -23,22 +23,6 @@ h3(#volume). Are there any volume discounts?
 
 Yes. Ably's pricing is consumption-based using the number of messages, and channel and connection minutes consumed. The cost of each unit decreases as you use more per month.
 
-h3(#spaces-cost). Is there a cost to participate in the Spaces beta?
-
-You can use "Ably Spaces":/spaces at no cost while it is beta.
-
-Developers should be encouraged to explore the capabilities of the beta without concern for cost. The "Free package":/pricing/free is a great way to experiment with the Spaces SDK.
-
-Any users on a paid package are eligible for rebates on Spaces usage. "Raise a support ticket":https://ably.com/support to initiate the rebate process.
-
-h3(#chat-cost). Is there a cost to participate in the Chat beta?
-
-You can use "Ably Chat":/chat at no cost while it is beta.
-
-Developers should be encouraged to explore the capabilities of the beta without concern for cost. The "Free package":/pricing/free is a great way to experiment with the Chat SDK.
-
-Any users on a paid package are eligible for rebates on Chat usage. "Raise a support ticket":https://ably.com/support to initiate the rebate process.
-
 h2(#concepts). Concepts and limits
 
 FAQs related to pricing concepts and package limits.

--- a/content/spaces/index.textile
+++ b/content/spaces/index.textile
@@ -41,7 +41,3 @@ The following are a selection of additional features that can be built using Abl
 * 'Follow me' and 'bring to me' functionality
 
 Use the "multiplayer reference guide":https://ably.com/reference-guide-multiplayer#multiplayer-features for guidance on how to build each of these features with Ably.
-
-h2(#status). Development status
-
-Spaces is in public beta so that you can explore its capabilities. Your feedback will help prioritize improvements and fixes in a subsequent release. The features have been validated for a set of use-cases and are stable and perform well, but API changes may occur that impact functionality. The beta is implemented to work under real-world situations and load, but you should use caution when deciding under what conditions to use it.

--- a/content/spaces/space.textile
+++ b/content/spaces/space.textile
@@ -15,7 +15,7 @@ The following features can be implemented within a space:
 * "Live cursors":/spaces/cursors
 * "Component locking":/spaces/locking
 
-The @space@ namespace consists of a state object that represents the realtime status of all members in a given virtual space. This includes a list of which members are currently online or have recently left and each member's location within the application. The position of members' cursors are excluded from the space state due to their high frequency of updates. In the beta release, which UI components members have locked are also excluded from the space state.
+The @space@ namespace consists of a state object that represents the realtime status of all members in a given virtual space. This includes a list of which members are currently online or have recently left and each member's location within the application. The position of members' cursors are excluded from the space state due to their high frequency of updates. The UI components that members have locked are also excluded from the space state.
 
 Space state can be "subscribed":#subscribe to in the @space@ namespace. Alternatively, subscription listeners can be registered for individual features, such as avatar stack events and member location updates. These individual subscription listeners are intended to provide flexibility when implementing collaborative features. Individual listeners are client-side filtered events, so irrespective of whether you choose to subscribe to the space state or individual listeners, each event only counts as a single message.
 

--- a/data/yaml/page-content/asset-tracking.yaml
+++ b/data/yaml/page-content/asset-tracking.yaml
@@ -10,7 +10,7 @@ sections:
       Asset Tracking enables you to track the location of assets such as drivers, vehicles or containers in realtime.
     level: h1
     features: []
-    releaseStage: Beta
+    releaseStage: ''
     callToAction:
       text: Read more about Asset Tracking
       href: '/asset-tracking'

--- a/data/yaml/page-content/chat.yaml
+++ b/data/yaml/page-content/chat.yaml
@@ -11,10 +11,10 @@ sections:
 
       The Chat SDK contains a set of purpose-built APIs that abstract away the complexities involved in how you would architect chat features. The SDK is built on top of Ably's distributed platform, which means that the same [performance guarantees](https://ably.com/four-pillars-of-dependability) apply to Chat.
 
-      [Request an invite](https://forms.gle/iEFxLJBNYSy8onmz5) to access the private beta. If you have any feedback or feature requests, [let us know](https://forms.gle/SmCLNFoRrYmkbZSf8). All feedback will help prioritize improvements and enhancements in subsequent releases. Note that API changes may occur that impact functionality during the beta program.
+      If you have any feedback or feature requests, [let us know](https://forms.gle/SmCLNFoRrYmkbZSf8). All feedback will help prioritize improvements and enhancements in subsequent releases.
     level: h1
     features: []
-    releaseStage: Private Beta
+    releaseStage: ''
     callToAction:
       text: View setup instructions
       href: '/chat/setup'

--- a/data/yaml/page-content/livesync.yaml
+++ b/data/yaml/page-content/livesync.yaml
@@ -13,7 +13,7 @@ sections:
 
     level: h1
     features: []
-    releaseStage: Beta
+    releaseStage: ''
   - title: Discover the database connectors
     description: Pick a database connector below to start synchronizing changes in your database to frontend clients at scale.
     columns: 2

--- a/data/yaml/page-content/spaces.yaml
+++ b/data/yaml/page-content/spaces.yaml
@@ -12,7 +12,7 @@ sections:
       It provides high-level APIs for managing the data related to members collaborating synchronously in an application, such as their online status, or the position of their cursors. This is also known as participant state. Each API is optimized based on the payload structure and frequency of updates that are anticipated for that feature.
     level: h1
     features: []
-    releaseStage: Beta
+    releaseStage: ''
     callToAction:
       text: Read more about Spaces
       href: '/spaces'


### PR DESCRIPTION
## Description

This PR updates the product statues for Spaces, Chat, LiveSync and Asset Tracking: 

* Removes the beta tag and status notice from Spaces.
* Removes the beta tag from Chat and the notice about signing up for the beta.
* Removes the beta tag from LiveSync, and moves the status notice to the Postgres and MongoDB connectors (alpha and beta respectively).
* Removes the beta tag from Asset Tracking.


