### PR TITLE
chore: bump ably-ui to 16.1.1, update outdated lh var usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "no-githooks": "git config --unset core.hooksPath"
   },
   "dependencies": {
-    "@ably/ui": "16.1.0",
+    "@ably/ui": "16.1.1",
     "@codesandbox/sandpack-react": "^2.9.0",
     "@mdx-js/react": "^2.3.0",
     "@react-hook/media-query": "^1.1.1",

--- a/src/components/Select/styles.ts
+++ b/src/components/Select/styles.ts
@@ -32,7 +32,7 @@ export const selectMenuStyles: StylesConfig<ReactSelectOption, false> = {
     backgroundColor: 'transparent',
     boxShadow: 'none',
     fontSize: '14px',
-    lineHeight: 'var(--lh-snug)',
+    lineHeight: 'var(--lh-dense)',
     height: SELECT_HEIGHT,
     minHeight: SELECT_HEIGHT,
     cursor: 'pointer',

--- a/src/components/blocks/api-reference/headings/ApiReferenceH5.tsx
+++ b/src/components/blocks/api-reference/headings/ApiReferenceH5.tsx
@@ -3,7 +3,7 @@ import LinkableHtmlBlock from 'src/components/blocks/Html/LinkableHtmlBlock';
 import { HtmlAttributes } from 'src/components/html-component-props';
 
 const StyledApiReferenceH5: FC<HtmlAttributes<'h5'>> = ({ children, ...attribs }) => (
-  <h5 {...attribs} className="ui-text-h5 font-sans my-16 font-bold leading-normal">
+  <h5 {...attribs} className="ui-text-h5 font-sans my-16 font-bold leading-tight">
     {children}
   </h5>
 );

--- a/src/components/blocks/dividers/dividers.module.css
+++ b/src/components/blocks/dividers/dividers.module.css
@@ -72,17 +72,16 @@ div.versioningContainer {
   padding-top: var(--spacing-8);
   padding-left: var(--spacing-8);
   border-left: solid 1px;
-  color: #89929F;
+  color: #89929f;
 }
 
 div.versioningContainer * {
-  font-size: var(--fs-p3);
-  line-height: var(--lh-normal);
+  @apply leading-tight text-p3;
 }
 
 div.versioningContainer code {
   padding: 0;
   background-color: transparent;
   border: none;
-  color: #89929F;
+  color: #89929f;
 }

--- a/src/components/blocks/headings/H5.tsx
+++ b/src/components/blocks/headings/H5.tsx
@@ -3,7 +3,7 @@ import LinkableHtmlBlock from 'src/components/blocks/Html/LinkableHtmlBlock';
 import { HtmlAttributes } from 'src/components/html-component-props';
 
 const AblyH5 = ({ ...props }: HtmlAttributes<'h5'>) => (
-  <h5 className="ui-text-h5 font-sans my-16 font-bold leading-normal" {...props} />
+  <h5 className="ui-text-h5 font-sans my-16 font-bold leading-tight" {...props} />
 );
 
 export default LinkableHtmlBlock(AblyH5);

--- a/src/components/blocks/software/Pre.tsx
+++ b/src/components/blocks/software/Pre.tsx
@@ -161,7 +161,7 @@ const Pre = ({
           <div className="mt-2">
             <Icon name="icon-gui-information-circle-micro" size="1rem" />
           </div>
-          <div className="ml-8 leading-normal">
+          <div className="ml-8 leading-tight">
             You&apos;re currently viewing the <span className="font-semibold">{languageLabel ?? pageLanguage}</span>{' '}
             docs. There either isn&apos;t a {languageLabel ?? pageLanguage} code sample for this example, or this
             feature isn&apos;t supported in {languageLabel ?? pageLanguage}. Switch language to view this example in a

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,10 +76,6 @@ module.exports = extendConfig((ablyUIConfig) => ({
     },
     extend: {
       ...ablyUIConfig.theme.extend,
-      lineHeight: {
-        ...ablyUIConfig.theme.lineHeight,
-        normal: 'var(--lh-normal)',
-      },
       width: {
         ...ablyUIConfig.theme.extend.width,
         24: '1.5rem',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.1.0.tgz#09ed477942616c9577645fe8948390a42c6efc7e"
-  integrity sha512-jhZ2KTcQ96eo7ujyCDGTN814IoXi+I9dN/CgJh4iVic7rKGUtLMnnVYRiIyg3Lb2WMFlYjBAQF5tjyGbMkMKrQ==
+"@ably/ui@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.1.1.tgz#bddfe9bb4df2ea06e981fa2901cda18cac63ca4b"
+  integrity sha512-GrsR/SDmeNg3HbRB3ThefIA2hzuiBvOT+1Xlq5JoIsxm+OKWEioKQuxu7aYtgpPgFP/9fOf2G97Jqnl7CaQKzg==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
Followup to #2531 that migrates to the latest CSS line height definitions in ably-ui.