### PR TITLE
[WEB-4261] Open Hubspot chat when conversation Meta tag is present

### DIFF
--- a/src/external-scripts/hubspot.test.ts
+++ b/src/external-scripts/hubspot.test.ts
@@ -92,4 +92,65 @@ describe('Hubspot', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('openFromMetaTag', () => {
+    beforeEach(() => {
+      document.head.innerHTML = '';
+      jest.spyOn(window.history, 'pushState').mockImplementation();
+      global.window.HubSpotConversations = {
+        widget: {
+          load: jest.fn(),
+          open: jest.fn(),
+        },
+      };
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('opens chat widget when conversation meta tag exists', () => {
+      // Add a meta tag to the document
+      const metaTag = document.createElement('meta');
+      metaTag.name = 'conversation';
+      metaTag.content = 'sales';
+      document.head.appendChild(metaTag);
+
+      hubspot('12345');
+
+      // Simulate the HubSpot script loading by calling the registered callback
+      global.hsConversationsOnReady[0]();
+
+      expect(window.history.pushState).toHaveBeenCalledWith({}, '', '?chat-type=sales');
+      expect(global.window.HubSpotConversations.widget.load).toHaveBeenCalled();
+      expect(global.window.HubSpotConversations.widget.open).toHaveBeenCalled();
+    });
+
+    it('does not open chat widget when no conversation meta tag exists', () => {
+      document.head.innerHTML = '<meta name="other-tag" content="something">';
+
+      hubspot('12345');
+
+      // Simulate the HubSpot script loading
+      global.hsConversationsOnReady[0]();
+
+      expect(window.history.pushState).not.toHaveBeenCalled();
+      expect(global.window.HubSpotConversations.widget.load).not.toHaveBeenCalled();
+      expect(global.window.HubSpotConversations.widget.open).not.toHaveBeenCalled();
+    });
+
+    it('correctly sets URL query parameter from meta tag content', () => {
+      const metaTag = document.createElement('meta');
+      metaTag.name = 'conversation';
+      metaTag.content = 'support';
+      document.head.appendChild(metaTag);
+
+      hubspot('12345');
+
+      // Simulate the HubSpot script loading
+      global.hsConversationsOnReady[0]();
+
+      expect(window.history.pushState).toHaveBeenCalledWith({}, '', '?chat-type=support');
+    });
+  });
 });

--- a/src/external-scripts/hubspot.ts
+++ b/src/external-scripts/hubspot.ts
@@ -6,6 +6,10 @@ declare global {
   type HubspotItem = string | Record<string, string>;
   interface Window {
     _hsq: Array<string | Record<string, string>>[];
+    hsConversationsSettings?: {
+      loadImmediately: boolean;
+    };
+    hsConversationsOnReady?: Array<() => void>;
   }
 }
 
@@ -22,12 +26,25 @@ export type HubspotUser = {
   adminUrl: string;
 };
 
-const hubspot = (hubspotTrackingId, loadImmediately = true) => {
+const hubspot = (hubspotTrackingId: string, loadImmediately = true) => {
+  const openFromMetaTag = () => {
+    const metaConversation = document.querySelector('meta[name="conversation"]') as HTMLMetaElement;
+
+    if (metaConversation) {
+      window.history.pushState({}, '', `?chat-type=${metaConversation.content}`);
+
+      window.HubSpotConversations?.widget.load();
+      window.HubSpotConversations?.widget.open();
+    }
+  };
+
   scriptLoader(document, `//js.hs-scripts.com/${hubspotTrackingId}.js`, { id: 'hs-script-loader' });
   window._hsq = window._hsq || [];
   window.hsConversationsSettings = {
     loadImmediately: loadImmediately,
   };
+
+  window.hsConversationsOnReady = [...(window.hsConversationsOnReady || []), openFromMetaTag];
 };
 
 export const hubspotIdentifyUser = ({


### PR DESCRIPTION
## Description

When the conversation  meta tag is present, open the hubspot chat with the relevant query parameter.

### Testing

Use review app to complete journey below. On the last page visit, the chat should popup

[Platform](https://website-main-t4yfv4bfuhczstedk.herokuapp.com/docs/platform)
[Chat Setup](https://website-main-t4yfv4bfuhczstedk.herokuapp.com/docs/chat/setup)

### Copilot Summary

This pull request introduces new functionality to the Hubspot integration by adding the ability to open the chat widget based on a meta tag in the document. The changes include updates to the test cases, global window interface, and the main Hubspot function.

### New functionality for Hubspot integration:

* [`src/external-scripts/hubspot.ts`](diffhunk://#diff-1c934127749e2cd330bf85ba35e376d92f3304b3b09602ec674ff68cc5486d40L25-R47): Added `openFromMetaTag` function to check for a meta tag and open the chat widget if it exists. Updated the `hubspot` function to register `openFromMetaTag` as a callback for `hsConversationsOnReady`.
* [`src/external-scripts/hubspot.ts`](diffhunk://#diff-1c934127749e2cd330bf85ba35e376d92f3304b3b09602ec674ff68cc5486d40R9-R12): Extended the global `Window` interface to include `hsConversationsSettings` and `hsConversationsOnReady` properties.

### Test cases for new functionality:

* [`src/external-scripts/hubspot.test.ts`](diffhunk://#diff-ffb333a247ef993a64afc4b97bfdbf278278c3e96833dfb4e32d25f5d3721c07R95-R155): Added test cases for `openFromMetaTag` to verify the chat widget opens when the meta tag is present, does not open when the meta tag is absent, and correctly sets the URL query parameter based on the meta tag content.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
