### PR TITLE
EDU-576: Datadog integration

### DIFF
--- a/content/integrations/index.textile
+++ b/content/integrations/index.textile
@@ -26,6 +26,7 @@ The following pre-built Webhooks can be configured:
 * "Zapier":/docs/integrations/webhooks/zapier
 * "Cloudflare Workers":/docs/integrations/webhooks/cloudflare
 * "IFTTT":/docs/integrations/webhooks/ifttt
+* "Datadog":/docs/integrations/webhooks/datadog
 
 h2(#continuous). Outbound streaming
 

--- a/content/integrations/streaming/datadog.textile
+++ b/content/integrations/streaming/datadog.textile
@@ -1,0 +1,84 @@
+---
+title: Datadog
+meta_description: "Connect Ably and Datadog to monitor messages, channels, and connections in realtime, integrating your Ably statistics with your existing Datadog setup."
+meta_keywords: "Datadog, integrations, statistics, metrics, monitoring, analytics, enterprise"
+---
+
+The Ably "Datadog":https://docs.datadoghq.com/integrations/ably/ integration enables you to monitor your application's statistics. Every 60 seconds, Ably streams a comprehensive set of "statistics":/docs/metadata-stats/stats#metrics to the Datadog API.
+
+h2(#setup). Setup the Datadog integration
+
+To connect Ably with Datadog, you must "Raise a support ticket":https://ably.com/support to gain access to the integration via your Ably dashboard. Once granted, you can authorize the integration through Datadog's "OAuth":https://docs.datadoghq.com/developers/integrations/oauth_for_integrations/ flow. This process requires the @api_keys_write@ scope, allowing Ably to push data to your Datadog account.
+
+Once the integration is active, Datadog provides a specific Ably "dashboard":https://docs.datadoghq.com/integrations/ably/, enabling you to monitor key metrics without extra setup.
+
+The following steps setup the Datadog integration:
+
+# In Datadog, go to *Integrations*, find the *Ably* tile, and click *Install Integration*.
+# Click *Connect Accounts* to start the authorization process. Datadog redirects you to Ably.
+# Log in to your *Ably* account.
+# Select your application from the *Your Apps* page.
+# Navigate to *Integrations*, and select *Connect to Datadog*.
+# Datadog authorization page, authorize Ably using *OAuth* to grant access. The required authorization scope is: @api_keys_write@.
+# After completing authorization, you will be redirected to the *Ably dashboard*, and the process is complete.
+
+h2(#remove). Remove access
+
+Removing access disconnects Ably from Datadog, stopping data transmission and revoking authorization. Follow the steps remove the Ably and Datadog integration using either platform.
+
+h3(#in-ably). Remove access using Ably
+
+* Open your application's integration settings.
+* Click *Remove* next to the Datadog integration.
+* Ably revokes OAuth credentials and stops metric transmission.
+
+h3(#in-datadog). Remove access using Datadog
+
+* Remove associated Ably API keys via *Integrations* or *API Keys*.
+* Adjust scopes or entirely revoke OAuth tokens if necessary.
+
+h2(#lite). Datadog lite
+
+Datadog Lite is a lightweight version of the full Datadog integration that sends a reduced set of "statistics":/docs/metadata-stats/stats#metrics to the Datadog API. This integration is designed for use cases where full statistics are not required, such as when you only need to monitor a limited number channels or connections.
+
+The following statistics are streamed from Ably to Datadog using the Lite integration:
+
+|_. Metric Name |_. Description |
+|@messages.all.all.count@|Total number of messages that were successfully sent, summed over all message types and transports.|
+|@messages.all.all.billableCount@|Total number of billable messages that were successfully sent, summed over all message types and transports.|
+|@messages.all.all.data@|Total message size of all messages that were successfully sent, summed over all message types and transports.|
+|@messages.all.all.uncompressedData@|Total uncompressed message size, excluding delta compression.|
+|@messages.all.all.failed@|Total number of messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as they were rejected by an external integration target, or a service issue on Ably's side.|
+|@messages.all.all.refused@|Total number of messages that were refused by Ably. For example, due to rate limiting, malformed messages, or incorrect client permissions.|
+|@messages.all.messages.count@|Total message count, excluding presence and state messages.|
+|@messages.all.messages.billableCount@|Total billable message count, excluding presence and state messages.|
+|@messages.all.messages.data@|Total message size, excluding presence and state messages.|
+|@messages.all.messages.uncompressedData@|Total number of messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as they were rejected by an external integration target, or a service issue on Ably's side.|
+|@messages.all.messages.failed@|Total number of messages excluding presence and state messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as they were rejected by an external integration target, or a service issue on Ably’s side.|
+|@messages.all.messages.refused@|Total number of messages excluding presence and state messages that were refused by Ably. For example, due to rate limiting, malformed messages, or incorrect client permissions.|
+|@messages.all.presence.count@|Total presence message count.|
+|@messages.all.presence.billableCount@|Total billable presence message count.|
+|@messages.all.presence.data@|Total presence message size.|
+|@messages.all.presence.uncompressedData@|Total uncompressed presence message size, excluding delta compression.|
+|@messages.all.messages.failed@|Total number of presence messages excluding presence and state messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as they were rejected by an external integration target, or a service issue on Ably's side.|
+|@messages.all.messages.refused@|Total number of presence messages excluding presence and state messages that were refused by Ably. For example, due to rate limiting, malformed messages, or incorrect client permissions.|
+|@messages.inbound.all.all.count@|Total inbound message count, received by Ably from clients.|
+|@messages.inbound.all.all.data@|Total inbound message size, received by Ably from clients.|
+|@messages.inbound.all.all.uncompressedData@|Total uncompressed inbound message size, excluding delta compression, received by Ably from clients.|
+|@messages.inbound.all.all.failed@|Total number of inbound messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as a service issue on Ably's side.|
+|@messages.inbound.all.all.refused@|Total number of inbound messages that were refused by Ably. For example, due to rate limiting, malformed messages, or incorrect client permissions.|
+|@messages.outbound.all.all.count@|Total outbound message count, sent from Ably to clients.|
+|@messages.outbound.all.all.billableCount@|Total billable outbound message count, sent from Ably to clients.|
+|@messages.outbound.all.all.data@|Total outbound message size, sent from Ably to clients.|
+|@messages.outbound.all.all.uncompressedData@|Total uncompressed outbound message size, excluding delta compression, sent from Ably to clients.|
+|@messages.outbound.all.all.failed@|Total number of outbound messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as rejection by an external integration target, or a service issue on Ably's side.|
+|@messages.outbound.all.all.refused@|Total number of outbound messages that were refused by Ably. This is generally due to rate limiting.|
+|@connections.all.peak@	|Peak connection count.|
+|@channels.peak@ |Peak active channel count.|
+|@push.channelMessages@	|Total number of channel messages published over Ably that contained a push payload. Each of these may have triggered notifications to be sent to a device with a matching registered push subscription.|
+|@messages.persisted.messages.count@ |Total count of persisted messages, excluding presence and state messages.|
+|@messages.persisted.messages.data@	|Total size of persisted messages, excluding presence and state messages.|
+|@messages.persisted.messages.uncompressedData@	|Total uncompressed persisted message size, excluding delta compression, and presence and state messages.|
+|@messages.persisted.presence.count@ |Total count of persisted presence messages.|
+|@messages.persisted.presence.data@ |Total size of persisted presence messages.|
+|@messages.persisted.presence.uncompressedData@ |Total uncompressed persisted presence message size, excluding delta compression.|

--- a/content/pricing/enterprise.textile
+++ b/content/pricing/enterprise.textile
@@ -14,7 +14,7 @@ Enterprise packages can include features such as:
 - Custom CNAMEs := use your own custom domain, or a subdomain of Ably for your application or service.
 - SAML and SCIM := authenticate with Ably using your own Identity Provider (IdP) and automatically provision users within your Ably account.
 - Active traffic management := Ably can monitor the health of your own endpoints and proactively take steps to isolate, or move, traffic to ensure business continuity.
-- DataDog := send metrics from Ably into your DataDog account.
+- DataDog := send metrics from Ably into your "DataDog":/docs/integrations/streaming/datadog account.
 - PrivateLink := enable traffic from your users and servers into Ably without using the public internet via "AWS PrivateLink":https://aws.amazon.com/privatelink/.
 - Private clusters := guaranteed capacity and isolation from all other Ably users.
 

--- a/content/pricing/pro.textile
+++ b/content/pricing/pro.textile
@@ -18,7 +18,7 @@ The Pro package includes the following limits on the key units of consumption:
 Pro package users also have access to the following features:
 
 * Google and GitHub SSO
-* DataDog Lite
+* "DataDog Lite":/docs/integrations/streaming/datadog#lite
 
 h2(#pricing). Pricing and billing
 

--- a/content/pricing/standard.textile
+++ b/content/pricing/standard.textile
@@ -18,7 +18,7 @@ The Standard package includes the following limits on the key units of consumpti
 Standard package users also have access to the following features:
 
 * Google and GitHub SSO
-* DataDog Lite (30 day trial)
+* "DataDog Lite":/docs/integrations/streaming/datadog#lite (30 day trial)
 
 h2(#pricing). Pricing and billing
 

--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -171,6 +171,10 @@ export default {
               name: 'Pulsar',
               link: '/docs/integrations/streaming/pulsar',
             },
+            {
+              name: 'DataDog',
+              link: '/docs/integrations/streaming/datadog',
+            },
           ],
         },
         {


### PR DESCRIPTION
This PR introduces documentation for the Ably Datadog integration, covering:

- How the integration works.
- Installation and configuration steps.
- The type of data sent to Datadog.
- Availability details (the feature is exclusive to enterprise-grade committed use customers; others should contact sales for upgrade options). 
- Additionally, this documentation includes details on Datadog-Lite trials.

[EDU-576](https://ably.atlassian.net/browse/EDU-576)

[EDU-576]: https://ably.atlassian.net/browse/EDU-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ