### PR TITLE
Fix the LiveObjects quick start examples

### DIFF
--- a/content/liveobjects/quickstart.textile
+++ b/content/liveobjects/quickstart.textile
@@ -178,11 +178,11 @@ blang[javascript].
   await visitsCounter.increment(5);
   // console: "Visits counter updated: 5"
   await visitsCounter.decrement(2);
-  // console: "Visits counter updated: 2"
+  // console: "Visits counter updated: 3"
 
   await reactionsMap.set('like', 10);
   // console: "Reactions map updated: [['like',10]]"
-  await reactionsMap.set('love', 10);
+  await reactionsMap.set('love', 5);
   // console: "Reactions map updated: [['like',10],['love',5]]"
   await reactionsMap.remove('like');
   // console: "Reactions map updated: [['love',5]]"


### PR DESCRIPTION
## Description

This fixes the LiveObjects quick start examples:

- decrementing a counter from 5 by 2 results in 3
- align the setting of `love` in the map with the comment

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
