### PR TITLE
Chat: Bump api version in API docs

### DIFF
--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ably Chat REST API
-  version: 2.0.0
+  version: 3.0.0
   description: |
     # Chat API
 


### PR DESCRIPTION
## Description

Bumping the version in the API docs to 3.0.0 to reflect the move to single channel.