### PR TITLE
ably-chat-js react subpath changes

### DIFF
--- a/content/chat/connect.textile
+++ b/content/chat/connect.textile
@@ -37,7 +37,7 @@ const error = chatClient.connection.error;
 ```
 
 ```[react]
-import { useChatConnection } from '@ably/chat';
+import { useChatConnection } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { currentStatus } = useChatConnection({
@@ -61,7 +61,7 @@ blang[react].
   Hooks related to chat features, such as @useMessages@ and @useTyping@, also return the current @connectionStatus@ in their response.
 
   ```[react]
-  import { useMessages } from '@ably/chat';
+  import { useMessages } from '@ably/chat/react';
 
   const MyComponent = () => {
     const { connectionStatus } = useMessages({
@@ -84,7 +84,7 @@ const { off } = chatClient.connection.onStatusChange((change) => console.log(cha
 ```
 
 ```[react]
-import { useOccupancy } from '@ably/chat';
+import { useOccupancy } from '@ably/chat/react';
 
 const MyComponent = () => {
   useOccupancy({
@@ -159,7 +159,7 @@ const { off } = room.messages.onDiscontinuity((reason?: ErrorInfo) => {
 
 ```[react]
 import { useState } from 'react';
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   useMessages({

--- a/content/chat/rooms/history.textile
+++ b/content/chat/rooms/history.textile
@@ -32,7 +32,7 @@ if (historicalMessages.hasNext()) {
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { get } = useMessages();
@@ -110,7 +110,7 @@ if (historicalMessages.hasNext()) {
 
 ```[react]
 import { useEffect, useState } from 'react';
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const [loading, setLoading] = useState(true);

--- a/content/chat/rooms/index.textile
+++ b/content/chat/rooms/index.textile
@@ -35,7 +35,8 @@ const room = await chatClient.rooms.get('basketball-stream', AllFeaturesEnabled)
 
 ```[react]
 import * as Ably from 'ably';
-import { ChatClientProvider, ChatRoomProvider, LogLevel, AllFeaturesEnabled } from '@ably/chat';
+import { LogLevel, AllFeaturesEnabled } from '@ably/chat';
+import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 
 const realtimeClient = new Ably.Realtime({ key: '{{API_KEY}}', clientId: 'clientId' });
 const chatClient = new ChatClient(realtimeClient);
@@ -177,7 +178,7 @@ await room.attach();
 ```
 
 ```[react]
-import { useRoom } from '@ably/chat';
+import { useRoom } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { attach } = useRoom();
@@ -251,7 +252,7 @@ const currentError = room.error;
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { roomStatus, roomError } = useMessages({
@@ -334,7 +335,7 @@ blang[react].
   Listeners can also be registered to monitor the changes in room status. Any hooks that take an optional listener to monitor their events, such as typing indicator events in the @useTyping@ hook, can also register a status change listener. Changing the value provided for a listener will cause the previously registered listener instance to stop receiving events. All messages will be received by exactly one listener.
 
   ```[react]
-  import { useOccupancy } from '@ably/chat';
+  import { useOccupancy } from '@ably/chat/react';
 
   const MyComponent = () => {
     useOccupancy({

--- a/content/chat/rooms/messages.textile
+++ b/content/chat/rooms/messages.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 
 ```[react]
 import { useState } from 'react';
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   useMessages({
@@ -157,7 +157,7 @@ await room.messages.send({text: 'hello'});
 ```
 
 ```[react]
-import { useMessages } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { send } = useMessages();
@@ -202,7 +202,8 @@ await room.messages.update(updatedMessage, { description: "Message update by use
 ```
 
 ```[react]
-import { Message, useMessages } from '@ably/chat';
+import { Message } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { update } = useMessages();
@@ -273,7 +274,8 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 ```
 
 ```[react]
-import { MessageEvents, useMessages } from '@ably/chat';
+import { MessageEvents } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   useMessages({
@@ -386,7 +388,8 @@ await room.messages.delete(messageToDelete, { description: 'Message deleted by u
 ```
 
 ```[react]
-import { Message, useMessages } from '@ably/chat';
+import { Message } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { deleteMessage } = useMessages();
@@ -458,7 +461,8 @@ const {unsubscribe} = room.messages.subscribe((event) => {
 ```
 
 ```[react]
-import { MessageEvents, useMessages } from '@ably/chat';
+import { MessageEvents } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
   useMessages({

--- a/content/chat/rooms/occupancy.textile
+++ b/content/chat/rooms/occupancy.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.occupancy.subscribe((event) => {
 ```
 
 ```[react]
-import { useOccupancy } from '@ably/chat';
+import { useOccupancy } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { connections, presenceMembers } = useOccupancy({

--- a/content/chat/rooms/presence.textile
+++ b/content/chat/rooms/presence.textile
@@ -33,7 +33,7 @@ const { unsubscribe } = room.presence.subscribe((event) => {
 
 ```[react]
 import React from 'react';
-import { usePresenceListener } from '@ably/chat';
+import { usePresenceListener } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { presenceData, error } = usePresenceListener({
@@ -180,7 +180,7 @@ await room.presence.enter({ status: 'available' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat';
+import { usePresence } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { leave, isPresent } = usePresence({
@@ -220,7 +220,7 @@ await room.presence.update({ status: 'busy' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat';
+import { usePresence } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { update, isPresent } = usePresence({
@@ -264,7 +264,7 @@ await room.presence.leave({ status: 'Be back later!' });
 
 ```[react]
 import React from 'react';
-import { usePresence } from '@ably/chat';
+import { usePresence } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { leave, isPresent } = usePresence({

--- a/content/chat/rooms/reactions.textile
+++ b/content/chat/rooms/reactions.textile
@@ -33,7 +33,7 @@ const {unsubscribe} = room.reactions.subscribe((reaction) => {
 
 ```[react]
 import React, { useCallback } from 'react';
-import { useRoomReactions } from '@ably/chat';
+import { useRoomReactions } from '@ably/chat/react';
 
 const MyComponent = () => {
   useRoomReactions({
@@ -139,7 +139,7 @@ await room.reactions.send({type: "heart", metadata: {"effect": "fireworks"}});
 ```
 
 ```[react]
-import { useRoomReactions } from '@ably/chat';
+import { useRoomReactions } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { send } = useRoomReactions();

--- a/content/chat/rooms/typing.textile
+++ b/content/chat/rooms/typing.textile
@@ -30,7 +30,7 @@ const {unsubscribe} = room.typing.subscribe((event) => {
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat';
+import { useTyping } from '@ably/chat/react';
 
 const MyComponent = () => {
   const {currentlyTyping, error } = useTyping({
@@ -137,7 +137,7 @@ await room.typing.start();
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat';
+import { useTyping } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { start, currentlyTyping, error } = useTyping();
@@ -174,7 +174,7 @@ await room.typing.stop();
 ```
 
 ```[react]
-import { useTyping } from '@ably/chat';
+import { useTyping } from '@ably/chat/react';
 
 const MyComponent = () => {
   const { stop, error } = useTyping();

--- a/content/chat/setup.textile
+++ b/content/chat/setup.textile
@@ -62,7 +62,8 @@ blang[javascript,react].
 
   ```[react]
   import * as Ably from 'ably';
-  import { ChatClient, ChatClientProvider} from '@ably/chat';
+  import { ChatClient } from '@ably/chat';
+  import { ChatClientProvider } from '@ably/chat/react';
   ```
 
 blang[swift,kotlin].
@@ -205,7 +206,8 @@ const chatClient = new ChatClient(ably, {logHandler: logWriteFunc, logLevel: 'de
 
 ```[react]
 import * as Ably from 'ably';
-import { ChatClientProvider, LogLevel } from '@ably/chat';
+import { LogLevel } from '@ably/chat';
+import { ChatClientProvider } from '@ably/chat/react';
 
 const ably = new Ably.Realtime({ key: '{{API_KEY}}', clientId: '<clientId>'});
 const chatClient = new ChatClient(ably, {logHandler: logWriteFunc, logLevel: 'debug' });

--- a/examples/chat-online-status/react/src/App.tsx
+++ b/examples/chat-online-status/react/src/App.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from 'react';
 import {
+  ChatClient,
+  AllFeaturesEnabled,
+} from '@ably/chat';
+import {
   useChatClient,
   useRoom,
   usePresenceListener,
   usePresence,
-  ChatClient,
   ChatClientProvider,
   ChatRoomProvider,
-  AllFeaturesEnabled,
-} from '@ably/chat';
+} from '@ably/chat/react';
 import { Realtime } from 'ably';
 import minifaker from 'minifaker';
 import 'minifaker/locales/en';

--- a/examples/chat-room-history/react/src/App.tsx
+++ b/examples/chat-room-history/react/src/App.tsx
@@ -1,4 +1,5 @@
-import { ChatClient, ChatClientProvider, ChatRoomProvider, AllFeaturesEnabled } from '@ably/chat';
+import { ChatClient, AllFeaturesEnabled } from '@ably/chat';
+import { ChatClientProvider, ChatRoomProvider } from '@ably/chat/react';
 import { Realtime } from 'ably';
 import minifaker from 'minifaker';
 import 'minifaker/locales/en';

--- a/examples/chat-room-history/react/src/Chat.tsx
+++ b/examples/chat-room-history/react/src/Chat.tsx
@@ -1,4 +1,5 @@
-import { Message, useMessages, useChatClient } from '@ably/chat';
+import { Message } from '@ably/chat';
+import { useChatClient, useMessages } from '@ably/chat/react';
 import { useState } from 'react';
 import './styles/styles.css';
 

--- a/examples/chat-room-history/react/src/Home.tsx
+++ b/examples/chat-room-history/react/src/Home.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useRoom, useMessages } from '@ably/chat';
+import { useRoom, useMessages } from '@ably/chat/react';
 import { useNavigate } from 'react-router-dom';
 import './styles/styles.css';
 

--- a/examples/chat-room-messages/react/src/App.tsx
+++ b/examples/chat-room-messages/react/src/App.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import {
   Message,
+  ChatClient,
+  AllFeaturesEnabled,
+} from '@ably/chat';
+import {
   useRoom,
   useMessages,
   useChatClient,
-  ChatClient,
   ChatClientProvider,
   ChatRoomProvider,
-  AllFeaturesEnabled,
-} from '@ably/chat';
+} from '@ably/chat/react';
 import { Realtime } from 'ably';
 import './styles/styles.css';
 

--- a/examples/chat-room-reactions/react/src/App.tsx
+++ b/examples/chat-room-reactions/react/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { ChatClient, ChatClientProvider, ChatRoomProvider, AllFeaturesEnabled } from '@ably/chat';
+import { ChatClient, AllFeaturesEnabled, Reaction as ReactionInterface } from '@ably/chat';
+import { ChatClientProvider, ChatRoomProvider, useRoom, useRoomReactions } from '@ably/chat/react';
 import { Realtime } from 'ably';
-import { Reaction as ReactionInterface, useRoom, useRoomReactions } from '@ably/chat';
 import './styles/styles.css';
 
 const mockNames = ['Bob', 'Jane', 'John', 'Sammy'];

--- a/examples/chat-typing-indicator/react/src/App.tsx
+++ b/examples/chat-typing-indicator/react/src/App.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react';
 import {
   TypingEvent,
-  useChatClient,
-  useRoom,
-  useTyping,
-  ChatClient,
-  ChatClientProvider,
-  ChatRoomProvider,
+  ChatClient  ,
   AllFeaturesEnabled,
   TypingOptions,
 } from '@ably/chat';
+import {
+  useTyping,
+  useChatClient,
+  useRoom,
+  ChatClientProvider,
+  ChatRoomProvider,
+} from '@ably/chat/react';
 import { Realtime } from 'ably';
 import './styles/styles.css';
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -86,7 +86,7 @@
     "spaces-member-location-react": "yarn workspace spaces-member-location-react dev"
   },
   "dependencies": {
-    "@ably/chat": "^0.5.0",
+    "@ably/chat": "^0.6.0",
     "@ably/spaces": "^0.4.0",
     "ably": "^2.5.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Description

- updates all chat examples to use the new subpath import for react APIs from the ably-chat-js SDK. see https://github.com/ably/ably-chat-js/pull/525 for the SDK changes.
- bumps chat JS SDK version to 0.6 in anticipation of the release which will include these changes.
- i assume some part of CI will fail because this version does not exist yet - do not merge this until that change is released and CI passes