### PR TITLE
EDU-1833: updates js code

### DIFF
--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -884,7 +884,7 @@ The following example shows how to subscribe for push notifications using @clien
 
 ```[realtime_javascript]
 const channel = realtime.channels.get("pushenabled:foo");
-await channel.subscribeClient();
+await channel.push.subscribeClient()
 ```
 
 ```[realtime_java]
@@ -927,7 +927,7 @@ await realtime.channels.get("pushenabled:foo").push.subscribeClient();
 
 ```[rest_javascript]
 const channel = rest.channels.get("pushenabled:foo");
-await channel.subscribeClient();
+await channel.push.subscribeClient()
 ```
 
 ```[rest_java]


### PR DESCRIPTION
This PR:

- Corrects javascript examples for push subscribe on `/push/publish?lang=javascript#sub-channels`
  - `channel.subscribeClient();` -> `channel.push.subscribeClient()`
 - As per the [js repo ](https://ably.com/docs/push/publish?lang=javascript#sub-channels)

[EDU-1833](https://ably.atlassian.net/browse/EDU-1833)