### PR TITLE
[WEB-4263] fix: redoc responsiveness / code block api key truncation

### DIFF
--- a/src/components/Redoc/Loader.tsx
+++ b/src/components/Redoc/Loader.tsx
@@ -57,7 +57,7 @@ export const Loader = ({ specUrl }: { specUrl: string }) => {
     <>
       <GoTopButton />
       {specUrl ? (
-        <div id="redoc-container" className="redoc-content"></div>
+        <div id="redoc-container" className="redoc-content max-w-[100vw]"></div>
       ) : (
         <div className="ml-24 mb-20">
           Missing <span className="ui-text-code">{specUrl}</span> metadata

--- a/src/components/blocks/software/Code/MultilineCodeContent.tsx
+++ b/src/components/blocks/software/Code/MultilineCodeContent.tsx
@@ -7,6 +7,7 @@ import languagesRegistry from '@ably/ui/core/utils/syntax-highlighter-registry';
 registerDefaultLanguages(languagesRegistry);
 
 const TRUNCATION_CHARACTER_THRESHOLD = 20;
+const truncationRegex = new RegExp(`^[A-Za-z0-9_-]{6}.[A-Za-z0-9_-]{6}:[A-Za-z0-9_-]{43}$`, 'gu');
 
 const chooseString = (condition: boolean, firstString: string, secondString: string) =>
   condition ? firstString : secondString;
@@ -48,8 +49,8 @@ export const MultilineCodeContent = ({
     contentWithObfuscatedKey,
   );
 
-  const truncatedContent = renderedContent.replace(
-    new RegExp(`'([a-zA-Z0-9\\p{P}]{${TRUNCATION_CHARACTER_THRESHOLD},})'`, 'gu'),
+  const truncatedContent = renderedContent.replaceAll(
+    truncationRegex,
     (_, p1) => `'${truncate({ length: TRUNCATION_CHARACTER_THRESHOLD }, p1)}'`,
   );
 


### PR DESCRIPTION
Seems like this is enough for redoc's responsive behaviour to kick in.

Also contains an additional fix to specify api keys when truncating code block text contents.

This pull request includes a small change to the `Loader` component in the `src/components/Redoc/Loader.tsx` file. The change updates the `redoc-container` div to include a new CSS class for maximum width.

* [`src/components/Redoc/Loader.tsx`](diffhunk://#diff-67c7665f011e4bbb465e16730aca10a5b05f2a8546e001b913e0f680f9af54feL60-R60): Added `max-w-[100vw]` class to the `redoc-container` div to ensure it does not exceed the viewport width.