### PR TITLE
Remove line about publish on behalf failing when the connectionKey be…

### DIFF
--- a/content/pub-sub/advanced.textile
+++ b/content/pub-sub/advanced.textile
@@ -1115,6 +1115,5 @@ If the realtime connection is "identified":/docs/auth/identified-clients by bein
 The publish attempt will fail in the following scenarios:
 
 * the @connectionKey@ is invalid
-* the @connectionKey@ belongs to a connection that has since been closed
 * the REST publisher is using a different Ably application to the realtime client
 * the @clientId@s don't match between the realtime connection and the REST publish


### PR DESCRIPTION
…longs to a connection that has since been closed

## Description

This was discussed internally a while ago that the point that a publish on behalf will fail if the connection has been closed was not implemented see https://ably-real-time.slack.com/archives/C8SPU4589/p1725016403673869?thread_ts=1695381322.160069&cid=C8SPU4589 

This should be reviewed by the pubsub team to clarify this change in the docs should be approved and merged

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
