### PR TITLE
Fix bug where support link goes to /docs/support

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -119,7 +119,7 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
           external: true,
         },
         {
-          href: '/docs/support',
+          href: '/support',
           label: 'Support',
         },
       ]}


### PR DESCRIPTION
A bug has been raised where the link at the top right of the docs to go to support now links to `/docs/support` which doesn't exist, so a 404 is returned. This will likely have been a side effect to some changes to the navigation of the docs recently released. A screenshot of the link is shown below:

![Screenshot 2025-03-12 at 09 54 52](https://github.com/user-attachments/assets/a60a36f9-ac13-47cb-a4e0-2a8501414935)
