### PR TITLE
[EDU-1836] - Updated java example of server side activation for push

### DIFF
--- a/content/push/configure/device.textile
+++ b/content/push/configure/device.textile
@@ -293,40 +293,51 @@ class MyAblyBroadcastReceiver : BroadcastReceiver() {
 ```
 
 ```[realtime_java]
-class MyAblyBroadcastReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context, intent: Intent) {
-        val ably = getAblyRealtime()
-        val action = intent.action
+public class MyAblyBroadcastReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        AblyRealtime ably = getAblyRealtime();
+        String action = intent.getAction();
 
-        when (action) {
-            "io.ably.broadcast.PUSH_REGISTER_DEVICE" -> {
-                val device = ably.device(context)
-                val isNew = intent.getBooleanExtra("isNew", false)
+        if ("io.ably.broadcast.PUSH_REGISTER_DEVICE".equals(action)) {
+            Intent response = new Intent("io.ably.broadcast.PUSH_DEVICE_REGISTERED");
+            boolean isNew = intent.getBooleanExtra("isNew", false);
 
-                val response = Intent("io.ably.broadcast.PUSH_DEVICE_REGISTERED")
+            LocalDevice device;
 
-                try {
-                    val deviceIdentityToken: String = registerThroughYourServer(device, isNew)
-                    response.putExtra("deviceIdentityToken", deviceIdentityToken)
-                } catch (e: AblyException) {
-                    IntentUtils.addErrorInfo(response, e.errorInfo)
-                }
-
-                LocalBroadcastManager.getInstance(context.applicationContext).sendBroadcast(response)
+            try {
+                device = ably.device();
+            } catch (AblyException e) {
+                IntentUtils.addErrorInfo(response, e.errorInfo);
+                return;
             }
-            "io.ably.broadcast.PUSH_DEREGISTER_DEVICE" -> {
-                val device = ably.device(context)
 
-                val response = Intent("io.ably.broadcast.PUSH_DEVICE_DEREGISTERED")
-
-                try {
-                    deregisterThroughYourServer(device.id)
-                } catch (e: AblyException) {
-                    IntentUtils.addErrorInfo(response, e.errorInfo)
-                }
-
-                LocalBroadcastManager.getInstance(context.applicationContext).sendBroadcast(response)
+            try {
+                String deviceIdentityToken = registerThroughYourServer(device, isNew);
+                response.putExtra("deviceIdentityToken", deviceIdentityToken);
+            } catch (AblyException e) {
+                IntentUtils.addErrorInfo(response, e.errorInfo);
             }
+
+            LocalBroadcastManager.getInstance(context.getApplicationContext()).sendBroadcast(response);
+        } else if ("io.ably.broadcast.PUSH_DEREGISTER_DEVICE".equals(action)) {
+            Intent response = new Intent("io.ably.broadcast.PUSH_DEVICE_DEREGISTERED");
+            LocalDevice device;
+
+            try {
+                device = ably.device();
+            } catch (AblyException e) {
+                IntentUtils.addErrorInfo(response, e.errorInfo);
+                return;
+            }
+
+            try {
+                deregisterThroughYourServer(device.id);
+            } catch (AblyException e) {
+                IntentUtils.addErrorInfo(response, e.errorInfo);
+            }
+
+            LocalBroadcastManager.getInstance(context.getApplicationContext()).sendBroadcast(response);
         }
     }
 }


### PR DESCRIPTION
The server side activation for Android push was actually Kotlin and not Java: https://github.com/ably/docs/issues/2450

This update adds the Java equivalent.