### PR TITLE
[EDU-1974] Ensure page titles aren't duplicated with use of 'overview'

### DIFF
--- a/content/account/app/index.textile
+++ b/content/account/app/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: App management overview
 meta_description: " Manage and monitor your applications on the Ably platform using the Ably dashboard. Create new apps, view existing ones, and configure settings from your browser."
 meta_keywords: “Ably dashboard, manage applications, monitor apps, app creation, application settings, Ably platform”
 ---

--- a/content/auth/index.textile
+++ b/content/auth/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+title: Authentication overview
 meta_description: "Ably supports two main authentication schemes: basic authentication and token authentication. Token authentication can be implemented using JWTs, Ably tokens, and Ably token requests."
 redirect_from:
   - /docs/rest/authentication
@@ -19,7 +19,7 @@ redirect_from:
   - /docs/general/_authentication_capabilities
 ---
 
-Before a client or server can issue requests to Ably, such as subscribe to channels, or publish messages, it must authenticate with Ably. Authentication requires an Ably API key. 
+Before a client or server can issue requests to Ably, such as subscribe to channels, or publish messages, it must authenticate with Ably. Authentication requires an Ably API key.
 
 h2(#api-keys). Ably API keys
 
@@ -27,7 +27,7 @@ Every Ably app can have one or more API keys associated with it in order to auth
 
 h3(#format). API key format
 
-An Ably API key string has the following format: @I2E_JQ.OqUdfg:EVKVTCBlzLBPYJiCZTsIW_pqylJ9WVRB5K9P19Ap1y0@.  
+An Ably API key string has the following format: @I2E_JQ.OqUdfg:EVKVTCBlzLBPYJiCZTsIW_pqylJ9WVRB5K9P19Ap1y0@.
 
 The API key is made up of three parts:
 
@@ -61,23 +61,23 @@ h2(#mechanisms). Available authentication mechanisms
 The two authentication mechanisms available to authenticate with Ably are:
 
 1. "Basic authentication":/docs/auth/basic, which uses your Ably API key directly.
-2. "Token authentication":/docs/auth/token, which uses short-lived tokens for access. These tokens are periodically renewed, and can be revoked if required. 
+2. "Token authentication":/docs/auth/token, which uses short-lived tokens for access. These tokens are periodically renewed, and can be revoked if required.
 
 h3(#client). Client-side authentication
 
-"Token authentication":/docs/auth/token is the recommended authentication mechanism on the client-side, as it provides more fine-grained access control and limits the risk of exposing your Ably API key. 
+"Token authentication":/docs/auth/token is the recommended authentication mechanism on the client-side, as it provides more fine-grained access control and limits the risk of exposing your Ably API key.
 
-In production systems you should never use basic authentication on the client-side as it exposes your Ably API key. API keys don't have an expiry, so once compromised, they could be used indefinitely by an attacker. 
+In production systems you should never use basic authentication on the client-side as it exposes your Ably API key. API keys don't have an expiry, so once compromised, they could be used indefinitely by an attacker.
 
 Tokens have an expiry, and so there is only a small period of time during which the compromised token can be used. It is also possible to "revoke tokens":/docs/auth/revocation, should that be necessary for security reasons.
 
 h3(#server). Server-side authentication
 
-Use "basic authentication":/docs/auth/basic on the server-side. You should never use token authentication server-side, as this results in unnecessary overhead due the server needing to periodically make token requests to authenticate itself. 
+Use "basic authentication":/docs/auth/basic on the server-side. You should never use token authentication server-side, as this results in unnecessary overhead due the server needing to periodically make token requests to authenticate itself.
 
 h2(#selecting-auth). Selecting an authentication mechanism
 
-When deciding on which authentication method you will be using, it is recommended you bear in mind the "principle of least privilege":https://en.wikipedia.org/wiki/Principle_of_least_privilege. 
+When deciding on which authentication method you will be using, it is recommended you bear in mind the "principle of least privilege":https://en.wikipedia.org/wiki/Principle_of_least_privilege.
 
 A client should ideally only possess the credentials and rights that it needs to accomplish what it wants. This way, if the credentials are compromised, the rights that can be abused by an attacker are minimized.
 

--- a/content/channels/options/index.textile
+++ b/content/channels/options/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Channel options
+title: Channel options overview
 meta_description: "Channel options customize the functionality of channels."
 languages:
   - csharp

--- a/content/connect/index.textile
+++ b/content/connect/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Connections
+title: Connections overview
 meta_description: "Establish and maintain a persistent connection to Ably using the realtime interface of an Ably SDK."
 languages:
   - javascript

--- a/content/metadata-stats/metadata/index.textile
+++ b/content/metadata-stats/metadata/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Metadata
+title: Metadata overview
 meta_description: "Metadata retrieves information about app activity, such as connections, channels and API requests."
 redirect_from:
   - /docs/realtime/channel-metadata

--- a/content/presence-occupancy/index.textile
+++ b/content/presence-occupancy/index.textile
@@ -1,9 +1,9 @@
 ---
-title: Overview
+title: Presence and occupancy overview
 meta_description: "Presence and occupancy provide information about clients attached to channels. This includes metrics about the attached clients, and details of the individual members attached to the channel."
 ---
 
-"Presence":/docs/presence-occupancy/presence and "occupancy":/docs/presence-occupancy/occupancy are features that provide information about the clients and "connections":/docs/connect attached to a channel. Occupancy returns high level metrics about the clients attached to a channel, whereas presence provides details about individual members that have joined a channel's presence set. 
+"Presence":/docs/presence-occupancy/presence and "occupancy":/docs/presence-occupancy/occupancy are features that provide information about the clients and "connections":/docs/connect attached to a channel. Occupancy returns high level metrics about the clients attached to a channel, whereas presence provides details about individual members that have joined a channel's presence set.
 
 h2(#presence-vs-occupancy). Occupancy versus presence
 

--- a/content/push/index.textile
+++ b/content/push/index.textile
@@ -1,5 +1,5 @@
 ---
-title: Push notifications
+title: Push notifications overview
 meta_description: "Ably delivers push notifications to user devices or browsers."
 meta_keywords: "Push, push notifications, Apple push notification service, Google Firebase cloud messaging service, APNs, FCM, Web Push"
 redirect_from:


### PR DESCRIPTION
## Description

This PR updates existing page titles to include the topic, and/or 'overview' when referring to a section. This is to avoid duplication of page titles throughout. It does not effect the side navigation. 

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
