### PR TITLE
Remove references to example app from LiveObjects docs

### DIFF
--- a/content/liveobjects/index.textile
+++ b/content/liveobjects/index.textile
@@ -62,10 +62,3 @@ h3(#batch). Batch operations
 "Batching":/docs/liveobjects/batch enables multiple LiveObjects operations to be grouped into a single channel message, ensuring atomic application of grouped operations. This prevents partial updates of your data and ensures consistency across all users.
 
 Batching is particularly useful in scenarios where multiple dependent updates need to be processed together, ensuring a seamless experience for users.
-
-h2(#examples). Examples
-
-Take a look at the LiveObjects examples to help you get started:
-
-* "Voting system powered by LiveCounter":https://examples.ably.dev/liveobjects-live-counter : Demonstrates how to use a LiveCounter to track votes in a realtime poll.
-* "Realtime Task Board powered by LiveMap":https://examples.ably.dev/liveobjects-live-map : Demonstrates how LiveMap can be used to store and manage shared list of tasks between users.

--- a/content/liveobjects/quickstart.textile
+++ b/content/liveobjects/quickstart.textile
@@ -196,5 +196,4 @@ This quickstart introduced the basic concepts of LiveObjects and demonstrated ho
 * Read more about "LiveCounter":/docs/liveobjects/counter and "LiveMap":/docs/liveobjects/map.
 * Learn about "Batching Operations":/docs/liveobjects/batch.
 * Learn about "Objects Lifecycle Events":/docs/liveobjects/lifecycle.
-* Explore "LiveObjects examples":https://examples.ably.dev.
 * Add "Typings":/docs/liveobjects/typing for your LiveObjects.


### PR DESCRIPTION
## Description

The examples for LiveObjects will be added in a separate PR [1] and require a new examples page structure released in production. In order to allow us to release the LiveObjects docs, we remove the references to the example apps for now. Will revert this commit and set the correct links once new examples page structure is released.

[1] https://github.com/ably/docs/pull/2437

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
