### PR TITLE
[INF-5819] feat: add deprecation notice for TLS 1.0 and 1.1 support

### DIFF
--- a/content/platform/deprecate/tls-v1-1.textile
+++ b/content/platform/deprecate/tls-v1-1.textile
@@ -1,0 +1,36 @@
+---
+title: Deprecation of TLS 1.0 and 1.1 - June 2025
+meta_description: "A policy detailing how Ably is deprecating support for TLS 1.0 and 1.1."
+meta_keywords: "Ably, deprecation policy, deprecation, sunset, TLS, security"
+---
+
+Support for TLS (Transport Layer Security) versions 1.0 and 1.1 will be sunset on 1st June 2025.
+
+As part of Ably's ongoing commitment to ensure the highest standards of security and performance, support for older TLS versions across the service will be deprecated. After this date, all connections to Ably must use TLS 1.2 or higher.
+
+h2(#impact). Impact
+
+After 1st June 2025, requests using TLS 1.0 or 1.1 will be refused. This affects all connections to Ably's services, including:
+
+* Realtime and WebSocket connections
+* REST API calls
+* Any other service that communicates with Ably
+
+h2(#error). Error messages
+
+When attempting to connect using TLS 1.0 or 1.1, you may receive a TLS protocol version error. The error message will reference @protocol_version@ to indicate that the TLS version is not supported.
+
+h2(#recommendations). Recommended actions
+
+* **Verify compatibility:** Ensure that your systems, applications, and integrations are configured to support TLS 1.2 or higher.
+* **Update legacy systems:** If you are using older platforms, consult with your IT team or integration partners to update any components that still rely on TLS 1.0 or 1.1.
+
+For customers who have a custom environment or active traffic management enabled, Ably can update your settings at any time.
+
+h2(#requests). Request failures
+
+From 1st June 2025, attempts to connect to Ably using TLS 1.0 or 1.1 will start to fail. Failures will be phased, with only a fraction of traffic being rejected at first, until 100% of requests are rejected after several weeks.
+
+Requests that are rejected will contain an error message and code referencing this deprecation notice and the associated "deprecation policy.":/docs/platform/deprecate
+
+Contact "support":https://ably.com/support if you have any questions.

--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -80,6 +80,10 @@ export default {
               name: 'Nov 2025 - Protocol v1',
               link: '/docs/platform/deprecate/protocol-v1',
             },
+            {
+              name: 'June 2025 - TLS v1.0 and v1.1',
+              link: '/docs/platform/deprecate/tls-v1-1',
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Description

Adding deprecation page re: TLS 1.0/1.1 support deprecation. Effective June 2025. See https://changelog.ably.com/deprecation-of-support-for-tls-1-0-and-1-1-304006

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
