### PR TITLE
[EDU-1706] Chat post-release fixes

### DIFF
--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -136,8 +136,14 @@ Releasing a room may be optional for many applications. If you have multiple tra
 blang[javascript,swift,kotlin].
   Once <span lang="javascript">"@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Rooms.html#release</span><span lang="swift">"@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-swift/main/AblyChat/documentation/ablychat/rooms/release%28roomid%3A%29</span><span lang="kotlin">"@rooms.release()@":https://sdk.ably.com/builds/ably/ably-chat-kotlin/main/dokka/chat-android/com.ably.chat/-rooms/release.html</span> has been called, the room will be unusable and a new instance will need to be created using "@rooms.get()@":#create if you want to reuse it.
 
+blang[react].
+
+blang[javascript].
   Note that any unresolved promises from @rooms.get()@ will be rejected when @rooms.release()@ is called.
 
+blang[react,swift,kotlin].
+
+blang[javascript,swift,kotlin].
   ```[javascript]
   await rooms.release('basketball-stream');
   ```

--- a/data/yaml/page-content/chat.yaml
+++ b/data/yaml/page-content/chat.yaml
@@ -17,7 +17,7 @@ sections:
     releaseStage: ''
     callToAction:
       text: View setup instructions
-      href: '/chat/setup'
+      href: '/docs/chat/setup'
       type: link
   - title: Demo
     description: Take a look at a livestream chat demo for an example of what you can build with Ably Chat.


### PR DESCRIPTION
## Description

This PR fixes two small bugs noticed after the release of Swift and Kotlin:

* The setup link on the chat homepage was incorrect.
* A sentence under `rooms.release()` was incorrectly displaying for Swift and Kotlin.
