### PR TITLE
Add comment explaining reusing the assetTracking badge color for liveObjects in ExamplesGrid

### DIFF
--- a/src/components/Examples/ExamplesGrid.tsx
+++ b/src/components/Examples/ExamplesGrid.tsx
@@ -32,6 +32,7 @@ const ExamplesGrid = ({
       case 'assetTracking':
         return 'text-green-600';
       case 'liveObjects':
+        // Reusing Asset Tracking color as no examples exist for it yet.
         return 'text-green-600';
       default:
         return 'text-orange-700';


### PR DESCRIPTION
## Description

It's fine to use the Asset Tracking color for LiveObjects for now, since we don't have any examples for Asset Tracking and aren't likely to build any in the near future.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
