### PR TITLE
[WEB-4401] Update nav product idents to heavier-stroked variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "16.2.7",
+    "@ably/ui": "16.2.8",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "16.2.3",
+    "@ably/ui": "16.2.7",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/src/components/Layout/LeftSidebar.tsx
+++ b/src/components/Layout/LeftSidebar.tsx
@@ -126,7 +126,10 @@ const constructProductNavData = (activePageTree: PageTreeNode[], inHeader: boole
 
     return {
       name: product.name,
-      icon: activePageTree[0]?.page.name === product.name ? product.icon.open : product.icon.closed,
+      icon:
+        activePageTree[0]?.page.name === product.name
+          ? { name: product.icon.open, css: 'text-orange-600' }
+          : { name: product.icon.closed },
       onClick: () => {
         // When a product is clicked, find and scroll to any open accordion element
         if (typeof document !== 'undefined') {

--- a/src/data/nav/assettracking.ts
+++ b/src/data/nav/assettracking.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably Asset Tracking',
   link: '/docs/asset-tracking',
   icon: {
-    closed: 'icon-product-asset-tracking-mono',
-    open: 'icon-product-asset-tracking',
+    closed: 'icon-gui-prod-asset-tracking-outline',
+    open: 'icon-gui-prod-asset-tracking-solid',
   },
   content: [
     {

--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably Chat',
   link: '/docs/chat',
   icon: {
-    closed: 'icon-product-chat-mono',
-    open: 'icon-product-chat',
+    closed: 'icon-gui-prod-chat-outline',
+    open: 'icon-gui-prod-chat-solid',
   },
   content: [
     {

--- a/src/data/nav/liveobjects.ts
+++ b/src/data/nav/liveobjects.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably LiveObjects',
   link: '/docs/liveobjects',
   icon: {
-    closed: 'icon-product-liveobjects-mono',
-    open: 'icon-product-liveobjects',
+    closed: 'icon-gui-prod-liveobjects-outline',
+    open: 'icon-gui-prod-liveobjects-solid',
   },
   content: [
     {

--- a/src/data/nav/livesync.ts
+++ b/src/data/nav/livesync.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably LiveSync',
   link: '/docs/livesync',
   icon: {
-    closed: 'icon-product-livesync-mono',
-    open: 'icon-product-livesync',
+    closed: 'icon-gui-prod-livesync-outline',
+    open: 'icon-gui-prod-livesync-solid',
   },
   content: [
     {

--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably Pub/Sub',
   link: '/docs/basics',
   icon: {
-    closed: 'icon-product-pubsub-mono',
-    open: 'icon-product-pubsub',
+    closed: 'icon-gui-prod-pubsub-outline',
+    open: 'icon-gui-prod-pubsub-solid',
   },
   content: [
     {

--- a/src/data/nav/spaces.ts
+++ b/src/data/nav/spaces.ts
@@ -4,8 +4,8 @@ export default {
   name: 'Ably Spaces',
   link: '/docs/spaces',
   icon: {
-    closed: 'icon-product-spaces-mono',
-    open: 'icon-product-spaces',
+    closed: 'icon-gui-prod-spaces-outline',
+    open: 'icon-gui-prod-spaces-solid',
   },
   content: [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.2.7":
-  version "16.2.7"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.7.tgz#96af2cdf902dbc9251efaf6ea10704e7736e4115"
-  integrity sha512-UUbDscLtGXDPQ3UCm5YKFx+IxUFthDYeH3pQGEVueobONQOolEQUEJ5o8Hcae8oKqK57uOE76mRkLbsvwNecKg==
+"@ably/ui@16.2.8":
+  version "16.2.8"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.8.tgz#928bc0615e241471bac53cfef040c835c48e1619"
+  integrity sha512-lK+2nZL3+vE6wQQ57P1GppMQjuN9tGriE8Yh2iXQYhzDW15wqztl//cRL9KsIXiluaoDRrK9oj0T8IYCSi6bQw==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,17 +7,16 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@16.2.3":
-  version "16.2.3"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.3.tgz#a86ed31f75f3cb2d5354bdf0802301ea80fcd159"
-  integrity sha512-aywaX8RJH/6BjdJi4foT06++FW8rn1jYtNYZ6DXEa6kuzCKn3lD5rKFqz1N8mCA1Pw6UmOQsXCSqYYDveuk+gQ==
+"@ably/ui@16.2.7":
+  version "16.2.7"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-16.2.7.tgz#96af2cdf902dbc9251efaf6ea10704e7736e4115"
+  integrity sha512-UUbDscLtGXDPQ3UCm5YKFx+IxUFthDYeH3pQGEVueobONQOolEQUEJ5o8Hcae8oKqK57uOE76mRkLbsvwNecKg==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"
     "@radix-ui/react-select" "^2.2.2"
     "@radix-ui/react-switch" "^1.1.1"
     "@radix-ui/react-tabs" "^1.1.1"
-    addsearch-js-client "^1.0.2"
     array-flat-polyfill "^1.0.1"
     clsx "^2.1.1"
     dompurify "^3.2.4"
@@ -4701,17 +4700,6 @@ addsearch-js-client@^0.7.0:
     es6-promise "^4.2.8"
     js-base64 "^3.6.0"
 
-addsearch-js-client@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/addsearch-js-client/-/addsearch-js-client-1.0.3.tgz"
-  integrity sha512-B1Dr4LgNn2axrBfMMK9ApTXLNVjyDrO4tpubRoTOZKV9J95uep39w5zdV5U256K5X0Ju7eee1LBRZeIdoXMfiw==
-  dependencies:
-    axios "^1.7.2"
-    buffer "^6.0.3"
-    es6-promise "^4.2.8"
-    js-base64 "^3.6.0"
-    uuid "^11.0.3"
-
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
@@ -5185,15 +5173,6 @@ axios@^1.6.4:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
   integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.7.2:
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz"
-  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -15513,16 +15492,7 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16747,11 +16717,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid@^11.0.3:
-  version "11.0.5"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz"
-  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Updates the product icons in the left-hand nav for product headers in the closed state. They all now use the heavier stroke weight to bring them in line with the Platform icon.

Test would be go to a random product page like [this](https://ably-docs-web-4401-prod-ajcwmk.herokuapp.com/docs/chat/rooms/messages), all of the icons in the left bar should be as thick as each other.