### PR TITLE
[WEB-4360] fixes for LanguageSelector and RightSidebar

### DIFF
--- a/data/onCreatePage.ts
+++ b/data/onCreatePage.ts
@@ -59,7 +59,9 @@ export const onCreatePage: GatsbyNode['onCreatePage'] = async ({ page, actions }
       ...page,
       context: {
         ...page.context,
-        layout: pathOptions ? pathOptions[1] : { sidebar: true, searchBar: true, template: 'base' },
+        layout: pathOptions
+          ? pathOptions[1]
+          : { leftSidebar: true, rightSidebar: true, searchBar: true, template: 'base' },
         ...(isMDX ? { languages: Array.from(detectedLanguages) } : {}),
       },
       component: isMDX ? `${mdxWrapper}?__contentFilePath=${page.component}` : page.component,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "16.2.2",
+    "@ably/ui": "16.2.3",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@mdx-js/react": "^2.3.0",

--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -9,7 +9,7 @@ import { LanguageKey } from 'src/data/languages/types';
 import { useLayoutContext } from 'src/contexts/layout-context';
 
 const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language }) => {
-  const { activePage, setLanguage } = useLayoutContext();
+  const { activePage } = useLayoutContext();
   const selectedLanguage = getTrimmedLanguage(language);
   const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(selectedLanguage, activePage.language);
   /*
@@ -22,9 +22,6 @@ const LanguageButton: FC<LanguageNavigationComponentProps> = ({ language }) => {
   const handleClick = () => {
     const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, selectedLanguage);
 
-    if (!isPageLanguageDefault) {
-      setLanguage(language);
-    }
     navigate(href);
   };
 

--- a/src/components/Layout/LanguageSelector.test.tsx
+++ b/src/components/Layout/LanguageSelector.test.tsx
@@ -123,6 +123,15 @@ describe('LanguageSelector', () => {
       state: null,
     });
 
+    mockUseLayoutContext.mockReturnValue({
+      activePage: {
+        tree: [0],
+        languages: ['javascript', 'python'],
+        language: 'python',
+      },
+      products: [['pubsub']],
+    });
+
     jest.spyOn(window, 'URLSearchParams').mockImplementation(
       () =>
         ({
@@ -136,7 +145,7 @@ describe('LanguageSelector', () => {
     );
 
     render(<LanguageSelector />);
-    expect(screen.queryByText('icon-tech-javascript')).not.toBeInTheDocument();
     expect(screen.getByText('icon-tech-python')).toBeInTheDocument();
+    expect(screen.queryByText('icon-tech-javascript')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Layout/LanguageSelector.tsx
+++ b/src/components/Layout/LanguageSelector.tsx
@@ -75,7 +75,6 @@ const LanguageSelectorOption = ({ isOption, setMenuOpen, langParam, ...props }: 
 
 export const LanguageSelector = () => {
   const { activePage } = useLayoutContext();
-  const location = useLocation();
   const languageVersions = languageData[activePage.product ?? 'pubsub'];
   const [menuOpen, setMenuOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<LanguageSelectorOptionData | null>(null);
@@ -95,13 +94,10 @@ export const LanguageSelector = () => {
     [activePage.languages, languageVersions],
   );
 
-  const queryParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
-  const langParam = queryParams.get('lang');
-
   useEffect(() => {
-    const defaultOption = options.find((option) => option.label === langParam) || options[0];
+    const defaultOption = options.find((option) => option.label === activePage.language) || options[0];
     setSelectedOption(defaultOption);
-  }, [langParam, options]);
+  }, [activePage.language, options]);
 
   const handleClick = (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -130,9 +126,16 @@ export const LanguageSelector = () => {
         menuIsOpen={menuOpen}
         components={{
           Option: (props) => (
-            <LanguageSelectorOption {...props} setMenuOpen={setMenuOpen} langParam={langParam} isOption />
+            <LanguageSelectorOption
+              {...props}
+              setMenuOpen={setMenuOpen}
+              langParam={selectedOption?.label || null}
+              isOption
+            />
           ),
-          SingleValue: (props) => <LanguageSelectorOption {...props} setMenuOpen={setMenuOpen} langParam={langParam} />,
+          SingleValue: (props) => (
+            <LanguageSelectorOption {...props} setMenuOpen={setMenuOpen} langParam={selectedOption?.label || null} />
+          ),
           IndicatorSeparator: null,
           DropdownIndicator: () => (
             <button

--- a/src/components/Layout/MDXWrapper.test.tsx
+++ b/src/components/Layout/MDXWrapper.test.tsx
@@ -20,7 +20,6 @@ jest.mock('./MDXWrapper', () => {
 jest.mock('src/contexts/layout-context', () => ({
   useLayoutContext: () => ({
     activePage: { language: 'javascript' },
-    setLanguage: jest.fn(),
   }),
   LayoutProvider: ({ children }: { children: ReactNode }) => <div data-testid="layout-provider">{children}</div>,
 }));

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { PageProps } from 'gatsby';
+import { navigate, PageProps } from 'gatsby';
 import CodeSnippet, { CodeSnippetProps } from '@ably/ui/core/CodeSnippet';
 import cn from '@ably/ui/core/utils/cn';
 
@@ -18,7 +18,7 @@ type MDXWrapperProps = PageProps<unknown, PageContextType>;
 const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext }) => {
   const { frontmatter } = pageContext;
   const title = frontmatter?.title;
-  const { activePage, setLanguage } = useLayoutContext();
+  const { activePage } = useLayoutContext();
 
   // Use the copyable headers hook
   useCopyableHeaders();
@@ -28,8 +28,7 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext }) => {
       <CodeSnippet
         lang={activePage.language}
         onChange={(lang) => {
-          setLanguage(lang);
-          window.history.replaceState({}, '', `${location.pathname}?lang=${lang}`);
+          navigate(`${location.pathname}?lang=${lang}`);
         }}
         className={cn(props.className, 'mb-20')}
         {...props}

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -12,6 +12,7 @@ import { useCopyableHeaders } from './mdx/headers';
 import { useLayoutContext } from 'src/contexts/layout-context';
 import Aside from '../blocks/dividers/Aside';
 import { HtmlComponentPropsData } from '../html-component-props';
+import { languageData } from 'src/data/languages';
 
 type MDXWrapperProps = PageProps<unknown, PageContextType>;
 
@@ -31,6 +32,9 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext }) => {
           navigate(`${location.pathname}?lang=${lang}`);
         }}
         className={cn(props.className, 'mb-20')}
+        languageOrdering={
+          activePage.product && languageData[activePage.product] ? Object.keys(languageData[activePage.product]) : []
+        }
         {...props}
       />
     );

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -1,6 +1,6 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState, createContext, useContext } from 'react';
 import { navigate, PageProps } from 'gatsby';
-import CodeSnippet, { CodeSnippetProps } from '@ably/ui/core/CodeSnippet';
+import CodeSnippet, { CodeSnippetProps, SDKType } from '@ably/ui/core/CodeSnippet';
 import cn from '@ably/ui/core/utils/cn';
 
 import PageTitle from '../PageTitle';
@@ -13,89 +13,86 @@ import { useLayoutContext } from 'src/contexts/layout-context';
 import Aside from '../blocks/dividers/Aside';
 import { HtmlComponentPropsData } from '../html-component-props';
 import { languageData } from 'src/data/languages';
+import { ActivePage } from './utils/nav';
+import { Table, TableHead, TableBody, TableRow, TableHeader, TableCell } from './mdx/tables';
 
 type MDXWrapperProps = PageProps<unknown, PageContextType>;
+
+// Create SDK Context
+type SDKContextType = {
+  sdk: SDKType;
+  setSdk: (sdk: SDKType) => void;
+};
+
+const SDKContext = createContext<SDKContextType | undefined>(undefined);
+
+const useSDK = () => {
+  const context = useContext(SDKContext);
+  if (!context) {
+    throw new Error('useSDK must be used within an SDKProvider');
+  }
+  return context;
+};
+
+const WrappedCodeSnippet: React.FC<{ activePage: ActivePage } & CodeSnippetProps> = ({ activePage, ...props }) => {
+  const { sdk, setSdk } = useSDK();
+
+  return (
+    <CodeSnippet
+      lang={activePage.language}
+      sdk={sdk}
+      onChange={(lang, sdk) => {
+        setSdk(sdk ?? null);
+        navigate(`${location.pathname}?lang=${lang}`);
+      }}
+      className={cn(props.className, 'mb-20')}
+      languageOrdering={
+        activePage.product && languageData[activePage.product] ? Object.keys(languageData[activePage.product]) : []
+      }
+      {...props}
+    />
+  );
+};
+
+const WrappedAside = (props: PropsWithChildren<{ 'data-type': string }>) => {
+  return (
+    <Aside
+      attribs={{ 'data-type': props['data-type'] }}
+      data={(<>{props.children}</>) as unknown as HtmlComponentPropsData}
+    />
+  );
+};
 
 const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext }) => {
   const { frontmatter } = pageContext;
   const title = frontmatter?.title;
   const { activePage } = useLayoutContext();
+  const [sdk, setSdk] = useState<SDKType>(null);
 
   // Use the copyable headers hook
   useCopyableHeaders();
 
-  const WrappedCodeSnippet: React.FC<CodeSnippetProps> = (props) => {
-    return (
-      <CodeSnippet
-        lang={activePage.language}
-        onChange={(lang) => {
-          navigate(`${location.pathname}?lang=${lang}`);
-        }}
-        className={cn(props.className, 'mb-20')}
-        languageOrdering={
-          activePage.product && languageData[activePage.product] ? Object.keys(languageData[activePage.product]) : []
-        }
-        {...props}
-      />
-    );
-  };
-
-  const WrappedAside = (props: PropsWithChildren<{ 'data-type': string }>) => {
-    return (
-      <Aside
-        attribs={{ 'data-type': props['data-type'] }}
-        data={(<>{props.children}</>) as unknown as HtmlComponentPropsData}
-      />
-    );
-  };
-
-  // Table components with responsive styling
-  const Table = (props: React.HTMLAttributes<HTMLTableElement>) => (
-    <div className="overflow-x-auto mb-8">
-      <table className="min-w-full border-collapse" {...props} />
-    </div>
-  );
-
-  const TableHead = (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
-    <thead className="bg-gray-50 border-b" {...props} />
-  );
-
-  const TableBody = (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
-    <tbody className="divide-y divide-gray-200" {...props} />
-  );
-
-  const TableRow = (props: React.HTMLAttributes<HTMLTableRowElement>) => <tr className="hover:bg-gray-50" {...props} />;
-
-  const TableHeader = (props: React.ThHTMLAttributes<HTMLTableHeaderCellElement>) => (
-    <th
-      className="px-8 py-8 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-      {...props}
-    />
-  );
-
-  const TableCell = (props: React.TdHTMLAttributes<HTMLTableDataCellElement>) => (
-    <td className="px-6 py-4 text-sm" {...props} />
-  );
-
   return (
-    <Article>
-      <MarkdownProvider
-        components={{
-          If,
-          Code: WrappedCodeSnippet,
-          Aside: WrappedAside,
-          table: Table,
-          thead: TableHead,
-          tbody: TableBody,
-          tr: TableRow,
-          th: TableHeader,
-          td: TableCell,
-        }}
-      >
-        {title && <PageTitle>{title}</PageTitle>}
-        {children}
-      </MarkdownProvider>
-    </Article>
+    <SDKContext.Provider value={{ sdk, setSdk }}>
+      <Article>
+        <MarkdownProvider
+          components={{
+            If,
+            Code: (props) => <WrappedCodeSnippet activePage={activePage} {...props} />,
+            Aside: WrappedAside,
+            table: Table,
+            thead: TableHead,
+            tbody: TableBody,
+            tr: TableRow,
+            th: TableHeader,
+            td: TableCell,
+          }}
+        >
+          {title && <PageTitle>{title}</PageTitle>}
+          {children}
+        </MarkdownProvider>
+      </Article>
+    </SDKContext.Provider>
   );
 };
 

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -60,13 +60,18 @@ const externalLinks = (
   ];
 };
 
+const getHeaderId = (element: Element) => {
+  const customId = element.querySelector('a')?.getAttribute('id') ?? element.querySelector('a')?.getAttribute('name');
+  return customId ?? element.id;
+};
+
 const RightSidebar = () => {
+  const location = useLocation();
   const { activePage } = useLayoutContext();
   const [headers, setHeaders] = useState<SidebarHeader[]>([]);
-  const [activeHeader, setActiveHeader] = useState<Pick<SidebarHeader, 'id'>>();
+  const [activeHeader, setActiveHeader] = useState<Pick<SidebarHeader, 'id'>>({ id: location.hash.slice(1) });
   const intersectionObserver = useRef<IntersectionObserver>();
   const manualSelection = useRef<boolean>(false);
-  const location = useLocation();
   const showLanguageSelector = activePage?.languages.length > 0;
   const language = new URLSearchParams(location.search).get('lang') as LanguageKey;
 
@@ -80,12 +85,17 @@ const RightSidebar = () => {
       const headerElements = articleElement.querySelectorAll('h2, h3, h6') ?? [];
       const headerData = Array.from(headerElements)
         .filter((element) => element.id && element.textContent)
-        .map((header) => ({
-          type: header.tagName,
-          label: header.textContent ?? '',
-          id: header.id,
-          height: header.getBoundingClientRect().height,
-        }));
+        .map((header) => {
+          const customId =
+            header.querySelector('a')?.getAttribute('id') ?? header.querySelector('a')?.getAttribute('name');
+
+          return {
+            type: header.tagName,
+            label: header.textContent ?? '',
+            id: customId ?? header.id,
+            height: header.getBoundingClientRect().height,
+          };
+        });
 
       setHeaders(headerData);
 
@@ -117,7 +127,7 @@ const RightSidebar = () => {
 
           if (topEntry.target.id) {
             setActiveHeader({
-              id: topEntry.target.id,
+              id: getHeaderId(topEntry.target),
             });
           }
         }

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -10,6 +10,7 @@ import { useLayoutContext } from 'src/contexts/layout-context';
 import { languageInfo } from 'src/data/languages';
 import { PageTreeNode, sidebarAlignmentClasses, sidebarAlignmentStyles } from './utils/nav';
 import { INKEEP_ASK_BUTTON_HEIGHT } from './utils/heights';
+import { LanguageKey } from 'src/data/languages/types';
 
 type SidebarHeader = {
   id: string;
@@ -36,7 +37,7 @@ const externalLinks = (
       githubBasePath +
       (githubPathSegments.length === 1 ? `${githubPathName}/index.textile` : `${githubPathName}.textile`);
 
-    const language = new URLSearchParams(location.search).get('lang');
+    const language = new URLSearchParams(location.search).get('lang') as LanguageKey;
     const requestTitle = `Change request for: ${currentPage.link}`;
     const requestBody = encodeURIComponent(`
   **Page name**: ${currentPage.name}

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -69,7 +69,9 @@ const RightSidebar = () => {
   const location = useLocation();
   const { activePage } = useLayoutContext();
   const [headers, setHeaders] = useState<SidebarHeader[]>([]);
-  const [activeHeader, setActiveHeader] = useState<Pick<SidebarHeader, 'id'>>({ id: location.hash.slice(1) });
+  const [activeHeader, setActiveHeader] = useState<Pick<SidebarHeader, 'id'>>({
+    id: location.hash ? location.hash.slice(1) : '#',
+  });
   const intersectionObserver = useRef<IntersectionObserver>();
   const manualSelection = useRef<boolean>(false);
   const showLanguageSelector = activePage?.languages.length > 0;

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useLocation, WindowLocation } from '@reach/router';
 import cn from '@ably/ui/core/utils/cn';
 import Icon from '@ably/ui/core/Icon';
@@ -72,10 +72,21 @@ const RightSidebar = () => {
   const [activeHeader, setActiveHeader] = useState<Pick<SidebarHeader, 'id'>>({
     id: location.hash ? location.hash.slice(1) : '#',
   });
-  const intersectionObserver = useRef<IntersectionObserver>();
+  const intersectionObserver = useRef<IntersectionObserver | undefined>(undefined);
   const manualSelection = useRef<boolean>(false);
   const showLanguageSelector = activePage?.languages.length > 0;
   const language = new URLSearchParams(location.search).get('lang') as LanguageKey;
+
+  const handleHeaderClick = useCallback((headerId: string) => {
+    // Set manual selection flag to prevent intersection observer updates
+    manualSelection.current = true;
+    setActiveHeader({ id: headerId });
+
+    // Reset the flag after scroll animation completes
+    setTimeout(() => {
+      manualSelection.current = false;
+    }, 1000);
+  }, []);
 
   useEffect(() => {
     const articleElement = document.querySelector('article');
@@ -209,16 +220,7 @@ const RightSidebar = () => {
                       { 'text-neutral-1300 dark:text-neutral-000': header.id === activeHeader?.id },
                       { 'ml-8': header.type !== 'H2' },
                     )}
-                    onClick={() => {
-                      // Set manual selection flag to prevent intersection observer updates
-                      manualSelection.current = true;
-                      setActiveHeader({ id: header.id });
-
-                      // Reset the flag after scroll animation completes
-                      setTimeout(() => {
-                        manualSelection.current = false;
-                      }, 1000);
-                    }}
+                    onClick={() => handleHeaderClick(header.id)}
                   >
                     {header.label}
                   </a>

--- a/src/components/Layout/mdx/tables.tsx
+++ b/src/components/Layout/mdx/tables.tsx
@@ -17,14 +17,14 @@ const TableBody = (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
 
 const TableRow = (props: React.HTMLAttributes<HTMLTableRowElement>) => <tr className="hover:bg-gray-50" {...props} />;
 
-const TableHeader = (props: React.ThHTMLAttributes<HTMLTableHeaderCellElement>) => (
+const TableHeader = (props: React.HTMLAttributes<HTMLTableCellElement>) => (
   <th
     className="px-8 py-8 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
     {...props}
   />
 );
 
-const TableCell = (props: React.TdHTMLAttributes<HTMLTableDataCellElement>) => (
+const TableCell = (props: React.HTMLAttributes<HTMLTableCellElement>) => (
   <td className="px-6 py-4 text-sm" {...props} />
 );
 

--- a/src/components/Layout/mdx/tables.tsx
+++ b/src/components/Layout/mdx/tables.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+// Table components with responsive styling
+const Table = (props: React.HTMLAttributes<HTMLTableElement>) => (
+  <div className="overflow-x-auto mb-8">
+    <table className="min-w-full border-collapse" {...props} />
+  </div>
+);
+
+const TableHead = (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <thead className="bg-gray-50 border-b" {...props} />
+);
+
+const TableBody = (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <tbody className="divide-y divide-gray-200" {...props} />
+);
+
+const TableRow = (props: React.HTMLAttributes<HTMLTableRowElement>) => <tr className="hover:bg-gray-50" {...props} />;
+
+const TableHeader = (props: React.ThHTMLAttributes<HTMLTableHeaderCellElement>) => (
+  <th
+    className="px-8 py-8 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
+    {...props}
+  />
+);
+
+const TableCell = (props: React.TdHTMLAttributes<HTMLTableDataCellElement>) => (
+  <td className="px-6 py-4 text-sm" {...props} />
+);
+
+export { Table, TableHead, TableBody, TableRow, TableHeader, TableCell };

--- a/src/components/Layout/utils/heights.ts
+++ b/src/components/Layout/utils/heights.ts
@@ -5,4 +5,4 @@
 */
 
 export const LANGUAGE_SELECTOR_HEIGHT = 38;
-export const INKEEP_ASK_BUTTON_HEIGHT = 96;
+export const INKEEP_ASK_BUTTON_HEIGHT = 48;

--- a/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
+++ b/src/components/Menu/LanguageNavigation/LanguageNavigation.tsx
@@ -2,7 +2,7 @@ import { Dispatch, FunctionComponent as FC, SetStateAction } from 'react';
 import { SingleValue } from 'react-select';
 import { navigate } from 'gatsby';
 
-import { DEFAULT_LANGUAGE, DEFAULT_PREFERRED_LANGUAGE, SDK_INTERFACES } from '../../../../data/createPages/constants';
+import { DEFAULT_PREFERRED_LANGUAGE, SDK_INTERFACES } from '../../../../data/createPages/constants';
 import { dropdownContainer, horizontalNav } from './LanguageNavigation.module.css';
 import SDKInterfacePanel from '../../SDKInterfacePanel/SDKInterfacePanel';
 
@@ -40,23 +40,19 @@ export interface LanguageNavigationProps {
   setPreviousSDKInterfaceTab: Dispatch<SetStateAction<string>>;
 }
 
-const changePageOnSelect =
-  (pageLanguage: string, callback: (arg: string) => void) => (newValue: SingleValue<ReactSelectOption>) => {
-    if (newValue) {
-      const language = newValue.value;
-      const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
-        getTrimmedLanguage(language),
-        pageLanguage,
-      );
+const changePageOnSelect = (pageLanguage: string) => (newValue: SingleValue<ReactSelectOption>) => {
+  if (newValue) {
+    const language = newValue.value;
+    const { isLanguageDefault, isPageLanguageDefault } = getLanguageDefaults(
+      getTrimmedLanguage(language),
+      pageLanguage,
+    );
 
-      const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language);
-      if (!isPageLanguageDefault) {
-        callback(language);
-      }
+    const href = createLanguageHrefFromDefaults(isPageLanguageDefault, isLanguageDefault, language);
 
-      navigate(href);
-    }
-  };
+    navigate(href);
+  }
+};
 
 const LanguageNavigation = ({
   items,
@@ -65,13 +61,12 @@ const LanguageNavigation = ({
   setSelectedSDKInterfaceTab,
   setPreviousSDKInterfaceTab,
 }: LanguageNavigationProps) => {
-  const { activePage, setLanguage } = useLayoutContext();
-  const selectedPageLanguage =
-    activePage.language === DEFAULT_LANGUAGE ? DEFAULT_PREFERRED_LANGUAGE : activePage.language;
+  const { activePage } = useLayoutContext();
+  const selectedPageLanguage = activePage.language ?? DEFAULT_PREFERRED_LANGUAGE;
   const options = items.map((item) => ({ label: item.content, value: item.props.language }));
   const value = options.find((option) => option.value === selectedPageLanguage);
 
-  const onSelectChange = changePageOnSelect(activePage.language, setLanguage);
+  const onSelectChange = changePageOnSelect(activePage.language);
 
   const isSDKInterFacePresent = allListOfLanguages
     ? checkIfLanguageHasSDKInterface(allListOfLanguages, SDK_INTERFACES)

--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`<Pre /> should successfully render Code elements with language 1`] = `
                 <div
                   class="ably-select__single-value css-9aszhm-singleValue"
                 >
-                  JavaScript v2.7
+                  JavaScript v2.9
                 </div>
                 <input
                   aria-activedescendant=""

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
               <div
                 class="ably-select__single-value css-9aszhm-singleValue"
               >
-                JavaScript v2.7
+                JavaScript v2.9
               </div>
               <input
                 aria-activedescendant=""

--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -81,21 +81,20 @@ export const LayoutProvider: React.FC<PropsWithChildren<{ pageContext: PageConte
   }, [location.pathname]); // Re-run when the path changes
 
   const activePage = useMemo(() => {
+    // Use DOM languages if available, otherwise fall back to pageContext languages
+    const activeLanguages = (domLanguages.length > 0 ? domLanguages : pageContext.languages ?? []) as LanguageKey[];
     const activePageData = determineActivePage(productData, location.pathname);
+    const activeLanguage = determineActiveLanguage(activeLanguages, location.search, activePageData?.product ?? null);
 
     if (!activePageData) {
       return {
         tree: [],
         page: { name: '', link: '' },
         languages: [],
-        language: DEFAULT_LANGUAGE as LanguageKey,
+        language: activeLanguage,
         product: null,
       };
     }
-
-    // Use DOM languages if available, otherwise fall back to pageContext languages
-    const activeLanguages = (domLanguages.length > 0 ? domLanguages : pageContext.languages ?? []) as LanguageKey[];
-    const activeLanguage = determineActiveLanguage(activeLanguages, location.search, activePageData.product);
 
     return {
       ...activePageData,

--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -82,7 +82,7 @@ export const LayoutProvider: React.FC<PropsWithChildren<{ pageContext: PageConte
 
   const activePage = useMemo(() => {
     // Use DOM languages if available, otherwise fall back to pageContext languages
-    const activeLanguages = (domLanguages.length > 0 ? domLanguages : pageContext.languages ?? []) as LanguageKey[];
+    const activeLanguages = (domLanguages.length > 0 ? domLanguages : pageContext?.languages ?? []) as LanguageKey[];
     const activePageData = determineActivePage(productData, location.pathname);
     const activeLanguage = determineActiveLanguage(activeLanguages, location.search, activePageData?.product ?? null);
 
@@ -101,7 +101,7 @@ export const LayoutProvider: React.FC<PropsWithChildren<{ pageContext: PageConte
       languages: (activePageData.page.languages as LanguageKey[]) ?? activeLanguages,
       language: activeLanguage,
     };
-  }, [location.pathname, location.search, pageContext.languages, domLanguages]);
+  }, [location.pathname, location.search, pageContext?.languages, domLanguages]);
 
   return (
     <LayoutContext.Provider

--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -5,19 +5,18 @@ import { productData } from 'src/data';
 import { LanguageKey } from 'src/data/languages/types';
 import { languageData, languageInfo } from 'src/data/languages';
 import { PageContextType } from 'src/components/Layout/Layout';
+import { ProductKey } from 'src/data/types';
 
 /**
  * LayoutContext
  *
  * activePage - The navigation tree that leads to the current page, and a list of languages referenced on the page.
- * setLanguage - Set the active language for the current page.
  */
 
 export const DEFAULT_LANGUAGE = 'javascript';
 
 const LayoutContext = createContext<{
   activePage: ActivePage;
-  setLanguage: (language: LanguageKey) => void;
 }>({
   activePage: {
     tree: [],
@@ -26,74 +25,89 @@ const LayoutContext = createContext<{
     language: DEFAULT_LANGUAGE,
     product: null,
   },
-  setLanguage: (language) => {
-    console.warn('setLanguage called without a provider', language);
-  },
 });
+
+const determineActiveLanguage = (
+  activeLanguages: LanguageKey[],
+  location: string,
+  product: ProductKey | null,
+): LanguageKey => {
+  const params = new URLSearchParams(location);
+  const langParam = params.get('lang') as LanguageKey;
+
+  if (langParam && Object.keys(languageInfo).includes(langParam)) {
+    return langParam;
+  } else if (activeLanguages.length > 0 && product) {
+    const relevantLanguages = activeLanguages.filter((lang) => Object.keys(languageData[product]).includes(lang));
+    return relevantLanguages[0];
+  }
+
+  return DEFAULT_LANGUAGE;
+};
+
+// Function to get languages from DOM (for Textile pages)
+const getLanguagesFromDOM = (): LanguageKey[] => {
+  const languageBlocks = document.querySelectorAll('.docs-language-navigation');
+
+  if (languageBlocks.length > 0) {
+    const languagesSet = new Set<LanguageKey>();
+
+    languageBlocks.forEach((element) => {
+      const languages = element.getAttribute('data-languages');
+      if (languages) {
+        languages.split(',').forEach((language) => languagesSet.add(language as LanguageKey));
+      }
+    });
+
+    return Array.from(languagesSet);
+  }
+
+  return [];
+};
 
 export const LayoutProvider: React.FC<PropsWithChildren<{ pageContext: PageContextType }>> = ({
   children,
   pageContext,
 }) => {
   const location = useLocation();
-  const [languages, setLanguages] = useState<LanguageKey[]>(pageContext?.languages ?? []);
-  const [language, setLanguage] = useState<LanguageKey>(DEFAULT_LANGUAGE);
+  const [domLanguages, setDomLanguages] = useState<LanguageKey[]>([]);
 
+  // Effect to update DOM languages after render
   useEffect(() => {
-    const languageBlocks = document.querySelectorAll('.docs-language-navigation');
-
-    if (languageBlocks.length > 0) {
-      const languagesSet = new Set<LanguageKey>();
-
-      document.querySelectorAll('.docs-language-navigation').forEach((element) => {
-        const languages = element.getAttribute('data-languages');
-        if (languages) {
-          languages.split(',').forEach((language) => languagesSet.add(language as LanguageKey));
-        }
-      });
-
-      setLanguages(Array.from(languagesSet));
+    if (typeof document !== 'undefined') {
+      const languages = getLanguagesFromDOM();
+      setDomLanguages(languages);
     }
-  }, [location.pathname]);
+  }, [location.pathname]); // Re-run when the path changes
 
   const activePage = useMemo(() => {
     const activePageData = determineActivePage(productData, location.pathname);
-    return activePageData
-      ? {
-          ...activePageData,
-          languages: activePageData.page.languages ?? languages,
-          language,
-        }
-      : {
-          tree: [],
-          page: { name: '', link: '' },
-          languages: [],
-          language,
-          product: null,
-        };
-  }, [location.pathname, languages, language]);
 
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const langParam = params.get('lang') as LanguageKey;
-
-    if (langParam && Object.keys(languageInfo).includes(langParam)) {
-      setLanguage(langParam);
-    } else if (activePage.product && activePage.languages.length > 0) {
-      const productLanguages = languageData[activePage.product];
-      const defaultLanguage =
-        Object.keys(productLanguages ?? []).filter((lang) => activePage.languages.includes(lang))[0] ??
-        DEFAULT_LANGUAGE;
-
-      setLanguage(defaultLanguage);
+    if (!activePageData) {
+      return {
+        tree: [],
+        page: { name: '', link: '' },
+        languages: [],
+        language: DEFAULT_LANGUAGE as LanguageKey,
+        product: null,
+      };
     }
-  }, [location.search, activePage.product, activePage.languages]);
+
+    // Use DOM languages if available, otherwise fall back to pageContext languages
+    const activeLanguages = (domLanguages.length > 0 ? domLanguages : pageContext.languages ?? []) as LanguageKey[];
+    const activeLanguage = determineActiveLanguage(activeLanguages, location.search, activePageData.product);
+
+    return {
+      ...activePageData,
+      languages: (activePageData.page.languages as LanguageKey[]) ?? activeLanguages,
+      language: activeLanguage,
+    };
+  }, [location.pathname, location.search, pageContext.languages, domLanguages]);
 
   return (
     <LayoutContext.Provider
       value={{
         activePage,
-        setLanguage,
       }}
     >
       {children}

--- a/src/data/languages/languageData.ts
+++ b/src/data/languages/languageData.ts
@@ -42,4 +42,4 @@ export default {
     swift: 1.0,
     kotlin: 1.7,
   },
-} satisfies Record<ProductKey, Partial<LanguageData>>;
+} satisfies Partial<Record<ProductKey, LanguageData>>;

--- a/src/data/languages/types.ts
+++ b/src/data/languages/types.ts
@@ -26,4 +26,4 @@ export const languageKeys = [
 
 export type LanguageKey = (typeof languageKeys)[number];
 
-export type LanguageData = Record<LanguageKey, number>;
+export type LanguageData = Partial<Record<LanguageKey, number>>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.2.2":
-  version "16.2.2"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.2.tgz#df868de005607ef254710d898e4aa90f67403afb"
-  integrity sha512-UMgvsgk2VkdvOEsDkKgaIYOHaCh3hkJx4s1zSDTgZCH9Yr66uCF2tpLPBxf6wYNVnhcY3BgbI6rFROUDD9E3eQ==
+"@ably/ui@16.2.3":
+  version "16.2.3"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.3.tgz#a86ed31f75f3cb2d5354bdf0802301ea80fcd159"
+  integrity sha512-aywaX8RJH/6BjdJi4foT06++FW8rn1jYtNYZ6DXEa6kuzCKn3lD5rKFqz1N8mCA1Pw6UmOQsXCSqYYDveuk+gQ==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
Sorts out a bunch of state problems involving the Language Selector in the right nav, i.e. not updating properly between page changes and Code Snippet tab changes in upcoming MDX pages. Simplifies the overall LayoutContext as well, removing a setter we no longer need.

Also improves the functionality of the scroll-spy behaviour in the right nav heading list.

Note: needs https://github.com/ably/ably-ui/pull/767 to be merged and released first. (edit, it has been)

Review app: https://ably-docs-web-4360-sele-jsazru.herokuapp.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a suite of styled, responsive table components for improved content presentation.
  - Enhanced sidebar header tracking for better navigation and user experience.

- **Refactor**
  - Centralized SDK state management in code snippets using a new React context.
  - Simplified language selection logic across the app, removing reliance on URL query parameters and explicit state setters.
  - Improved default layout structure to distinguish left and right sidebars.

- **Bug Fixes**
  - Addressed issues with language selection and navigation to ensure accurate language display and switching.

- **Chores**
  - Updated a UI dependency to the latest version.
  - Adjusted layout constants for better interface alignment.

- **Tests**
  - Updated tests to reflect changes in language selection and context management.

- **Style**
  - Improved header and table styling for a more consistent look and feel.

- **Documentation**
  - No user-facing documentation changes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->