### PR TITLE
EDU-1992: Adds new use case

### DIFF
--- a/content/auth/capabilities.textile
+++ b/content/auth/capabilities.textile
@@ -514,8 +514,6 @@ It is possible for JWTs to contain authenticated claims for users that can be us
 
 Messages can be annotated with trusted metadata copied from the client's authentication token by Ably servers. Clients are unable to directly publish messages with user claim metadata, and claims contained within the authentication token are signed to prevent tampering. Claims can be scoped to individual channels or to namespaces of "channels":/docs/channels. The most specific user claim will be added to the message as part of the @extras@ object. Note that this does not apply to presence or metadata messages.
 
-An example use case is when using "message interactions":/docs/channels/messages#interactions. You might want to use trusted claims to define 'moderator' users in a chat channel who have the ability to delete any sent messages. When the moderator sends an interaction to mark messages in a channel as deleted, your application should check that user's claims to verify they are a moderator for that channel before actioning their request.
-
 To set the trusted fields you need to include @ably.channel.*@ in your JWT authentication payload, for example:
 
 ```[javascript]


### PR DESCRIPTION
This PR:

Updates the example use case in `content/auth/capabilities` a live sports streaming app, replacing the previous outdated "message interactions".

#2558

https://ably.atlassian.net/browse/EDU-1992

