### PR TITLE
EDU-1990: Correct typo in metachannels on errors overview page

### DIFF
--- a/content/errors/index.textile
+++ b/content/errors/index.textile
@@ -80,8 +80,8 @@ Ably provides a set of "metachannels":/docs/metadata-stats/metadata/subscribe#me
 
 There are two metachannels related to "logging:":/docs/metadata-stats/metadata/subscribe#log
 
-- @Meta[log]@ := Publishes errors that aren't visible to clients, except those related to push notifications.
-- @Meta[log:push]@ := Similar to @[meta]log@, but only publishes errors related to the delivery of push notifications.
+- @[meta]log@ := Publishes errors that aren't visible to clients, except those related to push notifications.
+- @[meta]log:push@ := Similar to @[meta]log@, but only publishes errors related to the delivery of push notifications.
 
 The following example subscribes to the @[meta]log@ channel:
 


### PR DESCRIPTION
This PR:

Updates the `content/errors/index` doc to correct the formatting of two logging metachannel names:

- Fixed from `Meta[log]` to `[meta]log`
- Fixed from `Meta[log:push]` to `[meta]log:push`

https://github.com/ably/docs/issues/2558

https://ably.atlassian.net/browse/EDU-1990