### PR TITLE
Upgrade ably-ui 16.0.0 - new Meganav & Footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "no-githooks": "git config --unset core.hooksPath"
   },
   "dependencies": {
-    "@ably/ui": "15.8.1",
+    "@ably/ui": "16.0.2",
     "@codesandbox/sandpack-react": "^2.9.0",
     "@mdx-js/react": "^2.3.0",
     "@react-hook/media-query": "^1.1.1",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,8 +4,7 @@
 
 @import '@ably/ui/reset/styles.css';
 @import '@ably/ui/core/styles.css';
-@import '@ably/ui/core/Meganav/component.css';
-@import '@ably/ui/core/Footer/component.css';
+
 @import '@ably/ui/core/CookieMessage/component.css';
 @import '@ably/ui/core/Slider/component.css';
 @import '@ably/ui/core/Code/component.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@15.8.1":
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-15.8.1.tgz#be59ffe07c0ce826c1061adbcb8ff2a75dcfd78c"
-  integrity sha512-o2wpZEHpXDeLH1i+YaEeBf2PxqnG3EzBmmqB4Lx80NjbpTXFY19wI25bZ53fUuFroU04Yj1UQ/T94Qmbld6wkg==
+"@ably/ui@16.0.2":
+  version "16.0.2"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.0.2.tgz#01ddf48202114a7f9a14b811401f3348ec7cbb16"
+  integrity sha512-P7bIfclXCEDsDOeQ4cESTU6pTW0of+9YD7+KOD2TL9YJgZzQt4AEHi9HUPkrTN5GvqWhSD3GM7gI8IVYMpBzoQ==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
## Description

WEB-4266 Since docs using the ably-ui `Header` component and imported some old Meganav css files. 
The docs nav still looks good and not been touched :D 

This pull request includes updates to dependencies and style imports. The most important changes are:

Dependency updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R42): Updated the `@ably/ui` dependency from version `15.8.1` to `16.0.0`.

Style import adjustments:
* [`src/styles/global.css`](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL7-R7): Removed imports for `Meganav` and `Footer` components from `@ably/ui/core` styles.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
