### PR TITLE
[WEB-4211] Add 'Request a meeting' button to Inkeep chat

### DIFF
--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -5,7 +5,7 @@ const inkeepChat = (apiKey, integrationId, organizationId) => {
     return;
   }
 
-  scriptLoader(document, 'https://unpkg.com/@inkeep/uikit-js@0.3.9/dist/embed.js', {
+  scriptLoader(document, 'https://unpkg.com/@inkeep/uikit-js@0.3.19/dist/embed.js', {
     defer: true,
     async: false,
     type: 'module',
@@ -35,6 +35,14 @@ const aiChatSettings = {
     botAvatarSrcUrl: 'https://storage.googleapis.com/organization-image-assets/ably-botAvatarSrcUrl-1721406747144.png',
     getHelpCallToActions: [
       {
+        name: 'Request a meeting',
+        url: 'https://meetings.hubspot.com/ably-sales/book-a-demo',
+
+        type: 'OPEN_LINK',
+        pinToToolbar: true,
+        shouldCloseModal: false,
+      },
+      {
         name: 'Chat with support',
         url: 'https://ably.com/support',
         icon: {
@@ -44,6 +52,7 @@ const aiChatSettings = {
         callback: () => {
           openHubSpotConversations();
         },
+        pinToToolbar: true,
         shouldCloseModal: true,
       },
     ],


### PR DESCRIPTION
## Description

Bumps Inkeep to `0.3.19` and adds a menu link to Hubspot meeting request.

### Copilot Summary 
This pull request to `src/external-scripts/inkeep.ts` includes updates to the Inkeep chat integration and enhancements to the AI chat settings. The most important changes include updating the Inkeep UI Kit version and adding new call-to-action options for users.

Updates to Inkeep chat integration:

* Updated the Inkeep UI Kit version from `0.3.9` to `0.3.19` to ensure compatibility with the latest features and bug fixes.

Enhancements to AI chat settings:

* Added a new call-to-action option "Request a meeting" with a link to book a demo, including settings to pin it to the toolbar and keep the modal open.
* Modified the existing "Chat with support" call-to-action to pin it to the toolbar for easier access.

## Review

[Screencast from 2025-02-21 15-16-04.webm](https://github.com/user-attachments/assets/df58bbaa-e461-4879-b9aa-402e217345fd)
