### PR TITLE
EDU-1931: Fixes broken img syntax

### DIFF
--- a/content/channels/options/deltas.textile
+++ b/content/channels/options/deltas.textile
@@ -24,8 +24,8 @@ As @delta@ only applies to channel subscriptions, it is only available when usin
 
 Using delta mode can significantly reduce the encoded size of each message when the difference between successive message payload sizes are small, relative to the overall size. The reduction can reduce bandwidth costs and transit latencies, and enable greater message throughput on a connection.
 
-<a href="@content/docs/realtime/delta-messages.png" target="_blank">
-  <img src="@content/docs/realtime/delta-messages.png" style="max-width:100%" alt="Deltas explanation">
+<a href="@content/realtime/delta-messages.png" target="_blank">
+  <img src="@content/realtime/delta-messages.png" style="max-width:100%" alt="Deltas explanation">
 </a>
 
 h2(#processing). Delta processing


### PR DESCRIPTION
This PR:
- Makes a quick fix to the broken `<img>` syntax.
  - For the page `/docs/channels/options/deltas`.
 
To save you a few seconds, here is the link to the fix: https://ably-docs-edu-1931-delt-2kfkfn.herokuapp.com/docs/channels/options/deltas 😃 

https://ably.atlassian.net/browse/EDU-1931