### PR TITLE
Added extras to push docs for Swift

### DIFF
--- a/content/push/publish.textile
+++ b/content/push/publish.textile
@@ -1193,6 +1193,25 @@ channel = realtime.channels.get('pushenabled:foo');
 channel.publish(message);
 ```
 
+```[realtime_swift]
+let extras = ["push": [
+    "notification": [
+        "title": "Hello from Ably!",
+        "body": "Example push notification from Ably!"
+    ]
+]] as any ARTJsonCompatible
+
+let message = ARTMessage(name: "name", data: "data")
+message.extras = extras
+
+let channel = realtime.channels.get("pushenabled:foo")
+channel.publish([message]) { error in
+    if let error = error {
+        print("Error publishing message: \(error)")
+    }
+}
+```
+
 ```[rest_javascript]
 var extras = {
   push: {


### PR DESCRIPTION
## Description

Raised an issue in [this repo](https://github.com/ably/docs/issues/2638), there was a Swift code sample for adding extras param to the push notifications section missing.