### PR TITLE
Fixed issue where Changelog descriptions on Docs dashboard

### DIFF
--- a/src/components/Homepage/Changelog.tsx
+++ b/src/components/Homepage/Changelog.tsx
@@ -84,7 +84,9 @@ const stripHtml = (html: string | null | undefined): string => {
   if (!html) {
     return '';
   }
+
   const doc = parse(html);
+
   return doc.textContent || '';
 };
 
@@ -120,7 +122,7 @@ const parseChangelogContent = (htmlContent: string): { tags: string[]; descripti
             break;
           }
 
-          const paragraphHtml = htmlContent.substring(pStartIndex + 3, pEndIndex);
+          const paragraphHtml = htmlContent.substring(pStartIndex, pEndIndex + 4);
           const strippedText = stripHtml(paragraphHtml).trim();
 
           if (strippedText) {


### PR DESCRIPTION
The `<p>` tags were already being stripped but the `parse` function was expecting HTML not mostly plain text. So this was causing the error.
![Screenshot 2025-05-08 at 09 49 51](https://github.com/user-attachments/assets/1760188f-865f-437b-9ab9-8e8405da201d)
