### PR TITLE
[WEB-4185] Bump ably UI to 15.3.1, perform icon name replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "no-githooks": "git config --unset core.hooksPath"
   },
   "dependencies": {
-    "@ably/ui": "^15.1.0",
+    "@ably/ui": "^15.3.1",
     "@codesandbox/sandpack-react": "^2.9.0",
     "@mdx-js/react": "^2.3.0",
     "@react-hook/media-query": "^1.1.1",

--- a/src/components/Header/Dropdown/Button/DropdownButton.tsx
+++ b/src/components/Header/Dropdown/Button/DropdownButton.tsx
@@ -44,7 +44,7 @@ export const DropdownButtonAndMenu = ({
         aria-controls={dropdownDataID}
       >
         <span className="font-bold">{titleOverride || dropdownDataID}</span>
-        <Icon name="icon-gui-disclosure-arrow" size="1.5rem" additionalCSS={chevronDown} />
+        <Icon name="icon-gui-chevron-right-micro" size="1.5rem" additionalCSS={chevronDown} />
       </button>
       {isOpen && <DropdownMenu {...dropdownData[dropdownDataID]} />}
     </div>

--- a/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarDropdownPopulatedItem/MaybeShowHamburgerSummaryLink.tsx
+++ b/src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarDropdownPopulatedItem/MaybeShowHamburgerSummaryLink.tsx
@@ -9,7 +9,7 @@ export const MaybeShowHamburgerSummaryLink = ({ summaryLink }: { summaryLink?: D
       <Link className="mr-4" href={summaryLink.href}>
         {summaryLink.text}
       </Link>
-      <Icon name="icon-gui-arrow-right" size="1rem" />
+      <Icon name="icon-gui-arrow-long-right-micro" size="1rem" />
     </div>
   ) : (
     <div></div>

--- a/src/components/Header/SearchBar/SearchBar.tsx
+++ b/src/components/Header/SearchBar/SearchBar.tsx
@@ -118,7 +118,7 @@ export const SearchBar = ({
               onChange={handleSearch}
               style={{ ...extraInputStyle }}
             />
-            <Icon name="icon-gui-search" size="24px" additionalCSS="absolute left-16 top-12" />
+            <Icon name="icon-gui-magnifying-glass-outline" size="24px" additionalCSS="absolute left-16 top-12" />
             {!isInFocus && (
               <div className="absolute right-16 top-12 hidden lg:flex items-center justify-end">
                 <KeyIcon className="mr-4">{keyIcon}</KeyIcon>

--- a/src/components/Header/SearchBar/SuggestionBox.tsx
+++ b/src/components/Header/SearchBar/SuggestionBox.tsx
@@ -94,7 +94,7 @@ export const SuggestionBox = ({ results, isActive, error, query, displayLocation
             className="text-gui-active hover:underline"
           >
             our main site
-            <Icon name="icon-gui-external-link" size="12px" additionalCSS="inline-block ml-4" />
+            <Icon name="icon-gui-arrow-top-right-on-square-outline" size="12px" additionalCSS="inline-block ml-4" />
           </a>
           .
         </EmptyState>

--- a/src/components/Homepage/BodySection/Card/SdkCard.tsx
+++ b/src/components/Homepage/BodySection/Card/SdkCard.tsx
@@ -13,7 +13,12 @@ export const SdkCard = ({ title, content, image, callToAction }: CardProps) => (
         <div className="mt-auto mb-40 sm:mb-0">
           <Link to={callToAction.href} external={callToAction.external} className="ui-button-primary">
             {callToAction.text}
-            <Icon name="icon-gui-arrow-right" size="1.5rem" color="text-white" additionalCSS="ml-8 -mr-12" />
+            <Icon
+              name="icon-gui-arrow-long-right-outline"
+              size="1.5rem"
+              color="text-white"
+              additionalCSS="ml-8 -mr-12"
+            />
           </Link>
         </div>
       ) : null}

--- a/src/components/Markdown/CodeBlock.tsx
+++ b/src/components/Markdown/CodeBlock.tsx
@@ -48,7 +48,7 @@ export const CodeBlock: FC<{ children: React.ReactNode; language: string }> = ({
       </div>
       <div className="absolute top-16 right-8">
         <ButtonWithTooltip tooltip="Copy" notification="Copied!" onClick={handleCopy} className="text-white">
-          <Icon name="icon-gui-copy" size="1rem" color="white" />
+          <Icon name="icon-gui-square-2-stack-micro" size="1rem" color="text-neutral-000" />
         </ButtonWithTooltip>
       </div>
     </pre>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -38,7 +38,7 @@ export const Notification = ({
         </Link>
       </div>
       <button type="button" className="text-black ml-12 flex items-center" onClick={handleDismiss} aria-label="Close">
-        <Icon name="icon-gui-close" size="16px" />
+        <Icon name="icon-gui-x-mark-outline" size="16px" />
       </button>
     </div>
   ) : null;

--- a/src/components/ProductPage/BodySection/Card/Links.tsx
+++ b/src/components/ProductPage/BodySection/Card/Links.tsx
@@ -20,7 +20,7 @@ export const Links = ({ links }: { links?: LinkProps[] }) =>
                   >
                     {text}
                   </Link>
-                  <Icon name="icon-gui-arrow-right" size="1rem" />
+                  <Icon name="icon-gui-arrow-long-right-micro" size="1rem" />
                 </div>
               );
             })}

--- a/src/components/Redoc/GoTopButton.tsx
+++ b/src/components/Redoc/GoTopButton.tsx
@@ -22,9 +22,9 @@ export const GoTopButton = () => {
     <div className={showGoTop ? 'block' : 'hidden'} onClick={handleScrollUp}>
       <div className="rounded text-white py-8 px-8 bg-cool-black fixed bottom-0 left-0 m-16 z-20 cursor-pointer">
         <Icon
-          name="icon-gui-link-arrow"
+          name="icon-gui-arrow-long-up-outline"
           size="1.5rem"
-          additionalCSS="block text-white transform -rotate-90 align-text-bottom w-24 h-24 m-10"
+          additionalCSS="block text-white align-text-bottom w-24 h-24 m-10"
         />
       </div>
     </div>

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -16,7 +16,12 @@ const SDKToolTip = ({ tooltip }: { tooltip: string }) => {
       onMouseOver={showTooltipHover}
       onMouseOut={hideTooltipHover}
     >
-      <Icon name="icon-gui-info" size="1.25rem" color="text-neutral-500" additionalCSS="mt-12 ml-16" />
+      <Icon
+        name="icon-gui-information-circle-outline"
+        size="1.25rem"
+        color="text-neutral-500"
+        additionalCSS="mt-12 ml-16"
+      />
       {tooltipHover ? (
         <aside
           className="w-240 max-w-240 absolute box-border

--- a/src/components/SDKsPage/Card/index.tsx
+++ b/src/components/SDKsPage/Card/index.tsx
@@ -26,7 +26,7 @@ const Card = ({ githubRepoURL, setupLink, title, image, text }: CardProps) => {
       <p className="ui-text-p3 py-16">{text}</p>
       <div className="flex flex-col justify-center gap-8">
         <Link to={setupLink} rel="noreferrer" className={cn(btn_sdks, 'ui-button-primary gap-8')}>
-          Setup <Icon name="icon-gui-arrow-right" size="1rem" />
+          Setup <Icon name="icon-gui-arrow-long-right-micro" size="1rem" />
         </Link>
         <a
           href={githubRepoURL}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -11,7 +11,7 @@ const CustomOption = ({ innerProps, innerRef, isSelected, label }: OptionProps<R
       className="text-cool-black rounded w-full hover:bg-light-grey cursor-pointer hover:text-gui-active p-8 flex items-center justify-between font-sans text-btn2"
     >
       {label}
-      {isSelected && <Icon name="icon-gui-tick" size="1rem" />}
+      {isSelected && <Icon name="icon-gui-check-micro" size="1rem" />}
     </div>
   );
 };

--- a/src/components/Sidebar/ExpandableIndicator.tsx
+++ b/src/components/Sidebar/ExpandableIndicator.tsx
@@ -12,7 +12,7 @@ export const ExpandableIndicator = ({
   className?: string;
 }) => (
   <Icon
-    name="icon-gui-disclosure-arrow"
+    name="icon-gui-chevron-right-micro"
     size="1rem"
     additionalCSS={cn(
       expendableIndicator,

--- a/src/components/blocks/Html/__snapshots__/Html.test.tsx.snap
+++ b/src/components/blocks/Html/__snapshots__/Html.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<Html /> renders correct Dl based on PageLanguageContext value 1`] = `
   
 	
   <dd
-    class="font-light"
+    class=""
   >
     event name for the published message
     <span

--- a/src/components/blocks/dividers/Aside.tsx
+++ b/src/components/blocks/dividers/Aside.tsx
@@ -34,7 +34,7 @@ const Aside = ({ data, attribs }: HtmlComponentProps<'div'>) => {
         <>
           <span className={`${leftSideElement} ${pitfallElement}`}>&nbsp;</span>
           <strong className={tipTitleElement}>
-            <Icon name="icon-gui-warning" size="1rem" additionalCSS="mr-12" />
+            <Icon name="icon-gui-exclamation-triangle-micro" size="1rem" additionalCSS="mr-12" />
             <span className="ui-text-p2 font-bold text-neutral-1300 mb-48">Important</span>
           </strong>
         </>
@@ -62,7 +62,7 @@ const Aside = ({ data, attribs }: HtmlComponentProps<'div'>) => {
         <>
           <span className={`${leftSideElement} ${noteElement}`}>&nbsp;</span>
           <strong className={tipTitleElement}>
-            <Icon name="icon-gui-document-generic" size="1rem" additionalCSS="mr-12" />
+            <Icon name="icon-gui-document-text-micro" size="1rem" additionalCSS="mr-12" />
             <span className="ui-text-p2 font-bold text-neutral-1300 mb-48">Note</span>
           </strong>
         </>

--- a/src/components/blocks/software/Code/ApiKeyIndicator.tsx
+++ b/src/components/blocks/software/Code/ApiKeyIndicator.tsx
@@ -16,7 +16,7 @@ const APIKeyIndicator = ({ tooltip }: ApiKeyIndicatorProps) => {
       <div className="docs-api-key-label" title={tooltip}>
         Demo Only
       </div>
-      <Icon additionalCSS="ml-4 cursor-help" name="icon-gui-info" size="1rem" />
+      <Icon additionalCSS="ml-4 cursor-help" name="icon-gui-information-circle-micro" size="1rem" />
       {tooltipHover ? (
         <aside
           className="w-240 max-w-240 absolute -mt-140 box-border

--- a/src/components/blocks/software/Code/CodeCopyButton.tsx
+++ b/src/components/blocks/software/Code/CodeCopyButton.tsx
@@ -23,7 +23,7 @@ const CodeCopyButton: FC<Props> = ({ content, language }) => {
   return (
     <div className="absolute top-64 right-16">
       <ButtonWithTooltip tooltip="Copy" notification="Copied!" onClick={handleCopy} className="text-white">
-        <Icon name="icon-gui-copy" size="1rem" color="white" />
+        <Icon name="icon-gui-square-2-stack-micro" size="1rem" color="text-neutral-000" />
       </ButtonWithTooltip>
     </div>
   );

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -155,7 +155,7 @@ const Pre = ({
       {shouldDisplayTip && (
         <aside className="mb-16 flex justify-between items-start">
           <div className="mt-2">
-            <Icon name="icon-gui-info" size="1rem" />
+            <Icon name="icon-gui-information-circle-micro" size="1rem" />
           </div>
           <div className="ml-8 leading-normal">
             You&apos;re currently viewing the <span className="font-semibold">{languageLabel ?? pageLanguage}</span>{' '}

--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`<Pre /> should successfully render code elements with  only Realtime la
             style="width: 1.25rem; height: 1.25rem;"
           >
             <use
-              xlink:href="#sprite-icon-gui-info"
+              xlink:href="#sprite-icon-gui-information-circle-outline"
             />
           </svg>
         </div>
@@ -271,7 +271,7 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
             style="width: 1.25rem; height: 1.25rem;"
           >
             <use
-              xlink:href="#sprite-icon-gui-info"
+              xlink:href="#sprite-icon-gui-information-circle-outline"
             />
           </svg>
         </div>
@@ -405,7 +405,7 @@ exports[`<Pre /> should successfully render code elements with both Rest and Rea
             style="width: 1.25rem; height: 1.25rem;"
           >
             <use
-              xlink:href="#sprite-icon-gui-info"
+              xlink:href="#sprite-icon-gui-information-circle-outline"
             />
           </svg>
         </div>

--- a/src/components/blocks/wrappers/CopyLink.tsx
+++ b/src/components/blocks/wrappers/CopyLink.tsx
@@ -49,7 +49,7 @@ const CopyLink = ({
               [isHidden]: notificationIsVisible,
             })}
           >
-            <Icon name="icon-gui-link" size="1rem" />
+            <Icon name="icon-gui-link-micro" size="1rem" />
           </button>
         </div>
         <div

--- a/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
+++ b/src/components/blocks/wrappers/__snapshots__/ConditionalChildrenLanguageDisplay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><dd> pair of children from alternatives for parsed definition lists ConditionalChildrenLanguageDisplay displays the expected results from HTML data 1`] = `
 <dl
-  className="listDl"
+  className="listDl ui-text-p2"
 >
   
 	
@@ -17,7 +17,7 @@ exports[`Integration: ConditionalChildrenLanguageDisplay only displays one <dt><
       </div>
     </dt>
     <dd
-      className="font-light"
+      className=""
     >
       is a function of the form 
       <code

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
@@ -120,11 +120,11 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
         type="button"
       >
         <svg
-          class="white"
+          class="text-neutral-000"
           style="width: 1rem; height: 1rem;"
         >
           <use
-            xlink:href="#sprite-icon-gui-copy"
+            xlink:href="#sprite-icon-gui-square-2-stack-micro"
           />
         </svg>
       </button>

--- a/src/pages/api/control-api.tsx
+++ b/src/pages/api/control-api.tsx
@@ -28,9 +28,9 @@ const ControlApi = () => {
           <div className="text-gui-default hover:text-gui-hover focus:text-gui-focus focus:outline-gui-focus group ui-text-p2">
             <Link to="/api">
               <Icon
-                name="icon-gui-disclosure-arrow"
+                name="icon-gui-chevron-left-micro"
                 size="1rem"
-                additionalCSS="align-middle transform rotate-180 mr-4 h-16 w-16 ui-link"
+                additionalCSS="align-middle mr-4 h-16 w-16 ui-link"
               />
               API Reference
             </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@^15.1.0":
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-15.1.0.tgz#6d6132ff41a896d6cc4e9b5464c1f9f608a1e86f"
-  integrity sha512-I5l7L6OOUXXah3/s/pj7aeqt3xK7TyBFfz8KnBSL/dnvQUH93bc2yPCuvtCxDVcrd/C3pVx4jKPsp7z1jgTM3Q==
+"@ably/ui@^15.3.1":
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-15.3.1.tgz#9303988bc85646fbdaa895df958d857662567bdf"
+  integrity sha512-QTOxfPJHUZEu20W7OUUMr3gkWtW5BQRXK53LFcvDrBL+lVo0jSCNrBTpcK8eqjEJ8eSz+H2yP8ngiXPyRaAz3w==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-switch" "^1.1.1"


### PR DESCRIPTION
By bumping `ably-ui` to `15.3.1`, we perform a repo-wide GUI icon replacement, bringing in the new hero icons and the naming convention that comes with them. This PR aims to make these substitutions based upon the recommended translations in the design team's Figma docs.

Review env: https://ably-docs-bump-ably-ui--ffsskv.herokuapp.com/

Bot's word:
This pull request includes multiple updates to the project, focusing on upgrading dependencies and updating icon usage across various components. The most important changes are summarized below:

### Dependency Upgrade:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R42): Updated the `@ably/ui` dependency from version `^15.1.0` to `^15.3.1`.

### Icon Updates:
* [`src/components/Header/Dropdown/Button/DropdownButton.tsx`](diffhunk://#diff-f66a9290c39f45013f55af0c257ee4d53389ea61461406803fdc21ef6e6814fdL47-R47): Changed the icon from `icon-gui-disclosure-arrow` to `icon-gui-chevron-right-micro`.
* [`src/components/Header/HamburgerMenu/HamburgerDropdown/HamburgerSidebarRenderer/HamburgerSidebarDropdownPopulatedItem/MaybeShowHamburgerSummaryLink.tsx`](diffhunk://#diff-43ac565b928659d64b467696bcb95994d1a5e03b070db95642740934de9e6f66L12-R12): Changed the icon from `icon-gui-arrow-right` to `icon-gui-arrow-long-right-micro`.
* [`src/components/Header/SearchBar/SearchBar.tsx`](diffhunk://#diff-698828f4a6004b94b157fe2051fec3a1787cf887d508f10d2a44624f1cb8d7aeL121-R121): Changed the icon from `icon-gui-search` to `icon-gui-magnifying-glass-outline`.
* [`src/components/Header/SearchBar/SuggestionBox.tsx`](diffhunk://#diff-a81487aabea62475531cd89f95654cf341c00caad273502405b3f77213cf274dL97-R97): Changed the icon from `icon-gui-external-link` to `icon-gui-arrow-top-right-on-square-outline`.
* [`src/components/Homepage/BodySection/Card/SdkCard.tsx`](diffhunk://#diff-2f4af5152cc8ec0c26b671b324cfd0f13d3dda4946b4e99447eb7a53d9e420b7L16-R21): Changed the icon from `icon-gui-arrow-right` to `icon-gui-arrow-long-right-outline`.
* [`src/components/Markdown/CodeBlock.tsx`](diffhunk://#diff-be1abb71b0dc9ea5ed9b28d4c02a23ff4081ba05b4dda7b562fa03d13fb19262L51-R51): Changed the icon from `icon-gui-copy` to `icon-gui-square-2-stack-micro`.
* [`src/components/Notification/Notification.tsx`](diffhunk://#diff-1019e818df12ccb2db0eafad4b181840c4eeecd95b057fe177466b21a68d7b54L41-R41): Changed the icon from `icon-gui-close` to `icon-gui-x-mark-outline`.
* [`src/components/ProductPage/BodySection/Card/Links.tsx`](diffhunk://#diff-3dc197c0233eec3efa4c5cba055015d9b83f9ea0e3ae514b1918e5a15bfcc55fL23-R23): Changed the icon from `icon-gui-arrow-right` to `icon-gui-arrow-long-right-micro`.
* [`src/components/Redoc/GoTopButton.tsx`](diffhunk://#diff-e4f72e1528d94cf29a1001d43035a8938c4828b0721cbcc8e7a6df4358bb6957L25-R25): Changed the icon from `icon-gui-link-arrow` to `icon-gui-arrow-long-right-outline`.
* [`src/components/SDKInterfacePanel/SDKInterfacePanel.tsx`](diffhunk://#diff-42968b9103d2cc5965a0d04dfc1cc5b504ae6f7953bba25235b0f24b445652f5L19-R24): Changed the icon from `icon-gui-info` to `icon-gui-information-circle-outline`.
* [`src/components/SDKsPage/Card/index.tsx`](diffhunk://#diff-e0ca8c8147aa5860c40f6f5279aed358db02d89b11699a7bda784d35675149beL29-R29): Changed the icon from `icon-gui-arrow-right` to `icon-gui-arrow-long-right-micro`.
* [`src/components/Select/Select.tsx`](diffhunk://#diff-d6181d40b4597b102e57c0daacdac25ca9f5082357c4360133812235abc7bee1L14-R14): Changed the icon from `icon-gui-tick` to `icon-gui-check-micro`.
* [`src/components/Sidebar/ExpandableIndicator.tsx`](diffhunk://#diff-9582c871af9d85fc101d2c636951e759c4fa8f8ad6bbc81261400faf235998bfL15-R15): Changed the icon from `icon-gui-disclosure-arrow` to `icon-gui-chevron-right-micro`.
* [`src/components/blocks/dividers/Aside.tsx`](diffhunk://#diff-b7ce4b6c7857969a7396821e65ad0220f2448fda902172460395e1b66db20dfbL37-R37): Changed the icon from `icon-gui-warning` to `icon-gui-exclamation-triangle-micro` and from `icon-gui-document-generic` to `icon-gui-document-text-micro`. [[1]](diffhunk://#diff-b7ce4b6c7857969a7396821e65ad0220f2448fda902172460395e1b66db20dfbL37-R37) [[2]](diffhunk://#diff-b7ce4b6c7857969a7396821e65ad0220f2448fda902172460395e1b66db20dfbL65-R65)
* [`src/components/blocks/software/Code/ApiKeyIndicator.tsx`](diffhunk://#diff-d3cb3c189ba4616dca14037365d823952534ae2044fa1bd2135c7174ae95a6fbL19-R19): Changed the icon from `icon-gui-info` to `icon-gui-information-circle-micro`.
* [`src/components/blocks/software/Code/CodeCopyButton.tsx`](diffhunk://#diff-50815665c2402dcc499ec068e96c18e29d30031dee0c3f7c63b1f748cf686b6fL26-R26): Changed the icon from `icon-gui-copy` to `icon-gui-square-2-stack-micro`.
* [`src/components/blocks/software/Pre.tsx`](diffhunk://#diff-b39cd09edae4b9ffa18614113aa7a1fcb5ae2933bfb1c2f22c25f3256573e613L158-R158): Changed the icon from `icon-gui-info` to `icon-gui-information-circle-micro`.
* [`src/components/blocks/software/__snapshots__/Pre.test.tsx.snap`](diffhunk://#diff-4c5c213f97ffe6de3467e09fc89a0b19e1f10e5f0722466d2831bb1ce33fc7a0L145-R145): Updated the snapshot references for icons from `icon-gui-info` to `icon-gui-information-circle-outline`. [[1]](diffhunk://#diff-4c5c213f97ffe6de3467e09fc89a0b19e1f10e5f0722466d2831bb1ce33fc7a0L145-R145) [[2]](diffhunk://#diff-4c5c213f97ffe6de3467e09fc89a0b19e1f10e5f0722466d2831bb1ce33fc7a0L274-R274) [[3]](diffhunk://#diff-4c5c213f97ffe6de3467e09fc89a0b19e1f10e5f0722466d2831bb1ce33fc7a0L408-R408)

### Minor Changes:
* [`src/components/blocks/Html/__snapshots__/Html.test.tsx.snap`](diffhunk://#diff-045365fef21d2fd8e2b3c701f3454affb0066117545e739750ed41bae8f175abL15-R15): Removed the `font-light` class from a `dd` element.