### PR TITLE
[WEB-4211, WEB-4176, WEB-4245] Redoc and LeftSidebar fixes

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -19,7 +19,7 @@ type PageContextType = {
 type LayoutProps = PageProps<unknown, PageContextType>;
 
 const Layout: React.FC<LayoutProps> = ({ children, pageContext }) => {
-  const { searchBar, sidebar, template } = pageContext.layout;
+  const { searchBar, sidebar, template } = pageContext.layout ?? {};
 
   return (
     <GlobalLoading template={template}>

--- a/src/components/Layout/LeftSidebar.tsx
+++ b/src/components/Layout/LeftSidebar.tsx
@@ -44,10 +44,10 @@ const NavPage = ({
   const linkId = 'link' in page ? composeNavLinkId(page.link) : undefined;
   const { activePage } = useLayoutContext();
   const treeMatch = indices.every((value, index) => value === activePage.tree[index]?.index);
-  const pageActive = 'link' in page && treeMatch;
 
   if ('link' in page) {
     const language = new URLSearchParams(location.search).get('lang');
+    const pageActive = treeMatch && page.link === activePage.page.link;
 
     return (
       <Link

--- a/src/components/Layout/utils/nav.ts
+++ b/src/components/Layout/utils/nav.ts
@@ -3,10 +3,11 @@ import { AccordionProps } from '@ably/ui/core/Accordion';
 import { ProductData, ProductKey } from 'src/data/types';
 import { NavProductContent, NavProductPage, NavProductPages } from 'src/data/nav/types';
 import { componentMaxHeight, HEADER_HEIGHT } from './heights';
+import { LanguageKey } from 'src/data/languages/types';
 
 export type PageTreeNode = { index: number; page: NavProductPage };
 
-type ActivePage = { tree: PageTreeNode[]; page: NavProductPage };
+export type ActivePage = { tree: PageTreeNode[]; page: NavProductPage; languages: LanguageKey[] };
 
 /**
  * Determines the active page based on the provided target link.
@@ -59,7 +60,11 @@ export const determineActivePage = (data: ProductData, targetLink: string): Acti
 
     if (data[key].nav.link === strippedTargetLink) {
       const { name, link } = data[key].nav;
-      return { tree: [{ index: Object.keys(data).indexOf(key), page: { name, link } }], page: { name, link } };
+      return {
+        tree: [{ index: Object.keys(data).indexOf(key), page: { name, link } }],
+        page: { name, link },
+        languages: [],
+      };
     }
 
     /* 
@@ -89,7 +94,7 @@ export const determineActivePage = (data: ProductData, targetLink: string): Acti
           data[key].nav[apiResult ? 'api' : 'content'],
         );
 
-        return { tree, page: page?.[0] as NavProductPage };
+        return { tree, page: page?.[0] as NavProductPage, languages: [] };
       }
     }
   }

--- a/src/components/Layout/utils/nav.ts
+++ b/src/components/Layout/utils/nav.ts
@@ -129,7 +129,7 @@ export const commonAccordionOptions = (
         'h-[1rem] ui-text-menu2 !font-semibold md:ui-text-menu4': !topLevel,
       },
     ),
-    selectedHeaderCSS: 'text-neutral-1300 mb-8',
+    selectedHeaderCSS: '!text-neutral-1300 mb-8',
     contentCSS: cn('[&>div]:pb-0'),
     rowIconSize: '20px',
     defaultOpenIndexes: !inHeader && openIndex !== undefined ? [openIndex] : [],

--- a/src/components/Redoc/Loader.tsx
+++ b/src/components/Redoc/Loader.tsx
@@ -1,6 +1,7 @@
 import { scriptLoader } from '../../external-scripts/utils';
 import './redoc.module.css';
 import { GoTopButton } from './GoTopButton';
+import { overrideMenuItemNavigation } from './utils';
 
 export const Loader = ({ specUrl }: { specUrl: string }) => {
   const redocDependencyScript = '//cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js';
@@ -48,7 +49,7 @@ export const Loader = ({ specUrl }: { specUrl: string }) => {
     scriptLoader(document, redocDependencyScript, {
       onload: () => {
         // @ts-ignore
-        Redoc.init(specUrl, options, document.getElementById('redoc-container'));
+        Redoc.init(specUrl, options, document.getElementById('redoc-container'), overrideMenuItemNavigation);
       },
     });
   }

--- a/src/components/Redoc/utils.ts
+++ b/src/components/Redoc/utils.ts
@@ -1,0 +1,96 @@
+import throttle from 'lodash.throttle';
+
+/*
+  This function introduces click listeners to override the functionality for each menu item in the sidebar,
+  and also listens for hash changes via scroll to update the currently opened menu section.
+  Sadly, this is necessary because Redoc opens the wrong menu item when clicking on a menu trigger, and is a bit
+  broken in general.
+*/
+export const overrideMenuItemNavigation = () => {
+  let trackedSection = '';
+  const menuItems = document.querySelectorAll('#redoc-container .menu-content .scrollbar-container > ul > li');
+
+  const scrollHandler = throttle(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('clicked') === 'true') {
+      setTimeout(() => {
+        params.delete('clicked');
+        window.history.replaceState({}, '', window.location.pathname + '?' + params.toString());
+      }, 500);
+      return;
+    }
+
+    const decodedHash = decodeURIComponent(window.location.hash).split('/')?.[1];
+
+    if (decodedHash !== trackedSection) {
+      trackedSection = decodedHash;
+
+      menuItems.forEach((item) => {
+        const ul = item.querySelector('ul');
+        const svg = item.querySelector('svg');
+
+        if (ul) {
+          ul.style.display = '';
+        }
+        if (svg) {
+          svg.style.transform = '';
+        }
+      });
+    }
+  }, 500);
+
+  document.addEventListener('scroll', scrollHandler);
+
+  const clickHandlers = new Map();
+
+  menuItems.forEach((targetItem) => {
+    const clickHandler = () => {
+      // Add clicked query param
+      const url = new URL(window.location.href);
+      url.searchParams.set('clicked', 'true');
+      window.history.replaceState({}, '', url);
+
+      menuItems.forEach((item) => {
+        const isOther = item !== targetItem;
+        const ul = item.querySelector('ul');
+        const svg = item.querySelector('svg');
+
+        if (ul) {
+          ul.style.display = isOther ? 'none' : 'block';
+        }
+        if (svg) {
+          svg.style.transform = isOther ? 'rotate(-90deg)' : 'rotate(0deg)';
+        }
+      });
+    };
+
+    clickHandlers.set(targetItem, clickHandler);
+    targetItem.addEventListener('click', clickHandler);
+  });
+
+  // Clean up function to remove all event listeners
+  const cleanup = () => {
+    document.removeEventListener('scroll', scrollHandler);
+    menuItems.forEach((item) => {
+      const handler = clickHandlers.get(item);
+      if (handler) {
+        item.removeEventListener('click', handler);
+      }
+    });
+    clickHandlers.clear();
+  };
+
+  // Watch for URL changes
+  const observer = new MutationObserver(() => {
+    if (window.location.pathname !== '/docs/api/control-api') {
+      cleanup();
+    }
+  });
+
+  const body = document.querySelector('body');
+  if (body) {
+    observer.observe(body, { childList: true, subtree: true });
+  }
+
+  return cleanup;
+};

--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react';
 import { useLocation } from '@reach/router';
-import { PageTreeNode, determineActivePage } from 'src/components/Layout/utils/nav';
+import { ActivePage, determineActivePage } from 'src/components/Layout/utils/nav';
 import { productData } from 'src/data';
 import { NavProduct } from 'src/data/nav/types';
 import { ProductData, ProductKey } from 'src/data/types';
@@ -14,11 +14,11 @@ import { LanguageKey } from 'src/data/languages/types';
  */
 
 const LayoutContext = createContext<{
-  activePage: { tree: PageTreeNode[]; languages: LanguageKey[] };
+  activePage: ActivePage;
   products: [ProductKey, NavProduct][];
   setLanguages: (languages: LanguageKey[]) => void;
 }>({
-  activePage: { tree: [], languages: [] },
+  activePage: { tree: [], page: { name: '', link: '' }, languages: [] },
   products: [],
   setLanguages: (languages) => {
     console.warn('setLanguages called without a provider', languages);
@@ -33,7 +33,7 @@ export const LayoutProvider: React.FC<PropsWithChildren> = ({ children }) => {
     const activePageData = determineActivePage(productData, location.pathname);
     return activePageData
       ? { ...activePageData, languages: activePageData.page.languages ?? languages }
-      : { tree: [], languages: [] };
+      : { tree: [], page: { name: '', link: '' }, languages: [] };
   }, [location.pathname, languages]);
 
   const products = useMemo(

--- a/src/pages/docs/api/control-api.tsx
+++ b/src/pages/docs/api/control-api.tsx
@@ -1,8 +1,8 @@
+import { Link, withAssetPrefix } from 'gatsby';
+import Icon from '@ably/ui/core/Icon';
 import { useSiteMetadata } from '../../../hooks/use-site-metadata';
 import { Head } from '../../../components/Head';
 import { Loader } from '../../../components/Redoc';
-import { Link, withPrefix } from 'gatsby';
-import Icon from '@ably/ui/core/Icon';
 
 const ControlApi = () => {
   const { canonicalUrl } = useSiteMetadata();
@@ -10,7 +10,7 @@ const ControlApi = () => {
   const meta_title = 'Control API';
   const meta_description =
     'The Control API is a REST API that enables you to manage your Ably account programmatically. This is the Control API Reference guide.';
-  const controlAPI = withPrefix('/open-specs/control-v1.yaml');
+  const controlAPI = withAssetPrefix('/open-specs/control-v1.yaml');
 
   return (
     <>


### PR DESCRIPTION
This PR fixes a bunch of miscellaneous things:
- the [control api is broken](https://ably.com/docs/api/control-api) as the path to the data YAML isn't right. This PR updates the path to one that exists, but only in a production env
- adds a script to override clicks on menu items in the redoc navigator as it's pretty broken. The script ensures that the targeted menu is opened when a heading is clicked (https://github.com/ably/docs/pull/2393, https://ably.atlassian.net/browse/WEB-4176)
- fixes the colour on the selected header on the LeftSidebar (https://ably.atlassian.net/browse/WEB-4245)
- prevents active page highlighting on both the main links and the API references in the LeftSidebar when the tree indices match

Review link: https://ably-docs-fix-control-v-32pbux.herokuapp.com/