### PR TITLE
chat: combine chat + react packages into one

### DIFF
--- a/content/chat/connect.textile
+++ b/content/chat/connect.textile
@@ -37,7 +37,7 @@ const error = chatClient.connection.error;
 ```
 
 ```[react]
-import { useChatConnection } from '@ably/chat/react';
+import { useChatConnection } from '@ably/chat';
 
 const MyComponent = () => {
   const { currentStatus } = useChatConnection({
@@ -61,7 +61,7 @@ blang[react].
   Hooks related to chat features, such as @useMessages@ and @useTyping@, also return the current @connectionStatus@ in their response.
 
   ```[react]
-  import { useMessages } from '@ably/chat/react';
+  import { useMessages } from '@ably/chat';
 
   const MyComponent = () => {
     const { connectionStatus } = useMessages({
@@ -84,7 +84,7 @@ const { off } = chatClient.connection.onStatusChange((change) => console.log(cha
 ```
 
 ```[react]
-import { useOccupancy } from '@ably/chat/react';
+import { useOccupancy } from '@ably/chat';
 
 const MyComponent = () => {
   useOccupancy({
@@ -159,7 +159,7 @@ const { off } = room.messages.onDiscontinuity((reason?: ErrorInfo) => {
 
 ```[react]
 import { useState } from 'react';
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   useMessages({

--- a/content/chat/rooms/history.textile
+++ b/content/chat/rooms/history.textile
@@ -32,7 +32,7 @@ if (historicalMessages.hasNext()) {
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const { get } = useMessages();
@@ -109,7 +109,7 @@ if (historicalMessages.hasNext()) {
 
 ```[react]
 import { useEffect, useState } from 'react';
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const [loading, setLoading] = useState(true);

--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -34,9 +34,8 @@ const room = await chatClient.rooms.get('basketball-stream', RoomOptionsDefaults
 ```
 
 ```[react]
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 import * as Ably from 'ably';
-import { LogLevel, RoomOptionsDefaults } from '@ably/chat';
+import { ChatClientProvider, ChatRoomProvider, LogLevel, RoomOptionsDefaults } from '@ably/chat';
 
 const realtimeClient = new Ably.Realtime({ key: '{{API_KEY}}', clientId: 'clientId' });
 const chatClient = new ChatClient(realtimeClient);
@@ -178,7 +177,7 @@ await room.attach();
 ```
 
 ```[react]
-import { useRoom } from '@ably/chat/react';
+import { useRoom } from '@ably/chat';
 
 const MyComponent = () => {
   const { attach } = useRoom();
@@ -252,7 +251,7 @@ const currentError = room.error;
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const { roomStatus, roomError } = useMessages({
@@ -335,7 +334,7 @@ blang[react].
   Listeners can also be registered to monitor the changes in room status. Any hooks that take an optional listener to monitor their events, such as typing indicator events in the @useTyping@ hook, can also register a status change listener. Changing the value provided for a listener will cause the previously registered listener instance to stop receiving events. All messages will be received by exactly one listener.
 
   ```[react]
-  import { useOccupancy } from '@ably/chat/react';
+  import { useOccupancy } from '@ably/chat';
 
   const MyComponent = () => {
     useOccupancy({

--- a/content/chat/rooms/messages.textile
+++ b/content/chat/rooms/messages.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 
 ```[react]
 import { useState } from 'react';
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   useMessages({
@@ -163,7 +163,7 @@ await room.messages.send({text: 'hello'});
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
+import { useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const { send } = useMessages();
@@ -207,8 +207,7 @@ await room.messages.update(messageToUpdate, { text: "my updated text" }, { descr
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
-import { Message } from '@ably/chat';
+import { Message, useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const { update } = useMessages();
@@ -256,8 +255,7 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
-import { MessageEvents } from '@ably/chat';
+import { MessageEvents, useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   useMessages({
@@ -330,8 +328,7 @@ await room.messages.delete(messageToDelete, { description: 'Message deleted by u
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
-import { Message } from '@ably/chat';
+import { Message, useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   const { deleteMessage } = useMessages();
@@ -380,8 +377,7 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat/react';
-import { MessageEvents } from '@ably/chat';
+import { MessageEvents, useMessages } from '@ably/chat';
 
 const MyComponent = () => {
   useMessages({

--- a/content/chat/rooms/occupancy.textile
+++ b/content/chat/rooms/occupancy.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.occupancy.subscribe((event) => {
 ```
 
 ```[react]
-import { useOccupancy } from '@ably/chat/react';
+import { useOccupancy } from '@ably/chat';
 
 const MyComponent = () => {
   const { connections, presenceMembers } = useOccupancy({

--- a/content/chat/rooms/presence.textile
+++ b/content/chat/rooms/presence.textile
@@ -33,7 +33,7 @@ const { unsubscribe } = room.presence.subscribe((event) => {
 
 ```[react]
 import React from 'react';
-import { usePresenceListener } from '@ably/chat/react';
+import { usePresenceListener } from '@ably/chat';
 
 const MyComponent = () => {
   const { presenceData, error } = usePresenceListener({
@@ -180,7 +180,7 @@ await room.presence.enter({ status: 'available' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat/react';
+import { usePresence } from '@ably/chat';
 
 const MyComponent = () => {
   const { leave, isPresent } = usePresence({
@@ -220,7 +220,7 @@ await room.presence.update({ status: 'busy' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat/react';
+import { usePresence } from '@ably/chat';
 
 const MyComponent = () => {
   const { update, isPresent } = usePresence({
@@ -264,7 +264,7 @@ await room.presence.leave({ status: 'Be back later!' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat/react';
+import { usePresence } from '@ably/chat';
 
 const MyComponent = () => {
   const { leave, isPresent } = usePresence({

--- a/content/chat/rooms/reactions.textile
+++ b/content/chat/rooms/reactions.textile
@@ -33,7 +33,7 @@ const {unsubscribe} = room.reactions.subscribe((reaction) => {
 
 ```[react]
 import React, { useCallback } from 'react';
-import { useRoomReactions } from '@ably/chat/react';
+import { useRoomReactions } from '@ably/chat';
 
 const MyComponent = () => {
   useRoomReactions({
@@ -139,7 +139,7 @@ await room.reactions.send({type: "heart", metadata: {"effect": "fireworks"}});
 ```
 
 ```[react]
-import { useRoomReactions } from '@ably/chat/react';
+import { useRoomReactions } from '@ably/chat';
 
 const MyComponent = () => {
   const { send } = useRoomReactions();

--- a/content/chat/rooms/typing.textile
+++ b/content/chat/rooms/typing.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.typing.subscribe((event) => {
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat/react';
+import { useTyping } from '@ably/chat';
 
 const MyComponent = () => {
   const {currentlyTyping, error } = useTyping({
@@ -137,7 +137,7 @@ await room.typing.start();
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat/react';
+import { useTyping } from '@ably/chat';
 
 const MyComponent = () => {
   const { start, currentlyTyping, error } = useTyping();
@@ -174,7 +174,7 @@ await room.typing.stop();
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat/react';
+import { useTyping } from '@ably/chat';
 
 const MyComponent = () => {
   const { stop, error } = useTyping();

--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -57,44 +57,15 @@ blang[javascript,react].
 
   ```[javascript]
   import * as Ably from 'ably';
-  import ChatClient from '@ably/chat';
+  import { ChatClient } from '@ably/chat';
   ```
 
   ```[react]
   import * as Ably from 'ably';
-  import ChatClient from '@ably/chat';
-  import { ChatClientProvider } from '@ably/chat/react';
+  import { ChatClient, ChatClientProvider} from '@ably/chat';
   ```
 
 blang[swift,kotlin].
-
-blang[react].
-  h3(#react-native). React Native
-
-  If you're using React Native, you may need to perform extra steps to use the Chat SDK.
-
-  The React package is exported as an ESM module called @@ably/chat/react@, which makes use of the exports field in @package.json@. The Metro bundler used by React Native does not utilize this field by default which results in the imports not being found.
-
-  To fix this issue:
-  * Set the @type@ field of your React Native project to @module@
-  * Update your @tsconfig.json@ to set @"moduleResolution": "Bundler"@
-  * Include the @unstable_enablePackageExports@ field in your @metro.config.cjs@
-
-  The following is an example of setting @unstable_enablePackageExports@ in @metro.config.cjs@:
-
-  ```[react]
-    const { getDefaultConfig } = require('expo/metro-config');
-
-    const defaultConfig = getDefaultConfig(__dirname);
-
-    module.exports = {
-      ...defaultConfig,
-      resolver: {
-        ...defaultConfig.resolver,
-        unstable_enablePackageExports: true, // Enable 'exports' field in package.json,
-      },
-    };
-  ```
 
 blang[javascript].
   h3(#cdn). CDN
@@ -223,9 +194,8 @@ const chatClient = new ChatClient(ably, {logHandler: logWriteFunc, logLevel: 'de
 ```
 
 ```[react]
-import { ChatClientProvider } from '@ably/chat/react';
 import * as Ably from 'ably';
-import { LogLevel } from '@ably/chat';
+import { ChatClientProvider, LogLevel } from '@ably/chat';
 
 const ably = new Ably.Realtime({ key: '{{API_KEY}}', clientId: '<clientId>'});
 const chatClient = new ChatClient(ably, {logHandler: logWriteFunc, logLevel: 'debug' });

--- a/examples/chat-online-status/react/src/app/layout.tsx
+++ b/examples/chat-online-status/react/src/app/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Inter } from "next/font/google";
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 import { Realtime } from 'ably';
-import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults } from '@ably/chat';
 import { ReactNode } from 'react';
 import { faker } from '@faker-js/faker';
 import '../../styles/styles.css';

--- a/examples/chat-online-status/react/src/app/page.tsx
+++ b/examples/chat-online-status/react/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from 'react';
-import { useChatClient, useRoom, usePresenceListener, usePresence } from '@ably/chat/react';
+import { useChatClient, useRoom, usePresenceListener, usePresence } from '@ably/chat';
 import '../../styles/styles.css';
 
 interface OnlineStatus {

--- a/examples/chat-room-history/react/src/app/chat/page.tsx
+++ b/examples/chat-room-history/react/src/app/chat/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useMessages, useChatClient } from '@ably/chat/react';
-import { Message } from '@ably/chat';
+import { Message, useMessages, useChatClient } from '@ably/chat';
 import { useEffect, useState } from 'react';
 import '../../../styles/styles.css';
 

--- a/examples/chat-room-history/react/src/app/layout.tsx
+++ b/examples/chat-room-history/react/src/app/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Inter } from "next/font/google";
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 import { Realtime } from 'ably';
-import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults } from '@ably/chat';
 import { faker } from '@faker-js/faker';
 import '../../styles/styles.css'
 

--- a/examples/chat-room-history/react/src/app/page.tsx
+++ b/examples/chat-room-history/react/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRoom, useMessages } from '@ably/chat/react';
+import { useRoom, useMessages } from '@ably/chat';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import '../../styles/styles.css'

--- a/examples/chat-room-messages/react/src/app/layout.tsx
+++ b/examples/chat-room-messages/react/src/app/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Inter } from "next/font/google";
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults } from '@ably/chat';
 import { Realtime } from 'ably';
-import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
 import '../../styles/styles.css'
 
 const inter = Inter({ subsets: ["latin"] });

--- a/examples/chat-room-messages/react/src/app/page.tsx
+++ b/examples/chat-room-messages/react/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useRoom, useMessages, useChatClient } from '@ably/chat/react';
-import { Message } from '@ably/chat';
+import { Message, useRoom, useMessages, useChatClient } from '@ably/chat';
 import { useState } from 'react';
 import '../../styles/styles.css'
 

--- a/examples/chat-room-reactions/react/src/app/layout.tsx
+++ b/examples/chat-room-reactions/react/src/app/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Inter } from "next/font/google";
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults } from '@ably/chat';
 import { Realtime } from 'ably';
-import { ChatClient, RoomOptionsDefaults } from '@ably/chat';
 import '../../styles/styles.css'
 
 const inter = Inter({ subsets: ["latin"] });

--- a/examples/chat-room-reactions/react/src/app/page.tsx
+++ b/examples/chat-room-reactions/react/src/app/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { useRoom, useRoomReactions } from '@ably/chat/react';
-import { Reaction as ReactionInterface } from '@ably/chat';
+import { Reaction as ReactionInterface, useRoom, useRoomReactions } from '@ably/chat';
 import '../../styles/styles.css'
 
 export default function Home() {

--- a/examples/chat-typing-indicator/react/src/app/layout.tsx
+++ b/examples/chat-typing-indicator/react/src/app/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Inter } from "next/font/google";
-import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 import { Realtime } from 'ably';
-import { ChatClient, RoomOptionsDefaults, TypingOptions } from '@ably/chat';
+import { ChatClient, ChatClientProvider, ChatRoomProvider, RoomOptionsDefaults, TypingOptions } from '@ably/chat';
 import { time } from "console";
 
 const inter = Inter({ subsets: ["latin"] });

--- a/examples/chat-typing-indicator/react/src/app/page.tsx
+++ b/examples/chat-typing-indicator/react/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useChatClient, useRoom, useTyping } from '@ably/chat/react';
+import { useChatClient, useRoom, useTyping } from '@ably/chat';
 import '../../styles/styles.css'
 
 const Loading = () => <div>Loading...</div>;


### PR DESCRIPTION
## Description

Replaces all references to @ably/chat/react with @ably/chat, as part of combining all packages into one, per CHADR-083.

JS PR: https://github.com/ably/ably-chat-js/pull/448

## Review

All chat pages - check that any references to `@ably/chat/react` are replaced with `@ably/chat`, and imports copied over.
