### PR TITLE
Fixed incorrectly updated --profile-data in getting started guides fo…

### DIFF
--- a/content/getting-started/react-native.textile
+++ b/content/getting-started/react-native.textile
@@ -557,7 +557,7 @@ The application will now display a list of clients currently present on the chan
 You can have another client join the presence set using the Ably CLI:
 
 ```[sh]
-ably channels presence enter my-first-channel --client-id "my-cli" --profile-data '{"status":"From CLI"}'
+ably channels presence enter my-first-channel --client-id "my-cli" --data '{"status":"From CLI"}'
 ```
 
 h2(#step-4). Step 4: Retrieve message history

--- a/content/getting-started/swift.textile
+++ b/content/getting-started/swift.textile
@@ -159,7 +159,7 @@ channel?.presence.enter("I'm here!") { error in
 * You can have another client join the presence set using the Ably CLI:
 
 ```[sh]
-ably channels presence enter my-first-channel --client-id "my-cli" --profile-data '{"status":"learning about Ably!"}'
+ably channels presence enter my-first-channel --client-id "my-cli" --data '{"status":"learning about Ably!"}'
 ```
 
 *To run:*


### PR DESCRIPTION
A mistake was updated to the CLI which updated `--data` to `--profile-data` when entering the presence set for Pub/Sub. This then was updated in two of the getting started guides. This PR reverts that change.