### PR TITLE
MongoDB LiveSync connector is not Beta

### DIFF
--- a/content/livesync/mongodb/index.textile
+++ b/content/livesync/mongodb/index.textile
@@ -23,10 +23,6 @@ The integration rule exists as a "database connector" component that is entirely
 
 When a change event is received over the Change Streams API it is published to an Ably channel. When you configure the integration rule, you can specify how change events are mapped to individual Ably channels. Clients can then subscribe to database changes by subscribing to Ably channels. Ably "Auth":/docs/auth and "Capabilities":/docs/auth/capabilities control which channels a client can interact with.
 
-h2(#development-status). Development status
-
-The MongoDB database connector is currently in beta status. Your "feedback":https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform will help prioritize improvements and fixes for subsequent releases.
-
 h2(#integration-rule). Integration rule
 
 h3(#create). Create a rule


### PR DESCRIPTION
Remove wording as such from docs

We don't call it beta anywhere else, so remove that wording.

<img width="920" alt="image" src="https://github.com/user-attachments/assets/7f38e934-1813-427e-b4f4-37a7c7718a68" />
