### PR TITLE
[WEB-3484] fix: use character encodings for double quotes in subscribe textile to avoid processing

### DIFF
--- a/content/metadata-stats/metadata/subscribe.textile
+++ b/content/metadata-stats/metadata/subscribe.textile
@@ -36,7 +36,7 @@ It is never possible to publish or be present on a metachannel, however you can 
 The following is an example of a capability that provides access to subscribe to all metachannels:
 
 ```[json]
-{"[meta]*":["subscribe"]}
+{&#0034;[meta]*&#0034;:[&#0034;subscribe&#0034;]}
 ```
 
 h2(#connection-lifecycle). Connection lifecycle events


### PR DESCRIPTION
This pull request includes a change to the `content/metadata-stats/metadata/subscribe.textile` file to correct the JSON syntax in the example provided.

* [`content/metadata-stats/metadata/subscribe.textile`](diffhunk://#diff-6f6001432a7ceb234debf544e211f40c6dc4e652e18f057fbafaf675e44b3821L39-R39): Corrected JSON syntax by replacing single quotes with double quotes in the example of subscribing to all metachannels.