### PR TITLE
Request method version missing

### DIFF
--- a/content/messages/batch.textile
+++ b/content/messages/batch.textile
@@ -62,7 +62,7 @@ The following is an example of a batch publish request using the "@request()@":/
 ```[rest_javascript]
 const ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 const content = { 'channels': [ 'test1', 'test2' ], 'messages': { 'data': 'myData' } }
-const batchPublish = await ablyRest.request('post', '/messages', null, content, null);
+const batchPublish = await ablyRest.request('post', '/messages', 2, null, content, null);
 
 console.log('Success! status code was ' + batchPublish.statusCode)
 ```


### PR DESCRIPTION
See https://github.com/ably/specification/blob/main/textile/features.textile, the method signature is `request(String method, String path, Int version, Dict<String, String> params?, JsonObject | JsonArray body?, Dict<String, String> headers?)`.

This PR should not be merged, but should serve as the basis to check where else we refer to the request method with an incorrect signature.

In addition, we should we which SDKs are 2.x and thus use this new signature.
