### PR TITLE
[WEB-4367] Fix column dimensions, default menu expansion behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "16.2.0",
+    "@ably/ui": "16.2.1",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@js-bits/dom-parser": "^1.0.3",

--- a/src/components/Layout/Header.test.tsx
+++ b/src/components/Layout/Header.test.tsx
@@ -50,7 +50,7 @@ describe('Header', () => {
     render(<Header />);
     expect(screen.getAllByAltText('Ably logo').length).toBeGreaterThan(0);
 
-    expect(screen.getByText('Documentation')).toBeInTheDocument();
+    expect(screen.getByText('Docs')).toBeInTheDocument();
     expect(screen.getByText('Examples')).toBeInTheDocument();
   });
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -23,7 +23,7 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
     account: userContext.sessionState.account ?? { links: { dashboard: { href: '#' } } },
   };
 
-  const tabs = ['Documentation', 'Examples'];
+  const tabs = ['Docs', 'Examples'];
   const tabLinks = ['/docs', '/examples'];
 
   return (
@@ -83,6 +83,7 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
           />
         ) : null
       }
+      headerCenterClassName="max-w-[280px]"
       headerLinks={[
         {
           href: '/docs/sdks',

--- a/src/components/Layout/LanguageSelector.tsx
+++ b/src/components/Layout/LanguageSelector.tsx
@@ -120,7 +120,7 @@ export const LanguageSelector = () => {
         classNames={{
           control: () => '!border-none !inline-flex !cursor-pointer group/lang-dropdown',
           valueContainer: () => '!p-0',
-          menu: () => 'absolute right-0 w-240 z-10',
+          menu: () => 'absolute right-0 w-[240px] z-10',
         }}
         styles={{
           control: () => ({ height: LANGUAGE_SELECTOR_HEIGHT }),

--- a/src/components/Layout/utils/nav.ts
+++ b/src/components/Layout/utils/nav.ts
@@ -152,7 +152,7 @@ export const commonAccordionOptions = (
   },
 });
 
-export const sidebarAlignmentClasses = 'absolute md:sticky w-240 md:pb-128 pt-24';
+export const sidebarAlignmentClasses = 'absolute md:sticky w-[240px] md:pb-128 pt-24';
 
 export const sidebarAlignmentStyles: React.CSSProperties = {
   top: HEADER_HEIGHT,

--- a/src/components/Layout/utils/nav.ts
+++ b/src/components/Layout/utils/nav.ts
@@ -144,7 +144,7 @@ export const commonAccordionOptions = (
       },
     ),
     selectedHeaderCSS: '!text-neutral-1300 mb-8',
-    contentCSS: cn('[&>div]:pb-0'),
+    contentCSS: '[&>div]:pb-0',
     rowIconSize: '20px',
     defaultOpenIndexes: !inHeader && openIndex !== undefined ? [openIndex] : [],
     hideBorders: true,

--- a/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
+++ b/src/components/SDKInterfacePanel/SDKInterfacePanel.tsx
@@ -25,7 +25,7 @@ const SDKToolTip = ({ tooltip }: { tooltip: string }) => {
       />
       {tooltipHover ? (
         <aside
-          className="w-240 max-w-240 absolute box-border
+          className="w-[240px] max-w-[240px] absolute box-border
           whitespace-pre-wrap bg-white shadow-tooltip rounded border border-light-grey
           p-16 text-center ui-text-p3 cursor-default -ml-160 -mt-88"
         >

--- a/src/components/blocks/software/Code/ApiKeyIndicator.tsx
+++ b/src/components/blocks/software/Code/ApiKeyIndicator.tsx
@@ -19,7 +19,7 @@ const APIKeyIndicator = ({ tooltip }: ApiKeyIndicatorProps) => {
       <Icon additionalCSS="ml-4 cursor-help" name="icon-gui-information-circle-micro" size="1rem" />
       {tooltipHover ? (
         <aside
-          className="w-240 max-w-240 absolute -mt-140 box-border
+          className="w-[240px] max-w-[240px] absolute -mt-[140px] box-border
           whitespace-pre-wrap bg-white shadow-tooltip rounded border border-light-grey
           text-cool-black font-sans p-16 text-center text-p3 leading-5 cursor-default"
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.2.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.0.tgz#2469a89cb27a46f14d30af19cd955905d08e345a"
-  integrity sha512-i2/gfp+FME34eudF/521Y7EAE/05UD6at3viTuSW+FIkp6JJVfopiVFmc6ADsfuhk1z8BlzMvBjhp1HxtUV8ew==
+"@ably/ui@16.2.1":
+  version "16.2.1"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.1.tgz#1666be723a4edceae384fe15136527680118e2a6"
+  integrity sha512-DaixO2fr8q0YV0fPOUvR/ivX9qxF48Ft01Zh7QKNMX7n2C3vnTj/37RMfouVU812rlqKOWpHCih5X/Pi/WpNxg==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
Fixes two things from Matt's docs feedback:
- sorts out the styling classes on the nav outer columns, not sure when this regressed but Tailwind wasn't picking up the width classes (https://ably-real-time.slack.com/archives/C01LR5XFHFX/p1746537594249259)
- left nav doesn't respect and maintain product context when navigating from the homepage to a product page (https://ably-real-time.slack.com/archives/C01LR5XFHFX/p1746540944026369)

Also improves responsive behaviour for the header now that we have a TabMenu section up there taking more space.

Review link: https://ably-docs-web-4367-fix--5jgh9r.herokuapp.com/