### PR TITLE
Add LiveObjects product to site navigation

### DIFF
--- a/src/components/ProductNavigation/ProductNavigation.tsx
+++ b/src/components/ProductNavigation/ProductNavigation.tsx
@@ -28,6 +28,7 @@ const ProductNavigation = ({ currentProduct = 'channels' }: { currentProduct?: s
   const onChannels = currentProduct === 'channels';
   const onLiveSync = currentProduct === 'livesync';
   const onChat = currentProduct === 'chat';
+  const onLiveObjects = currentProduct === 'liveobjects';
   const onAssetTracking = currentProduct === 'asset-tracking';
 
   return (
@@ -49,6 +50,9 @@ const ProductNavigation = ({ currentProduct = 'channels' }: { currentProduct?: s
       </Item>
       <Item to="/docs/products/chat" active={onChat}>
         Chat
+      </Item>
+      <Item to="/docs/products/liveobjects" active={onLiveObjects}>
+        LiveObjects
       </Item>
       <Item to="/docs/products/asset-tracking" active={onAssetTracking}>
         Asset Tracking

--- a/src/components/common/meta-title.test.ts
+++ b/src/components/common/meta-title.test.ts
@@ -7,6 +7,7 @@ describe('getMetaTitle', () => {
       ['spaces', 'Ably Spaces', 'Setup'],
       ['livesync', 'Ably LiveSync', 'Begin'],
       ['chat', 'Ably Chat', 'Emojis'],
+      ['liveobjects', 'Ably LiveObjects', 'Setup'],
       ['asset-tracking', 'Ably Asset Tracking', 'Examples'],
       ['api-reference', 'API References', 'Setup'],
       ['pub_sub', 'Ably Pub/Sub', 'Authentication'],

--- a/src/components/common/meta-title.ts
+++ b/src/components/common/meta-title.ts
@@ -6,6 +6,7 @@ export const getMetaTitle = (title: string, product: ProductName): string => {
     spaces: 'Ably Spaces',
     livesync: 'Ably LiveSync',
     chat: 'Ably Chat',
+    liveobjects: 'Ably LiveObjects',
     'asset-tracking': 'Ably Asset Tracking',
     'api-reference': 'API References',
     pub_sub: 'Ably Pub/Sub',

--- a/src/data/content/homepage.ts
+++ b/src/data/content/homepage.ts
@@ -54,6 +54,13 @@ export default {
           links: [{ text: 'Get started', href: '/docs/spaces' }],
         },
         {
+          title: 'LiveObjects',
+          type: 'feature',
+          content: 'Seamlessly sync application state between clients.',
+          image: 'liveobjects.png',
+          links: [{ text: 'Get started', href: '/docs/liveobjects' }],
+        },
+        {
           title: 'LiveSync',
           type: 'feature',
           content: 'Seamlessly sync database changes with frontend clients.',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,7 @@
 import {
   assetTrackingNavData,
   chatNavData,
+  liveObjectsNavData,
   liveSyncNavData,
   platformNavData,
   pubsubNavData,
@@ -26,6 +27,10 @@ export const productData = {
   spaces: {
     nav: spacesNavData,
     languages: languageData.spaces,
+  },
+  liveObjects: {
+    nav: liveObjectsNavData,
+    languages: languageData.liveObjects,
   },
   liveSync: {
     nav: liveSyncNavData,

--- a/src/data/languages/languageData.ts
+++ b/src/data/languages/languageData.ts
@@ -3,13 +3,13 @@ import { LanguageData } from './types';
 
 export default {
   platform: {
-    javascript: 2.6,
-    nodejs: 2.6,
+    javascript: 2.7,
+    nodejs: 2.7,
   },
   pubsub: {
-    javascript: 2.6,
-    nodejs: 2.6,
-    react: 2.6,
+    javascript: 2.7,
+    nodejs: 2.7,
+    react: 2.7,
     csharp: 1.2,
     flutter: 1.2,
     java: 1.2,
@@ -30,6 +30,9 @@ export default {
   spaces: {
     javascript: 0.4,
     react: 0.4,
+  },
+  liveObjects: {
+    javascript: 2.7,
   },
   liveSync: {
     javascript: 0.4,

--- a/src/data/nav/index.ts
+++ b/src/data/nav/index.ts
@@ -1,8 +1,17 @@
 import platformNavData from './platform';
 import pubsubNavData from './pubsub';
 import chatNavData from './chat';
+import liveObjectsNavData from './liveobjects';
 import spacesNavData from './spaces';
 import liveSyncNavData from './livesync';
 import assetTrackingNavData from './assettracking';
 
-export { platformNavData, pubsubNavData, chatNavData, spacesNavData, liveSyncNavData, assetTrackingNavData };
+export {
+  platformNavData,
+  pubsubNavData,
+  chatNavData,
+  liveObjectsNavData,
+  spacesNavData,
+  liveSyncNavData,
+  assetTrackingNavData,
+};

--- a/src/data/nav/liveobjects.ts
+++ b/src/data/nav/liveobjects.ts
@@ -1,0 +1,67 @@
+import { NavProduct } from './types';
+
+export default {
+  name: 'Ably LiveObjects',
+  link: '/docs/liveobjects',
+  icon: {
+    closed: 'icon-product-liveobjects-mono',
+    open: 'icon-product-liveobjects',
+  },
+  content: [
+    {
+      name: 'Introduction',
+      pages: [
+        {
+          name: 'About LiveObjects',
+          link: '/docs/liveobjects',
+        },
+      ],
+    },
+    {
+      name: 'Get started',
+      pages: [
+        {
+          name: 'Quickstart',
+          link: '/docs/liveobjects/quickstart',
+        },
+      ],
+    },
+    {
+      name: 'LiveObjects features',
+      pages: [
+        {
+          name: 'LiveCounter',
+          link: '/docs/liveobjects/counter',
+        },
+        {
+          name: 'LiveMap',
+          link: '/docs/liveobjects/map',
+        },
+        {
+          name: 'Batch Operations',
+          link: '/docs/liveobjects/batch',
+        },
+        {
+          name: 'Lifecycle Events',
+          link: '/docs/liveobjects/lifecycle',
+        },
+        {
+          name: 'Typing',
+          link: '/docs/liveobjects/typing',
+        },
+      ],
+    },
+  ],
+  api: [
+    {
+      name: 'API References',
+      pages: [
+        {
+          link: 'https://ably.com/docs/sdk/js/v2.0/interfaces/ably.Objects.html',
+          name: 'JavaScript SDK',
+          external: true,
+        },
+      ],
+    },
+  ],
+} satisfies NavProduct;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -3,7 +3,7 @@ import { LanguageData } from './languages/types';
 import { NavProduct } from './nav/types';
 
 const pageKeys = ['homepage'] as const;
-const productKeys = ['platform', 'pubsub', 'chat', 'spaces', 'liveSync', 'assetTracking'] as const;
+const productKeys = ['platform', 'pubsub', 'chat', 'spaces', 'liveObjects', 'liveSync', 'assetTracking'] as const;
 
 export type ProductKey = (typeof productKeys)[number];
 type PageKey = (typeof pageKeys)[number];

--- a/src/templates/template-data.d.ts
+++ b/src/templates/template-data.d.ts
@@ -35,13 +35,22 @@ export type AblyPageContext = {
   script: string;
 };
 
-export type ProductName = 'channels' | 'spaces' | 'livesync' | 'chat' | 'asset-tracking' | 'api-reference' | 'home';
+export type ProductName =
+  | 'channels'
+  | 'spaces'
+  | 'livesync'
+  | 'chat'
+  | 'liveobjects'
+  | 'asset-tracking'
+  | 'api-reference'
+  | 'home';
 
 export type ProductTitle =
   | 'Channels'
   | 'Ably Spaces'
   | 'Ably LiveSync'
   | 'Ably Chat'
+  | 'Ably LiveObjects'
   | 'Ably Asset Tracking'
   | 'API References'
   | 'Home'


### PR DESCRIPTION
## Description

Adds navigation for LiveObjects product in `src` folder.

This was added by searching for "livesync" in "src" folder and adding corresponding "liveObjects" sections where necessary.

Currently missing:

- [ ] Need a png for main docs page for LiveObjects https://github.com/ably/docs/pull/2464/files#diff-74d9b85d26804605bb64641c8787195382c4dc7674c01c5fd5c1716fe168144dR60
- [x] Need LiveObjects icons for docs navigation https://github.com/ably/docs/pull/2464/files#diff-39bc77ddcd9f663f1666da2e0f9a528358251e8f7285384b8f53c47845b06075R7-R8

### Checklist

- [x] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
