### PR TITLE
[WEB-4280] Add Inkeep intent configuration

### DIFF
--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -112,7 +112,8 @@ const getTools = () => [
 
 const aiChatSettings = () => ({
   organizationDisplayName: 'Ably',
-  aiAssistantAvatar: 'https://storage.googleapis.com/organization-image-assets/ably-botAvatarSrcUrl-1721406747144.png',
+  aiAssistantAvatar:
+    'https://storage.googleapis.com/organization-image-assets/ably-botAvatarDarkSrcUrl-1744125448083.png',
   getHelpOptions: [
     {
       name: 'Request a meeting',


### PR DESCRIPTION
## Description

WEB-4280

[Review App](https://ably-docs-web-4280-inke-sotlbo.herokuapp.com/docs)

### Copilot Summary

This pull request to `src/external-scripts/inkeep.ts` includes several updates to enhance the functionality of the Inkeep integration and improve the user interface. The most important changes include updating the script version, integrating PostHog for feature flagging, adding a new tool for contacting sales, and applying custom styles to the chat interface.

Enhancements to Inkeep integration:

* Updated the Inkeep script to version `0.5.40` and integrated PostHog for feature flagging. [[1]](diffhunk://#diff-da7f7711b6957ca8a9bd500d1c8e3dc0403363f49fe3eff8381e473da6386cdeR2-R17) [[2]](diffhunk://#diff-da7f7711b6957ca8a9bd500d1c8e3dc0403363f49fe3eff8381e473da6386cdeL85-R140)
* Added a new tool for detecting buyer intent and contacting sales based on AI confidence levels.

User interface improvements:

* Applied custom CSS styles to the chat message toolbar and tool actions to enhance the visual appearance and usability.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
