### PR TITLE
Remove `async` from JS authCallback example

### DIFF
--- a/content/auth/token.textile
+++ b/content/auth/token.textile
@@ -153,7 +153,7 @@ You can specify an authentication callback function when you create the Ably cli
 
 ```[realtime_javascript]
 const ablyClient = new Realtime({
-    authCallback: async (tokenParams, callback) => {
+    authCallback: (tokenParams, callback) => {
         let tokenRequest;
         try {
             tokenRequest = await obtainTokenRequest(); // Make a network request to your server
@@ -168,7 +168,7 @@ const ablyClient = new Realtime({
 
 ```[realtime_nodejs]
 const ablyClient = new Realtime({
-    authCallback: async (tokenParams, callback) => {
+    authCallback: (tokenParams, callback) => {
         let tokenRequest;
         try {
             tokenRequest = await obtainTokenRequest(); // Make a network request to your server


### PR DESCRIPTION
It's misleading; it suggests that you can return the token asynchronously without using the `callback` argument, which:

1. you can't
2. doesn't match the rest of the example