### PR TITLE
[WEB-4440] Update ably-ui to 17.3.3, remove spritesheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.2.1",
+    "@ably/ui": "17.3.3",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/src/components/GlobalLoading/GlobalLoading.tsx
+++ b/src/components/GlobalLoading/GlobalLoading.tsx
@@ -3,8 +3,6 @@ import { useStaticQuery, graphql } from 'gatsby';
 
 // Session-related scripts
 import '@ably/ui/core/scripts';
-import { loadSprites } from '@ably/ui/core/scripts';
-import sprites from '@ably/ui/core/sprites.svg';
 import UserContext from '../../contexts/user-context';
 
 import externalScriptInjector from 'src/external-scripts';
@@ -57,12 +55,6 @@ const GlobalLoading: FC<GlobalLoadingProps> = ({ children, template }) => {
   useEffect(() => {
     sessionTracker(sessionState);
   }, [sessionState, sessionTracker]);
-
-  useEffect(() => {
-    if (!document.querySelector('.ably-sprites')) {
-      loadSprites(sprites);
-    }
-  }, []);
 
   return <>{children}</>;
 };

--- a/src/components/LanguageButton/LanguageButton.test.tsx
+++ b/src/components/LanguageButton/LanguageButton.test.tsx
@@ -32,7 +32,7 @@ describe(`<LanguageButton />`, () => {
     );
     expect(screen.getByRole('button')).toMatchInlineSnapshot(`
       <button
-        class="button ui-text-label3 isActive"
+        class="button ui-text-label3"
       >
         JavaScript
       </button>

--- a/src/components/blocks/Html/__snapshots__/Html.test.tsx.snap
+++ b/src/components/blocks/Html/__snapshots__/Html.test.tsx.snap
@@ -16,75 +16,20 @@ exports[`<Html /> renders correct Dl based on PageLanguageContext value 1`] = `
   >
     event name for the published message
     <span
-      lang="python"
+      lang="default"
     >
       <em>
         Type: 
-        <code
-          class="ui-text-code-inline"
-        >
-          Unicode
-        </code>
-         for Python 2, 
         <code
           class="ui-text-code-inline"
         >
           String
         </code>
-         for Python 3
       </em>
     </span>
   </dd>
   
 	
-  <div
-    lang="python"
-  >
-    <dt
-      class="listDt"
-    >
-      <div>
-        data
-      </div>
-    </dt>
-    <dd
-      class=""
-    >
-      data payload for the message. The supported payload types are unicode Strings, Dict, or List objects that can be serialized to 
-      <span
-        class="caps"
-      >
-        JSON
-      </span>
-       using 
-      <code
-        class="ui-text-code-inline"
-      >
-        json.dumps
-      </code>
-      , binary data as 
-      <code
-        class="ui-text-code-inline"
-      >
-        bytearray
-      </code>
-       (in Python 3, 
-      <code
-        class="ui-text-code-inline"
-      >
-        bytes
-      </code>
-       also works), and None.
-      <em>
-        Type: 
-        <code
-          class="ui-text-code-inline"
-        >
-          Object
-        </code>
-      </em>
-    </dd>
-  </div>
   
 	
   

--- a/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
+++ b/src/components/blocks/software/__snapshots__/Pre.test.tsx.snap
@@ -139,11 +139,20 @@ exports[`<Pre /> should successfully render code elements with  only Realtime la
           tabindex="0"
         >
           <svg
+            aria-hidden="true"
             class="text-neutral-500 mt-3 ml-4"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
             style="width: 1.25rem; height: 1.25rem;"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <use
-              xlink:href="#sprite-icon-gui-information-circle-outline"
+            <path
+              d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             />
           </svg>
         </div>
@@ -254,11 +263,18 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
       class="mt-0.5"
     >
       <svg
+        aria-hidden="true"
         class=""
+        data-slot="icon"
+        fill="currentColor"
         style="width: 1rem; height: 1rem;"
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <use
-          xlink:href="#sprite-icon-gui-information-circle-micro"
+        <path
+          clip-rule="evenodd"
+          d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0ZM9 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM6.75 8a.75.75 0 0 0 0 1.5h.75v1.75a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8.25 8h-1.5Z"
+          fill-rule="evenodd"
         />
       </svg>
     </div>
@@ -308,11 +324,20 @@ exports[`<Pre /> should successfully render code elements with  only Rest langua
           tabindex="0"
         >
           <svg
+            aria-hidden="true"
             class="text-neutral-500 mt-3 ml-4"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
             style="width: 1.25rem; height: 1.25rem;"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <use
-              xlink:href="#sprite-icon-gui-information-circle-outline"
+            <path
+              d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             />
           </svg>
         </div>
@@ -354,11 +379,20 @@ exports[`<Pre /> should successfully render code elements with both Rest and Rea
           tabindex="0"
         >
           <svg
+            aria-hidden="true"
             class="text-neutral-500 mt-3 ml-4"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
             style="width: 1.25rem; height: 1.25rem;"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <use
-              xlink:href="#sprite-icon-gui-information-circle-outline"
+            <path
+              d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             />
           </svg>
         </div>

--- a/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
+++ b/src/components/blocks/wrappers/__snapshots__/LocalLanguageAlternatives.test.tsx.snap
@@ -121,11 +121,19 @@ exports[`<LocalLanguageAlternatives /> renders correctly 1`] = `
         type="button"
       >
         <svg
+          aria-hidden="true"
           class="text-neutral-000"
+          data-slot="icon"
+          fill="currentColor"
           style="width: 1rem; height: 1rem;"
+          viewBox="0 0 16 16"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <use
-            xlink:href="#sprite-icon-gui-square-2-stack-micro"
+          <path
+            d="M5 6.5A1.5 1.5 0 0 1 6.5 5h6A1.5 1.5 0 0 1 14 6.5v6a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 5 12.5v-6Z"
+          />
+          <path
+            d="M3.5 2A1.5 1.5 0 0 0 2 3.5v6A1.5 1.5 0 0 0 3.5 11V6.5a3 3 0 0 1 3-3H11A1.5 1.5 0 0 0 9.5 2h-6Z"
           />
         </svg>
       </button>

--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -247,6 +247,10 @@ export const inkeepOnLoad = (apiKey: string, conversationsUrl: string) => {
           key: 'custom-style',
           type: 'style',
           value: `css
+            .ikp-chat-button__container {
+              z-index: 10;
+            }
+
             .ikp-ai-chat-message-toolbar {
               flex-wrap: wrap;
               justify-content: flex-end;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,11 +7,12 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.2.1":
-  version "17.2.1"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.2.1.tgz#4a4442220f6c476b5042a5313f5b8e849ab37007"
-  integrity sha512-mQTvr0DFqfHQSL16eARwoyj4aSHk8TO4bRUO3FRegUs4kQoZT+EolFxTzfCggsLwPKznBJM1yfIg6EAqCGREfw==
+"@ably/ui@17.3.3":
+  version "17.3.3"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.3.3.tgz#d1a72ce210468cb94b3718698995c317be5e46d6"
+  integrity sha512-bsbL++KRzjdfyiTBzIPBGFcGRnYbw6dl0fma6FdaBiGXMVkgSDGyVSwt5LDpHnZIcEUZyN9xUS14Hz9wS1DHyg==
   dependencies:
+    "@heroicons/react" "^2.2.0"
     "@radix-ui/react-accordion" "^1.2.1"
     "@radix-ui/react-navigation-menu" "^1.2.4"
     "@radix-ui/react-select" "^2.2.2"
@@ -1826,6 +1827,11 @@
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@heroicons/react@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"


### PR DESCRIPTION
As a result of this optimisation effort: https://github.com/ably/ably-ui/pull/815.

Icon loading is heavy and slow (~2s per load) due to reasons mentioned in that PR, this PR should sort that out. A small nudge towards a more positive user experience (Ably's target user would not expect 6-8 working days for icons to show)

Additionally, includes a fix for the inkeep button being buried under page text in prod.

Review link: https://ably-docs-web-4440-redu-7iuphn.herokuapp.com/docs
Acceptance criteria: icons should all render and they should be fast