### PR TITLE
Rename `ObjectsTypes` to `AblyObjectsTypes`

### DIFF
--- a/content/liveobjects/typing.textile
+++ b/content/liveobjects/typing.textile
@@ -14,11 +14,11 @@ blang[javascript].
 
   If you are using TypeScript in your project, you can leverage LiveObjects' built-in TypeScript support to ensure type safety and enable autocompletion when working with objects on a channel.
 
-  h2(#global). Global ObjectsTypes interface
+  h2(#global). Global AblyObjectsTypes interface
 
-  You can type objects on all your channels by defining a global @ObjectsTypes@ interface. If you only want to type the root object for a specific channel, see the "Typing channel.objects.getRoot()":#getroot section below.
+  You can type objects on all your channels by defining a global @AblyObjectsTypes@ interface. If you only want to type the root object for a specific channel, see the "Typing channel.objects.getRoot()":#getroot section below.
 
-  Define the @ObjectsTypes@ interface in a type declaration file. You can create a file named @ably.config.d.ts@ in the root of your application:
+  Define the @AblyObjectsTypes@ interface in a type declaration file. You can create a file named @ably.config.d.ts@ in the root of your application:
 
 blang[javascript].
 
@@ -35,7 +35,7 @@ blang[javascript].
   };
 
   declare global {
-    export interface ObjectsTypes {
+    export interface AblyObjectsTypes {
       root: MyCustomRoot;
     }
   }


### PR DESCRIPTION
## Description

Decided to rename to `AblyObjectsTypes` to avoid using a generic name like `ObjectsTypes` in a global namespace, see [1]

[1] https://github.com/ably/ably-js/pull/2007#discussion_r2054349487

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
