### PR TITLE
Add link to JS getting started in first section of chat intro

### DIFF
--- a/content/chat/index.textile
+++ b/content/chat/index.textile
@@ -9,6 +9,8 @@ Ably Chat is a product dedicated to making it quick and easy to build chat funct
 
 The Chat SDK contains a set of purpose-built APIs that abstract away the complexities involved in how you would architect chat features. It utilizes Ably's platform to benefit from all of the same performance guarantees and scaling potential.
 
+* "Getting started: Chat in JavaScript / TypeScript":/docs/chat/getting-started/javascript
+
 h2(#features). Chat features
 
 Ably Chat provides the following key features:

--- a/content/chat/index.textile
+++ b/content/chat/index.textile
@@ -43,3 +43,11 @@ h3(#reactions). Room reactions
 h2. Demo
 
 Take a look at a "livestream basketball game":https://ably-livestream-chat-demo.vercel.app with some simulated users chatting built using the Chat SDK. The "source code":https://github.com/ably/ably-chat-js/tree/main/demo is available in GitHub.
+
+h2(#next). Next steps
+
+* Read the "JavaScript / TypeScript getting started guide":/docs/chat/getting-started/javascript
+* Read more about using "rooms":/docs/chat/rooms and sending "messages":/docs/chat/rooms/messages.
+* Read into pulling messages from "history":/docs/chat/rooms/history and providing context to new joiners.
+* Learn about how to add "chat moderation":/docs/chat/moderation.
+* Understand "token authentication":/docs/authentication/token-authentication before going to production.


### PR DESCRIPTION
Add a link to the JavaScript/TypeScript getting started guide in the first section of the chat intro.

Add a "What's next" section at the end of the chat intro page.