### PR TITLE
[WEB-3950] fix: update canonical link generator to include section prefix

### DIFF
--- a/data/createPages/index.ts
+++ b/data/createPages/index.ts
@@ -213,6 +213,14 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions:
     redirectInBrowser: true,
   });
 
+  // TODO: remove when examples are ready to be released
+  createRedirect({
+    fromPath: '/docs/examples',
+    toPath: '/docs',
+    isPermanent: true,
+    redirectInBrowser: true,
+  });
+
   if (!documentResult.data) {
     throw new Error('Document result is undefined');
   }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -122,7 +122,7 @@ const Header: React.FC<HeaderProps> = ({ hideSearchBar = false }) => {
         },
       ]}
       sessionState={sessionState}
-      logoHref={process.env.NODE_ENV === 'development' ? '/' : '/docs'}
+      logoHref="/docs"
     />
   );
 };

--- a/src/pages/docs/api/control-api.tsx
+++ b/src/pages/docs/api/control-api.tsx
@@ -7,7 +7,7 @@ import { useSetLayoutOptions } from 'src/hooks/use-set-layout-options';
 
 const ControlApi = () => {
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl('/api/control-api');
+  const canonical = canonicalUrl('/docs/api/control-api');
   const meta_title = 'Control API';
   const meta_description =
     'The Control API is a REST API that enables you to manage your Ably account programmatically. This is the Control API Reference guide.';

--- a/src/pages/docs/examples.tsx
+++ b/src/pages/docs/examples.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { graphql, navigate } from 'gatsby';
+import { graphql } from 'gatsby';
 import { ImageProps } from '../../components/Image';
 import { Head } from '../../components/Head';
 import ExamplesContent from '../../components/Examples/ExamplesContent';
@@ -14,11 +14,6 @@ const Examples = ({
   data: { allFile: { images: ImageProps[] } };
 }) => {
   useSetLayoutOptions({ noSidebar: true, hideSearchBar: false, template: 'examples' });
-
-  // TODO: remove when examples are ready to be released
-  React.useEffect(() => {
-    navigate(process.env.NODE_ENV === 'development' ? '/' : '/docs', { replace: true });
-  }, []);
 
   const { canonicalUrl } = useSiteMetadata();
   const canonical = canonicalUrl('/docs/examples');

--- a/src/pages/docs/examples.tsx
+++ b/src/pages/docs/examples.tsx
@@ -21,7 +21,7 @@ const Examples = ({
   }, []);
 
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl('/examples');
+  const canonical = canonicalUrl('/docs/examples');
   const meta_title = 'Ably Examples - Code Samples and Implementation Guides';
   const meta_description =
     'Browse our collection of code examples, implementation guides, and sample projects to help you integrate Ably into your applications.';

--- a/src/pages/docs/how-to/pub-sub.tsx
+++ b/src/pages/docs/how-to/pub-sub.tsx
@@ -80,7 +80,7 @@ interface HowToFile {
 const PubSubHowTo = () => {
   const meta_description = `How to use basic publish and subscribe (pub/sub) functionality with Ably channels.`;
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl('/how-to/pub-sub');
+  const canonical = canonicalUrl('/docs/how-to/pub-sub');
   useSetLayoutOptions({ noSidebar: false, hideSearchBar: false, template: 'how-to' });
 
   const data = useStaticQuery(graphql`

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -24,7 +24,7 @@ const IndexPage = ({
   const { sections, meta } = pageData.homepage.content;
   const openGraphTitle = meta.title ?? 'Ably Realtime Docs';
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl('/');
+  const canonical = canonicalUrl('/docs');
 
   return (
     <>

--- a/src/pages/docs/sdks/index.tsx
+++ b/src/pages/docs/sdks/index.tsx
@@ -9,7 +9,7 @@ const SDKsIndexPage = ({ location: { search } }: { location: { search: string } 
   const title = 'SDKs';
   const meta_description = '';
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl('/sdks');
+  const canonical = canonicalUrl('/docs/sdks');
 
   const urlParams = new URLSearchParams(search);
   const tab = urlParams.get('tab') ?? '';

--- a/src/templates/base-template.tsx
+++ b/src/templates/base-template.tsx
@@ -50,7 +50,7 @@ const Template = ({
   const description = getMetaDataDetails(document, 'meta_description', META_DESCRIPTION_FALLBACK) as string;
   const menuLanguages = getMetaDataDetails(document, 'languages', languages) as string[];
   const { canonicalUrl } = useSiteMetadata();
-  const canonical = canonicalUrl(slug);
+  const canonical = canonicalUrl(`/docs/${slug}`);
 
   // when we don't get a product, peek into the metadata of the page for a default value
   currentProduct ??= getMetaDataDetails(document, 'product', META_PRODUCT_FALLBACK) as ProductName;


### PR DESCRIPTION
Docs routing release went alright, nothing bricked it, but the canonical link generator was overlooked, resulting in [broken canonical links](https://app.contentkingapp.com/websites/14-2162789/alerts/17601674/pages?filter=eyJmaWx0ZXIiOnsic3RhdHVzIjpbImNoYW5nZWQiXX0sInNvcnRCeSI6eyJrZXkiOiJyZWxldmFuY2UiLCJkaXJlY3Rpb24iOmZhbHNlfX0%3D) - affecting SEO performance.

This PR fixes this by explicitly adding in explicit section prefixes to the paths passed into the `canonicalUrl` helper.