### PR TITLE
Improve getting started project setup instructions

### DIFF
--- a/content/chat/getting-started/javascript.textile
+++ b/content/chat/getting-started/javascript.textile
@@ -38,20 +38,23 @@ ably apps switch
 ably auth keys switch
 ```
 
-* Install "Node.js":https://nodejs.org/en version 18 or greater.
-* Install "ts-node":https://www.npmjs.com/package/ts-node to execute TypeScript files:
-
-```[sh]
-npm install ts-node
-```
-
-* Create a new project in your IDE and install the Ably Chat JavaScript SDK. This will also install the Ably Pub/Sub SDK as it is a dependency:
+* Install any current LTS version of "Node.js":https://nodejs.org/en and create a new project:
 
 ```[sh]
 npm init -y
-tsc --init
+```
 
-npm install @ably/chat
+* Install "typescript":https://www.npmjs.com/package/typescript to compile TypeScript files.
+* Install "ts-node":https://www.npmjs.com/package/ts-node to execute TypeScript files directly.
+
+```[sh]
+npm install @ably/chat typescript ts-node
+```
+
+* Create a default TypeScript configuration in your project
+
+```[sh]
+npx tsc --init
 ```
 
 <aside data-type='note'>


### PR DESCRIPTION
Fixes a couple of issues with the javascript project setup here:

- Fixes usage of undocumented `tsc` requirement, now this is explicitly installed with NPM and used from the installed package rather than expected to be installed globally.
- Fixes `npm install` before `npm init -y`, both of these commands create `package.json` if it doesn't already exist but generally you're supposed to init the project first.
- General minor technical wording improvements