### PR TITLE
Fix incorrect Vite/Next Ably key variable names in READMEs

### DIFF
--- a/examples/chat-room-messages/page.md
+++ b/examples/chat-room-messages/page.md
@@ -57,7 +57,7 @@ cd /examples/chat-room-messages/react/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `NEXT_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 
@@ -93,7 +93,7 @@ cd /examples/chat-room-messages/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-channel-messages/javascript/README.md
+++ b/examples/pub-sub-channel-messages/javascript/README.md
@@ -22,7 +22,7 @@ cd /examples/pub-sub-channel-messages/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-channel-messages/page.md
+++ b/examples/pub-sub-channel-messages/page.md
@@ -57,7 +57,7 @@ cd /examples/pub-sub-channel-messages/react/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `NEXT_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 
@@ -93,7 +93,7 @@ cd /examples/pub-sub-channel-messages/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-channel-messages/react/README.md
+++ b/examples/pub-sub-channel-messages/react/README.md
@@ -22,7 +22,7 @@ cd /examples/pub-sub-channel-messages/react/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `NEXT_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-connection-state/page.md
+++ b/examples/pub-sub-connection-state/page.md
@@ -86,7 +86,7 @@ cd /examples/pub-sub-connection-state/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-history/page.md
+++ b/examples/pub-sub-history/page.md
@@ -57,7 +57,7 @@ cd /examples/pub-sub-history/react/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `NEXT_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 
@@ -93,7 +93,7 @@ cd /examples/pub-sub-history/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-message-encryption/javascript/README.md
+++ b/examples/pub-sub-message-encryption/javascript/README.md
@@ -22,7 +22,7 @@ cd /examples/pub-sub-message-encryption/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-message-encryption/page.md
+++ b/examples/pub-sub-message-encryption/page.md
@@ -93,7 +93,7 @@ cd /examples/pub-sub-message-encryption/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/pub-sub-presence/page.md
+++ b/examples/pub-sub-presence/page.md
@@ -58,7 +58,7 @@ cd /examples/pub-sub-presence/react/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `NEXT_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 
@@ -94,7 +94,7 @@ cd /examples/pub-sub-presence/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install dependencies:
 

--- a/examples/spaces-avatar-stack/page.md
+++ b/examples/spaces-avatar-stack/page.md
@@ -94,7 +94,7 @@ cd /examples/spaces-avatar-stack/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install depdencies:
 

--- a/examples/spaces-component-locking/page.md
+++ b/examples/spaces-component-locking/page.md
@@ -99,7 +99,7 @@ cd /examples/spaces-component-locking/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install depdencies:
 

--- a/examples/spaces-live-cursors/page.md
+++ b/examples/spaces-live-cursors/page.md
@@ -95,7 +95,7 @@ cd /examples/spaces-live-cursors/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install depdencies:
 

--- a/examples/spaces-member-location/page.md
+++ b/examples/spaces-member-location/page.md
@@ -94,7 +94,7 @@ cd /examples/spaces-member-location/javascript/
 mv .env.example .env.local
 ```
 
-4. In `.env.local` update the value of `VITE_PUBLIC_API_KEY` to be your Ably API key.
+4. In `.env.local` update the value of `VITE_PUBLIC_ABLY_KEY` to be your Ably API key.
 
 5. Install depdencies:
 


### PR DESCRIPTION
## Description

Fixes incorrect Vite/Next Ably key variable names in READMEs.
Spotted by coderabbit in https://github.com/ably/docs/pull/2437#discussion_r1965121216