### PR TITLE
[WEB-4440] fix: remove css tag from inkeep custom styles

### DIFF
--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -246,7 +246,7 @@ export const inkeepOnLoad = (apiKey: string, conversationsUrl: string) => {
         {
           key: 'custom-style',
           type: 'style',
-          value: `css
+          value: `
             .ikp-chat-button__container {
               z-index: 10;
             }


### PR DESCRIPTION
In #2660 I mentioned a layering fix for the Inkeep chat button but I just went off the docs for it. 

Turns out it doesn't actually work, so I got inkeep going locally and got to the bottom of it. Turns out this `css` tag at the start of the custom CSS string was affecting it - don't see a separate reason to keep it there (it's reminiscent of styled components, which is unusual)