### PR TITLE
EDU-1883: Adds new ttl line of code

### DIFF
--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -165,7 +165,8 @@ var recipient = {
 var data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -180,7 +181,8 @@ var recipient = {
 var data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -195,7 +197,8 @@ recipient = {
 data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -203,20 +206,18 @@ realtime.push.admin.publish(recipient, data)
 ```
 
 ```[realtime_java]
-
 JsonObject payload = JsonUtils.object()
     .add("notification", JsonUtils.object()
         .add("title", "Hello from Ably!")
         .add("body", "Example push notification from Ably.")
-    )
-    .add("data", JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux")
+        .add("ttl", 3600) // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     )
     .toJson();
 
-
-realtime.push.admin.publish(new Param[]{new Param("deviceId", "xxxxxxxxxxxx")}, payload);
+realtime.push.admin.publish(
+    new Param[] { new Param("deviceId", "xxxxxxxxxxxx") },
+    payload
+);
 ```
 
 ```[realtime_python]
@@ -227,7 +228,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -245,7 +247,8 @@ var data = new JObject
     ["notification"] = new JObject
     {
         { "title", "Hello from Ably!" },
-        { "body", "Example push notification from Ably." }
+        { "body", "Example push notification from Ably." },
+        { "ttl", 3600 } // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 
@@ -260,7 +263,8 @@ var recipient = {
 var data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -275,7 +279,8 @@ var recipient = {
 var data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -290,7 +295,8 @@ recipient = {
 data = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -302,15 +308,14 @@ JsonObject payload = JsonUtils.object()
     .add("notification", JsonUtils.object()
         .add("title", "Hello from Ably!")
         .add("body", "Example push notification from Ably.")
-    )
-    .add("data", JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux")
+        .add("ttl", 3600) // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     )
     .toJson();
 
-
-rest.push.admin.publish(new Param[]{new Param("deviceId", "xxxxxxxxxxxx")}, payload);
+rest.push.admin.publish(
+    new Param[] { new Param("deviceId", "xxxxxxxxxxxx") },
+    payload
+);
 ```
 
 ```[rest_python]
@@ -321,7 +326,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -336,14 +342,15 @@ $recipient = [
 $data = [
     'notification' => [
         'title' => 'Hello from Ably!',
-        'body' => 'Example push notification from Ably.'
+        'body' => 'Example push notification from Ably.',
+        'ttl' => 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     ]
 ];
 
 $rest->push->admin->publish($recipient, $data);
 
-var channel = rest.channels.get('pushenabled:foo');
-channel.publish({'name': 'example', 'data': 'data', 'extras': extras});
+$channel = $rest->channels->get('pushenabled:foo');
+$channel->publish(['name' => 'example', 'data' => 'data', 'extras' => $extras]);
 ```
 
 ```[rest_csharp]
@@ -357,7 +364,8 @@ var data = new JObject
     ["notification"] = new JObject
     {
         { "title", "Hello from Ably!" },
-        { "body", "Example push notification from Ably." }
+        { "body", "Example push notification from Ably." },
+        { "ttl", 3600 } // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 
@@ -374,13 +382,14 @@ The following example publishes a push notification using the @clientId@:
 
 ```[realtime_javascript]
 var recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 };
 
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -389,13 +398,14 @@ realtime.push.admin.publish(recipient, notification);
 
 ```[realtime_nodejs]
 var recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 };
 
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -404,13 +414,14 @@ realtime.push.admin.publish(recipient, notification);
 
 ```[realtime_ruby]
 recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 }
 
 notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -422,10 +433,7 @@ JsonObject payload = JsonUtils.object()
     .add("notification", JsonUtils.object()
         .add("title", "Hello from Ably!")
         .add("body", "Example push notification from Ably.")
-    )
-    .add("data", JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux")
+        .add("ttl", 3600) // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     )
     .toJson();
 
@@ -440,7 +448,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -448,14 +457,15 @@ realtime.push.admin.publish(recipient, message)
 ```
 
 ```[realtime_csharp]
-var recipient = new { clientId = "bob" };
+var recipient = new { clientId = "xxxxxxxxxxxx" };
 
 var notification = new
 {
     notification = new
     {
         title = "Hello from Ably!",
-        body = "Example push notification from Ably."
+        body = "Example push notification from Ably.",
+        ttl = 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 
@@ -464,13 +474,14 @@ realtime.Push.Admin.Publish(recipient, notification);
 
 ```[rest_javascript]
 var recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 };
 
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -479,13 +490,14 @@ rest.push.admin.publish(recipient, notification);
 
 ```[rest_nodejs]
 var recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 };
 
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -494,13 +506,14 @@ rest.push.admin.publish(recipient, notification);
 
 ```[rest_ruby]
 recipient = {
-  clientId: 'bob'
+  clientId: 'xxxxxxxxxxxx'
 }
 
 notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -512,10 +525,7 @@ JsonObject payload = JsonUtils.object()
     .add("notification", JsonUtils.object()
         .add("title", "Hello from Ably!")
         .add("body", "Example push notification from Ably.")
-    )
-    .add("data", JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux")
+        .add("ttl", 3600) // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     )
     .toJson();
 
@@ -530,7 +540,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -545,25 +556,27 @@ $recipient = [
 $data = [
     'notification' => [
         'title' => 'Hello from Ably!',
-        'body' => 'Example push notification from Ably.'
+        'body' => 'Example push notification from Ably.',
+        'ttl' => 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     ]
 ];
 
 $rest->push->admin->publish($recipient, $data);
 
-var channel = rest.channels.get('pushenabled:foo');
-channel.publish({'name': 'example', 'data': 'data', 'extras': extras});
+$channel = $rest->channels->get('pushenabled:foo');
+$channel->publish(['name' => 'example', 'data' => 'data', 'extras' => $extras]);
 ```
 
 ```[rest_csharp]
-var recipient = new { clientId = "bob" };
+var recipient = new { clientId = "xxxxxxxxxxxx" };
 
 var notification = new
 {
     notification = new
     {
         title = "Hello from Ably!",
-        body = "Example push notification from Ably."
+        body = "Example push notification from Ably.",
+        ttl = 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 
@@ -588,7 +601,8 @@ var recipient = {
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -604,7 +618,8 @@ var recipient = {
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -620,7 +635,8 @@ recipient = {
 notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -632,14 +648,16 @@ Message message = new Message("example", "rest data");
 message.extras = io.ably.lib.util.JsonUtils.object()
     .add("notification", io.ably.lib.util.JsonUtils.object()
         .add("title", "Hello from Ably!")
-        .add("body", "Example push notification from Ably."))
-    .add("data", io.ably.lib.util.JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux"));
+        .add("body", "Example push notification from Ably.")
+        .add("ttl", 3600)); // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
 
-realtime.push.admin.publish(arrayOf(Param("transportType", "apns"), Param("deviceToken", deviceToken)), message);
-
-ably.push.admin.publish(new Param[]{new Param("transportType","fcm"),new Param("registrationToken","<my_registration_token>")},payload);
+realtime.push.admin.publish(
+    new Param[] {
+        new Param("transportType", "apns"),
+        new Param("deviceToken", deviceToken)
+    },
+    message
+);
 ```
 
 ```[realtime_python]
@@ -651,7 +669,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -659,14 +678,15 @@ realtime.push.admin.publish(recipient, message)
 ```
 
 ```[realtime_csharp]
-var recipient = new { transport_type: 'apns' };
+var recipient = new { transport_type = "apns", deviceToken = "XXXXXXXXXX" };
 
 var notification = new
 {
     notification = new
     {
         title = "Hello from Ably!",
-        body = "Example push notification from Ably."
+        body = "Example push notification from Ably.",
+        ttl = 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 
@@ -682,7 +702,8 @@ var recipient = {
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -698,7 +719,8 @@ var recipient = {
 var notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 };
 
@@ -714,7 +736,8 @@ recipient = {
 notification = {
   notification: {
     title: 'Hello from Ably!',
-    body: 'Example push notification from Ably.'
+    body: 'Example push notification from Ably.',
+    ttl: 3600 # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
   }
 }
 
@@ -726,12 +749,16 @@ Message message = new Message("example", "rest data");
 message.extras = io.ably.lib.util.JsonUtils.object()
     .add("notification", io.ably.lib.util.JsonUtils.object()
         .add("title", "Hello from Ably!")
-        .add("body", "Example push notification from Ably."))
-    .add("data", io.ably.lib.util.JsonUtils.object()
-        .add("foo", "bar")
-        .add("baz", "qux"));
+        .add("body", "Example push notification from Ably.")
+        .add("ttl", 3600)); // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
 
-rest.push.admin.publish(arrayOf(Param("transportType", "apns"), Param("deviceToken", deviceToken)), message);
+rest.push.admin.publish(
+    new Param[] {
+        new Param("transportType", "apns"),
+        new Param("deviceToken", deviceToken)
+    },
+    message
+);
 ```
 
 ```[rest_python]
@@ -743,7 +770,8 @@ recipient = {
 message = {
     'notification': {
         'title': 'Hello from Ably!',
-        'body': 'Example push notification from Ably.'
+        'body': 'Example push notification from Ably.',
+        'ttl': 3600  # Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 }
 
@@ -753,27 +781,30 @@ rest.push.admin.publish(recipient, message)
 ```[rest_php]
 $recipient = [
     'transportType' => 'apns',
-    'deviceToken' => 'XXXXXXX',
+    'deviceToken' => 'XXXXXXX'
+];
 
 $data = [
     'notification' => [
         'title' => 'Hello from Ably!',
-        'body' => 'Example push notification from Ably.'
+        'body' => 'Example push notification from Ably.',
+        'ttl' => 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     ]
 ];
 
-$rest->push->admin->publish( $recipient, $data );
+$rest->push->admin->publish($recipient, $data);
 ```
 
 ```[rest_csharp]
-var recipient = new { transport_type: 'apns' };
+var recipient = new { transport_type = "apns", deviceToken = "XXXXXXXXXX" };
 
 var notification = new
 {
     notification = new
     {
         title = "Hello from Ably!",
-        body = "Example push notification from Ably."
+        body = "Example push notification from Ably.",
+        ttl = 3600 // Required for Web Push on some platforms and browsers like Microsoft Edge (WNS)
     }
 };
 


### PR DESCRIPTION
This PR:

- Adds `ttl` field to payloads for Web Push compatibility.
- Improved code consistency across realtime and REST variants for:
  - `deviceId`
  - `clientId`
  - recipient attributes

https://ably.atlassian.net/browse/EDU-1883