### PR TITLE
[WEB-4315] Fix inline code blocks inside anchors to inherit colour from the anchor

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -59,6 +59,11 @@
     font-weight: inherit;
   }
 
+  /* inline code blocks inside anchor tags should have the colour of the anchor tag */
+  a > code.ui-text-code-inline {
+    color: inherit;
+  }
+
   #headway-widget-target .HW_badge_cont {
     position: absolute;
     right: -30px;


### PR DESCRIPTION
## Description

@m-hulbert pointed out that we don't properly style inline code blocks inside anchor tags, so people don't know they can click on them, as seen below on [this](https://ably.com/docs/channels/options/rewind) page.

<img width="494" alt="Screenshot 2025-04-09 at 11 57 26" src="https://github.com/user-attachments/assets/3e2bb4f8-e641-4248-9a2d-d542992f6e07" />

This fix forces inline code blocks inside anchors to inherit the colour of the anchor:

<img width="480" alt="Screenshot 2025-04-09 at 11 59 41" src="https://github.com/user-attachments/assets/e9c18acc-c707-4519-8ed1-d4547408bf45" />


### Checklist

- [x] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
