### PR TITLE
Update Message object attributes

### DIFF
--- a/content/messages/index.textile
+++ b/content/messages/index.textile
@@ -27,7 +27,7 @@ The following are the properties of a message:
 
 - name := The name of the message.
 - data := The contents of the message. Also known as the message payload.
-- id := Each message sent through Ably is assigned a unique ID. Update this ID if you are using idempotent publishing.
+- id := Each message sent through Ably is assigned a unique ID, unless you provide your own ID. Client specified IDs ensure "publishes are idempotent.":/docs/pub-sub/advanced#idempotency 
 - clientId := The "ID of the client":/docs/auth/identified-clients that published the message.
 - connectionId := The ID of the connection used to publish the message.
 - timestamp := The timestamp of when the message was received by Ably, as milliseconds since the Unix epoch.


### PR DESCRIPTION
Previous description for idempotency was confusing. You don't update a message with an ID, you provide an ID before publishing. We also did not link to any idempotent docs.
