### PR TITLE
Fix: make it clear in push admin that it is a push sub

### DIFF
--- a/content/partials/types/_push_admin.textile
+++ b/content/partials/types/_push_admin.textile
@@ -347,7 +347,7 @@ bq(definition).
   swift,objc: listChannels(params: NSDictionary *, callback: (("ARTPaginatedResult":#paginated-result?, ARTErrorInfo?) -> Void)
   java,android: "PaginatedResult":#paginated-result listChannels(Param[] params)
 
-Retrieve a list of channels with at least one subscribed device as a paginated list of channel name @String@ objects. Requires @push-admin@ permission.
+Retrieve a list of channels that have at least one device "subscribed to push notifications":/docs/push/publish#sub-channels as a paginated list of channel name @String@ objects. Requires @push-admin@ permission.
 
 h4. Parameters
 


### PR DESCRIPTION
## Description

This PR makes it clear that the push admin channel subscription enumeration only returns those devices specifically subscribed to receive push notifications. 

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
