### PR TITLE
chat: add product to about page

### DIFF
--- a/content/chat/index.textile
+++ b/content/chat/index.textile
@@ -1,6 +1,7 @@
 ---
 title: About Chat
 meta_description: "Learn more about Ably Chat and the features that enable you to quickly build functionality into new and existing applications."
+product: chat
 redirect_from: /docs/products/chat
 ---
 


### PR DESCRIPTION
## Description

Adds the product to the "about" page so it appears on the tab, as it currently says PubSub.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
