### PR TITLE
[WEB-4393] Review app improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.3.0
+  node: circleci/node@7.1.0
 
 parameters:
   content-update:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
     environment:
       PORT: 3001
       STACK: heroku-24
+      ENABLE_BASIC_AUTH: "true"
     steps:
       - checkout
       - attach_workspace:
@@ -122,6 +123,10 @@ jobs:
                 printf '.'
                 sleep 1
             done
+      - run:
+          name: Test basic auth for review apps
+          command: |
+            ./bin/assert-basic-auth.sh /docs/getting-started/quickstart
       - run:
           name: Smoke test trailing slash redirects
           command: |

--- a/app.json
+++ b/app.json
@@ -9,5 +9,11 @@
     {
       "url": "https://github.com/leoafarias/heroku-buildpack-node-modules-cleanup"
     }
-  ]
+  ],
+  "env": {
+    "ENABLE_BASIC_AUTH": {
+      "description": "Enable basic auth for review apps",
+      "value": "true"
+    }
+  }
 }

--- a/bin/assert-basic-auth.sh
+++ b/bin/assert-basic-auth.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# A utility script to assert basic auth is working correctly
+#
+# Usage: assert-basic-auth.sh PATH
+#
+# - PATH - Local URL path, like /docs
+
+URI_PATH=${1}
+
+if [[ -z $URI_PATH ]]; then
+  echo "Usage: assert-basic-auth.sh PATH"
+  exit 1
+fi
+
+# Test without credentials (should get 401)
+NO_AUTH_CODE=$(curl --header "X-Forwarded-Proto: https" \
+                    --silent --output /dev/null \
+                    --write-out "%{http_code}" \
+                    http://localhost:3001${URI_PATH})
+
+if [ ${NO_AUTH_CODE} -ne 401 ]; then
+  echo "Expected 401 status code without credentials, got '${NO_AUTH_CODE}'"
+  exit 1
+fi
+
+# Test with correct credentials (should get 200)
+AUTH_CODE=$(curl --header "X-Forwarded-Proto: https" \
+                 --silent --output /dev/null \
+                 --write-out "%{http_code}" \
+                 --user preview:preview \
+                 http://localhost:3001${URI_PATH})
+
+if [ ${AUTH_CODE} -ne 200 ]; then
+  echo "Expected 200 status code with correct credentials, got '${AUTH_CODE}'"
+  exit 1
+fi
+
+echo "OK: Basic auth is working correctly for '${URI_PATH}'"

--- a/bin/assert-redirect.sh
+++ b/bin/assert-redirect.sh
@@ -16,9 +16,16 @@ if [[ -z $FROM || -z $TO ]]; then
   exit 1
 fi
 
+# Add basic auth if enabled
+AUTH_OPTS=""
+if [[ "${ENABLE_BASIC_AUTH}" == "true" ]]; then
+  AUTH_OPTS="--user preview:preview"
+fi
+
 OUTPUT=$(curl --header "X-Forwarded-Proto: https" \
               --silent --output /dev/null \
               --write-out "%{http_code} %{redirect_url}" \
+              ${AUTH_OPTS} \
               http://localhost:3001${FROM})
 
 CODE=$(echo $OUTPUT | cut -f 1 -d " ")

--- a/bin/assert-success.sh
+++ b/bin/assert-success.sh
@@ -14,9 +14,16 @@ if [[ -z $URI_PATH ]]; then
   exit 1
 fi
 
+# Add basic auth if enabled
+AUTH_OPTS=""
+if [[ "${ENABLE_BASIC_AUTH}" == "true" ]]; then
+  AUTH_OPTS="--user preview:preview"
+fi
+
 CODE=$(curl --header "X-Forwarded-Proto: https" \
               --silent --output /dev/null \
               --write-out "%{http_code}" \
+              ${AUTH_OPTS} \
               http://localhost:3001${URI_PATH})
 
 if [ ${CODE} -ne 200 ]; then

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -13,6 +13,7 @@ PORT=${PORT:-3001} \
     NGINX_ERROR_LOG_PATH=${NGINX_ERROR_LOG_PATH:-"/dev/stderr"} \
     NGINX_ROOT=$(pwd)/public \
     SKIP_HTTPS=${SKIP_HTTPS:-true} \
+    ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-false} \
     erb config/nginx.conf.erb > config/nginx.conf
 
 # Cleanup when we're done

--- a/config/.htpasswd
+++ b/config/.htpasswd
@@ -1,0 +1,1 @@
+preview:$2y$05$lbdXr/rHqkB2cDDZx4x9OOagjzznFBnD3ZOijLD6B7sz..7pmgkrC

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -74,6 +74,12 @@ http {
 
     error_page 404 500 /404.html;
 
+    <% if ENV['ENABLE_BASIC_AUTH'] == 'true' %>
+    # Basic Authentication
+    auth_basic "Restricted Access";
+    auth_basic_user_file .htpasswd;
+    <% end %>
+
     # Removes trailing slashes everywhere (by redirecting)
     rewrite ^/(.*)/$ <%= ENV['SKIP_HTTPS'] == 'true' ? '$scheme' : 'https' %>://$host/$1 permanent;
 

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -9,10 +9,14 @@ const stripTrailingSlash = (str: string) => (str.endsWith('/') ? str.slice(0, -1
 
 const mainWebsite = stripTrailingSlash(process.env.GATSBY_ABLY_MAIN_WEBSITE ?? 'http://localhost:3000');
 
-// Set the provided asset prefix so we can fetch assets from elsewhere when specified
-export const assetPrefix = process.env.ASSET_PREFIX;
+// Define an asset prefix to serve static assets from a different domain or CDN
+// This is used for Heroku PR deployments or when explicitly set via ASSET_PREFIX environment variable
+export const assetPrefix =
+  process.env.ASSET_PREFIX ||
+  (process.env.HEROKU_PR_NUMBER ? `https://${process.env.HEROKU_APP_NAME}.herokuapp.com` : undefined);
 
 export const trailingSlash = 'never';
+
 export const siteMetadata = {
   siteUrl: mainWebsite,
   title: 'Documentation | Ably Realtime',

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -31,7 +31,7 @@ export const siteMetadata = {
     oneTrustTest: process.env.ONE_TRUST_TEST,
     inkeepEnabled: process.env.INKEEP_CHAT_ENABLED,
     inkeepApiKey: process.env.INKEEP_CHAT_API_KEY,
-    insightsEnabled: !!process.env.INSIGHTS_ENABLED,
+    insightsEnabled: process.env.INSIGHTS_ENABLED === 'true',
     insightsDebug: process.env.INSIGHTS_DEBUG === 'true',
     mixpanelApiKey: process.env.MIXPANEL_API_KEY,
     mixpanelAutoCapture: !!process.env.MIXPANEL_AUTO_CAPTURE,


### PR DESCRIPTION
## Description

This PR is a step towards improving our review apps in two key ways: firstly it protects review apps from being accessed by bots/crawlers and secondly it improves the Gatsby config for review apps.

The first bit aligns the docs review apps with the website ones by using HTTP basic auth as wall to prevent indexing and crawling of preview content, especially to feed AI slop machines.

The second, setting an explicit `assetPrefix`, makes it a lot simpler to access review apps via website proxies for testing more deeply integrated features. A fix to how Ably Insights is configured also means it won't show up on review apps.

The review app for this PR already has the basic auth enabled, so you can test it out by visiting the review app URL.

## Bot says 🤖 

This pull request introduces basic authentication for review apps, updates CI/CD configurations, and enhances static asset handling for Heroku PR deployments. The changes ensure better security and flexibility during development and deployment.

### Basic Authentication Implementation:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R87): Added `ENABLE_BASIC_AUTH` environment variable to the review app configuration and included a test step to verify basic authentication. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R87) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R126-R129)
* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L12-R18): Introduced the `ENABLE_BASIC_AUTH` environment variable with a default value of `true`.
* [`config/.htpasswd`](diffhunk://#diff-dd1d7226cf0fd87f5c3be8f35f3dd0f7ce04323ac4d821d2712f4fa375b133a2R1): Added an `.htpasswd` file with credentials for basic authentication.
* [`config/nginx.conf.erb`](diffhunk://#diff-8536d045800ebd99dc58c8e5d9fab522ded64838c446ba361c1c4c6d8ce3b4d4R77-R82): Configured NGINX to enable basic authentication when the `ENABLE_BASIC_AUTH` environment variable is set to `true`.

### CI/CD Updates:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L4-R4): Upgraded the `circleci/node` orb from version `5.3.0` to `7.1.0` for improved compatibility and features.

### Static Asset Handling:
* [`gatsby-config.ts`](diffhunk://#diff-26b5c624a22b9f24d3e683f7ee5b69788ee6b166a655b7423b6a4c5a1ef6f0a1L12-R19): Enhanced the `assetPrefix` configuration to dynamically use a Heroku-specific domain for PR deployments when applicable, improving asset delivery flexibility.

## Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced optional HTTP Basic Authentication for review apps, protecting access with a username and password.
- **Chores**
  - Updated environment variables and configuration files to support authentication and asset serving enhancements.
  - Improved test scripts to verify authentication and adapt to new security settings.
- **Refactor**
  - Enhanced asset prefix logic for serving static assets from Heroku review app domains.
  - Refined environment variable handling for external script settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->