### PR TITLE
[WEB-4457] Add back yaml to the CORS checks

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -147,7 +147,7 @@ http {
       rewrite ^ $redirected_url permanent;
     }
 
-    location ~* \.json$ {
+    location ~* \.(json|yaml)$ {
       # Only do CORS checks on preflight requests
       if ($request_method = OPTIONS) {
         <%= cors_headers %>


### PR DESCRIPTION
## Description

Regression in b1b97f8633ac when syncing the nginx updates with Voltaire, broke redoc trying to fetch yaml specs

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
