### PR TITLE
[WEB-4394] fix: only set overflow-x on layout container when not control api

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { PageProps } from 'gatsby';
+import { useLocation } from '@reach/router';
+import cn from '@ably/ui/core/utils/cn';
 
 import '../../styles/global.css';
 import { Container } from 'src/components';
@@ -23,14 +25,16 @@ export type PageContextType = {
 type LayoutProps = PageProps<unknown, PageContextType>;
 
 const Layout: React.FC<LayoutProps> = ({ children, pageContext }) => {
+  const location = useLocation();
   const { searchBar, leftSidebar, rightSidebar, template } = pageContext.layout ?? {};
+  const isControlApiPage = location.pathname === '/docs/api/control-api';
 
   return (
     <GlobalLoading template={template}>
       <Header searchBar={searchBar} />
       <div className="flex pt-64 md:gap-48 lg:gap-64 xl:gap-80 justify-center ui-standard-container mx-auto">
         {leftSidebar ? <LeftSidebar /> : null}
-        <Container as="main" className="flex-1 overflow-x-auto">
+        <Container as="main" className={cn('flex-1', { 'overflow-x-auto': !isControlApiPage })}>
           {leftSidebar ? <Breadcrumbs /> : null}
           {children}
           <Footer />


### PR DESCRIPTION
From the MDX work, we set `overflow-x` on the outer container in the layout because it solves a lot of element constraint problems. However, the patchwork quilt of js that is redocly's UI falls apart if you do this.

This PR conditionally sets the overflow property depending on whether you're on the control api or not.