### PR TITLE
EDU-1652: Adds token auth copy

### DIFF
--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -9,7 +9,6 @@ languages:
   - objc
   - csharp
   - flutter
-  - javascript
 redirect_from:
   - /docs/push/configure/devices
   - /docs/realtime/push/activate-subscribe
@@ -23,7 +22,7 @@ To send push notifications with Ably, you must first configure the device using 
 <p>To configure web browsers using Web Push, see "configure web browsers.":/docs/push/configure/web</p>
 </aside>
 
-h2(#configure). Configure devices
+h2(#configure-devices). Configure devices
 
 Configuration is the first step in setting up push notifications with Ably. This step requires setting up the necessary infrastructure on the device's operating system or platform, as well as on the Ably platform.
 
@@ -31,7 +30,7 @@ Configuration is the first step in setting up push notifications with Ably. This
   <img src="@content/diagrams/push-process-configure-highlighted.png" style="width: 100%" alt="Push Notifications in Ably">
 </a>
 
-h3. Configure FCM for Android devices
+h3(#fcm). Configure FCM for Android devices
 
 * Go to the "Firebase Console.":https://firebase.google.com/
 * Click *add project* and follow the steps to *create and manage service account keys*.
@@ -40,14 +39,14 @@ h3. Configure FCM for Android devices
 * Go to *push notifications setup*, click *configure push*.
 * Add your service account *JSON file* to the *setting up Firebase cloud messaging* section.
 
-h3. Configure APNs for iOS devices
+h3(#apns). Configure APNs for iOS devices
 
 To enable push notifications for iOS devices, you need to configure your app to communicate with Apple Push Notification Service (APNs). You can do this in two ways:
 
 1. Use "token-based":#token authentication (recommended) with a *.p8 file*.
 2. Use "certificate-based":#token authentication with a *.p12* or *.cer* file.
 
-h4. Token-based authentication
+h4(#token). Token-based authentication
 
 Use token-based authentication for new or updated apps because it is easier to manage and does not require yearly renewal like certificates. Token-based authentication relies on a private key (.p8) instead of .p12 certificates, making it the preferred choice for modern push notification setups.
 
@@ -82,7 +81,7 @@ h4(#cert). Certificate-based authentication
 ** Copy everything between and including @-----BEGIN CERTIFICATE-----@ and @-----END CERTIFICATE-----@, and paste it into the *PEM cert* text box of the Apple push notification service section of your Ably notifications app "dashboard":https://ably.com/accounts.
 ** Similarly, copy everything between and including @-----BEGIN PRIVATE KEY-----@ and @-----END PRIVATE KEY-----@, and paste it into the *PEM private key* text box of the same section. Then, click *save*.
 
-h3. Install and set up your Ably SDK
+h3(#set-up). Install and set up your Ably SDK
 
 Use the following code to install and set up your Ably SDK:
 
@@ -161,7 +160,7 @@ dependencies:
 import 'package:ably_flutter/ably_flutter.dart' as ably;
 ```
 
-h2. Activate devices
+h2(#activate). Activate devices
 
 To receive push notifications using Ably, each device must first register with it's platform-specific push notification service (FCM or APNs). Ably's SDK facilitates this registration process and provides a unified API to manage it across different platforms.
 
@@ -220,7 +219,7 @@ AblyRealtime ably = getAblyRealtime();
 ably.push.activate();
 ```
 
-h4. Test your push notification activation
+h4(#test-activation). Test your push notification activation
 
 * Use the Ably "dashboard":https://ably.com/accounts or "API":/docs/api/realtime-sdk/push-admin to send a test push notification to a registered device.
 * Ensure your application correctly receives and handles the push notification.
@@ -246,7 +245,7 @@ The following diagram demonstrates the process for activating devices from a ser
 <p>Utilize the "push notifications admin API":/docs/api/realtime-sdk/push-admin on your server to register devices.</p>
 </aside>
 
-h4. Activate Android devices via server
+h4(#andriod). Activate Android devices via server
 
 Your application must interact with the Ably SDK to configure server-side registration for push notifications, utilizing the "@LocalBroadcastManager@":https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager for communication.
 
@@ -366,7 +365,7 @@ public class MyAblyBroadcastReceiver extends BroadcastReceiver {
 }
 ```
 
-h4. Activate iOS device via server
+h4(#ios). Activate iOS device via server
 
 When setting up server-side registration for push notifications on iOS, your application must interact with the Ably SDK to handle device registration and de-registration securely and effectively. Implement the following optional methods from @ARTPushRegistererDelegate@ in your @UIApplicationDelegate@ to customize the registration process:
 
@@ -425,7 +424,7 @@ func ablypushCustomDeregister(_ error: ARTErrorInfo?, deviceId: String, callback
 
 ```
 
-h4. Activate Android and iOS devices via server using .NET
+h4(#net). Activate Android and iOS devices via server using .NET
 
 Initialize the specific mobile device. You can achieve this by using either @AppleMobileDevice.Initialize@ or @AndroidMobileDevice.Initialize@. To initialize, you need to pass a valid @Ably.ClientOptions@, which will be used to initialize the Ably realtime or REST client, and an instance of @PushCallbacks@, which you can use to receive notifications when the device is activated, deactivated, or when sync registration fails.
 
@@ -477,12 +476,12 @@ private ClientOptions GetAblyOptions(string clientId)
 ```
 
 
-h4. Test your push notification activation
+h4(#test-push). Test your push notification activation
 
 * Use the Ably "dashboard":https://ably.com/accounts or "API":https://ably.com/docs/docs/api/realtime-sdk/push-admin to send a test push notification to a registered device.
 * Ensure your application correctly receives and handles the push notification.
 
-h3. Device activation lifecycle
+h3(#lifecycle). Device activation lifecycle
 
 When the "@push.activate()@":/docs/api/realtime-sdk/push#activate and "@push.deactivate()@":/docs/api/realtime-sdk/push#deactivate methods are called, the device registers with FCM or APNs. In addition, whenever there is an update to the push token (registration token for FCM or device token for APNs), the Ably SDK attempts to update this token on Ably's servers.
 

--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -42,6 +42,29 @@ h3. Configure FCM for Android devices
 
 h3. Configure APNs for iOS devices
 
+To enable push notifications for iOS devices, you need to configure your app to communicate with Apple Push Notification Service (APNs). You can do this in two ways:
+
+1. Use "token-based":#token authentication (recommended) with a *.p8 file*.
+2. Use "certificate-based":#token authentication with a *.p12* or *.cer* file.
+
+h4. Token-based authentication
+
+Use token-based authentication for new or updated apps because it is easier to manage and does not require yearly renewal like certificates. Token-based authentication relies on a private key (.p8) instead of .p12 certificates, making it the preferred choice for modern push notification setups.
+
+* Download the *.p8 file*:
+** Go to the "Apple Developer Program":https://developer.apple.com/documentation/usernotifications/establishing-a-token-based-connection-to-apns and sign in.
+** Follow the steps top create a new *APNs authentication key* and download the *.p8 file*.
+* Obtain your credentials:
+** Locate the *Key ID* associated with the authentication key.
+** Find your *Team ID* or equivalent organization identifier.
+** Identify the *Topic header*, typically your app's bundle or project identifier.
+* Configure authentication:
+** Upload the *.p8 file* to your server or push notification platform.
+** Use the *Key ID* and *Team ID* to generate an authentication token.
+** Set the appropriate *Topic header* in your notification requests. Then, click *save*.
+
+h4(#cert). Certificate-based authentication
+
 * Go to the "Apple Developer Program.":https://developer.apple.com/programs/
 * Use the Apple developer portal to create a *push notification* service certificate for your app.
 * Export the certificate as a *.p12 file*.


### PR DESCRIPTION
This PR:

- Adds new instructions to the `/push/configure/device` section.
  - Keeps Apple Dev Portal steps generic yet useable.
- Creates subsection for ios configuration
  - Token-based auth, and Cerifatte base auth.
 
- Crates new anchor IDs.

[EDU-1652](https://ably.atlassian.net/browse/EDU-1652)



[EDU-1652]: https://ably.atlassian.net/browse/EDU-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ