### PR TITLE
[WEB-4211] chore: allow open access to yaml files

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -89,7 +89,7 @@ http {
       rewrite ^ $redirected_url permanent;
     }
 
-    location ~* \.json$ {
+    location ~* \.(json|yaml)$ {
       more_set_headers 'Access-Control-Allow-Origin: *';
     }
 


### PR DESCRIPTION
Getting a CORS issue when pulling the control api YAML from docs.ably.com. This PR opens up access to YAML files as we don't care about who accesses YAMLs we make publicly accessible.

This pull request includes a change to the `config/nginx.conf.erb` file to enhance the handling of specific file types in the Nginx configuration.

* [`config/nginx.conf.erb`](diffhunk://#diff-8536d045800ebd99dc58c8e5d9fab522ded64838c446ba361c1c4c6d8ce3b4d4L92-R92): Updated the `location` block to include both `.json` and `.yaml` file types, allowing for proper handling and setting of headers for these file types.