### PR TITLE
[WEB-4356] Fix homepage images

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -113,7 +113,7 @@ export const plugins = [
     resolve: 'gatsby-source-filesystem',
     options: {
       name: 'images',
-      path: './src/images/content',
+      path: './src/images',
       fastHash: true,
     },
     __key: 'images',

--- a/src/hooks/use-content-images.tsx
+++ b/src/hooks/use-content-images.tsx
@@ -10,7 +10,7 @@ export type Image = {
 
 export const findImage = (images: Image[]) => {
   return (rawSrc: string) => {
-    const src = rawSrc.replace('@content/', '');
+    const src = rawSrc.replace('@content/', 'content/');
 
     return images.find((image) => image.relativePath === src);
   };
@@ -26,7 +26,7 @@ export const useContentImages = () => {
       }
     }
     query {
-      images: allFile(filter: { sourceInstanceName: { eq: "images" } }) {
+      images: allFile(filter: { sourceInstanceName: { eq: "images" }, relativeDirectory: { glob: "content/**" } }) {
         nodes {
           ...ContentImage
         }

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -46,7 +46,7 @@ const IndexPage = ({
 
 export const query = graphql`
   query HomePageQuery {
-    allFile(filter: { relativeDirectory: { eq: "homepage" } }) {
+    allFile(filter: { sourceInstanceName: { eq: "images" }, relativeDirectory: { eq: "homepage" } }) {
       images: nodes {
         extension
         base


### PR DESCRIPTION
## Description

A change to the 'images' filesystem source in #2614 (7b698bf) was too specific and resulted in the homepage image queries not returning any images.

This PR loosens up the filesystem source and tightens up the GraphQL queries instead, giving us working homepage images and textile images.

Supersedes the nuclear option that was #2617.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
