### PR TITLE
[WEB-4296] fix: enforce remounting of inkeep search bar

### DIFF
--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -40,6 +40,7 @@ declare global {
         config: object,
       ) => {
         update: (config: object) => void;
+        remount: () => void;
       };
     };
   }
@@ -175,7 +176,7 @@ const loadInkeepSearch = (config: object) => {
     modalSettings: {
       defaultView: 'SEARCH',
     },
-  });
+  }).remount();
 };
 
 export type InkeepUser = {


### PR DESCRIPTION
There's a bug where the inkeep search bar dies between templates. Never used to be the case, but now it is.

The surrounding inkeep instantiation logic is called on template change, but the search bar does not reinitialise. Perhaps there is a flag stored somewhere that prevents this.

My first approach would be to, within this inkeep logic, check for if `#inkeep-search` has child nodes and then remount from there if not, but the instantiation is async and there is no promise to latch onto, so I'm just going to remount every time. Suboptimal, but seems to do the job and there's no time for anything else.

Initial thread: https://ably-real-time.slack.com/archives/C01LR5XFHFX/p1743429479133079