### PR TITLE
[WEB-4440] Add Open in ChatGPT button to right sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.1.0",
+    "@ably/ui": "17.2.1",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -7,10 +7,11 @@ import { componentMaxHeight, HEADER_HEIGHT, HEADER_BOTTOM_MARGIN } from '@ably/u
 
 import { LanguageSelector } from './LanguageSelector';
 import { useLayoutContext } from 'src/contexts/layout-context';
+import { productData } from 'src/data';
+import { LanguageKey } from 'src/data/languages/types';
 import { languageInfo } from 'src/data/languages';
 import { ActivePage, sidebarAlignmentClasses, sidebarAlignmentStyles } from './utils/nav';
 import { INKEEP_ASK_BUTTON_HEIGHT } from './utils/heights';
-import { LanguageKey } from 'src/data/languages/types';
 
 type SidebarHeader = {
   id: string;
@@ -58,7 +59,7 @@ const externalLinks = (
 `);
 
   const requestPath = `${requestBasePath}?title=${requestTitle}&body=${requestBody}`;
-  const prompt = `Tell me more about Ably's '${activePage.page.name}' feature from https://ably.com${activePage.page.link}${language ? ` for ${languageInfo[language]?.label}` : ''}`;
+  const prompt = `Tell me more about ${activePage.product ? productData[activePage.product]?.nav.name : 'Ably'}'s '${activePage.page.name}' feature from https://ably.com${activePage.page.link}${language ? ` for ${languageInfo[language]?.label}` : ''}`;
   const gptPath = `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
 
   return [

--- a/src/components/Layout/utils/nav.ts
+++ b/src/components/Layout/utils/nav.ts
@@ -14,7 +14,7 @@ export type ActivePage = {
   tree: PageTreeNode[];
   page: NavProductPage;
   languages: LanguageKey[];
-  language: LanguageKey;
+  language: LanguageKey | null;
   product: ProductKey | null;
   template: PageTemplate;
 };

--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -92,16 +92,18 @@ export const LayoutProvider: React.FC<PropsWithChildren<{ pageContext: PageConte
         tree: [],
         page: { name: '', link: '' },
         languages: [],
-        language: activeLanguage,
+        language: null,
         product: null,
         template: null,
       };
     }
 
+    const languages = (activePageData.page.languages as LanguageKey[]) ?? activeLanguages;
+
     return {
       ...activePageData,
-      languages: (activePageData.page.languages as LanguageKey[]) ?? activeLanguages,
-      language: activeLanguage,
+      languages,
+      language: languages.includes(activeLanguage) ? activeLanguage : null,
       template: (pageContext?.layout?.mdx ? 'mdx' : 'textile') as PageTemplate,
     };
   }, [location.pathname, location.search, pageContext?.languages, domLanguages, pageContext?.layout?.mdx]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.1.0":
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.1.0.tgz#5c3612d37cb75668f2ef3058ad96c0bc17761ed9"
-  integrity sha512-tRztxGCwzJ9+9yy/1TurefoTXDjWTvTluOzsQzeZIGD6uRaF/JrA0WggtiYnFnw0FKudQN57ENvXpHpfOZunIg==
+"@ably/ui@17.2.1":
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.2.1.tgz#4a4442220f6c476b5042a5313f5b8e849ab37007"
+  integrity sha512-mQTvr0DFqfHQSL16eARwoyj4aSHk8TO4bRUO3FRegUs4kQoZT+EolFxTzfCggsLwPKznBJM1yfIg6EAqCGREfw==
   dependencies:
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"


### PR DESCRIPTION
Adds an "Open in ChatGPT" button to the right-hand nav sidebar in docs with the prompt "Tell me more about Ably's X feature from Y for Z" where
- `X` is the name of the feature
- `Y` is the docs page describing the feature (we can update this to a Markdown resource later when that functionality is ready - currently in the works by @kennethkalmer)
- `Z` is the targeted programming language, only appended if applicable (it wouldn't be on the Chat index page, for instance) 

Review link (with example page): https://ably-docs-web-4440-gpt--8g8gqj.herokuapp.com/docs/chat/rooms/message-reactions

<img width="267" alt="Screenshot 2025-06-11 at 17 40 25" src="https://github.com/user-attachments/assets/6305fe8a-acf2-4d21-80dd-fee2f0b1d5e6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Open in ChatGPT" external link in the sidebar, allowing users to quickly generate prompts based on the current page.

- **Style**
  - Updated the border styling for sidebar external links for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->