### PR TITLE
[WEB-3380] Enforce canonical access to HTML content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
 
   build:
     environment:
-      COMPRESS_MAX_THREADS: 8
+      ASSET_COMPRESSION_ITERATIONS: 1
+      COMPRESS_MAX_THREADS: 4
     executor:
       name: default
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,12 @@ jobs:
           name: Verify all files are compressed
           command: ./bin/assert-compressed.sh
       - run:
+          name: Test content request auth tokens
+          command: |
+            export PATH="$PWD/bin:$PWD/buildpack/build/.heroku-buildpack-nginx/ruby/bin:$PATH"
+            mkdir -p logs/nginx
+            ./bin/assert-content-auth.sh
+      - run:
           name: Test nginx configuration
           command: |
             export PATH="$PWD/bin:$PWD/buildpack/build/.heroku-buildpack-nginx/ruby/bin:$PATH"

--- a/bin/assert-content-auth.sh
+++ b/bin/assert-content-auth.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+# set -x # uncomment to help debugging
+
+#
+# This script verifies that the content request bearer tokens work as expected
+#
+
+# Make sure basic auth is disabled for these tests as it will interfere with the content request auth tokens
+export ENABLE_BASIC_AUTH=false
+
+# First we define some utility functions to help us in the test
+
+wait_for_nginx_pid_file() {
+    local operation=$1  # "start" or "stop"
+    local count=0
+
+    while ( [ "$operation" = "start" ] && [ ! -f /tmp/nginx.pid ] ) || \
+          ( [ "$operation" = "stop" ] && [ -f /tmp/nginx.pid ] ); do
+        # nginx operations are quick so we can be impatient here
+        sleep 0.1
+        count=$((count + 1))
+        if [ $count -ge 100 ]; then  # 0.1s * 100 = 10s
+            echo "Error: Timeout waiting for nginx to $operation"
+            exit 1
+        fi
+    done
+}
+
+start_nginx() {
+    # Start nginx in the background
+    ./bin/start-nginx &
+
+    # Wait for nginx to start successfully (pid file is created)
+    wait_for_nginx_pid_file "start"
+
+    # Get the PID from the nginx.pid file
+    NGINX_PID=$(cat /tmp/nginx.pid)
+
+    # Check if nginx is still running
+    if ! kill -0 $NGINX_PID 2>/dev/null; then
+        echo "Error: Failed to start nginx"
+        exit 1
+    fi
+}
+
+stop_nginx() {
+    # Read the PID from the file
+    if [ -f /tmp/nginx.pid ]; then
+        NGINX_PID=$(cat /tmp/nginx.pid)
+        # Kill nginx if it's still running
+        if kill -0 $NGINX_PID 2>/dev/null; then
+            kill $NGINX_PID
+        fi
+
+        # Wait for nginx to stop (pid file to be removed)
+        wait_for_nginx_pid_file "stop"
+    fi
+}
+
+# Set up trap to stop nginx on script exit or failure
+trap stop_nginx EXIT
+
+# Function to run a single test case
+run_test() {
+    local path="$1"
+    local expected_status="$2"
+    local expected_content_type="$3"
+    local expected_redirect_url="${4:-}"
+    local auth_token="${5:-}"
+    local test_name="${6:-Test case}"
+
+    echo "--------------------------------"
+    echo "Running test: $test_name"
+    echo
+
+    # Start nginx
+    start_nginx
+
+    # Prepare curl command
+    local curl_cmd="curl --silent --output /dev/null --write-out %{http_code}|%{content_type}|%{redirect_url}"
+
+    # Add auth token if provided
+    if [ -n "$auth_token" ]; then
+        curl_cmd="$curl_cmd --oauth2-bearer $auth_token"
+    fi
+
+    # Make the request
+    local response=$($curl_cmd "http://localhost:${PORT}${path}")
+    local status_code=$(echo "$response" | cut -d'|' -f1)
+    local content_type=$(echo "$response" | cut -d'|' -f2)
+    local redirect_url=$(echo "$response" | cut -d'|' -f3)
+
+    # Verify status code
+    if [ "$status_code" != "$expected_status" ]; then
+        echo "Expected status code $expected_status, got $status_code"
+        exit 1
+    fi
+
+    # Verify content type
+    if [[ ! $content_type =~ $expected_content_type ]]; then
+        echo "Expected Content-Type to contain $expected_content_type, got $content_type"
+        exit 1
+    fi
+
+    # Verify redirect URL if expected
+    if [ -n "$expected_redirect_url" ] && [[ ! $redirect_url =~ $expected_redirect_url ]]; then
+        echo "Expected redirect URL to contain $expected_redirect_url, got $redirect_url"
+        exit 1
+    fi
+
+    echo "OK: $test_name passed"
+    stop_nginx
+    echo
+}
+
+export PORT=4001
+
+# Example usage of the test function:
+# run_test "/" "200" "text/html" "" "" "Root path without auth"
+# run_test "/" "404" "text/html" "" "" "Root path with auth tokens but no auth"
+# run_test "/" "301" "text/html" "http://www.example.com/" "" "Root path with canonical host"
+# run_test "/" "200" "text/html" "" "foo" "Root path with auth"
+
+# 1. Verify that things work as normal when the tokens aren't set
+run_test "/" "200" "text/html" "" "" "Root path without auth tokens"
+
+# 2. Verify that things work as expected when the tokens are set
+export CONTENT_REQUEST_AUTH_TOKENS=foo,bar
+run_test "/" "404" "text/html" "" "" "Root path with auth tokens but no auth"
+
+# 3. Verify that things work as expected when the tokens are set and the canonical host is set
+export CONTENT_REQUEST_CANONICAL_HOST=www.example.com
+run_test "/" "301" "text/html" "http://www.example.com/" "" "Root path with canonical host"
+
+# 4. Verify that things work as expected when the tokens are set and the canonical host is set and the request is authenticated
+run_test "/" "200" "text/html" "" "foo" "Root path with auth token"
+
+# 5. Verify that things work as expected when the tokens are set and the canonical host is set and the request is authenticated and the request is for a .html file
+run_test "/index.html" "200" "text/html" "" "foo" "index.html with auth token"
+
+# 6. Verify that things work as expected when the tokens are set and the canonical host is set and the request is authenticated and the request is for a .html file and the request is for a path that doesn't exist
+run_test "/index.html" "301" "text/html" "http://www.example.com/" "" "index.html without auth token"
+
+# 7. Verify that things work as expected when the tokens are set and the canonical host is set and the request is authenticated and the request is for a .html file and the request is for a path that doesn't exist
+run_test "/does-not-exist.html" "404" "text/html" "" "foo" "Does not exist with auth token"
+
+# 8. Verify assets requests work without auth
+FIRST_ASSET=$(find public -name "*.jpg" -type f | head -n1 | sed 's|^public/||')
+run_test "/${FIRST_ASSET}" "200" "image/jpeg" "" "" "JPEG without auth"
+
+# 9. Verify JSON requests work without auth
+run_test "/page-data/app-data.json" "200" "application/json" "" "" "Page data without auth"
+
+# Clean up environment variables
+unset CONTENT_REQUEST_AUTH_TOKENS
+unset CONTENT_REQUEST_CANONICAL_HOST

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -12,12 +12,13 @@ PORT=${PORT:-3001} \
     NGINX_ACCESS_LOG_PATH=${NGINX_ACCESS_LOG_PATH:-"/dev/stdout"} \
     NGINX_ERROR_LOG_PATH=${NGINX_ERROR_LOG_PATH:-"/dev/stderr"} \
     NGINX_ROOT=$(pwd)/public \
+    NGINX_PID_FILE=${NGINX_PID_FILE:-"/tmp/nginx.pid"} \
     SKIP_HTTPS=${SKIP_HTTPS:-true} \
     ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-false} \
     erb config/nginx.conf.erb > config/nginx.conf
 
 # Cleanup when we're done
-trap "rm -f config/nginx.conf /tmp/nginx.socket" EXIT
+trap "rm -f config/nginx.conf /tmp/nginx.socket /tmp/nginx.pid" EXIT
 
 # Start nginx
 nginx -p . -c config/nginx.conf

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,53 +1,42 @@
-# Based off https://github.com/heroku/heroku-buildpack-nginx/blob/main/config/nginx-solo-sample.conf.erb
-
 daemon off;
-# Heroku dynos have at least 4 cores.
-worker_processes <%= ENV['NGINX_WORKERS'] || 'auto' %>;
+worker_processes auto;
 
 events {
-  <% unless RbConfig::CONFIG['host_os'] =~ /darwin/ %>
+<% unless RbConfig::CONFIG['host_os'] =~ /darwin/ %>
   use epoll;
-  <% end %>
+<% end %>
   accept_mutex on;
   worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
 }
 
+<% if pid_file = ENV['NGINX_PID_FILE'] %>
+# Be explicit about the pid file location
+pid <%= pid_file %>;
+<% end %>
+
 http {
   gzip on;
-  gzip_comp_level 2;
+  gzip_comp_level 6;
   gzip_min_length 512;
-  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss font/woff font/woff2 image/svg+xml;
   gzip_vary on;
   gzip_proxied any; # Heroku router sends Via header
 
-	server_tokens off;
+  server_tokens off;
 
-	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
-	access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
-	error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %> error;
+  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+  access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
+  error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %> notice;
 
-	include mime.types;
-	default_type application/octet-stream;
-	sendfile on;
+  include mime.types;
+  default_type application/octet-stream;
+  sendfile on;
 
-	# Must read the body in 5 seconds.
-	client_body_timeout <%= ENV['NGINX_CLIENT_BODY_TIMEOUT'] || 5 %>;
+  # Must read the body in 5 seconds.
+  client_body_timeout 5;
 
   map_hash_max_size 8192;
   map_hash_bucket_size 8192;
-
-  # Be as explicit as possible with our CORS origins. We can't use the
-  # `hostnames` directive as ably.com doesn't work with it
-  map $http_origin $cors_origin {
-    https://ably.com $http_origin;
-    https://www.ably.io $http_origin;
-    https://ably-dev.com $http_origin;
-    https://ik.imagekit.io $http_origin;
-    https://ably-docs.herokuapp.com $http_origin;
-    ~*https://website-[a-z0-9\-]*\.herokuapp\.com $http_origin;
-    ~*https://ably-docs-[a-z0-9\-]*\.herokuapp\.com $http_origin;
-    http://localhost:<%= ENV['PORT'] %> $http_origin;
-  }
 
   # Creates a map of redirects for us
   map $uri $redirected_url {
@@ -59,20 +48,55 @@ http {
     <% end %>
   }
 
-	server {
-	  listen <%= ENV["PORT"] %> reuseport;
-	  server_name _;
-	  keepalive_timeout 5;
-	  client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
+  ##
+  # CORS CONFIGURATION
 
-    add_header X-Frame-Options SAMEORIGIN always;
+  # We can't use the `hostnames` directive because of the layers of proxying and varying hostnames.
+  # If the origin of the request is in the list below we'll get that value set as
+  # $cors_origin and we can use it further down the line.
+  map $http_origin $cors_origin {
+    https://ably.com $http_origin;
+    https://ably-dev.com $http_origin;
+    https://ik.imagekit.io $http_origin;
+    https://ably-docs.herokuapp.com $http_origin;
+    ~*https://website-[a-z0-9\-]*\.herokuapp\.com $http_origin;
+    ~*https://ably-docs-[a-z0-9\-]*\.herokuapp\.com $http_origin;
+    ~http://localhost:\d+ $http_origin;
+    ~https?://ably\.test $http_origin;
+  }
 
-    # Prevent nginx from adding the PORT to any redirects
+  # Further down in the configs where we can expect CORS requests we combine
+  # $request_method checks and $cors_origin to set the correct headers,
+  # including the Vary header to ensure the browser know we'll change the response
+  # based on the Origin request header. We make use of an ERB snippet to make it
+  # easier to maintain the shared configs
+
+  <%
+    cors_headers = <<~ERB
+        more_set_headers 'Access-Control-Allow-Origin: $cors_origin';
+        more_set_headers 'Access-Control-Allow-Headers: sentry-trace, baggage';
+        more_set_headers 'Access-Control-Allow-Methods: GET, OPTIONS';
+        more_set_headers 'Access-Control-Allow-Credentials: true';
+        more_set_headers 'Vary: Origin';
+    ERB
+  %>
+
+  # / CORS CONFIGURATION
+
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    charset UTF-8;
     port_in_redirect off;
+    keepalive_timeout 5;
 
     root <%= ENV['NGINX_ROOT'] || '/app/public' %>;
 
+    # Use our error page instead of the nginx default
     error_page 404 500 /404.html;
+
+    # Serve pre-gzipped versions of assets
+    gzip_static on;
 
     <% if ENV['ENABLE_BASIC_AUTH'] == 'true' %>
     # Basic Authentication
@@ -82,9 +106,6 @@ http {
 
     # Removes trailing slashes everywhere (by redirecting)
     rewrite ^/(.*)/$ <%= ENV['SKIP_HTTPS'] == 'true' ? '$scheme' : 'https' %>://$host/$1 permanent;
-
-    # Serve pre-gzipped versions of assets
-    gzip_static on;
 
     <% unless ENV['SKIP_HTTPS'] == 'true' %>
     # Enforce HTTPS
@@ -98,13 +119,19 @@ http {
       rewrite ^ $redirected_url permanent;
     }
 
-    location ~* \.(json|yaml)$ {
+    location ~* \.json$ {
+      # Only do CORS checks on preflight requests
+      if ($request_method = OPTIONS) {
+        <%= cors_headers %>
+        return 204;
+      }
+
       more_set_headers 'Access-Control-Allow-Origin: *';
     }
 
     # Optimize for pre-compiled assets scattered all over the place
     location ~* \.(js|css|jpg|jpeg|gif|svg|png|woff|woff2)$ {
-      # expires 1y;
+      expires 1y;
       more_set_headers 'Cache-Control: public';
 
       # Some browsers still send conditional-GET requests if there's a
@@ -120,11 +147,26 @@ http {
         more_set_headers 'Access-Control-Allow-Origin: *';
       }
 
-      # Set explicit allowed origin for svg that are requested by methods that need
+      # Set explicit allowed origin for svg/png that are requested by methods that need
       # explicit headers like "fetch"
-      location ~* \.svg$ {
-        more_set_headers 'Access-Control-Allow-Origin: $cors_origin';
+      location ~* \.(svg|png)$ {
+        <%= cors_headers %>
       }
+
+      # Stop processing here and 404 if the asset/pack doesn't exist
+      break;
+    }
+
+    # Optimize for pre-compiled assets in the static directory
+    location ~ ^/static/ {
+      expires 1y;
+      more_set_headers 'Cache-Control: public';
+
+      # Some browsers still send conditional-GET requests if there's a
+      # Last-Modified header or an ETag header even if they haven't
+      # reached the expiry date sent in the Expires header.
+      more_clear_headers 'Last-Modified';
+      more_clear_headers 'ETag';
 
       # Stop processing here and 404 if the asset/pack doesn't exist
       break;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -83,6 +83,34 @@ http {
 
   # / CORS CONFIGURATION
 
+  ##
+  # PROTECTED CONTENT REQUESTS
+  <%
+    # By setting CONTENT_REQUEST_AUTH_TOKENS, we can protect content requests
+    # to the site. This is useful for preventing bad crawlers (the slop feeders
+    # that don't respect robots.txt) from crawling the content while still
+    # allowing the website to fetch and serve the content.
+    #
+    # The tokens are set as a comma-separated list of Bearer tokens in the
+    # CONTENT_REQUEST_AUTH_TOKENS environment variable.
+    #
+    # The CONTENT_REQUEST_CANONICAL_HOST environment variable can be set to
+    # redirect the request to a canonical host if the request is not authenticated.
+    #
+    content_request_auth_tokens = (ENV['CONTENT_REQUEST_AUTH_TOKENS'] || '').split(',').map(&:strip).reject(&:empty?)
+    content_request_protected = content_request_auth_tokens.any?
+  %>
+
+  <% if content_request_protected %>
+  # Define a variable to check if the bearer token in the Authorization header is valid
+  map $http_authorization $token_auth_status {
+    <% content_request_auth_tokens.each do |token| %>
+    "Bearer <%= token %>" "allowed";
+    <% end %>
+  }
+  <% end %>
+
+  # / PROTECTED CONTENT REQUESTS
 
   server {
     listen <%= ENV["PORT"] %>;
@@ -93,7 +121,7 @@ http {
     root <%= ENV['NGINX_ROOT'] || '/app/public' %>;
 
     # Use our error page instead of the nginx default
-    error_page 404 500 /404.html;
+    error_page 404 500 /docs/404/index.html;
 
     # Serve pre-gzipped versions of assets
     gzip_static on;
@@ -173,16 +201,52 @@ http {
     }
 
     location / {
-      try_files $uri $uri.html $uri/index.html @404;
+      # Remove the .html extension here so it can fall through to the @html_auth location
+      rewrite ^/(.*)\.html$ /$1 break;
+
+      <% if content_request_protected %>
+      # Serve the file if it exists, otherwise try to authenticate
+      # (.html requests won't match here, they'll go to the @html_auth location)
+      try_files $uri @html_auth;
+      <% else %>
+      # Serve the file if it exists, try index.html for paths without a trailing slash, otherwise 404
+      try_files $uri $uri/index.html $uri/ =404;
+      <% end %>
     }
 
-    location ~ \.html$ {
-      try_files $uri =404;
+    <% if content_request_protected %>
+    # Authenticate .html requests by checking the token_auth_status variable
+    # which is set in the map block earlier in this file.
+    location @html_auth {
+      if ($token_auth_status != "allowed") {
+        # .html request without authentication, so handle it here by 404ing or redirecting to the canonical host
+        # depending on whether CONTENT_REQUEST_CANONICAL_HOST is set or not
+        <% if host = ENV['CONTENT_REQUEST_CANONICAL_HOST'] %>
+        return 301 <%= ENV['SKIP_HTTPS'] == 'true' ? '$scheme' : 'https' %>://<%= host %>$uri;
+        <% else %>
+        return 404;
+        <% end %>
+      }
+
+      # If the request is authenticated, break out of the location block and serve the file
+      try_files $uri.html $uri/index.html $uri/ =404;
     }
 
-    # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404
-    location @404 {
+    # Don't serve files with the .html extension here, send them to the canonical location
+    location ~* \.html$ {
+      # If the request is authenticated, break out of the location block and serve the file
+      if ($token_auth_status = "allowed") {
+        break;
+      }
+
+      # .html request without authentication, so handle it here by 404ing or redirecting to the canonical host
+      # depending on whether CONTENT_REQUEST_CANONICAL_HOST is set or not
+      <% if host = ENV['CONTENT_REQUEST_CANONICAL_HOST'] %>
+      return 301 <%= ENV['SKIP_HTTPS'] == 'true' ? '$scheme' : 'https' %>://<%= host %>$uri;
+      <% else %>
       return 404;
+      <% end %>
     }
-	}
+    <% end %>
+  }
 }

--- a/data/onPostBuild/compressAssets.ts
+++ b/data/onPostBuild/compressAssets.ts
@@ -51,10 +51,16 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ reporter }) => {
 /**
  * From here on down is the worker code that is executed by the worker threads
  * in Piscina to perform the actual compression.
+ *
+ * The number of iterations is set to 15 by default, but can be overridden by
+ * setting the ASSET_COMPRESSION_ITERATIONS environment variable. Lower number of
+ * iterations means faster compression but lower compression ratio (good for CI
+ * and review apps)
+ *
  */
 
 const options = {
-  numiterations: 15,
+  numiterations: parseInt(process.env.ASSET_COMPRESSION_ITERATIONS || '15', 10),
 };
 
 interface CompressInputs {


### PR DESCRIPTION
## Description

We have an issue where some of our content on `docs.ably.com` is being indexed by the large LLMs despite our `robots.txt` disallowing crawlers on the docs subdomains.

This work updates our nginx config to require a bearer token for HTML requests, which the website proxy can provide, while blocking unscrupulous crawlers from getting to the markup.

Static assets are not affected, no changes are required to how the site is built, deployed or served other than tweaking the values of `CONTENT_REQUEST_AUTH_TOKENS` and `CONTENT_REQUEST_CANONICAL_HOST` in the Heroku config when this is ready to be enabled.

> [!NOTE]
> This is a duplication of a similar piece of work done in Voltaire. See PR 1038 over there for prior discussions, as well as WEBDR-002 for an in-depth discussion on how we got here.

I also snuck in a little quality of life improvement: allowing the number of iterations on the asset compression to be tweaked, and I've tweaked it down in CI config here, and in Heroku review app configs already.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced content request authentication using bearer tokens for enhanced access control in Nginx-based environments.
  - Added explicit CORS handling with configurable allowed origins and improved preflight request support.
  - Improved asset caching and header management for static files, fonts, and SVG/PNG assets.

- **Bug Fixes**
  - Enhanced error handling and redirects for unauthenticated content requests.

- **Chores**
  - Updated environment variable options for asset compression and build processes.
  - Added new scripts and configuration improvements for automated testing and server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->