### PR TITLE
Small fixes after navigation release

### DIFF
--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -39,7 +39,7 @@ const externalLinks = (
     const requestTitle = `Change request for: ${currentPage.link}`;
     const requestBody = encodeURIComponent(`
   **Page name**: ${currentPage.name}
-  **URL**: [${currentPage.link}](https://ably.com/docs/${currentPage.link})
+  **URL**: [${currentPage.link}](https://ably.com${currentPage.link})
   ${language && languageInfo[language] ? `Language: **${languageInfo[language].label}` : ''}
 
   **Requested change or enhancement**:

--- a/src/data/languages/languageData.ts
+++ b/src/data/languages/languageData.ts
@@ -13,6 +13,7 @@ export default {
     csharp: 1.2,
     flutter: 1.2,
     java: 1.2,
+    kotlin: 1.2,
     objc: 1.2,
     php: 1.1,
     python: 2.0,


### PR DESCRIPTION
## Description

This PR adds two small fixes identified after the new navigation launched:

* Kotlin was missing as an available language for Pub/Sub causing it to not render correctly
* Updates the link to raise a change request after merging https://github.com/ably/docs/pull/2383

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
