### PR TITLE
[EDU-1661] Add documentation for message conflation

### DIFF
--- a/content/channels/index.textile
+++ b/content/channels/index.textile
@@ -202,6 +202,7 @@ The channel rules related to enabling features are:
 
 - Push notifications enabled := If checked, publishing messages with a push payload in the @extras@ field is permitted. This triggers the delivery of a "Push Notification":/push to devices registered for push on the channel.
 - Server-side batching := if enabled, messages are grouped into batches before being sent to subscribers. "Server-side batching":/messages/batch#server-side reduces the overall message count, lowers costs, and mitigates the risk of hitting rate limits during high-throughput scenarios.
+- Message conflation := if enabled, messages are aggregated over a set period of time and evaluated against a conflation key. All but the latest message for each conflation key value will be discarded, and the resulting message, or messages, will be delivered to subscribers as a single batch once the period of time elapses. "Message conflation":/messages#conflation reduces costs in high-throughput scenarios by removing redundant and outdated messages.
 
 <!-- DASHBOARD-INSTRUCTION: Setting a channel rule -->
 To set a channel rule in the Ably dashboard:

--- a/content/messages/batch.textile
+++ b/content/messages/batch.textile
@@ -49,6 +49,10 @@ Use the following steps to configure server-side batching for a channel, or chan
 # Choose a batching interval over which to aggregate messages.
 # Click *Create channel rule* to save.
 
+<aside data-type='note'>
+<p>Server side batching is mutually exclusive with "message conflation":/messages#conflation on a channel, or channel namespace.</p>
+</aside>
+
 h2(#batch-publish). Batch publish
 
 It is possible to publish messages to multiple channels with a single request. A batch request queries an API multiple times with single HTTP request. A batch request has a single set of request details containing the request body, parameters and headers. These are converted into an array of requests to the underlying API. Each individual request to the underlying API is performed in parallel and may succeed or fail independently.

--- a/content/messages/index.textile
+++ b/content/messages/index.textile
@@ -66,3 +66,7 @@ Use the following steps to configure message conflation for a channel, or channe
 # Choose a conflation interval over which to aggregate messages.
 # Enter a "conflation key":#routing to assess messages against.
 # Click *Create channel rule* to save.
+
+<aside data-type='note'>
+<p>Message conflation is mutually exclusive with "server-side batching":/messages/batch#server-side on a channel, or channel namespace.</p>
+</aside>

--- a/content/messages/index.textile
+++ b/content/messages/index.textile
@@ -2,16 +2,7 @@
 title: Message concepts
 meta_description: "Messages contain data and are sent and received through channels."
 languages:
-  - csharp
-  - flutter
-  - java
   - javascript
-  - nodejs
-  - objc
-  - php
-  - python
-  - ruby
-  - swift
 redirect_from:
   - /rest/messages
   - /rest/versions/v1.1/messages
@@ -42,3 +33,36 @@ The following are the properties of a message:
 - timestamp := The timestamp of when the message was received by Ably, as milliseconds since the Unix epoch.
 - extras := A JSON object of arbitrary key-value pairs that may contain metadata, and/or ancillary payloads. Valid payloads include those related to "Push Notifications":/push, "deltas":/channels/options/deltas and  and headers.
 - encoding := This is typically empty, as all messages received from Ably are automatically decoded client-side using this value. However, if the message encoding cannot be processed, this attribute contains the remaining transformations not applied to the data payload.
+
+h2(#conflation). Message conflation
+
+Use message conflation to ensure that clients only ever receive the most up-to-date message, by removing redundant and outdated messages. Message conflation will aggregate published messages for a set period of time and evaluate all messages against a "conflation key":#routing. All but the latest message for each conflation key value will be discarded, and the resulting message, or messages, will be delivered to subscribers as a single batch once the period of time elapses.
+
+For example, messages published with the following in the @extras.headers@ field will alternate between four different values for the market:
+
+```[javascript]
+market = pickOneFrom('market-A', 'market-B', 'market-C', 'market-D')
+headers = { market };
+channel.publish({ name: 'update', data: { market, update: counter++ }, extras: { headers }});
+```
+
+If the conflation key for this channel is set to @#{message.extras.headers['market']}@ with a 200ms conflation interval, then at the end of each 200ms interval a maximum of four messages will be delivered to subscribers in a single batch.
+
+Conflation is useful in scenarios where the latest state of a message matters most. Applications in the betting or stocks industry are good examples of this, where odds and prices are changing rapidly, but end-users don't need to be overwhelmed by receiving a message with every single change. Instead they can receive only the latest update every 100ms, for example.
+
+In these instances the frequency of updates for the subscriber are of less importance than the rate at which the updates are published. It also reduces the message cost of applications by not propagating every single update to subscribers.
+
+h3(#configure-conflation). Configure message conflation
+
+When configuring message conflation, you need to set a conflation interval, in milliseconds. Messages sent to Ably during this interval are temporarily held and assessed against the "conflation key":#routing. Once the interval elapses, the latest version of each message for a unique conflation key value will be delivered to subscribers as a single batch.
+
+Use the following steps to configure message conflation for a channel, or channel namespace:
+
+# On your "dashboard":https://ably.com/accounts/any, select one of your apps.
+# Go to *Settings*.
+# Under "channel rules":/channels#rules, click *Add new rule*.
+# Enter the channel name, or channel namespace to apply message conflation to.
+# Check *Conflation enabled*.
+# Choose a conflation interval over which to aggregate messages.
+# Enter a "conflation key":#routing to assess messages against.
+# Click *Create channel rule* to save.


### PR DESCRIPTION
## Description

This PR adds content for message conflation and how to enable it. It also adds a note stating that server-side batching is mutually exclusive with message conflation on a channel / channel namespace basis.

This PR is related to https://github.com/ably/docs/pull/2404
