### PR TITLE
[PUB-773] LiveObjects product docs

### DIFF
--- a/content/api/realtime-sdk/channels.textile
+++ b/content/api/realtime-sdk/channels.textile
@@ -151,6 +151,11 @@ h6(#push).
 
 Provides access to the "PushChannel":/docs/api/realtime-sdk/push#push-channel object for this channel which can be used to access members present on the channel, or participate in presence.
 
+h6(#objects).
+  default: objects
+
+Provides access to the "Objects":/docs/liveobjects object for this channel which can be used to read, modify and subscribe to LiveObjects on a channel.
+
 h3. Methods
 
 h6(#publish).

--- a/content/liveobjects/batch.textile
+++ b/content/liveobjects/batch.textile
@@ -1,0 +1,148 @@
+---
+title: Batch operations
+meta_description: "Group multiple objects operations into a single channel message to apply grouped operations atomically and improve performance."
+product: liveobjects
+languages:
+  - javascript
+---
+
+The Batching API in LiveObjects enables multiple updates to be grouped into a single channel message and applied atomically. It ensures that all operations in a batch either succeed together or are discarded entirely. Batching operations is essential when multiple related updates to channel objects must be applied as a single atomic unit, for example, when application logic depends on multiple objects being updated simultaneously. Without batching, if one operation succeeds while another fails, your application state could become inconsistent.
+
+Note that this differs from "Message batching":/docs/messages/batch, the native Pub/Sub messages feature. The LiveObjects Batching API is a separate API specifically designed to enable you to group object operations into a single channel message, ensuring that the Ably system guarantees the atomicity of the applied changes.
+
+h2(#create). Create batch context
+
+blang[javascript].
+
+  To batch object operations together, use the @channel.objects.batch()@ method. This method accepts a callback function, which is provided with a batch context object. The batch context object provides a synchronous API to work with objects on a channel that stores operations inside the batch instead of applying them immediately.
+
+  Using the batch context ensures that operations are grouped and sent in a single channel message after the batch callback function has run. This guarantees that all changes are applied atomically by both the server and all clients.
+
+  <aside data-type='important'>
+  <p>
+    The batch callback function must be synchronous because the batch method sends the grouped operations as soon as the callback function completes. If you need to perform asynchronous operations (such as fetching data to do operations inside a batch), do so outside the callback function before calling @channel.objects.batch()@.
+  </p>
+  </aside>
+
+blang[javascript].
+
+  ```[javascript]
+  await channel.objects.batch((ctx) => {
+    const root = ctx.getRoot();
+
+    root.set('foo', 'bar');
+    root.set('baz', 42);
+
+    const counter = root.get('counter');
+    counter.increment(5);
+
+    // Batched operations are sent to the Ably system when the batch callback has run.
+  });
+  ```
+
+If an error occurs within the batch, all operations are discarded, preventing partial updates and ensuring atomicity.
+
+h3(#context). Batch context object
+
+blang[javascript].
+
+  The batch context provides a synchronous API for objects operations inside the batch callback. It mirrors the asynchronous API found on @channel.objects@, including "LiveCounter":/docs/liveobjects/counter and "LiveMap":/docs/liveobjects/map.
+
+  To access the batch API, call @BatchContext.getRoot()@, which synchronously returns a wrapper around the "root":/docs/liveobjects/quickstart#step-4 object instance. This wrapper enables you to access and modify objects within a batch.
+
+  <aside data-type='note'>
+  <p>
+    Although the batch context provides a synchronous API, updates to objects are only applied _after_ the batch callback function has run and changes have been echoed back to the client, just like regular mutation operations.
+  </p>
+  </aside>
+
+blang[javascript].
+
+  ```[javascript]
+  await channel.objects.batch((ctx) => {
+    // Note: .getRoot() call on a batch context is synchronous.
+    // The returned root object is a special wrapper around a regular LiveMap instance,
+    // providing a synchronous mutation API.
+    const root = ctx.getRoot();
+
+    // Mutation operations like LiveMap.set and LiveCounter.increment
+    // are synchronous inside the batch and queue operations instead of applying them immediately.
+    root.set('foo', 'bar');
+    root.remove('baz');
+
+    // Access other objects through the root object from the BatchContext.getRoot() method.
+    const counter = root.get('counter');
+    counter.increment(5);
+  });
+  ```
+
+You cannot create new objects using the batch context. If you need to create new objects and add them to the channel as part of an atomic batch operation to guarantee atomicity, you must first create them using the regular @channel.objects@ API. Once the objects have been created, you can then assign them to the object tree inside a batch function.
+
+blang[javascript].
+
+  ```[javascript]
+  // First, create new objects outside the batch context
+  const counter = await channel.objects.createCounter();
+  const map = await channel.objects.createMap();
+
+  // Then, use a batch to assign them atomically to the channel objects
+  await channel.objects.batch((ctx) => {
+    const root = ctx.getRoot();
+    root.set('counter', counter);
+    root.set('map', map);
+  });
+  ```
+
+h3(#use-cases). When to batch operations
+
+Usually, you don't need to use batching for objects operations. It is only useful in situations where a group of operations must be applied together to maintain consistency in application state, or when there are multiple mutation operations that you might want to apply at the same time to improve the UI experience.
+
+For example, in a task dashboard application, you might want to remove all tasks on a board in a single operation to prevent excessive UI updates that the user would otherwise experience.
+
+blang[javascript].
+
+  ```[javascript]
+  await channel.objects.batch((ctx) => {
+    const root = ctx.getRoot();
+    const tasks = root.get('tasks');
+
+    for (const key of reactions.keys()) {
+      reactions.remove(key);
+    }
+  });
+  ```
+
+h3(#cancel). Cancel batch operation
+
+To explicitly cancel a batch before it is applied, throw an error inside the batch function. This prevents any queued operations from being applied.
+
+blang[javascript].
+
+  ```[javascript]
+  await channel.objects.batch((ctx) => {
+    const root = ctx.getRoot();
+    root.set('foo', 'bar');
+
+    // Throwing an error prevents any queued operations from being applied.
+    throw new Error('Cancel batch');
+  });
+  ```
+
+blang[javascript].
+
+  h3(#closed). Batch API cannot be used outside the callback function
+
+  The Batch API provided by the batch context object cannot be used outside the callback function. Attempting to do so results in an error. This applies both to @BatchContext.getRoot()@ and any object instances retrieved from it.
+
+blang[javascript].
+
+  ```[javascript]
+  let root;
+  await channel.objects.batch((ctx) => {
+    root = ctx.getRoot();
+  });
+
+  // Calling any Batch API methods outside the batch callback
+  // will throw an Error: Batch is closed.
+  root.set('foo', 'bar');
+  ```

--- a/content/liveobjects/counter.textile
+++ b/content/liveobjects/counter.textile
@@ -1,0 +1,186 @@
+---
+title: LiveCounter
+meta_description: "Create, update and receive updates for a numerical counter that synchronizes state across clients in realtime."
+product: liveobjects
+languages:
+  - javascript
+---
+
+LiveCounter is a synchronized numerical counter that supports increment and decrement operations. It ensures that all updates are correctly applied and synchronized across users in realtime, preventing inconsistencies when multiple users modify the counter value simultaneously.
+
+h2(#create). Create LiveCounter
+
+A @LiveCounter@ instance can be created using the @channel.objects.createCounter()@ method. It must be stored inside a @LiveMap@ object that is reachable from the "root object":/docs/liveobjects/quickstart#step-4.
+
+blang[javascript].
+
+  @channel.objects.createCounter()@ is asynchronous, as the client sends the create operation to the Ably system and waits for an acknowledgment of the successful counter creation.
+
+<aside data-type='note'>
+<p>
+  Note that you need to first "attach to the channel":/quickstart#step-3 before creating a new @LiveCounter@ instance, as this operation requires sending a message to the Ably system.
+</p>
+</aside>
+
+blang[javascript].
+
+  ```[javascript]
+  const counter = await channel.objects.createCounter();
+  await root.set('counter', counter);
+  ```
+
+Optionally, you can specify an initial value when creating the counter:
+
+blang[javascript].
+
+  ```[javascript]
+  const counter = await channel.objects.createCounter(100); // Counter starts at 100
+  ```
+
+h2(#value). Get counter value
+
+Get the current value of a counter using the @LiveCounter.value()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  console.log('Counter value:', counter.value());
+  ```
+
+h2(#subscribe-data). Subscribe to data updates
+
+You can subscribe to data updates on a counter to receive realtime changes made by you or other clients.
+
+<aside data-type='note'>
+<p>
+  @LiveCounter@ mutation methods do not directly modify the local counter state. Instead, they send the intended operation to the Ably system, and the change is applied only when the corresponding realtime operation is echoed back to the client. This means that the state retrieved immediately after a mutation may not reflect the latest updates yet. You will be notified via subscription when the counter is updated.
+</p>
+</aside>
+
+Subscribe to data updates on a counter using the @LiveCounter.subscribe()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  counter.subscribe((update) => {
+    console.log('Counter updated:', counter.value());
+    console.log('Update details:', update);
+  });
+  ```
+
+The update object provides details about the change, such as the amount by which the counter value was changed.
+
+Example structure of an update object when the counter was incremented by 5:
+
+```[json]
+{
+  {
+    "amount": 5
+  }
+}
+```
+
+Or decremented by 10:
+
+```[json]
+{
+  {
+    "amount": -10
+  }
+}
+```
+
+h3(#unsubscribe-data). Unsubscribe from data updates
+
+Use the @unsubscribe()@ function returned in the @subscribe()@ response to remove a counter update listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const { unsubscribe } = counter.subscribe(() => console.log(counter.value()));
+  // To remove the listener
+  unsubscribe();
+  ```
+
+Use the @LiveCounter.unsubscribe()@ method to deregister a provided listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const listener = () => console.log(counter.value());
+  counter.subscribe(listener);
+  // To remove the listener
+  counter.unsubscribe(listener);
+  ```
+
+Use the @LiveCounter.unsubscribeAll()@ method to deregister all counter update listeners:
+
+blang[javascript].
+
+  ```[javascript]
+  counter.unsubscribeAll();
+  ```
+
+h2(#update). Update LiveCounter
+
+Update the counter value by calling @LiveCounter.increment()@ or @LiveCounter.decrement()@. These operations are synchronized across all clients and trigger data subscription callbacks for the counter, including on the client making the request.
+
+blang[javascript].
+
+  These operations are asynchronous, as the client sends the corresponding update operation to the Ably system and waits for acknowledgment of the successful counter update.
+
+blang[javascript].
+
+  ```[javascript]
+  await counter.increment(5); // Increase value by 5
+  await counter.decrement(2); // Decrease value by 2
+  ```
+
+h2(#subscribe-lifecycle). Subscribe to lifecycle events
+
+Subscribe to lifecycle events on a counter using the @LiveCounter.on()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  counter.on('deleted', () => {
+    console.log('Counter has been deleted');
+  });
+  ```
+
+Read more about "objects lifecycle events":/docs/liveobjects/lifecycle#objects.
+
+h3(#unsubscribe-lifecycle). Unsubscribe from lifecycle events
+
+Use the @off()@ function returned in the @on()@ response to remove a lifecycle event listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const { off } = counter.on(('deleted') => console.log('Counter deleted'));
+  // To remove the listener
+  off();
+  ```
+
+Use the @LiveCounter.off()@ method to deregister a provided lifecycle event listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const listener = () => console.log('Counter deleted');
+  counter.on('deleted', listener);
+  // To remove the listener
+  counter.off('deleted', listener);
+  ```
+
+Use the @LiveCounter.offAll()@ method to deregister all lifecycle event listeners:
+
+blang[javascript].
+
+  ```[javascript]
+  counter.offAll();
+  ```

--- a/content/liveobjects/index.textile
+++ b/content/liveobjects/index.textile
@@ -1,0 +1,71 @@
+---
+title: About LiveObjects
+meta_description: "Learn about Ably LiveObjects, its features, use cases, and how it simplifies realtime state synchronization."
+product: liveobjects
+---
+
+Ably LiveObjects enables effortless realtime synchronization of application state across multiple users and devices at any scale. LiveObjects provides a set of purpose-built APIs and data structures to handle the complexities of persisting and synchronizing state, freeing you to focus on building features instead of managing concurrency or conflict resolution.
+
+LiveObjects enables you to store data as "objects" on a channel. These objects are automatically synchronized in realtime across all connected clients, and any conflicts that arise from concurrent updates are seamlessly resolved in the background.
+
+LiveObjects is managed and persisted on a per-channel basis and benefit from the same performance guarantees and scaling potential as "channels":/docs/channels.
+
+The LiveObjects API is available as a feature of "channels":/docs/channels within the Ably Pub/Sub SDK and can be accessed via the "@channel.objects@":/docs/api/realtime-sdk/channels#objects property.
+
+h2(#use-cases). Use cases
+
+Ably LiveObjects is useful when your application has data that:
+
+* Is shared by many users
+* Needs to be synchronized in realtime
+* Can be updated concurrently by many users
+
+Use Ably LiveObjects to build scalable realtime applications such as:
+
+* Voting and polling systems: Platforms that need the ability to count and display votes in realtime, such as audience engagement tools, quizzes, and decision-making applications.
+* Collaborative applications: Tools like shared whiteboards or content and product management applications where multiple users edit shared content simultaneously.
+* Live leaderboards: Multiplayer games or competition-based applications that require up-to-date rankings and scoreboards.
+* Game state: Applications that present dynamic in-game statistics or game state in realtime, such as player health, scores, and inventory changes.
+* Shared configuration, settings or controls: Systems where configuration parameters are shared or updated across multiple users or devices.
+
+h2(#features). LiveObjects features
+
+Ably LiveObjects provides the following key features:
+
+* "LiveCounter":#counter
+* "LiveMap":#map
+* "Composability":#composability
+* "Batching operations":#batch
+
+h3(#counter). LiveCounter
+
+"LiveCounter":/docs/liveobjects/counter is a numerical counter that supports increment and decrement operations. It ensures that all updates are correctly applied and synchronized across users in realtime, preventing inconsistencies when multiple users modify the counter value simultaneously.
+
+LiveCounter is ideal for scenarios such as:
+
+* Tracking reactions (likes, upvotes, or downvotes) in social applications.
+* Counting active users in a chatroom.
+* Maintaining live leaderboard scores in competitive applications.
+
+h3(#map). LiveMap
+
+"LiveMap":/docs/liveobjects/map is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans and buffers, as well as other objects, enabling "composable data structures":#composability.
+
+Conflicts in a LiveMap are automatically resolved with last-write-wins (LWW) semantics.
+
+h3(#composability). Composability
+
+A "LiveMap":/docs/liveobjects/map#composability can store references to other @LiveMap@ or @LiveCounter@ objects as values for its keys, enabling you to build complex, hierarchical object structure. This enables you to represent complex data models in your applications while ensuring realtime synchronization across clients.
+
+h3(#batch). Batch operations
+
+"Batching":/docs/liveobjects/batch enables multiple LiveObjects operations to be grouped into a single channel message, ensuring atomic application of grouped operations. This prevents partial updates of your data and ensures consistency across all users.
+
+Batching is particularly useful in scenarios where multiple dependent updates need to be processed together, ensuring a seamless experience for users.
+
+h2(#examples). Examples
+
+Take a look at the LiveObjects examples to help you get started:
+
+* "Voting system powered by LiveCounter":https://examples.ably.dev/liveobjects-live-counter : Demonstrates how to use a LiveCounter to track votes in a realtime poll.
+* "Realtime Task Board powered by LiveMap":https://examples.ably.dev/liveobjects-live-map : Demonstrates how LiveMap can be used to store and manage shared list of tasks between users.

--- a/content/liveobjects/lifecycle.textile
+++ b/content/liveobjects/lifecycle.textile
@@ -1,0 +1,66 @@
+---
+title: Lifecycle events
+meta_description: "Understand lifecycle events for Objects, LiveMap and LiveCounter to track synchronization events and object deletions."
+product: liveobjects
+languages:
+  - javascript
+---
+
+h2(#synchronization). Objects synchronization events
+
+The "@channel.objects@":/docs/api/realtime-sdk/channels#objects instance emits synchronization events that indicate when the local state on the client is being synchronized with the Ably service. These events can be useful for displaying loading indicators, preventing user interactions during synchronization, or triggering application logic when data is first loaded.
+
+* @syncing@ - Emitted when the local copy of objects on a channel begins synchronizing with the Ably service.
+* @synced@ - Emitted when the local copy of objects on a channel has been synchronized with the Ably service.
+
+blang[javascript].
+
+  ```[javascript]
+  channel.objects.on('syncing', () => {
+    console.log('Objects are syncing...');
+    // Show a loading indicator and disable edits in the application
+  });
+
+  channel.objects.on('synced', () => {
+    console.log('Objects have been synced.');
+    // Hide loading indicator
+  });
+  ```
+
+<aside data-type='important'>
+<p>
+  LiveObjects synchronization events do not replace "connection":/docs/connect/states or "channel":/docs/channel/states states. You should still monitor these states and handle "connection":/docs/connect/states#handling-failures and "channel":/docs/channel/states#failure failures to ensure your application behaves as expected. LiveObjects synchronization events specifically inform you about the progress of LiveObjects data synchronization and should be used alongside other state management mechanisms.
+</p>
+</aside>
+
+h2(#objects-lifecycle). LiveMap/LiveCounter lifecycle events
+
+Lifecycle events enable you to monitor changes in an object's lifecycle.
+
+Currently, only the @deleted@ event can be emitted. Understanding the conditions under which this event is emitted and handling it properly ensures that your application maintains expected behavior.
+
+h3(#objects-deleted). deleted event
+
+Objects that were created on a channel can become orphaned when they were never assigned to the object tree, or because their reference was removed using "@LiveMap.remove()@":/docs/liveobjects/map#remove and never reassigned. Orphaned objects will be garbage collected by Ably, typically after 24 hours. When this happens, a @deleted@ event is broadcast for the affected object. Once deleted, an object can no longer be interacted with, and any operations performed on it will result in an error.
+
+While the LiveObjects feature internally manages object deletions and removes them from its internal state, your application may still hold references to these deleted objects in separate data structures. The @deleted@ event provides a way to react accordingly by removing references to deleted objects and preventing potential errors.
+
+In most cases, subscribing to @deleted@ events is unnecessary. Your application should have already reacted to object removal when a corresponding "@LiveMap.remove()@":/docs/liveobjects/map#remove operation was received. However, if your application separately stores references to object instances and does not properly clear them when objects are orphaned, any later interactions with those objects after they are deleted will result in an error. In such cases, subscribing to @deleted@ events helps ensure that those references are cleaned up and runtime errors are avoided.
+
+<aside data-type='note'>
+<p>
+  The "root object":/docs/liveobjects/quickstart#step-4 cannot be deleted, so there is no need to subscribe to this event on the root object.
+</p>
+</aside>
+
+blang[javascript].
+
+  ```[javascript]
+  const { off } = counter.on('deleted', () => {
+    console.log('LiveCounter has been deleted.');
+    // Remove references to this object from your application
+    // as it can no longer be interacted with
+  });
+  ```
+
+Read more about subscribing to object lifecycle events for "LiveCounter":/docs/liveobjects/counter#subscribe-lifecycle and "LiveMap":/docs/liveobjects/map#subscribe-lifecycle.

--- a/content/liveobjects/map.textile
+++ b/content/liveobjects/map.textile
@@ -1,0 +1,246 @@
+---
+title: LiveMap
+meta_description: "Create, update and receive updates for a key/value data structure that synchronizes state across clients in realtime."
+product: liveobjects
+languages:
+  - javascript
+---
+
+LiveMap is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans and buffers, as well as other objects, "enabling you to build complex, hierarchical object structure":#composability.
+
+Conflicts in a LiveMap are automatically resolved with last-write-wins (LWW) semantics. The latest received operation on a key will be applied to the LiveMap and broadcast to all clients.
+
+h2(#create). Create LiveMap
+
+A @LiveMap@ instance can be created using the @channel.objects.createMap()@ method. It must be stored inside another @LiveMap@ object that is reachable from the "root object":/docs/liveobjects/quickstart#step-4.
+
+blang[javascript].
+
+  @channel.objects.createMap()@ is asynchronous, as the client sends the create operation to the Ably system and waits for an acknowledgment of the successful map creation.
+
+<aside data-type='note'>
+<p>
+  Note that you need to first "attach to the channel":/quickstart#step-3 before creating a new @LiveMap@ instance, as this operation requires sending a message to the Ably system.
+</p>
+</aside>
+
+blang[javascript].
+
+  ```[javascript]
+  const map = await channel.objects.createMap();
+  await root.set('myMap', map);
+  ```
+
+Optionally, you can specify an initial key/value structure when creating the map:
+
+blang[javascript].
+
+  ```[javascript]
+  // Pass a regular JavaScript object reflecting the initial state
+  const map = await channel.objects.createMap({ foo: 'bar', baz: 42 });
+  // You can also pass other objects as values for keys
+  await channel.objects.createMap({ nestedMap: map });
+  ```
+
+h2(#value). Get value for a key
+
+Get the current value for a key in a map using the @LiveMap.get()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  console.log('Value for my-key:', map.get('my-key'));
+  ```
+
+h2(#subscribe-data). Subscribe to data updates
+
+You can subscribe to data updates on a map to receive realtime changes made by you or other clients.
+
+<aside data-type='note'>
+<p>
+  @LiveMap@ mutation methods do not directly modify the local map state. Instead, they send the intended operation to the Ably system, and the change is applied only when the corresponding realtime operation is echoed back to the client. This means that the state retrieved immediately after a mutation may not reflect the latest updates yet. You will be notified via subscription when the map is updated.
+</p>
+</aside>
+
+Subscribe to data updates on a map using the @LiveMap.subscribe()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  map.subscribe((update) => {
+    console.log('Map updated:', [...map.entries()]);
+    console.log('Update details:', update);
+  });
+  ```
+
+The update object provides details about the change, listing the keys that were changed and indicating whether they were updated (value changed) or removed from the map.
+
+Example structure of an update object when the key @foo@ is updated and the key @bar@ is removed:
+
+```[json]
+{
+  {
+    "foo": "updated",
+    "bar": "removed"
+  }
+}
+```
+
+h3(#unsubscribe-data). Unsubscribe from data updates
+
+Use the @unsubscribe()@ function returned in the @subscribe()@ response to remove a map update listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const { unsubscribe } = map.subscribe(() => console.log('Map updated'));
+  // To remove the listener
+  unsubscribe();
+  ```
+
+Use the @LiveMap.unsubscribe()@ method to deregister a provided listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const listener = () => console.log('Map updated');
+  map.subscribe(listener);
+  // To remove the listener
+  map.unsubscribe(listener);
+  ```
+
+Use the @LiveMap.unsubscribeAll()@ method to deregister all map update listeners:
+
+blang[javascript].
+
+  ```[javascript]
+  map.unsubscribeAll();
+  ```
+
+h2(#set). Set keys in a LiveMap
+
+Set a value for a key in a map by calling @LiveMap.set()@. This operation is synchronized across all clients and triggers data subscription callbacks for the map, including on the client making the request.
+
+Keys in a map can contain numbers, strings, booleans and buffers, as well as other @LiveMap@ and @LiveCounter@ objects.
+
+blang[javascript].
+
+  This operation is asynchronous, as the client sends the corresponding update operation to the Ably system and waits for acknowledgment of the successful map key update.
+
+blang[javascript].
+
+  ```[javascript]
+  await map.set('foo', 'bar');
+  await map.set('baz', 42);
+
+  // Can also set a reference to another object
+  const counter = await channel.objects.createCounter();
+  await map.set('counter', counter);
+  ```
+
+h2(#remove). Remove a key from a LiveMap
+
+Remove a key from a map by calling @LiveMap.remove()@. This operation is synchronized across all clients and triggers data subscription callbacks for the map, including on the client making the request.
+
+blang[javascript].
+
+  This operation is asynchronous, as the client sends the corresponding remove operation to the Ably system and waits for acknowledgment of the successful map key removal.
+
+blang[javascript].
+
+  ```[javascript]
+  await map.remove('foo');
+  ```
+
+h2(#iterate). Iterate over key/value pairs
+
+blang[javascript].
+
+  Iterate over key/value pairs, keys or values using the @LiveMap.entries()@, @LiveMap.keys()@ and @LiveMap.values()@ methods respectively.
+
+  These methods return a "map iterator":https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator object for convenient traversal. Note that contrary to JavaScript's "Map":https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map counterpart, these methods do not guarantee that entries are returned in insertion order.
+
+blang[javascript].
+
+  ```[javascript]
+  for (const [key, value] of map.entries()) {
+    console.log(`Key: ${key}, Value: ${value}`);
+  }
+
+  for (const key of map.keys()) {
+    console.log(`Key: ${key}`);
+  }
+
+  for (const value of map.values()) {
+    console.log(`Value: ${value}`);
+  }
+  ```
+
+h2(#subscribe-lifecycle). Subscribe to lifecycle events
+
+Subscribe to lifecycle events on a map using the @LiveMap.on()@ method:
+
+blang[javascript].
+
+  ```[javascript]
+  map.on('deleted', () => {
+    console.log('Map has been deleted');
+  });
+  ```
+
+Read more about "objects lifecycle events":/docs/liveobjects/lifecycle#objects.
+
+h3(#unsubscribe-lifecycle). Unsubscribe from lifecycle events
+
+Use the @off()@ function returned in the @on()@ response to remove a lifecycle event listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const { off } = map.on(('deleted') => console.log('Map deleted'));
+  // To remove the listener
+  off();
+  ```
+
+Use the @LiveMap.off()@ method to deregister a provided lifecycle event listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Initial subscription
+  const listener = () => console.log('Map deleted');
+  map.on('deleted', listener);
+  // To remove the listener
+  map.off('deleted', listener);
+  ```
+
+Use the @LiveMap.offAll()@ method to deregister all lifecycle event listeners:
+
+blang[javascript].
+
+  ```[javascript]
+  map.offAll();
+  ```
+
+h2(#composability). Composability
+
+A @LiveMap@ can store other @LiveMap@ or @LiveCounter@ objects as values for its keys, enabling you to build complex, hierarchical object structure. This enables you to represent complex data models in your applications while ensuring realtime synchronization across clients.
+
+blang[javascript].
+
+  ```[javascript]
+  // Create a hierarchy of objects using LiveMap
+  const counter = await channel.objects.createCounter();
+  const map = await channel.objects.createMap({ nestedCounter: counter });
+  const outerMap = await channel.objects.createMap({ nestedMap: map });
+  await root.set('outerMap', outerMap);
+
+  // resulting structure:
+  // root (LiveMap)
+  // └── outerMap (LiveMap)
+  //     └── nestedMap (LiveMap)
+  //         └── nestedCounter (LiveCounter)
+  ```

--- a/content/liveobjects/quickstart.textile
+++ b/content/liveobjects/quickstart.textile
@@ -1,0 +1,200 @@
+---
+title: Quickstart
+meta_description: "A quickstart guide to learn the basics of integrating the Ably LiveObjects product into your application."
+product: liveobjects
+languages:
+  - javascript
+---
+
+This guide shows how to integrate Ably LiveObjects into your application.
+
+You will learn how to:
+
+* Create an Ably account and get an API key for authentication.
+* Install the Ably Pub/Sub SDK.
+* Create a channel with LiveObjects functionality enabled.
+* Create, update and subscribe to changes on LiveObjects data structures: "LiveMap":/docs/liveobjects/map and "LiveCounter":/docs/liveobjects/counter.
+
+h2(#step-0). Authentication
+
+An "API key":/docs/auth#api-keys is required to authenticate with Ably. API keys are used either to authenticate directly with Ably using "basic authentication":/docs/auth/basic, or to generate tokens for untrusted clients using "token authentication":/docs/auth/token.
+
+<aside data-type='important'>
+<p>The examples use "basic authentication":/docs/auth/basic to demonstrate features for convenience. In your own applications, basic authentication should never be used on the client-side as it exposes your Ably API key. Instead use "token authentication":/docs/auth/token. </p>
+</aside>
+
+"Sign up":https://ably.com/sign-up for a free account and create your own API key in the "dashboard":https://ably.com/dashboard or use the "Control API":/docs/account/control-api to create an API key programmatically.
+
+API keys and tokens have a set of "capabilities":/docs/auth/capabilities assigned to them that specify which operations can be performed on which resources. The following capabilities are available for LiveObjects:
+
+* @object-subscribe@ - grants clients read access to LiveObjects, allowing them to get the root object and subscribe to updates.
+* @object-publish@ - grants clients write access to LiveObjects, allowing them to perform mutation operations on objects.
+
+To use LiveObjects, an API key must have at least the @object-subscribe@ capability. With only this capability, clients will have read-only access, preventing them from calling mutation methods on LiveObjects.
+
+For the purposes of this guide, make sure your API key includes both @object-subscribe@ and @object-publish@ "capabilities":/docs/auth/capabilities to allow full read and write access.
+
+h2(#step-1). Install Ably Pub/Sub SDK
+
+blang[javascript].
+
+  LiveObjects is available as part of the Ably Pub/Sub SDK via the dedicated Objects plugin.
+
+blang[javascript].
+
+  h3(#npm). NPM
+
+  Install the Ably Pub/Sub SDK as an "NPM module":https://www.npmjs.com/package/ably:
+
+  ```[sh]
+  npm install ably
+  ```
+
+  Import the SDK and the Objects plugin into your project:
+
+  ```[javascript]
+  import * as Ably from 'ably';
+  import Objects from 'ably/objects';
+  ```
+
+blang[javascript].
+
+  h3(#cdn). CDN
+
+  Reference the Ably Pub/Sub SDK and the Objects plugin within your HTML file:
+
+  ```[html]
+  <script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
+  <script src="https://cdn.ably.com/lib/objects.umd.min-2.js"></script>
+  <script>
+    // Objects plugin is now available on the global object via the `AblyObjectsPlugin` property
+    const Objects = window.AblyObjectsPlugin;
+  </script>
+  ```
+
+h2(#step-2). Instantiate a client
+
+blang[javascript].
+
+  Instantiate an Ably Realtime client from the Pub/Sub SDK, providing the Objects plugin:
+
+  ```[javascript]
+  const realtimeClient = new Ably.Realtime({ key: '{{API_KEY}}', plugins: { Objects } });
+  ```
+
+blang[javascript].
+
+  A "@ClientOptions@":/docs/api/realtime-sdk#client-options object may be passed to the Pub/Sub SDK instance to further customize the connection, however at a minimum you must set an API key and provide an @Objects@ plugin so that the client can use LiveObjects functionality.
+
+h2(#step-3). Create a channel
+
+LiveObjects is managed and persisted on "channels":/docs/channels. To use LiveObjects, you must first create a channel with the correct "channel mode flags":/docs/channels/options#modes :
+
+* @OBJECT_SUBSCRIBE@ - required to access objects on a channel.
+* @OBJECT_PUBLISH@ - required to create and modify objects on a channel.
+
+<aside data-type='note'>
+<p>
+  When you provide an explicit @modes@ property for a channel, you override the set of "default modes":/docs/channels/options#modes used for that channel. So, if you're using the channel for anything in addition to LiveObjects, you need to ensure that you also include the other modes required by the features you are using.
+</p>
+</aside>
+
+blang[javascript].
+
+  ```[javascript]
+  const channelOptions = { modes: ['OBJECT_SUBSCRIBE', 'OBJECT_PUBLISH'] };
+  const channel = realtimeClient.channels.get('my_liveobjects_channel', channelOptions);
+  ```
+
+Next, you need to "attach to the channel":/docs/channels/states. Attaching to a channel starts an initial synchronization sequence where the objects on the channel are sent to the client.
+
+blang[javascript].
+
+  ```[javascript]
+  await channel.attach();
+  ```
+
+h2(#step-4). Get root object
+
+The "@channel.objects@":/docs/api/realtime-sdk/channels#objects property gives access to the LiveObjects API for a channel.
+
+Use it to get the root object, which is the entry point for accessing and persisting objects on a channel. The root object is a "@LiveMap@":/docs/liveobjects/map instance that always exists on a channel and acts as the top-level node in your object tree. You can get the root object using the @getRoot()@ function of LiveObjects:
+
+blang[javascript].
+
+  ```[javascript]
+  // The promise resolves once the LiveObjects state is synchronized with the Ably system
+  const root = await channel.objects.getRoot();
+  ```
+
+h2(#step-5). Create objects
+
+You can create new objects using dedicated functions of the LiveObjects API at "@channel.objects@":/docs/api/realtime-sdk/channels#objects. To persist them on a channel and share them between clients, you must assign objects to a parent @LiveMap@ instance connected to the root object. The root object itself is a @LiveMap@ instance, so you can assign objects to the root and start building your object tree from there.
+
+<aside data-type='note'>
+<p>
+  Objects that are not descendants of the root object are "unreachable" and will eventually be garbage collected. Read more in the "objects lifecycle events section":/docs/liveobjects/lifecycle#objects-lifecycle.
+</p>
+</aside>
+
+blang[javascript].
+
+  ```[javascript]
+  const visitsCounter = await channel.objects.createCounter();
+  const reactionsMap = await channel.objects.createMap();
+
+  await root.set('visits', visitsCounter);
+  await root.set('reactions', reactionsMap);
+  ```
+
+h2(#step-6). Subscribe to updates
+
+Subscribe to realtime updates to objects on a channel. You will be notified when an object is updated by other clients or by you.
+
+blang[javascript].
+
+  ```[javascript]
+  visitsCounter.subscribe(() => {
+    console.log('Visits counter updated:', visitsCounter.value());
+  });
+
+  reactionsMap.subscribe(() => {
+    console.log('Reactions map updated:', [...reactionsMap.entries()]);
+  });
+  ```
+
+h2(#step-7). Update objects
+
+Update objects using mutation methods. All subscribers (including you) will be notified of the changes when you update an object:
+
+blang[javascript].
+
+  ```[javascript]
+  await visitsCounter.increment(5);
+  // console: "Visits counter updated: 5"
+  await visitsCounter.decrement(2);
+  // console: "Visits counter updated: 2"
+
+  await reactionsMap.set('like', 10);
+  // console: "Reactions map updated: [['like',10]]"
+  await reactionsMap.set('love', 10);
+  // console: "Reactions map updated: [['like',10],['love',5]]"
+  await reactionsMap.remove('like');
+  // console: "Reactions map updated: [['love',5]]"
+  ```
+
+<aside data-type='note'>
+<p>
+  Mutation methods (such as @LiveMap.set@, @LiveCounter.increment@, etc.) do not directly modify the local object state. Instead, they send the intended operation to the Ably system, and the change is applied only when the corresponding realtime operation is echoed back to the client. This means that the state retrieved immediately after a mutation may not reflect the latest updates yet. You will be notified via subscription when the object is updated.
+</p>
+</aside>
+
+h2(#step-8). Next steps
+
+This quickstart introduced the basic concepts of LiveObjects and demonstrated how it works. The next steps are to:
+
+* Read more about "LiveCounter":/docs/liveobjects/counter and "LiveMap":/docs/liveobjects/map.
+* Learn about "Batching Operations":/docs/liveobjects/batch.
+* Learn about "Objects Lifecycle Events":/docs/liveobjects/lifecycle.
+* Explore "LiveObjects examples":https://examples.ably.dev.
+* Add "Typings":/docs/liveobjects/typing for your LiveObjects.

--- a/content/liveobjects/typing.textile
+++ b/content/liveobjects/typing.textile
@@ -1,0 +1,87 @@
+---
+title: Typing
+meta_description: "Type objects on a channel for type safety and code autocompletion."
+product: liveobjects
+languages:
+  - javascript
+---
+
+blang[javascript].
+
+  If you are using TypeScript in your project, you can leverage LiveObjects' built-in TypeScript support to ensure type safety and enable autocompletion when working with objects on a channel.
+
+  h2(#global). Global ObjectsTypes interface
+
+  You can type objects on all your channels by defining a global @ObjectsTypes@ interface. If you only want to type the root object for a specific channel, see the "Typing channel.objects.getRoot()":#getroot section below.
+
+  Define the @ObjectsTypes@ interface in a type declaration file. You can create a file named @ably.config.d.ts@ in the root of your application:
+
+blang[javascript].
+
+  ```[javascript]
+  // file: ably.config.d.ts
+  import { LiveCounter, LiveMap } from 'ably';
+
+  // Define dedicated types and export them for reuse in your application
+  export type MyCustomRoot = {
+    reactions: LiveMap<{
+      hearts: LiveCounter;
+      likes: LiveCounter;
+    }>;
+  };
+
+  declare global {
+    export interface ObjectsTypes {
+      root: MyCustomRoot;
+    }
+  }
+  ```
+
+blang[javascript].
+
+  This enables TypeScript to infer the correct types when accessing and mutating LiveObjects:
+
+blang[javascript].
+
+  ```[javascript]
+  // LiveMap<{ reactions: LiveMap<{ hearts: LiveCounter; likes: LiveCounter }> }>
+  const root = await channel.objects.getRoot();
+
+  // LiveMap<{ hearts: LiveCounter; likes: LiveCounter }>
+  const reactions = root.get('reactions');
+
+  // LiveCounter
+  const likes = reactions.get('likes');
+
+  reactions.set('hearts', 1); // Error: Argument of type 'number' is not assignable to parameter of type 'LiveCounter'.ts(2345)
+  ```
+
+blang[javascript].
+
+  h2(#getroot). Typing channel.objects.getRoot()
+
+  You can pass a type parameter directly to the @channel.objects.getRoot<T>()@ method call to type the root object for a channel explicitly:
+
+blang[javascript].
+
+  ```[javascript]
+  // Define types for different root objects
+  type ReactionsRoot = {
+    hearts: LiveCounter;
+    likes: LiveCounter;
+  };
+
+  type PollsRoot = {
+    currentPoll: LiveMap;
+  };
+
+  // LiveMap<{ hearts: LiveCounter; likes: LiveCounter }>
+  const reactionsRoot = await reactionsChannel.objects.getRoot<ReactionsRoot>();
+
+  // LiveMap<{ currentPoll: LiveMap }>
+  const pollsRoot = await pollsChannel.objects.getRoot<PollsRoot>();
+  ```
+
+blang[javascript].
+
+  Typing @channel.objects.getRoot<T>()@ is particularly useful when your application uses multiple channels, each with a different object structure.

--- a/src/data/nav/liveobjects.ts
+++ b/src/data/nav/liveobjects.ts
@@ -38,11 +38,11 @@ export default {
           link: '/docs/liveobjects/map',
         },
         {
-          name: 'Batch Operations',
+          name: 'Batch operations',
           link: '/docs/liveobjects/batch',
         },
         {
-          name: 'Lifecycle Events',
+          name: 'Lifecycle events',
           link: '/docs/liveobjects/lifecycle',
         },
         {


### PR DESCRIPTION
## Description

Adds LiveObjects product documentation to `content` section. Final docs structure can be found here: https://ably.atlassian.net/wiki/spaces/LOB/pages/3839623174/LORFC-001+LiveObjects+Product+Docs+structure.

This PR adds documentation for next LiveObjects pages:

- [x] About LiveObjects
- [x] Quickstart
- [x] Setup
- [x] LiveCounter
- [x] LiveMap
- [x] Batching Operations
- [x] Objects Lifecycle Events
- [x] Typing LiveObjects

Resolves [PUB-773](https://ably.atlassian.net/browse/PUB-773)
<!--  An in-depth description of what this PR is adding or updating. Include a link to the related JIRA issue if this exists. -->

Site navigation for LiveObjects is added in https://github.com/ably/docs/pull/2464, but can be moved into this PR if requested.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


[PUB-773]: https://ably.atlassian.net/browse/PUB-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ