### PR TITLE
Fixed issue where pub-sub-occupancy channel name is hard coded

### DIFF
--- a/examples/pub-sub-occupancy/javascript/src/script.ts
+++ b/examples/pub-sub-occupancy/javascript/src/script.ts
@@ -10,7 +10,9 @@ const client = new Ably.Realtime({
   clientId: nanoid(),
 });
 
-const channel = client.channels.get('occupancy-example', { params: { occupancy: 'metrics' } });
+const urlParams = new URLSearchParams(window.location.search);
+const channelName = urlParams.get('name') || 'pub-sub-occupancy';
+const channel = client.channels.get(channelName, { params: { occupancy: 'metrics' } });
 
 channel.subscribe((message: Message) => {
   console.log('occupancy: ', message.data);
@@ -27,7 +29,7 @@ async function simulatedOccupants() {
       clientId,
     });
 
-    const channel = client.channels.get('occupancy-example');
+    const channel = client.channels.get(channelName);
     // Attach would be called automatically when subscribing to a channel,
     // but for the simulation we do not need to subscribe. We just need to attach.
     const randomDuration = 5000 + Math.random() * 10000;

--- a/examples/pub-sub-occupancy/react/src/App.tsx
+++ b/examples/pub-sub-occupancy/react/src/App.tsx
@@ -5,9 +5,12 @@ import { useEffect, useState } from 'react';
 import { FaEye } from 'react-icons/fa';
 import './styles/styles.css';
 
+const urlParams = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '');
+const channelName = urlParams.get('name') || 'pub-sub-occupancy';
+
 function Stream() {
   const [occupancySubscribers, setOccupancySubscribers] = useState(0);
-  useChannel('occupancy-example', (message) => {
+  useChannel(channelName, (message) => {
     console.log('occupancy: ', message.data);
     setOccupancySubscribers(message.data.metrics.connections);
   });
@@ -49,7 +52,7 @@ async function simulatedOccupants() {
       clientId,
     });
 
-    const channel = client.channels.get('occupancy-example');
+    const channel = client.channels.get(channelName);
     // Attach would be called automatically when subscribing to a channel,
     // but for the simulation we do not need to subscribe. We just need to attach.
     const randomDuration = 5000 + Math.random() * 10000;
@@ -74,7 +77,7 @@ export default function App() {
 
   return (
     <AblyProvider client={client}>
-      <ChannelProvider channelName="occupancy-example" options={{ params: { occupancy: 'metrics' } }}>
+      <ChannelProvider channelName={channelName} options={{ params: { occupancy: 'metrics' } }}>
         <Stream />
       </ChannelProvider>
     </AblyProvider>


### PR DESCRIPTION
The pub-sub-occupancy examples for both javascript and react were hardcoding the channel name. This PR fixes that.