### PR TITLE
liveobjects: add inband objects docs

### DIFF
--- a/content/channels/options/index.textile
+++ b/content/channels/options/index.textile
@@ -234,7 +234,7 @@ await channel.setOptions(channelOptions);
 
 h2(#params). Params
 
-The @params@ property can be used to enable additional features on a channel-by-channel basis. These features include using @rewind@ to replay messages published prior to a client attaching to a channel, @delta@ so that message payloads only contain the difference between the current and previous message, and @occupancy@ to subscribe to metrics about the clients attached to a channel.
+The @params@ property can be used to enable additional features on a channel-by-channel basis.
 
 h3(#rewind). Rewind
 
@@ -403,6 +403,18 @@ Occupancy events have a payload in the @data@ property with a value of @occupanc
   }
 }
 ```
+
+h3(#objects). Inband Objects
+
+"Inband objects":/docs/liveobjects/inband-objects allows clients to subscribe to changes to "LiveObjects":/docs/liveobjects channel objects as regular channel messages.
+
+When using inband objects, the client receives messages with the special name @[meta]objects@ that describe the current set of objects on a channel.
+
+<aside class="note">
+<p>This feature enables clients to subscribe to LiveObjects updates in realtime even on platforms that don't yet have a dedicated LiveObjects Realtime client implementation. If you're using LiveObjects from JavaScript/TypeScript, use the LiveObjects "plugin":/docs/liveobjects/quickstart?lang=javascript which has dedicated support for all LiveObjects features.</p>
+</aside>
+
+For more information see the "inband objects":/docs/liveobjects/inband-objects documentation.
 
 h2(#modes). Modes
 

--- a/content/liveobjects/inband-objects.textile
+++ b/content/liveobjects/inband-objects.textile
@@ -1,0 +1,68 @@
+---
+title: Inband Objects
+meta_description: "Subscribe to LiveObjects updates from Pub/Sub SDKs."
+product: liveobjects
+languages:
+  - javascript
+---
+
+Inband objects enables clients to subscribe to LiveObjects updates in realtime, even on platforms that don't yet have a native LiveObjects Realtime client implementation.
+
+<aside class="note">
+<p>If you're using LiveObjects from JavaScript/TypeScript, use the LiveObjects "plugin":/docs/liveobjects/quickstart?lang=javascript which has dedicated support for all LiveObjects features.</p>
+</aside>
+
+Inband objects works by delivering changes to channel objects as regular channel messages, similar to "inband occupancy":/docs/channels/options#occupancy .
+
+h2(#inband-objects-enable). Enable Inband Objects
+
+To enable inband objects, use the @objects@ "channel parameter":/docs/channels/options#objects when getting a channel:
+
+blang[javascript].
+
+  ```[javascript]
+  // When getting a channel instance
+  const channelOpts = { params: { objects: 'objects' } };
+  const channel = realtime.channels.get('my-channel', channelOpts);
+
+  // Or using setOptions on an existing channel
+  await channel.setOptions({ params: { objects: 'objects' } });
+  ```
+
+<aside data-type='important'>
+<p>Clients require the @channel-metadata@ "capability":/docs/auth/capabilities to receive inband objects updates.</p>
+</aside>
+
+h2(#inband-objects-subscribe). Subscribe to updates
+
+When using inband objects, the client will receive special @[meta]objects@ messages whenever the objects on the channel are updated. These messages provide a snapshot of the current set of objects on the channel.
+
+<aside data-type='note'>
+<p>If there is a high rate of updates to the channel objects the inband messages will be throttled. However the client is guaranteed to receive a sequence of inband messages after the last change occurs so that the latest data is always available.</p>
+</aside>
+
+"Subscribe":/docs/api/realtime-sdk/channels#subscribe to @[meta]objects@ messages like you would any other message on the channel. For convenience, use a message name filter to only receive messages with the name @[meta]objects@ in your listener:
+
+blang[javascript].
+
+  ```[javascript]
+  // Subscribe to [meta]objects messages
+  channel.subscribe('[meta]objects', (message) => {
+    const { syncId, nextCursor, object } = message.data;
+    console.log("Received inband objects message:", syncId, nextCursor, JSON.stringify(message.data));
+  });
+  ```
+
+h2(#inband-objects-message-format). Message Format
+
+Inband objects messages are sent as a sequence of messages, where each message contains a snapshot of a single object on the channel. Taken together, a set of messages belonging to the same sequence describes the complete set of objects on the channel.
+
+Each inband objects message has a message @name@ of @[meta]objects@.
+
+The message @data@ is a JSON object with the following top-level properties:
+
+* @syncId@: A unique ID for this sequence. All messages with the same @syncId@ are part of the same sequence of messages which describes the complete set of the objects on the channel.
+* @nextCursor@: A cursor for the next message in the sequence, or @undefined@ if this is the last message in the sequence.
+* @object@: A JSON representation of the object included in the message.
+
+The shape of the @object@ is the same as the response format of an object when listing them via the "REST API":/docs/liveobjects/rest-api-usage?lang=javascript#fetching-objects-list-values .

--- a/src/data/nav/liveobjects.ts
+++ b/src/data/nav/liveobjects.ts
@@ -75,6 +75,10 @@ export default {
           name: 'Using the REST API',
           link: '/docs/liveobjects/rest-api-usage',
         },
+        {
+          name: 'Inband Objects',
+          link: '/docs/liveobjects/inband-objects',
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Description

Updates the Pub/Sub channel options docs to describe the new channel parameter for inband objects. Adds a new page to the advanced section of the LiveObjects docs that fully describes the feature.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
