### PR TITLE
[WEB-4194] Conflation ControlAPI

### DIFF
--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -4880,6 +4880,17 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           default: 20
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
+        conflationEnabled:
+          default: false
+          description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
+          example: false
+        conflationInterval:
+          type: integer
+          description: The interval in milliseconds over which messages are held and evaluated for conflation.
+          example: 1000
+        conflationKey:
+          type: string
+          description: The <a href="https://ably.com/docs/messages#routing">key</a> used to determine which messages should be conflated.
         tlsOnly:
           type: boolean
           default: false
@@ -4919,11 +4930,23 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           type: boolean
           default: false
           description: If `true`, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers.
+          example: false
         batchingInterval:
           type: integer
           default: 20
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
+        conflationEnabled:
+          default: false
+          description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
+          example: false
+        conflationInterval:
+          type: integer
+          description: The interval in milliseconds over which messages are held and evaluated for conflation.
+          example: 1000
+        conflationKey:
+          type: string
+          description: The <a href="https://ably.com/docs/messages#routing">key</a> used to determine which messages should be conflated.
         tlsOnly:
           type: boolean
           default: false
@@ -4978,6 +5001,17 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           default: 20
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
+        conflationEnabled:
+          default: false
+          description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
+          example: false
+        conflationInterval:
+          type: integer
+          description: The interval in milliseconds over which messages are held and evaluated for conflation.
+          example: 1000
+        conflationKey:
+          type: string
+          description: The <a href="https://ably.com/docs/messages#routing">key</a> used to determine which messages should be conflated.
         tlsOnly:
           type: boolean
           default: false

--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -4875,11 +4875,6 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           default: false
           description: If `true`, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers.
           example: false
-        batchingPolicy:
-          type: string
-          default: simple
-          description: If `true`, groups multiple incoming messages into a single batch.
-          example: simple
         batchingInterval:
           type: integer
           default: 20
@@ -4924,11 +4919,6 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           type: boolean
           default: false
           description: If `true`, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers.
-        batchingPolicy:
-          type: string
-          default: simple
-          description: If `true`, groups multiple incoming messages into a single batch.
-          example: simple
         batchingInterval:
           type: integer
           default: 20
@@ -4983,11 +4973,6 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           default: false
           description: If `true`, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers.
           example: false
-        batchingPolicy:
-          type: string
-          default: simple
-          description: If `true`, groups multiple incoming messages into a single batch.
-          example: simple
         batchingInterval:
           type: integer
           default: 20


### PR DESCRIPTION
See WEB-4194 for more details

Add ControlAPI fields to namespaces for conflation, and clean up batching fields


This pull request includes changes to the `static/open-specs/control-v1.yaml` file to update the message batching and conflation configurations. The most important changes involve the removal of the `batchingPolicy` field and the addition of new fields related to message conflation.

Changes to message batching and conflation configurations:

* Removed the `batchingPolicy` field from the configuration. [[1]](diffhunk://#diff-c3f40cc04a5166b4909647b17180a6605d4505faf64b7962cab695ff3ef62039L4876-L4880) [[2]](diffhunk://#diff-c3f40cc04a5166b4909647b17180a6605d4505faf64b7962cab695ff3ef62039L4925-R4934) [[3]](diffhunk://#diff-c3f40cc04a5166b4909647b17180a6605d4505faf64b7962cab695ff3ef62039L4984-L4988)
* Updated the `batchingInterval` description to clarify its role in determining the frequency of message batching.
* Added the `conflationEnabled` field to enable or disable message conflation.
* Added the `conflationInterval` field to specify the interval at which messages are conflated.
* Added the `conflationKey` field to determine which messages should be conflated based on a key.