### PR TITLE
Add chat message reactions HTTP API reference docs

### DIFF
--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -714,7 +714,7 @@ paths:
                   code: 50001
                   statusCode: 500
                   href: "https://help.ably.io/error/50001"
-  /chat/{version}/rooms/{roomId}/messages/{serial}/reactions:
+  /chat/{version}/rooms/{roomName}/messages/{serial}/reactions:
     post:
       summary: Add a reaction to a message
       description: |
@@ -731,12 +731,12 @@ paths:
           schema:
             type: string
             example: v3
-        - name: roomId
+        - name: roomName
           in: path
           required: true
           description: |
             The unique identifier of the room containing the message you wish to add a reaction to.
-            The `roomId` must be URI-encoded.
+            The `roomName` must be URI-encoded.
           schema:
             type: string
         - name: serial
@@ -860,12 +860,12 @@ paths:
           schema:
             type: string
             example: v3
-        - name: roomId
+        - name: roomName
           in: path
           required: true
           description: |
             The unique identifier of the room containing the message with the reaction you wish to delete.
-            The `roomId` must be URI-encoded.
+            The `roomName` must be URI-encoded.
           schema:
             type: string
         - name: serial

--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -714,3 +714,244 @@ paths:
                   code: 50001
                   statusCode: 500
                   href: "https://help.ably.io/error/50001"
+  /chat/{version}/rooms/{roomId}/messages/{serial}/reactions:
+    post:
+      summary: Add a reaction to a message
+      description: |
+        Adds a reaction to a specified message in a room.
+
+        A successful request returns the serial identifier of the newly added reaction. This will also broadcast the reaction to all subscribing members of the room.
+      tags:
+        - rooms
+      parameters:
+        - name: version
+          in: path
+          required: true
+          description: The version of the Chat API endpoint to use.
+          schema:
+            type: string
+            example: v3
+        - name: roomId
+          in: path
+          required: true
+          description: |
+            The unique identifier of the room containing the message you wish to add a reaction to.
+            The `roomId` must be URI-encoded.
+          schema:
+            type: string
+        - name: serial
+          in: path
+          required: true
+          description: |
+            The unique identifier of the message you wish to add a reaction to.
+            The `serial` must be URI-encoded.
+          schema:
+            type: string
+            example: "01826232498871-001@abcdefghij:001"
+        - $ref: '#/components/parameters/ClientIdHeader'
+        - $ref: '#/components/parameters/AuthorizationHeader'
+        - $ref: '#/components/parameters/AcceptHeader'
+      requestBody:
+        description: The reaction details to add to the specified message.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: |
+                    The type of reaction. Must be one of the supported reaction types:
+                    - `reaction:unique.v1`: Each user can add only one reaction of this type with a specific name.
+                    - `reaction:distinct.v1`: Each user can add only one reaction of each name.
+                    - `reaction:multiple.v1`: Users can add multiple reactions with counts.
+                  example: "reaction:unique.v1"
+                  enum:
+                    - "reaction:unique.v1"
+                    - "reaction:distinct.v1"
+                    - "reaction:multiple.v1"
+                name:
+                  type: string
+                  description: |
+                    The name of the reaction, such as an emoji or reaction identifier.
+                    Must not be empty.
+                  example: "like"
+                count:
+                  type: integer
+                  description: |
+                    The count for the reaction. Only applicable for `reaction:multiple.v1` type.
+                    For other types, this field is ignored and should not be provided.
+                    If not provided for `reaction:multiple.v1`, defaults to 1.
+                  minimum: 1
+                  example: 1
+              required:
+                - type
+                - name
+      responses:
+        '201':
+          description: |
+            Successfully added the reaction to the message.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  serial:
+                    type: string
+                    description: The unique identifier for the reaction.
+                    example: "01826232498871-001@abcdefghij:001"
+        '400':
+          description: Invalid request body or parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+        '401':
+          description: Unauthorized access.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Unauthorized access."
+                  code: 40005
+                  statusCode: 401
+                  href: "https://help.ably.io/error/40101"
+        '404':
+          description: Message not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Message not found."
+                  code: 40400
+                  statusCode: 404
+                  href: "https://help.ably.io/error/40401"
+        '500':
+          description: Server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Internal server error."
+                  code: 50001
+                  statusCode: 500
+                  href: "https://help.ably.io/error/50001"
+    
+    delete:
+      summary: Delete a reaction from a message
+      description: |
+        Removes a specific reaction from a message in a room.
+
+        A successful request returns the serial identifier of the deleted reaction. This will also broadcast the deletion to all subscribing members of the room.
+      tags:
+        - rooms
+      parameters:
+        - name: version
+          in: path
+          required: true
+          description: The version of the Chat API endpoint to use.
+          schema:
+            type: string
+            example: v3
+        - name: roomId
+          in: path
+          required: true
+          description: |
+            The unique identifier of the room containing the message with the reaction you wish to delete.
+            The `roomId` must be URI-encoded.
+          schema:
+            type: string
+        - name: serial
+          in: path
+          required: true
+          description: |
+            The unique identifier of the message containing the reaction you wish to delete.
+            The `serial` must be URI-encoded.
+          schema:
+            type: string
+            example: "01826232498871-001@abcdefghij:001"
+        - name: type
+          in: query
+          required: true
+          description: |
+            The type of reaction to delete. Must match one of the supported reaction types.
+          schema:
+            type: string
+            example: "reaction:unique.v1"
+            enum:
+              - "reaction:unique.v1"
+              - "reaction:distinct.v1" 
+              - "reaction:multiple.v1"
+        - name: name
+          in: query
+          required: true
+          description: |
+            The name of the reaction to delete. Required for all reaction types except reaction:unique.v1.
+          schema:
+            type: string
+            example: "like"
+        - $ref: '#/components/parameters/ClientIdHeader'
+        - $ref: '#/components/parameters/AuthorizationHeader'
+        - $ref: '#/components/parameters/AcceptHeader'
+      responses:
+        '200':
+          description: |
+            Successfully deleted the reaction from the message.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  serial:
+                    type: string
+                    description: The unique identifier for the delete annotation.
+                    example: "01826232498871-001@abcdefghij:001"
+        '400':
+          description: Invalid request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+        '401':
+          description: Unauthorized access.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Unauthorized access."
+                  code: 40005
+                  statusCode: 401
+                  href: "https://help.ably.io/error/40101"
+        '404':
+          description: Message or reaction not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Message not found."
+                  code: 40400
+                  statusCode: 404
+                  href: "https://help.ably.io/error/40401"
+        '500':
+          description: Server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInfo'
+              example:
+                error:
+                  message: "Internal server error."
+                  code: 50001
+                  statusCode: 500
+                  href: "https://help.ably.io/error/50001"


### PR DESCRIPTION
## Description

Add HTTP API reference for message reactions.

[CHA-976]

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


[CHA-976]: https://ably.atlassian.net/browse/CHA-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ