### PR TITLE
Update Stats docs

### DIFF
--- a/content/account/control-api.textile
+++ b/content/account/control-api.textile
@@ -169,13 +169,10 @@ The only operation available at the account-level is to retrieve account-wide st
 To retrieve account-level statistics:
 
 ```[sh]
-curl --location --request POST 'https://control.ably.net/v1/accounts/${ACCOUNT_ID}/stats' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer ${ACCESS_TOKEN}' \
---data-raw '{
-    "unit": "minute",
-    "limit": 2
-}'
+curl --request GET \
+  --url 'https://control.ably.net/v1/accounts/${ACCOUNT_ID}/stats?unit=minute&limit=2' \
+  --header 'Authorization: Bearer ${ACCESS_TOKEN}' \
+  --header 'Content-Type: application/json'
 ```
 
 See the "API reference":/docs/api/control-api#tag/accounts/paths/~1accounts~1{account_id}~1stats/get for information on the request body.

--- a/content/metadata-stats/stats.textile
+++ b/content/metadata-stats/stats.textile
@@ -36,45 +36,29 @@ Statistics are available as:
 
 h2(#account). Account statistics
 
-Account statistics provide information about all applications in your account.
-
-You can retrieve account statistics from:
-
-* The "Control API or REST API":#account-api
-* Your "account dashboard":#account-dashboard
+Account statistics aggregate metrics from all applications in your account with additional "account-only metrics":#account-only relating to peak rates monitored and enforced at an account level.
 
 h3(#account-api). Account statistics via API
-
-You can retrieve account statistics from the "Control API":/docs/account/control-api or the "REST API":/docs/api/rest-api.
-
-h4(#account-control). Account statistics via Control API
 
 You can retrieve account statistics using the "Control API":/docs/account/control-api by making a call to the @accounts@ endpoint using your @accountId@ and @accessToken@. For example, to retrieve the last two minutes of account statistics:
 
 ```[curl]
-curl --location --request POST 'https://control.ably.net/v1/accounts/${ACCOUNT_ID}/stats' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer ${ACCESS_TOKEN}' \
---data-raw '{
-    "unit": "minute",
-    "limit": 2
-}'
+curl --request GET \
+  --url 'https://control.ably.net/v1/accounts/${ACCOUNT_ID}/stats?unit=minute&limit=2' \
+  --header 'Authorization: Bearer ${ACCESS_TOKEN}' \
+  --header 'Content-Type: application/json'
 ```
 
-Use the @/me@ endpoint to find your @accountId@, or alternatively find it in the "*Settings*":https://ably.com/accounts/any/edit page of your account dashboard:
+This endpoint returns a "statistics response type":#payload including "account-only metrics":#account-only.
+
+<aside data-type='note'>
+  <p>To obtain your @ACCOUNT_ID@, you can use @/me@ Control API endpoint to find your @ACCOUNT_ID@, or alternatively find it in the "*Settings*":https://ably.com/accounts/any/edit page of your account dashboard:
+  </p>
+</aside>
 
 ```[curl]
-curl --location --request GET 'https://control.ably.net/v1/me' \
+curl 'https://control.ably.net/v1/me' \
 --header 'Authorization: Bearer ${ACCESS_TOKEN}'
-```
-
-h4(#account-rest). Account statistics via REST API
-
-You can use the "REST API":/docs/api/rest-api to retrieve account statistics by making a GET request to the "@stats@ endpoint":/docs/api/rest-api#stats. For example, to retrieve account statistics aggregated by hour:
-
-```[curl]
-curl https://rest.ably.io/stats?unit=hour \
- -u "{{API_KEY}}"
 ```
 
 h3(#account-dashboard). Account statistics from the dashboard
@@ -83,21 +67,19 @@ Your account statistics are available as graphs, tabular data, and for download 
 
 h2(#app). App statistics
 
-App statistics provide information about a specific application.
-
-You can retrieve account statistics:
+App statistics provide metrics scoped to each application. You can retrieve account statistics:
 
 * Via the "Control API":#app-control
 * Programmatically using the "Pub/Sub SDK":#app-sdk
 * In realtime by subscribing to a "meta channel":#app-meta
 * From your "application dashboard":#app-dashboard
 
-h3(#app-control). App statistics via API
+h3(#app-control). App statistics via Control API
 
-You can retrieve app statistics using the "Control API":/docs/account/control-api by making a call to the @apps@ endpoint using your @appId@ and @accessToken@:
+You can retrieve app statistics using the "Control API":/docs/account/control-api by making a call to the @apps@ endpoint using your @APP_ID@ and @ACCESS_TOKEN@:
 
 ```[curl]
-curl --location --request POST 'https://control.ably.net/v1/apps/${APP_ID}/stats' \
+curl 'https://control.ably.net/v1/apps/${APP_ID}/stats' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer ${ACCESS_TOKEN}' \
 --data-raw '{
@@ -106,13 +88,19 @@ curl --location --request POST 'https://control.ably.net/v1/apps/${APP_ID}/stats
 }'
 ```
 
-Your @appId@ can be found in the "*Settings*":https://ably.com/accounts/any/apps/any/edit tab of an application within your application dashboard.
+This endpoint returns a "statistics response type":#payload.
 
-h3(#app-sdk). App statistics programmatically
+<aside data-type='note'>
+  <p>
+    The @APP_ID@ can be found in the "*Settings*":https://ably.com/accounts/any/apps/any/edit tab of an application within your dashboard.
+  </p>
+</aside>
 
-App-level statistics are also available programmatically using an Ably SDK at one minute intervals, or aggregated up to the hour, day or month.
+h3(#app-sdk). App statistics via SDK
 
-The following is an example of querying app-level statistics:
+App-level statistics are also available programmatically using an "Ably SDK":/docs/sdks at one minute intervals, or aggregated up to the hour, day or month. Whilst it is possible to obtain statistics via the SDKs, this API is not actively maintained and may be deprecated in future. We recommend using "app-level stats via the Control API":#app-control.
+
+The following is an example of querying app-level statistics using the Ably SDK "@stats@ method":/docs/api/rest-sdk/statistics.
 
 ```[realtime_javascript]
 const realtime = new Ably.Realtime('{{API_KEY}}');
@@ -274,7 +262,7 @@ h3(#app-meta). Subscribe to app statistics
 
 You can subscribe to app statistics using the "@[meta]stats:minute@ metachannel":/docs/metadata-stats/metadata/subscribe#stats. Events are published at one minute intervals and contain the statistics for the previous minute.
 
-The following is an example of subscribing to the @[meta]stats@ channel:
+The following is an example of subscribing to the @[meta]stats:minute@ channel:
 
 ```[realtime_javascript]
 const channel = ably.channels.get("[meta]stats:minute");
@@ -331,40 +319,48 @@ h3(#app-dashboard). App statistics from the dashboard
 
 App statistics are available as graphs, tabular data, and for download from each "application dashboard":https://ably.com/accounts/any/apps/any in your account.
 
-h2(#payload). Statistics response payload
+h2(#payload). Statistics response
 
-Statistics responses are sparse to reduce the size of the JSON and improve performance.
+Statistic API and SDK requests return an array of "Statistics entry types":#metrics.
 
-This means that if a metric is empty, or contains only zero values then the metric will be omitted completely from the response.
+An example simplified response with one stats entry is shown below:
 
 ```[json]
-{
-  entries: {
-    'messages.all.all.count': 245,
-    'messages.all.all.data': 58654,
-    'messages.all.all.uncompressedData': 58654,
-    'messages.all.all.billableCount': 245,
-    'messages.all.messages.count': 245,
-    'messages.all.messages.data': 58654,
-    'messages.all.messages.uncompressedData': 58654,
-    'messages.all.messages.billableCount': 245,
-    'messages.inbound.realtime.all.count': 145,
-    'messages.inbound.realtime.all.data': 29127,
-    'messages.inbound.realtime.all.uncompressedData': 29127,
-    'messages.inbound.realtime.messages.count': 145,
-    ...
-  },
-  schema: 'https://schemas.ably.com/json/app-stats-0.0.5.json',
-  appId: '<appId>',
-  inProgress: '2025-01-20:15:11',
-  unit: 'hour',
-  intervalId: '2025-01-20:15'
-}
+[
+  {
+    entries: {
+      'messages.all.all.count': 245,
+      'messages.all.all.data': 58654,
+      'messages.all.all.uncompressedData': 58654,
+      'messages.all.all.billableCount': 245,
+      'messages.all.messages.count': 245,
+      'messages.all.messages.data': 58654,
+      'messages.all.messages.uncompressedData': 58654,
+      'messages.all.messages.billableCount': 245,
+      'messages.inbound.realtime.all.count': 145,
+      'messages.inbound.realtime.all.data': 29127,
+      'messages.inbound.realtime.all.uncompressedData': 29127,
+      'messages.inbound.realtime.messages.count': 145,
+      ...
+    },
+    schema: 'https://schemas.ably.com/json/app-stats-0.0.5.json',
+    appId: '<appId>',
+    inProgress: '2025-01-20:15:11',
+    unit: 'hour',
+    intervalId: '2025-01-20:15'
+  }
+]
 ```
 
-h2(#metrics). Statistics metrics
+<aside data-type='note'>
+  <p>
+    Each "statistics entry type":#metrics is "sparse" to reduce the size of the JSON and improve performance. That is, if a metric is empty, or contains only zero values then the metric will be omitted completely from the response, thus producing a sparsely populated response with only values that include a metric.
+  </p>
+</aside>
 
-The following metadata is returned for each request:
+h2(#metrics). Statistics entry type
+
+The following metadata is returned for each entry:
 
 |_. Property |_. Description |
 | appId | The ID of the Ably application the statistics are for. Only present when querying app statistics. |
@@ -376,7 +372,7 @@ The following metadata is returned for each request:
 
 h3(#messages). All messages
 
-The following metrics can be returned for all messages. 'All messages' includes totals for all messages sent and received by Ably and clients.
+All messages metrics include all messages types, such as those sent and received by Ably and clients, messages delivered via integrations and push notifications delivered to devices.
 
 |_. Metric |_. Description |
 | messages.all.all.count | Total number of messages that were successfully sent, summed over all message types and transports. |
@@ -400,7 +396,7 @@ The following metrics can be returned for all messages. 'All messages' includes 
 
 h3(#inbound). Inbound messages
 
-The following metrics can be returned for inbound messages. Inbound messages are messages that are sent by clients and received by Ably.
+Inbound messages metrics include those messages that are sent by clients and received inbound from those clients by Ably.
 
 |_. Metric |_. Description |
 | messages.inbound.realtime.all.count | Total inbound realtime message count, received by Ably from clients. |
@@ -460,7 +456,7 @@ The following metrics can be returned for inbound messages. Inbound messages are
 
 h3(#outbound). Outbound messages
 
-The following metrics can be returned for outbound messages. Outbound messages are messages that are sent from Ably to a client.
+Outbound message metrics include those messages that are sent outbound from Ably to either clients that subscribe or request messages (such as history requests), to "integrations":docs/integrations, or to "push notification":/docs/push targets.
 
 |_. Metric |_. Description |
 | messages.outbound.realtime.all.count | Total outbound realtime message count, sent from Ably to clients. |
@@ -596,7 +592,7 @@ The following metrics can be returned for outbound messages. Outbound messages a
 
 h3(#persisted). Persisted messages
 
-The following metrics can be returned for persisted messages. Persisted messages are messages "stored":/docs/storage-history/storage by Ably.
+Persisted messages metrics are calculated from the number of "messages stored":/docs/storage-history/storage by Ably.
 
 |_. Metric |_. Description |
 | messages.persisted.all.count | Total count of persisted messages. |
@@ -611,7 +607,7 @@ The following metrics can be returned for persisted messages. Persisted messages
 
 h3(#deltas). Message deltas
 
-The following metrics can be returned for message deltas. Message deltas are messages that are compressed by using the "delta":/docs/channels/options/deltas feature.
+Message deltas metrics are calculated from the number of "messages delta":/docs/channels/options/deltas generated.
 
 |_. Metric |_. Description |
 | messages.processed.delta.xdelta.succeeded | Total number of message deltas successfully generated. |
@@ -620,7 +616,7 @@ The following metrics can be returned for message deltas. Message deltas are mes
 
 h3(#connections). Connections
 
-The following metrics can be returned for connections. Connections are all client "connections":/docs/connect made to Ably.
+Connection metrics include all realtime "connections":/docs/connect made to Ably.
 
 |_. Metric |_. Description |
 | connections.all.peak | Peak connection count. |
@@ -631,7 +627,7 @@ The following metrics can be returned for connections. Connections are all clien
 
 h3(#channels). Channels
 
-The following metrics can be returned for channels. "Channels":/docs/channels are used to separate messages into different topics throughout Ably.
+Channel metrics include all active "channels":/docs/channels that are used to separate messages into different topics throughout Ably.
 
 |_. Metric |_. Description |
 | channels.peak | Peak active channel count. |
@@ -642,7 +638,7 @@ The following metrics can be returned for channels. "Channels":/docs/channels ar
 
 h3(#api). API requests
 
-The following metrics can be returned for API requests. API requests are all HTTP requests made to Ably, including those related to "token authentication":/docs/auth/token and "push notifications":/docs/push. They do not include those requests made to the "Control API":/docs/account/control-api.
+API request metrics include all HTTP requests made to Ably, including those related to "token authentication":/docs/auth/token and "push notifications":/docs/push. They do not include those requests made to the "Control API":/docs/account/control-api.
 
 |_. Metric |_. Description |
 | apiRequests.all.succeeded | Total number of API requests made. |
@@ -660,7 +656,7 @@ The following metrics can be returned for API requests. API requests are all HTT
 
 h3(#push). Push notifications
 
-The following metrics can be returned for push notifications. "Push notifications":/docs/push are all notifications sent to devices via a push transport.
+Push notification metrics include all "notifications":/docs/push sent to devices via one of the push transports such as APNS, FCM or web.
 
 |_. Metric |_. Description |
 | push.channelMessages | Total number of channel messages published over Ably that contained a @push@ payload. Each of these may have triggered notifications to be sent to a device with a matching registered push subscription. |
@@ -690,10 +686,10 @@ The following metrics can be returned for push notifications. "Push notification
 
 h3(#account-only). Account-only metrics
 
-The following metrics can only be returned when querying account statistics:
+The following metrics will only be returned when querying account statistics.
 
 |_. Metric |_. Description |
-| peakRates.messages | ThePeak rate of messages. |
+| peakRates.messages | Peak rate of messages. |
 | peakRates.apiRequests | Peak rate of api requests. |
 | peakRates.tokenRequests | Peak rate of token requests. |
 | peakRates.connections | Peak rate of opened connections. |


### PR DESCRIPTION
- Clarified the scope of account statistics
- Removed account stats from the REST API - there is no such API, API keys are scoped to apps only. Not sure how this was ever documented.
- Improved clarity around obtaining account IDs:. Using an <aside>. Is this correct?
- Found it odd that in code samples we refer to, for example, {ACCOUNT_ID} then in the docs we refer to that variable as @accountId@. I don't follow the inconsistency. Happy to change code examples to use accountId if preferred, but I don't see any merit in inconsistency in the same page.
- Adjusted headings, specifically differentiating between “Statistics response payload” and “Statistics response”, clarifying the API response structure. I don't think it was clear before what a statistics response payload was vs statistics metrics. I have made what I think is am improvement
- Improved metric definitions, clearly stating the inclusion of push notifications and integrations in outbound metrics. But also just made things a lot more concise.
- Simplified curl command examples, removing redundant --location, and I have no idea why `--request POST` flags was added for a GET method endpoint.
- Provided clearer context around API endpoints by explicitly linking to the correct documentation references.

---

Note I have some questions around whether we need `<aside>` for these smaller "tip" areas that are possibly more subtle, as opposed to stand out which I think this will do. 

Also, do we not need aside for the product release stages in PDR-057?