### PR TITLE
[WEB-4192] Fix broken call to action internal links

### DIFF
--- a/data/yaml/page-content/chat.yaml
+++ b/data/yaml/page-content/chat.yaml
@@ -17,7 +17,7 @@ sections:
     releaseStage: ''
     callToAction:
       text: View setup instructions
-      href: '/docs/chat/setup'
+      href: '/chat/setup'
       type: link
   - title: Demo
     description: Take a look at a livestream chat demo for an example of what you can build with Ably Chat.

--- a/src/components/Homepage/BodySection/BodySection.tsx
+++ b/src/components/Homepage/BodySection/BodySection.tsx
@@ -1,4 +1,5 @@
 import cn from '@ably/ui/core/utils/cn';
+import { withPrefix } from 'gatsby';
 import { ImageProps, getImageFromList } from 'src/components/Image';
 import { SectionProps } from '../HomepageContent';
 import { BodySectionDescription } from './BodySectionDescription';
@@ -6,6 +7,7 @@ import { HeroCard } from './Card/HeroCard';
 import { FeatureCard } from './Card/FeatureCard';
 import { SdkCard } from './Card/SdkCard';
 import FeatureLink from '@ably/ui/core/FeaturedLink';
+import { checkLinkIsInternal, normalizeLegacyDocsLink } from 'src/utilities/link-checks';
 
 const cardTypes = {
   hero: HeroCard,
@@ -38,6 +40,10 @@ export const BodySection = ({ section, images }: { section: SectionProps; images
   const columns = section.columns;
   const singleColumn = columns == 1;
   const bottomMargin = sectionBottomMarginVariants[section.bottomMargin];
+
+  if (section.callToAction && checkLinkIsInternal(section.callToAction.href)) {
+    section.callToAction.href = withPrefix(normalizeLegacyDocsLink(section.callToAction.href));
+  }
 
   return (
     <section className={bottomMargin}>

--- a/src/components/ProductPage/BodySection/BodySection.tsx
+++ b/src/components/ProductPage/BodySection/BodySection.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import { SectionProps } from '../ProductPageContent';
 import { BodySectionDescription } from './BodySectionDescription';
 import { FeatureCard, QuickstartCard, ExampleCard, TutorialCard } from './Card';
 import { ImageProps, getImageFromList } from 'src/components/Image';
 import FeatureLink from '@ably/ui/core/FeaturedLink';
+import { checkLinkIsInternal, normalizeLegacyDocsLink } from 'src/utilities/link-checks';
 
 const cardTypes = {
   feature: FeatureCard,
@@ -30,6 +32,10 @@ export const BodySection = ({ section, images }: { section: SectionProps; images
     5: 'lg:grid-cols-5',
     4: 'lg:grid-cols-4',
   };
+
+  if (section.callToAction && checkLinkIsInternal(section.callToAction.href)) {
+    section.callToAction.href = withPrefix(normalizeLegacyDocsLink(section.callToAction.href));
+  }
 
   return (
     <section className="mb-48">
@@ -63,11 +69,11 @@ export const BodySection = ({ section, images }: { section: SectionProps; images
           })}
         </div>
       )}
-      {section.callToAction ? (
+      {section.callToAction && (
         <FeatureLink {...section.callToAction} url={section.callToAction.href}>
           {section.callToAction.text}
         </FeatureLink>
-      ) : null}
+      )}
     </section>
   );
 };


### PR DESCRIPTION
This PR includes updates to internal link handling and call-to-action (CTA) links in the `BodySection` components for both the homepage and product pages, now we make sure that we check to see if the links are internal or external links privided in the call to action.

This will fix broken links on the pubsub and asset tracking, and improves on this #2381 
