### PR TITLE
add link to downgrade steps to close your account section

### DIFF
--- a/content/account/users.textile
+++ b/content/account/users.textile
@@ -39,19 +39,19 @@ User roles have the following permissions:
 
 h3(#change). Change user roles
 
-To add or remove roles from a user:
+The following steps add or remove roles from a user within an Ably account. You must be an account owner or admin to change user roles:
 
 1. Log in to your "account":https://ably.com/accounts/any.
 2. Select *Users* from the account navigation dropdown.
 3. Click the checkboxes corresponding to the roles you want to add or remove.
 
 <aside data-type='note'>
-<p> Follow "this process":https://faqs.ably.com/can-i-change-my-ably-account-owner to change account ownership.</p>
+<p> Follow "this process":https://faqs.ably.com/can-i-change-my-ably-account-owner to transfer account ownership.</p>
 </aside>
 
 h2(#invite). Invite a new user
 
-To invite a new user to your account:
+The following steps invite a new user to your account. You must be an account owner or admin to invite new users:
 
 1. Log in to your "account":https://ably.com/accounts/any.
 2. Select *Users* from the account navigation dropdown.
@@ -63,36 +63,52 @@ To invite a new user to your account:
 <p> You can view the status of pending invitations from the *Users* page. You can also re-send or revoke an invitation.</p>
 </aside>
 
-h3(#remove). Remove a user
+h2(#remove). Remove users from an account
 
-To remove a user from your account:
+The following steps remove a user from your account. You must be an account owner or admin to remove users:
 
 1. Log in to your "account":https://ably.com/accounts/any.
 2. Select *Users* from the account navigation dropdown.
-3. Click the *Delete* button next to the user to remove from the account.
-4. Confirm the action.
+3. Click the *Remove* button next to the user to remove them from the account.
+4. Confirm the action when prompted.
+
+h2(#leave). Delete your profile or leave an account
+
+The following steps delete your profile or remove yourself from an Ably account:
+
+1. Log in to your "account":https://ably.com/accounts/any.
+2. Go to "My Settings":https://ably.com/users/edit.
+3. "Disconnect SSO provider":#sso if you use SSO to log in.
+4. Scroll to *"Want to delete your profile?"*
+5. Click *Start* to remove yourself from this account.
+
+<aside data-type='important'>
+<p>*Account owners:* Deleting your profile will delete the entire account and all data. You must first "transfer ownership":https://faqs.ably.com/can-i-change-my-ably-account-owner to another user before deleting your profile.</p>
+</aside>
 
 h2(#close). Close your account
 
-You can close your account at any time by downgrading to the "Free package":/docs/pricing/free. Use the following steps to close your account:
+To close your Ably account, you must be the account owner and have downgraded to the Free package. The following steps outline the process to close your account:
 
-* Log in to your "account":https://ably.com/accounts/any.
-* Ensure you are the account "owner":/docs/account/users#roles.
-* Downgrade your paid "package":/docs/pricing#packages to Free:
-** Navigate to *Account* then "Billing":https://ably.com/accounts/any/package.
-** Click *Save billing details* to save your changes.
-* After your account has been downgraded to *Free*, go to the "My Settings":https://ably.com/users/edit page.
-** Navigate to *Want to delete your profile?*.
-** Click *start* to begin the closure process.
-* On the *Close Your Ably Account* page:
-** Review the account summary, including ownership, package type, and app details.
-** Click *Confirm Closure* to permanently deactivate your Ably account.
-
-Your account closure will take effect at the start of the next billing cycle (on the 1st of the month), once Ably confirms that your final invoice has been paid.
+* Log in to your "Ably account":https://ably.com/accounts/any.
+* Confirm that you are the "account owner":/docs/account/users#roles.
+* "Downgrade your current package":/docs/pricing/free#downgrade to the "Free package":/docs/pricing#packages.
 
 <aside data-type='note'>
-  <p>Be aware that this will permanently delete all information associated with your account, preventing future logins and removing your access to any other Ably accounts you are associated with. </p>
+  <p>You will not be able to delete your account until the 1st of the month following your downgrade, after your final invoice has been paid. </p>
 </aside>
+
+* "Disconnect SSO provider":#sso if you use SSO to log in.
+* Go to your "My Settings":https://ably.com/users/edit page.
+* Scroll to *Want to delete your profile?*
+
+<aside data-type='note'>
+  <p>If you are using an SSO login you'll see a *Contact us* link instead of a *Start* button, you'll need to "disconnect your SSO provider":#sso first. </p>
+</aside>
+
+* Click *Start* to proceed with permanently closing your account.
+* On the proceeding *Close Your Ably Account* page, review the accounts for closure.
+* Click *Close Account* to permanently deactivate your account.
 
 h3(#sso). Disconnect SSO provider
 


### PR DESCRIPTION
## Description

We say in the current steps in https://ably.com/docs/account/users#close

- Downgrade your paid [package](https://ably.com/docs/pricing#packages) to Free:
  - Navigate to Account then [Billing](https://ably.com/accounts/any/package).
  - Click Save billing details to save your changes.
  
Specifically "click save billing details to save your changes" is unrelated to the downgrade package steps and where in https://ably.com/docs/pricing/free#downgrade we say "click the Downgrade button"

