### PR TITLE
Edu 1989 remove how to guide from nav

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -111,10 +111,6 @@ export default {
           name: 'Advanced pub-sub',
           link: '/docs/pub-sub/advanced',
         },
-        {
-          name: 'How-to: Publish and subscribe',
-          link: '/docs/how-to/pub-sub',
-        },
       ],
     },
     {


### PR DESCRIPTION
This PR:

- Removes "How-to: Publish and subscribe" from the pub-sub navigation in `src/data/nav/pubsub.ts`.
- But keeps the page available via search (it hasn't been deleted)!

https://ably.atlassian.net/browse/EDU-1989