### PR TITLE
[EDU-1705] Remove realtime encryption sample for Go

### DIFF
--- a/content/channels/options/encryption.textile
+++ b/content/channels/options/encryption.textile
@@ -126,19 +126,6 @@ The following is an example of setting encryption when obtaining a channel insta
   channel.publish("unencrypted", data: "encrypted secret payload")
 ```
 
-```[realtime_go]
-realtime, _ := ably.NewRealtime(
-  ably.WithKey("{{API_KEY}}"))
-cipherKey, _ := ably.Crypto.GenerateRandomKey(0)
-channel := realtime.Channels.Get("[?rewind=10s]{{RANDOM_CHANNEL_NAME}}", ably.ChannelWithCipherKey(cipherKey))
-
-channel.SubscribeAll(context.Background(), func(message *ably.Message) {
-  log.Println(message.Name)
-  log.Println(message.Data)
-})
-channel.Publish(context.Background(), "unencrypted", "encrypted secret payload")
-```
-
 ```[realtime_flutter]
 final clientOptions = ably.ClientOptions(
   key: '{{API_KEY}}',


### PR DESCRIPTION
## Description

This PR removes the example of setting encryption when obtaining a channel instance using the realtime interface in Go. This was reverted in https://github.com/ably/ably-go/pull/611 and needs to be reimplemented. 


