### PR TITLE
Add metadata overview into the navigation

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -197,6 +197,10 @@ export default {
           name: 'Metadata',
           pages: [
             {
+              name: 'Overview',
+              link: '/metadata-stats/metadata',
+            },
+            {
               name: 'Metadata subscriptions',
               link: '/metadata-stats/metadata/subscribe',
             },


### PR DESCRIPTION
## Description

The metadata overview page (`/metadata-stats/metadata`) was missed out in the migration to the new nav. This adds it back in. 

