### PR TITLE
Moderation provider docs

### DIFF
--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -98,6 +98,10 @@ export default {
               name: 'Hive (Dashboard)',
               link: '/docs/chat/moderation/direct/hive-dashboard',
             },
+            {
+              name: 'Tisane',
+              link: '/docs/chat/moderation/direct/tisane',
+            },
           ],
         },
         {

--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -102,6 +102,10 @@ export default {
               name: 'Tisane',
               link: '/docs/chat/moderation/direct/tisane',
             },
+            {
+              name: 'Bodyguard',
+              link: '/docs/chat/moderation/direct/bodyguard',
+            }
           ],
         },
         {

--- a/src/pages/docs/chat/moderation/direct/bodyguard.mdx
+++ b/src/pages/docs/chat/moderation/direct/bodyguard.mdx
@@ -1,0 +1,34 @@
+---
+title: Bodyguard
+meta_description: "Detect and remove unwanted content in a Chat Room using Bodyguard AI."
+---
+
+[Bodyguard](https://bodyguard.ai/) is a powerful contextual analysis platform that can be used to moderate content in chat rooms. 
+
+The Bodyguard rule is a rule applied to chat rooms in Ably Chat which enables you to use Bodyguard's content moderation capabilities to detect and handle inappropriate content before it is published to other users.
+
+## Integration setup <a id="setup"/>
+
+Configure the integration rule in your [Ably dashboard](https://ably.com/accounts/any/apps/any/integrations) or using the [Control API](/docs/account/control-api).
+
+The following are the fields specific to Bodyguard configuration:
+
+| Field | Description |
+| ----- | ----------- |
+| Bodyguard API key | The API key for your Bodyguard account. |
+| Channel ID | The ID of your Bodyguard channel where moderation rules are configured. |
+| Default Language (optional) | The default language to use for content analysis. |
+| Model URL (optional) | A custom URL if using a custom moderation model. |
+| Retry timeout | Maximum duration (in milliseconds) that an attempt to invoke the rule may take (including any retries). The possible range is 0 - 5000ms. |
+| Max retries | Maximum number of retries after the first attempt at invoking the rule. |
+| Failed action | The action to take in the event that a rule fails to invoke. Options are reject the request or publish anyway. |
+| Too many requests action | The action to take in the event that Bodyguard returns a 429 (Too Many Requests Response). Options are to fail rule invocation, or retry. |
+| Room filter (optional) | A regular expression to match to specific chat rooms. |
+
+Messages will be rejected if Bodyguard's analysis returns a `REMOVE` recommended action based on the moderation rules configured in your Bodyguard channel.
+
+## Handling rejections <a id="rejections"/>
+
+If a message fails moderation and the rule policy is to reject, then it will be rejected by the server.
+
+Moderation rejections will use error code `42213`.

--- a/src/pages/docs/chat/moderation/direct/tisane.mdx
+++ b/src/pages/docs/chat/moderation/direct/tisane.mdx
@@ -1,0 +1,31 @@
+---
+title: Tisane
+meta_description: "Detect and remove unwanted content in a Chat Room using Tisane AI."
+---
+
+[Tisane](https://tisane.ai/) is a powerful Natural Language Understanding (NLU) platform that can be used to moderate content in chat rooms. 
+
+The Tisane rule is a rule applied to chat rooms in Ably Chat which enables you to use Tisane's text moderation capabilities to detect and handle inappropriate content before it is published to other users.
+
+## Integration setup <a id="setup"/>
+
+Configure the integration rule in your [Ably dashboard](https://ably.com/accounts/any/apps/any/integrations) or using the [Control API](/docs/account/control-api).
+
+The following are the fields specific to Tisane configuration:
+
+| Field | Description |
+| ----- | ----------- |
+| Tisane API key | The API key for your Tisane account. |
+| Thresholds | A map of [text moderation categories](https://docs.tisane.ai/apis/tisane-api-response-guide#supported-types) to severity levels (`low`, `medium`, `high`, `extreme`). When moderating text, any message deemed to be at or above a specified threshold will be rejected and not published to the chat room. |
+| Model URL (optional) | A custom URL if using a custom moderation model. |
+| Retry timeout | Maximum duration (in milliseconds) that an attempt to invoke the rule may take (including any retries). The possible range is 0 - 5000ms. |
+| Max retries | Maximum number of retries after the first attempt at invoking the rule. |
+| Failed action | The action to take in the event that a rule fails to invoke. Options are reject the request or publish anyway. |
+| Too many requests action | The action to take in the event that Tisane returns a 429 (Too Many Requests Response). Options are to fail rule invocation, or retry. |
+| Room filter (optional) | A regular expression to match to specific chat rooms. |
+
+## Handling rejections <a id="rejections"/>
+
+If a message fails moderation and the rule policy is to reject, then it will be rejected by the server.
+
+Moderation rejections will use error code `42213`.

--- a/src/pages/docs/chat/moderation/index.mdx
+++ b/src/pages/docs/chat/moderation/index.mdx
@@ -44,3 +44,11 @@ The second solution is the [dashboard](https://hivemoderation.com/dashboard). Th
 Tisane provides automated content moderation through their [API solution](https://tisane.ai/). The platform uses Natural Language Understanding (NLU) to analyze user-generated content and categorize it against various criteria for content moderation. Each analysis includes information about the type and location of potentially problematic content, allowing you to determine appropriate moderation actions for your chat room.
 
 Tisane also offers an [on-premises solution](https://tisane.ai/) for organizations that need to deploy the moderation engine within their own infrastructure. Both options can be integrated with Ably to provide automated content moderation for your chat rooms.
+
+### Bodyguard <a id="bodyguard"/>
+
+Bodyguard provides content moderation through their [API solution](https://bamboo.bodyguard.ai/api). The service performs contextual analysis of messages to detect and categorize inappropriate content based on configurable criteria. Each analysis provides detailed information about the content, allowing you to implement appropriate moderation actions in your chat room.
+
+The platform is accessed through a REST API and is integrated with Ably to provide automated content moderation for your chat rooms.
+
+

--- a/src/pages/docs/chat/moderation/index.mdx
+++ b/src/pages/docs/chat/moderation/index.mdx
@@ -39,4 +39,8 @@ Hive provide automated content moderation solutions. The first of these is the [
 
 The second solution is the [dashboard](https://hivemoderation.com/dashboard). This is an all-in-one moderation tool, that allows you to combine automated workflows using ML models as well as human review and decisions to control the content in your chat room.
 
-Ably is able to integrate your chat rooms directly directly with both of these solutions, to allow you to get up and running with Hive moderation with minimal code required.
+### Tisane <a id="tisane"/>
+
+Tisane provides automated content moderation through their [API solution](https://tisane.ai/). The platform uses Natural Language Understanding (NLU) to analyze user-generated content and categorize it against various criteria for content moderation. Each analysis includes information about the type and location of potentially problematic content, allowing you to determine appropriate moderation actions for your chat room.
+
+Tisane also offers an [on-premises solution](https://tisane.ai/) for organizations that need to deploy the moderation engine within their own infrastructure. Both options can be integrated with Ably to provide automated content moderation for your chat rooms.


### PR DESCRIPTION
**don't merge until website/control API have been updated**

Adds docs for the new tisane and bodyguard moderation providers, as implemented in https://github.com/ably/realtime/pull/7151 and https://github.com/ably/realtime/pull/7414 respectively.


https://ably.atlassian.net/browse/CHA-994