### PR TITLE
[EDU-1884] Add link to Control API schema in rendered reference

### DIFF
--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -5,8 +5,10 @@ info:
   version: 1.1.0
   description: |
     Use the Control API to manage your applications, namespaces, keys, queues, rules, and more.
-
+    </br></br>
     Detailed information on using this API can be found in the Ably <a href="https://ably.com/docs/account/control-api">Control API docs</a>.
+    </br></br>
+    The <a href="https://swagger.io/specification/">OpenAPI specification</a> file used to generate this REST API is available to view <a href="https://github.com/ably/docs/blob/main/static/open-specs/control-v1.yaml">here</a>.
 servers:
 - url: https://control.ably.net/v1
 paths:


### PR DESCRIPTION
## Description

This PR adds a link to the OpenSpecs file for the Control API intro it's introductory paragraph.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
