### PR TITLE
[WEB-4445] Add missing `/docs` prefix on URLs in `llms.txt`

### DIFF
--- a/data/onPostBuild/llmstxt.ts
+++ b/data/onPostBuild/llmstxt.ts
@@ -89,7 +89,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
     const { title, meta_description } = meta;
 
     try {
-      const url = prefixPath({ url: slug, siteUrl, pathPrefix: basePath });
+      const url = prefixPath({ url: `/docs/${slug}`, siteUrl, pathPrefix: basePath });
       const safeTitle = escapeMarkdown(title);
       const link = `[${safeTitle}](${url})`;
       const line = `- ${[link, meta_description].join(': ')}`;


### PR DESCRIPTION
## Description

I assumed the `slug` in the GraphQL queries returned the full path, but after inspecting the `createPages` function I realised we manually prefix slugs with `/docs/`, so doing that for the `llms.txt` as well.

### How to test

Open up https://ably-docs-web-4445-docs-sonsmr.herokuapp.com/llms.txt and verify all paths begin with `/docs/`.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
