### PR TITLE
chat: add react message reactions examples, restructure message reactions page

### DIFF
--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -15,9 +15,17 @@ The reaction `name` can be any string. Summaries are aggregated based on unique 
 
 ## Adding a message reaction <a id="adding-reactions"/>
 
+<If lang="javascript,swift,kotlin">
 To add a message reaction use `room.messages.reactions.send(message, params)`. This method takes the following parameters:
 * `message` - The message to add the reaction to. It can also be an object of format `{serial: "message serial"}`.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
+</If>
+
+<If lang="react">
+Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to add a reaction to a message. This method takes the following parameters:
+* `message` - The message to add the reaction to. It can also be an object of format `{serial: "message serial"}`.
+* `params` - Set the `name`, and optionally override the `type` or set a `count`.
+</If>
 
 <Code>
 ```javascript
@@ -87,9 +95,121 @@ room.messages.reactions.send(message,
   count = 100,
 )
 ```
+
+```react
+import { MessageReactionType } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const { addReaction } = useMessages();
+
+  const handleAddReaction = async (message) => {
+    try {
+      // Add a 👍 reaction using the default type
+      await addReaction(message, { name: '👍' });
+
+      // The reaction can be anything, not just UTF-8 emojis:
+      await addReaction(message, { name: ':like:' });
+      await addReaction(message, { name: '+1' });
+
+      // Add a :love: reaction using the Unique type
+      await addReaction(message, {
+        name: ':love:',
+        type: MessageReactionType.Unique,
+      });
+
+      // Add a ❤️ reaction with count 100 using the Multiple type
+      await addReaction(message, {
+        name: '❤️',
+        type: MessageReactionType.Multiple,
+        count: 100,
+      });
+    } catch (error) {
+      console.error('Error adding reaction:', error);
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={() => handleAddReaction(message)}>Add Reaction</button>
+    </div>
+  );
+};
+```
 </Code>
 
 The `annotation-publish` capability is required for adding reactions.
+
+## Removing a message reaction <a id="removing-reactions"/>
+
+<If lang="javascript,swift,kotlin">
+To remove a message reaction use `room.messages.reactions.delete(message, params)`. This method takes the following parameters:
+* `message` - The message to remove the reaction from. It can also be an object of format `{serial: "message serial"}`.
+* `params` - Set the `name`, and optionally override the `type` or set a `count`.
+</If>
+
+<If lang="react">
+Use the [`deleteReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#deleteReaction) method available from the response of the `useMessages` hook to remove a reaction from a message. This method takes the following parameters:
+* `message` - The message to remove the reaction from. It can also be an object of format `{serial: "message serial"}`.
+* `params` - Set the `name`, and optionally override the `type` or set a `count`.
+</If>
+
+<Code>
+```javascript
+// Remove a 👍 reaction using the default type
+await room.messages.reactions.delete(message, { name: '👍' });
+
+// Remove a :love: reaction using the Unique type
+await room.messages.reactions.delete(message, {
+    name: ':love:',
+    type: MessageReactionType.Unique,
+});
+
+// Remove a ❤️ reaction with count 50 using the Multiple type
+await room.messages.reactions.delete(message, {
+    name: '❤️',
+    type: MessageReactionType.Multiple,
+    count: 50,
+});
+```
+
+```react
+import { MessageReactionType } from '@ably/chat';
+import { useMessages } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const { deleteReaction } = useMessages();
+
+  const handleRemoveReaction = async (message) => {
+    try {
+      // Remove a 👍 reaction using the default type
+      await deleteReaction(message, { name: '👍' });
+
+      // Remove a :love: reaction using the Unique type
+      await deleteReaction(message, {
+        name: ':love:',
+        type: MessageReactionType.Unique,
+      });
+
+      // Remove a ❤️ reaction with count 50 using the Multiple type
+      await deleteReaction(message, {
+        name: '❤️',
+        type: MessageReactionType.Multiple,
+        count: 50,
+      });
+    } catch (error) {
+      console.error('Error removing reaction:', error);
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={() => handleRemoveReaction(message)}>Remove Reaction</button>
+    </div>
+  );
+};
+```
+</Code>
 
 ## Types of message reactions <a id="types-of-reactions"/>
 
@@ -133,6 +253,26 @@ val room = ablyChatClient.rooms.get("room1") {
         defaultMessageReactionType = MessageReactionType.Unique
     }
 }
+```
+
+```react
+import { MessageReactionType } from '@ably/chat';
+import { useChatClient } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const chatClient = useChatClient();
+
+  const getRoom = async () => {
+    const room = await chatClient.rooms.get('room1', {
+      messages: {
+        defaultMessageReactionType: MessageReactionType.Unique,
+      },
+    });
+    return room;
+  };
+
+  // ... rest of component
+};
 ```
 </Code>
 
@@ -181,7 +321,13 @@ Always call `Message.with(event)` when applying message events and reaction even
 
 ## Subscribing to message reactions <a id="subscribe"/>
 
+<If lang="javascript,swift,kotlin">
 Ably generates a summary (aggregate) of the reactions for each message and for each reaction type. For displaying accurate counts for message reactions, subscribe to changes in the message summary.
+</If>
+
+<If lang="react">
+Subscribe to message reactions with the [`useMessages`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/functions/chat-react.useMessages.html) hook. Supply a `reactionsListener` to receive message reaction summary events. Ably generates a summary (aggregate) of the reactions for each message and for each reaction type. For displaying accurate counts for message reactions, subscribe to changes in the message summary.
+</If>
 
 <Code>
 ```javascript
@@ -189,6 +335,7 @@ room.messages.reactions.subscribe((event) => {
     console.log("received reactions summary event", event);
 });
 ```
+
 ```swift
 room.messages.reactions.subscribe { event in
     print("received reactions summary event: \(event)")
@@ -199,6 +346,20 @@ room.messages.reactions.subscribe { event in
 room.messages.reactions.subscribe { event ->
     println("received reactions summary event: $event")
 }
+```
+
+```react
+import { useMessages } from '@ably/chat/react';
+
+const MyComponent = () => {
+  useMessages({
+    reactionsListener: (event) => {
+      console.log("received reactions summary event", event);
+    },
+  });
+
+  return <div>...</div>;
+};
 ```
 </Code>
 
@@ -259,6 +420,47 @@ room.messages.reactions.subscribe { event ->
     }
 }
 ```
+
+```react
+import { useState, useEffect } from 'react';
+import { useMessages, Message } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  const { get } = useMessages({
+    reactionsListener: (event) => {
+      // find the relevant message (in practice: use binary search or a map for lookups)
+      setMessages((prevMessages) => {
+        const idx = prevMessages.findLastIndex((msg) => msg.serial === event.summary.messageSerial);
+        if (idx === -1) {
+          // not found
+          return prevMessages;
+        }
+        // update message
+        const updatedMessages = [...prevMessages];
+        updatedMessages[idx] = updatedMessages[idx].with(event);
+        return updatedMessages;
+      });
+    },
+  });
+
+  // Initialize messages on component mount
+  useEffect(() => {
+    const initMessages = async () => {
+      try {
+        const result = await get({ limit: 50 });
+        setMessages(result.items);
+      } catch (error) {
+        console.error('Error fetching messages:', error);
+      }
+    };
+    initMessages();
+  }, [get]);
+
+  return <div>...</div>;
+};
+```
 </Code>
 
 ### Summary events are sent efficiently at scale <a id="throttle"/>
@@ -269,9 +471,17 @@ If multiple reactions are added in a short period of time, multiple reactions ma
 
 ### Subscribing to raw reactions <a id="raw-reactions"/>
 
+<If lang="javascript,swift,kotlin">
 Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.
 
 Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can configure them via a room option which, in turn, sets the appropriate channel options to enable receiving individual annotations and reactions:
+</If>
+
+<If lang="react">
+Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.
+
+Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can configure them via a room option which, in turn, sets the appropriate channel options to enable receiving individual annotations and reactions:
+</If>
 
 <Code>
 ```javascript
@@ -298,9 +508,34 @@ val room = ablyChatClient.rooms.get("room1") {
     }
 }
 ```
+
+```react
+import { useChatClient } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const chatClient = useChatClient();
+
+  const getRoom = async () => {
+    const room = await chatClient.rooms.get('room1', {
+      messages: {
+        rawMessageReactions: true,
+      },
+    });
+    return room;
+  };
+
+  // ... rest of component
+};
+```
 </Code>
 
+<If lang="javascript,swift,kotlin">
 Then you can receive raw reactions using the `room.messages.reactions.subscribeRaw()` method:
+</If>
+
+<If lang="react">
+Then you can receive raw reactions using the `rawReactionsListener` parameter in the `useMessages` hook:
+</If>
 
 <Code>
 ```javascript
@@ -331,6 +566,24 @@ room.messages.reactions.subscribeRaw { event ->
         println("reaction removed: ${event.reaction}")
     }
 }
+```
+
+```react
+import { MessageReactionEvents, useMessages } from '@ably/chat/react';
+
+const MyComponent = () => {
+  useMessages({
+    rawReactionsListener: (event) => {
+      if (event.type === MessageReactionEvents.Create) {
+        console.log("new reaction", event.reaction);
+      } else if (event.type === MessageReactionEvents.Delete) {
+        console.log("reaction removed", event.reaction);
+      }
+    },
+  });
+
+  return <div>...</div>;
+};
 ```
 </Code>
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -210,13 +210,13 @@ The `annotation-publish` capability is required for adding reactions.
 
 <If lang="javascript,swift,kotlin">
 To remove a message reaction use `room.messages.reactions.delete(message, params)`. This method takes the following parameters:
-* `message` - The message to remove the reaction from. It can also be an object of format `{serial: "message serial"}`.
+* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
 <If lang="react">
 Use the [`deleteReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#deleteReaction) method available from the response of the `useMessages` hook to remove a reaction from a message. This method takes the following parameters:
-* `message` - The message to remove the reaction from. It can also be an object of format `{serial: "message serial"}`.
+* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
@@ -502,17 +502,9 @@ If multiple reactions are added in a short period of time, multiple reactions ma
 
 ### Subscribing to raw reactions <a id="raw-reactions"/>
 
-<If lang="javascript,swift,kotlin">
 Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.
 
 Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can configure them via a room option which, in turn, sets the appropriate channel options to enable receiving individual annotations and reactions:
-</If>
-
-<If lang="react">
-Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.
-
-Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can configure them via a room option which, in turn, sets the appropriate channel options to enable receiving individual annotations and reactions:
-</If>
 
 <Code>
 ```javascript

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -13,6 +13,71 @@ The reaction `name` represents the reaction itself, for example an emoji. Reacti
 
 The reaction `name` can be any string. Summaries are aggregated based on unique `name` values. UTF-8 emojis are a common use case, but any string can be used as long as they are consistent across all front-ends of your app. Examples of common reaction names are `👍`, `❤️`, `:like:`, `like`, `+1`, and so on. How those are presented to the user is entirely up to the app.
 
+## Types of message reactions <a id="types-of-reactions"/>
+
+Ably Chat supports three types of message reactions. They differ in how they are aggregated and what are the rules for adding and removing them.
+
+| Type | Description | Example | Similar to |
+| ---- | ----------- | ------- | --------- |
+| `Unique`, `reaction:unique.v1` | A user can react to a message only once, with a reaction of their choice. When a user reacts a second time their reaction is changed. | Can 👍 or ❤️ but not both or more than once. | iMessage, WhatsApp, Facebook Messenger |
+| `Distinct`, `reaction:distinct.v1` | A user can react to a message with each reaction at most once. | Can 👍 and ❤️ but each reaction only once. No 👍👍. | Slack |
+| `Multiple`, `reaction:multiple.v1` | A user can react to a message with any reactions as many times as they like. Optionally a `count` parameter can be set when reacting. Reacting again adds to the existing count.| Can 👍 10 times and ❤️ 100 times. | Claps on Medium |
+
+Note that if adding two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
+
+### Configure the default reaction type <a id="default-type"/>
+
+The default reaction type can be configured at room-level using the Room Options. If nothing is set, the default is `Distinct`.
+
+<Code>
+```javascript
+import { MessageReactionType } from '@ably/chat';
+
+const room = await ablyChatClient.rooms.get('room1', {
+    messages: {
+        defaultMessageReactionType: MessageReactionType.Unique,
+    },
+});
+```
+
+```swift
+let room = try await ablyChatClient.rooms.get(
+    name: "room1",
+    options: .init(
+        messages: .init(defaultMessageReactionType: .unique)
+    )
+)
+```
+
+```kotlin
+val room = ablyChatClient.rooms.get("room1") {
+    messages {
+        defaultMessageReactionType = MessageReactionType.Unique
+    }
+}
+```
+
+```react
+import { MessageReactionType } from '@ably/chat';
+import { useChatClient } from '@ably/chat/react';
+
+const MyComponent = () => {
+  const chatClient = useChatClient();
+
+  const getRoom = async () => {
+    const room = await chatClient.rooms.get('room1', {
+      messages: {
+        defaultMessageReactionType: MessageReactionType.Unique,
+      },
+    });
+    return room;
+  };
+
+  // ... rest of component
+};
+```
+</Code>
+
 ## Adding a message reaction <a id="adding-reactions"/>
 
 <If lang="javascript,swift,kotlin">
@@ -207,71 +272,6 @@ const MyComponent = () => {
       <button onClick={() => handleRemoveReaction(message)}>Remove Reaction</button>
     </div>
   );
-};
-```
-</Code>
-
-## Types of message reactions <a id="types-of-reactions"/>
-
-Ably Chat supports three types of message reactions. They differ in how they are aggregated and what are the rules for adding and removing them.
-
-| Type | Description | Example | Similar to |
-| ---- | ----------- | ------- | --------- |
-| `Unique`, `reaction:unique.v1` | A user can react to a message only once, with a reaction of their choice. When a user reacts a second time their reaction is changed. | Can 👍 or ❤️ but not both or more than once. | iMessage, WhatsApp, Facebook Messenger |
-| `Distinct`, `reaction:distinct.v1` | A user can react to a message with each reaction at most once. | Can 👍 and ❤️ but each reaction only once. No 👍👍. | Slack |
-| `Multiple`, `reaction:multiple.v1` | A user can react to a message with any reactions as many times as they like. Optionally a `count` parameter can be set when reacting. Reacting again adds to the existing count.| Can 👍 10 times and ❤️ 100 times. | Claps on Medium |
-
-Note that if adding two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
-
-### Configure the default reaction type <a id="default-type"/>
-
-The default reaction type can be configured at room-level using the Room Options. If nothing is set, the default is `Distinct`.
-
-<Code>
-```javascript
-import { MessageReactionType } from '@ably/chat';
-
-const room = await ablyChatClient.rooms.get('room1', {
-    messages: {
-        defaultMessageReactionType: MessageReactionType.Unique,
-    },
-});
-```
-
-```swift
-let room = try await ablyChatClient.rooms.get(
-    name: "room1",
-    options: .init(
-        messages: .init(defaultMessageReactionType: .unique)
-    )
-)
-```
-
-```kotlin
-val room = ablyChatClient.rooms.get("room1") {
-    messages {
-        defaultMessageReactionType = MessageReactionType.Unique
-    }
-}
-```
-
-```react
-import { MessageReactionType } from '@ably/chat';
-import { useChatClient } from '@ably/chat/react';
-
-const MyComponent = () => {
-  const chatClient = useChatClient();
-
-  const getRoom = async () => {
-    const room = await chatClient.rooms.get('room1', {
-      messages: {
-        defaultMessageReactionType: MessageReactionType.Unique,
-      },
-    });
-    return room;
-  };
-
-  // ... rest of component
 };
 ```
 </Code>

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -19,9 +19,9 @@ Ably Chat supports three types of message reactions. They differ in how they are
 
 | Type | Description | Example | Similar to |
 | ---- | ----------- | ------- | --------- |
-| `Unique`, `reaction:unique.v1` | A user can react to a message only once, with a reaction of their choice. When a user reacts a second time their reaction is changed. | Can 👍 or ❤️ but not both or more than once. | iMessage, WhatsApp, Facebook Messenger |
-| `Distinct`, `reaction:distinct.v1` | A user can react to a message with each reaction at most once. | Can 👍 and ❤️ but each reaction only once. No 👍👍. | Slack |
-| `Multiple`, `reaction:multiple.v1` | A user can react to a message with any reactions as many times as they like. Optionally a `count` parameter can be set when reacting. Reacting again adds to the existing count.| Can 👍 10 times and ❤️ 100 times. | Claps on Medium |
+| `Unique` | A user can react to a message only once, with a reaction of their choice. When a user reacts a second time their reaction is changed. | Can 👍 or ❤️ but not both or more than once. | iMessage, WhatsApp, Facebook Messenger |
+| `Distinct` | A user can react to a message with each reaction at most once. | Can 👍 and ❤️ but each reaction only once. No 👍👍. | Slack |
+| `Multiple` | A user can react to a message with any reactions as many times as they like. Optionally a `count` parameter can be set when reacting. Reacting again adds to the existing count.| Can 👍 10 times and ❤️ 100 times. | Claps on Medium |
 
 Note that if adding two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -202,7 +202,9 @@ const MyComponent = () => {
 ```
 </Code>
 
+<Aside data-type='note'>
 The `annotation-publish` capability is required for adding reactions.
+</Aside>
 
 ## Removing a message reaction <a id="removing-reactions"/>
 
@@ -587,7 +589,9 @@ const MyComponent = () => {
 ```
 </Code>
 
+<Aside data-type='note'>
 The `annotation-subscribe` capability is required for receiving individual reactions, however it is not required to receive summaries.
+</Aside>
 
 You should be aware of the following limitations:
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -311,6 +311,36 @@ interface Message {
     }
 }
 ```
+
+```react
+interface Message {
+    // ... (other fields omitted)
+    reactions: {
+        unique: Ably.SummaryUniqueValues,
+        distinct: Ably.SummaryDistinctValues,
+        multiple: Ably.SummaryMultipleValues,
+    }
+}
+
+// example (in real use, it is unlikely that all reaction types are present):
+{
+    // ... other message fields omitted
+    reactions: {
+        unique: {
+            '👍': { total: 2, clientIds: ['clientA', 'clientB'] },
+            '❤️': { total: 1, clientIds: ['clientC'] },
+        },
+        distinct: {
+            '👍': { total: 2, clientIds: ['clientA', 'clientB'] },
+            '❤️': { total: 1, clientIds: ['clientA'] },
+        },
+        multiple: {
+            '👍': { total: 10, clientIds: {'clientA': 7, 'clientB': 3} },
+            '❤️': { total: 100, clientIds: {'clientA': 100} },
+        },
+    }
+}
+```
 </Code>
 
 All reaction types are always available via `Message.reactions`, regardless of the default reaction type configured via room options.

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -27,7 +27,13 @@ Note that if adding two identical reactions of type `Distinct`, the second one w
 
 ### Configure the default reaction type <a id="default-type"/>
 
+<If lang="javascript,swift,kotlin">
 The default reaction type can be configured at room-level by passing `RoomOptions` when calling `rooms.get`. If nothing is set, the default is `Distinct`.
+</If>
+
+<If lang="react">
+The default reaction type can be configured at room-level by passing `RoomOptions` to the `ChatRoomProvider`. If nothing is set, the default is `Distinct`.
+</If>
 
 <Code>
 ```javascript

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -27,7 +27,7 @@ Note that if adding two identical reactions of type `Distinct`, the second one w
 
 ### Configure the default reaction type <a id="default-type"/>
 
-The default reaction type can be configured at room-level using the Room Options. If nothing is set, the default is `Distinct`.
+The default reaction type can be configured at room-level by passing `RoomOptions` when calling `rooms.get`. If nothing is set, the default is `Distinct`.
 
 <Code>
 ```javascript

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -19,9 +19,9 @@ Ably Chat supports three types of message reactions. They differ in how they are
 
 | Type | Description | Example | Similar to |
 | ---- | ----------- | ------- | --------- |
-| `Unique` | A user can react to a message only once, with a reaction of their choice. When a user reacts a second time their reaction is changed. | Can 👍 or ❤️ but not both or more than once. | iMessage, WhatsApp, Facebook Messenger |
-| `Distinct` | A user can react to a message with each reaction at most once. | Can 👍 and ❤️ but each reaction only once. No 👍👍. | Slack |
-| `Multiple` | A user can react to a message with any reactions as many times as they like. Optionally a `count` parameter can be set when reacting. Reacting again adds to the existing count.| Can 👍 10 times and ❤️ 100 times. | Claps on Medium |
+| `Unique` | Users can add a single reaction per message. If they react again, their previous reaction is replaced with the new one. | A user can add a 👍, but adding a ❤️ will replace the 👍. | iMessage, WhatsApp, Facebook Messenger |
+| `Distinct` | Users can add each type of reaction once per message. Multiple different reactions are allowed, but duplicates are not. | A user can add both 👍 and ❤️, but cannot add a second 👍. | Slack |
+| `Multiple` | Users can add unlimited reactions, including duplicates. A count parameter specifies how many reactions to add at once. Each new reaction adds to the total count. | A user can add 10 👍 reactions and 100 ❤️ reactions to the same message. | Claps on Medium |
 
 Note that if adding two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -67,13 +67,13 @@ val room = ablyChatClient.rooms.get("room1") {
 import { MessageReactionType } from '@ably/chat';
 import { ChatRoomProvider } from '@ably/chat/react';
 
-const MyComponent = () => {
-  const roomOptions = {
-    messages: {
-      defaultMessageReactionType: MessageReactionType.Unique,
-    },
-  };
+const roomOptions = {
+  messages: {
+    defaultMessageReactionType: MessageReactionType.Unique,
+  },
+};
 
+const MyComponent = () => {
   return (
     <ChatRoomProvider name="room1" options={roomOptions}>
       <RoomContent />
@@ -541,15 +541,15 @@ val room = ablyChatClient.rooms.get("room1") {
 ```react
 import { ChatRoomProvider } from '@ably/chat/react';
 
-const MyComponent = () => {
-  const roomOptions = {
+const roomOptions = {
+  messages: {
     messages: {
-      messages: {
-        rawMessageReactions: true,
-      },
+      rawMessageReactions: true,
     },
-  };
+  },
+};
 
+const MyComponent = () => {
   return (
     <ChatRoomProvider name="room1" options={roomOptions}>
       <RoomContent />

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -504,7 +504,7 @@ If multiple reactions are added in a short period of time, multiple reactions ma
 
 Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.
 
-Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can configure them via a room option which, in turn, sets the appropriate channel options to enable receiving individual annotations and reactions:
+Individual reactions are not received by default to save bandwidth and to reduce the number of messages and cost. If you want to receive them, you can enable them via the `rawMessageReactions` room option:
 
 <Code>
 ```javascript

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -81,13 +81,13 @@ const MyComponent = () => {
 
 <If lang="javascript,swift,kotlin">
 To add a message reaction use `room.messages.reactions.send(message, params)`. This method takes the following parameters:
-* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
+* `message` - The message to add the reaction to. Can be either a Message object or a string containing the message serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
 <If lang="react">
 Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to add a reaction to a message. This method takes the following parameters:
-* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
+* `message` - The message to add the reaction to. Can be either a Message object or a string containing the message serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -59,21 +59,20 @@ val room = ablyChatClient.rooms.get("room1") {
 
 ```react
 import { MessageReactionType } from '@ably/chat';
-import { useChatClient } from '@ably/chat/react';
+import { ChatRoomProvider } from '@ably/chat/react';
 
 const MyComponent = () => {
-  const chatClient = useChatClient();
-
-  const getRoom = async () => {
-    const room = await chatClient.rooms.get('room1', {
-      messages: {
-        defaultMessageReactionType: MessageReactionType.Unique,
-      },
-    });
-    return room;
+  const roomOptions = {
+    messages: {
+      defaultMessageReactionType: MessageReactionType.Unique,
+    },
   };
 
-  // ... rest of component
+  return (
+    <ChatRoomProvider name="room1" options={roomOptions}>
+      <RoomContent />
+    </ChatRoomProvider>
+  );
 };
 ```
 </Code>
@@ -82,13 +81,13 @@ const MyComponent = () => {
 
 <If lang="javascript,swift,kotlin">
 To add a message reaction use `room.messages.reactions.send(message, params)`. This method takes the following parameters:
-* `message` - The message to add the reaction to. It can also be an object of format `{serial: "message serial"}`.
+* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
 <If lang="react">
-Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to add a reaction to a message. This method takes the following parameters:
-* `message` - The message to add the reaction to. It can also be an object of format `{serial: "message serial"}`.
+Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to add a reaction to a message. This method takes the following parameters:
+* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
@@ -214,7 +213,7 @@ To remove a message reaction use `room.messages.reactions.delete(message, params
 </If>
 
 <If lang="react">
-Use the [`deleteReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat_react.UseMessagesResponse.html#deleteReaction) method available from the response of the `useMessages` hook to remove a reaction from a message. This method takes the following parameters:
+Use the [`deleteReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#deleteReaction) method available from the response of the `useMessages` hook to remove a reaction from a message. This method takes the following parameters:
 * `message` - The message to remove the reaction from. It can also be an object of format `{serial: "message serial"}`.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
@@ -510,21 +509,22 @@ val room = ablyChatClient.rooms.get("room1") {
 ```
 
 ```react
-import { useChatClient } from '@ably/chat/react';
+import { ChatRoomProvider } from '@ably/chat/react';
 
 const MyComponent = () => {
-  const chatClient = useChatClient();
-
-  const getRoom = async () => {
-    const room = await chatClient.rooms.get('room1', {
+  const roomOptions = {
+    messages: {
       messages: {
         rawMessageReactions: true,
       },
-    });
-    return room;
+    },
   };
 
-  // ... rest of component
+  return (
+    <ChatRoomProvider name="room1" options={roomOptions}>
+      <RoomContent />
+    </ChatRoomProvider>
+  );
 };
 ```
 </Code>

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -171,25 +171,25 @@ import { MessageReactionType } from '@ably/chat';
 import { useMessages } from '@ably/chat/react';
 
 const MyComponent = () => {
-  const { addReaction } = useMessages();
+  const { sendReaction } = useMessages();
 
   const handleAddReaction = async (message) => {
     try {
       // Add a 👍 reaction using the default type
-      await addReaction(message, { name: '👍' });
+      await sendReaction(message, { name: '👍' });
 
       // The reaction can be anything, not just UTF-8 emojis:
-      await addReaction(message, { name: ':like:' });
-      await addReaction(message, { name: '+1' });
+      await sendReaction(message, { name: ':like:' });
+      await sendReaction(message, { name: '+1' });
 
       // Add a :love: reaction using the Unique type
-      await addReaction(message, {
+      await sendReaction(message, {
         name: ':love:',
         type: MessageReactionType.Unique,
       });
 
       // Add a ❤️ reaction with count 100 using the Multiple type
-      await addReaction(message, {
+      await sendReaction(message, {
         name: '❤️',
         type: MessageReactionType.Multiple,
         count: 100,


### PR DESCRIPTION
- adds react code examples for message reactions
- restructures the page so that reaction types and the default type are explained before 'how to actually send a reaction'.