### PR TITLE
[WEB-4277] Use device ID for Inkeep user

### DIFF
--- a/src/external-scripts/inkeep.test.ts
+++ b/src/external-scripts/inkeep.test.ts
@@ -1,8 +1,6 @@
 import * as scriptLoader from './utils';
 import inkeepChat, { inkeepChatIdentifyUser } from './inkeep';
 
-const identifyKey = 'key';
-
 describe('inkeepChat', () => {
   beforeEach(() => {
     document.body.innerHTML = `<script></script>`;
@@ -42,6 +40,28 @@ describe('inkeepChat', () => {
       inkeepChatIdentifyUser({ user: { uuid: '123' } });
 
       expect(spy).toHaveBeenCalledWith({ baseSettings: { userProperties: { id: '123' } } });
+    });
+
+    it('sets the Inkeep userId from device_id meta tag when user is not provided', () => {
+      const metaTag = document.createElement('meta');
+      metaTag.name = 'device_id';
+      metaTag.content = 'device123';
+      document.head.appendChild(metaTag);
+
+      inkeepChatIdentifyUser({});
+
+      expect(spy).toHaveBeenCalledWith({ baseSettings: { userProperties: { id: 'device123' } } });
+    });
+
+    it('sets the Inkeep userId from user uuid, even if device_id meta tag exists', () => {
+      const metaTag = document.createElement('meta');
+      metaTag.name = 'device_id';
+      metaTag.content = 'device123';
+      document.head.appendChild(metaTag);
+
+      inkeepChatIdentifyUser({ user: { uuid: 'user123' } });
+
+      expect(spy).toHaveBeenCalledWith({ baseSettings: { userProperties: { id: 'user123' } } });
     });
   });
 });

--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -280,14 +280,17 @@ export type InkeepUser = {
 };
 
 export const inkeepChatIdentifyUser = ({ user }: { user?: InkeepUser }) => {
-  if (!(window.inkeepWidget && user)) {
+  const deviceId = (document?.querySelector('meta[name="device_id"]') as HTMLMetaElement)?.content;
+  const userId = user?.uuid || deviceId;
+
+  if (!(window.inkeepWidget && userId)) {
     return;
   }
 
   window.inkeepWidget.update({
     baseSettings: {
       userProperties: {
-        id: user.uuid,
+        id: userId,
       },
     },
   });


### PR DESCRIPTION
## Description

Use the device ID from the meta tag as the Inkeep user ID when the user is not logged in.

### Copilot Summary

This pull request enhances the `inkeepChatIdentifyUser` functionality by adding support for identifying users via a `device_id` meta tag when a user UUID is not provided. It also includes corresponding test updates to ensure the new behavior is correctly implemented.

### Enhancements to user identification:

* [`src/external-scripts/inkeep.ts`](diffhunk://#diff-da7f7711b6957ca8a9bd500d1c8e3dc0403363f49fe3eff8381e473da6386cdeL283-R293): Modified `inkeepChatIdentifyUser` to check for a `device_id` meta tag as a fallback when the `user` object is not provided. The `id` is now determined by the user UUID if available, or the `device_id` otherwise.

### Test updates:

* `src/external-scripts/inkeep.test.ts`: Added two new test cases to verify the updated behavior:
  1. Ensures the `device_id` meta tag is used as the user ID when no user is provided.
  2. Confirms that the user UUID takes precedence over the `device_id` meta tag when both are present.
* Removed the unused `identifyKey` constant to clean up the test file.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
