### PR TITLE
Added improvements to Javascript getting started guide

### DIFF
--- a/content/getting-started/javascript.textile
+++ b/content/getting-started/javascript.textile
@@ -17,7 +17,7 @@ It will take you through the following steps:
 
 h2(#prerequisites). Prerequisites
 
-* Sign up for an Ably account.
+* "Sign up":https://ably.com/signup for an Ably account.
 ** Create a new app, and create your first API key.
 ** Your API key will need the @publish@, @subscribe@, @presence@ and @history@ capabilities.
 
@@ -63,12 +63,10 @@ Clients establish a connection with Ably when they instantiate an SDK instance. 
 import * as Ably from 'ably';
 
 async function getStarted() {
-
   const realtimeClient = new Ably.Realtime({ key: '{{API_KEY}}', clientId: 'my-first-client' });
 
   await realtimeClient.connection.once('connected');
-    console.log(`Made my first connection!`);
-
+  console.log(`Made my first connection!`);
 };
 
 getStarted();
@@ -103,6 +101,12 @@ ably channels subscribe my-first-channel
 ```
 
 Publish another message using the CLI and you will see that it's received instantly by the client you have running locally, as well as the subscribed terminal instance.
+
+To publish a message in your code, you can add the following line to your @getStarted@ method after subscribing to the channel:
+
+```[javascript]
+await channel.publish('example', 'A message sent from my first client!');
+```
 
 h2(#step-3). Step 3: Join the presence set
 
@@ -177,10 +181,10 @@ Continue to explore the documentation with JavaScript as the selected language:
 
 Read more about the concepts covered in this guide:
 
-* Revisit the basics of "Pub/Sub":/docs/pub-sub
-* Explore more "advanced":/docs/pub-sub/advanced Pub/Sub concepts
-* Understand realtime "connections":/docs/connect to Ably
-* Read more about how to use "presence":/docs/presence-occupancy/presence in your apps
-* Fetch message "history":/docs/storage-history/history in your apps
+* Revisit the basics of "Pub/Sub":/docs/pub-sub?lang=javascript
+* Explore more "advanced":/docs/pub-sub/advanced?lang=javascript Pub/Sub concepts
+* Understand realtime "connections":/docs/connect?lang=javascript to Ably
+* Read more about how to use "presence":/docs/presence-occupancy/presence?lang=javascript in your apps
+* Fetch message "history":/docs/storage-history/history?lang=javascript in your apps
 
-You can also explore the Ably CLI further, or visit the Pub/Sub "API references":/docs/api/realtime-sdk.
+You can also explore the Ably CLI further, or visit the Pub/Sub "API references":/docs/api/realtime-sdk?lang=javascript.


### PR DESCRIPTION
The Javascript getting started guide needed:

- Sign up to have a link.
- All Next Steps links to have `?lang=javascript` appended to them.
- Code snippet for programmatically publishing a message.