### PR TITLE
chat: change history retention periods

### DIFF
--- a/content/chat/rooms/history.textile
+++ b/content/chat/rooms/history.textile
@@ -9,7 +9,7 @@ languages:
   - kotlin
 ---
 
-The history feature enables users to retrieve messages that have been previously sent in a room. Ably stores chat messages for 24 hours by default. You can extend this up to 30 days by "contacting us":https://forms.gle/SmCLNFoRrYmkbZSf8.
+The history feature enables users to retrieve messages that have been previously sent in a room. Ably stores chat messages for 30 days by default. You can extend this up to 365 days by "contacting us":https://forms.gle/SmCLNFoRrYmkbZSf8.
 
 h2(#get). Retrieve previously sent messages
 


### PR DESCRIPTION
## Description

This change sets the chat history retention period default and max.

[CHA-767]

## Review

Chat -> History
