### PR TITLE
[EDU-1937] Update homepage tiles for LiveObjects release

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "16.2.1",
+    "@ably/ui": "16.2.2",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@mdx-js/react": "^2.3.0",

--- a/src/data/content/homepage.ts
+++ b/src/data/content/homepage.ts
@@ -31,16 +31,16 @@ export default {
         link: '/docs/spaces',
       },
       {
+        name: 'liveObjects',
+        link: '/docs/liveobjects',
+      },
+      {
         name: 'liveSync',
         link: '/docs/livesync',
       },
       {
         name: 'assetTracking',
         link: '/docs/asset-tracking',
-      },
-      {
-        name: 'liveObjects',
-        link: '/docs/liveobjects',
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.2.1":
-  version "16.2.1"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.1.tgz#1666be723a4edceae384fe15136527680118e2a6"
-  integrity sha512-DaixO2fr8q0YV0fPOUvR/ivX9qxF48Ft01Zh7QKNMX7n2C3vnTj/37RMfouVU812rlqKOWpHCih5X/Pi/WpNxg==
+"@ably/ui@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.2.tgz#df868de005607ef254710d898e4aa90f67403afb"
+  integrity sha512-UMgvsgk2VkdvOEsDkKgaIYOHaCh3hkJx4s1zSDTgZCH9Yr66uCF2tpLPBxf6wYNVnhcY3BgbI6rFROUDD9E3eQ==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
## Description

This PR:

* Upgrades ably-ui to 16.2.2 to remove the 'coming soon' from LiveObjects
* Re-orders the homepage tiles to reflect the side navigation. 

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
