### PR TITLE
[DRAFT][EDU-1899] Chat JS API references

### DIFF
--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -160,6 +160,35 @@ export default {
           link: '/docs/api/chat-rest',
           name: 'REST API',
         },
+        {
+          name: 'JavaScript SDK',
+          pages: [
+            {
+              name: 'Rooms',
+              link: '/docs/chat/api/javascript/rooms',
+            },
+            {
+              name: 'Room',
+              link: '/docs/chat/api/javascript/room',
+            },
+            {
+              name: 'Message',
+              link: '/docs/chat/api/javascript/message',
+            },
+            {
+              name: 'Presence',
+              link: '/docs/chat/api/javascript/presence',
+            },
+            {
+              name: 'Occupancy',
+              link: '/docs/chat/api/javascript/occupancy',
+            },
+            {
+              name: 'Typing',
+              link: '/docs/chat/api/javascript/typing',
+            },
+          ],
+        },
       ],
     },
   ],

--- a/src/pages/docs/chat/api/javascript/message.mdx
+++ b/src/pages/docs/chat/api/javascript/message.mdx
@@ -1,0 +1,399 @@
+---
+title: Message
+meta_description: ""
+---
+
+The `Message` interface represents a single message in a chat room.
+
+---
+
+## Properties
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `action` | The action type of the message. This can be used to determine if the message was created, updated, or deleted. | [`ChatMessageAction`](#chatmessageaction) |
+| `clientId` | The clientId of the user who created the message. | String |
+| `createdAt` | The timestamp at which the message was created. | Date |
+| `headers` | The headers of a chat message. Headers enable attaching extra info to a message, which can be used for various features such as linking to a relative point in time of a livestream video or flagging this message as important or pinned. This value is always set. If there are no headers, this is an empty object. Do not use the headers for authoritative information. There is no server-side validation. When reading the headers, treat them like user input. | [`MessageHeaders`](#messageheaders) |
+| `metadata` | The metadata of a chat message. Allows for attaching extra info to a message, which can be used for various features such as animations, effects, or simply to link it to other resources such as images, relative points in time, etc. This value is always set. If there is no metadata, this is an empty object. Do not use metadata for authoritative information. There is no server-side validation. When reading the metadata treat it like user input. | [`MessageMetadata`](#messagemetadata) |
+| `operation` | *Optional* The details of the operation that modified the message. This is only set for update and delete actions. It contains information about the operation: the clientId of the user who performed the operation, a description, and metadata. | [`Operation`](#operation) |
+| `reactions` | The reactions summary for this message. | [`MessageReactions`](#messagereactions) |
+| `serial` | The unique identifier of the message. | String |
+| `text` | The text of the message. | String |
+| `timestamp` | The timestamp at which this version was updated, deleted, or created. | Date |
+| `version` | A unique identifier for the latest version of this message. | String |
+
+### ChatMessageAction
+
+An enum that represents the types of action of a message.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `Create` | The message was created. |
+| `Update` | The message was updated. |
+| `Delete` | The message was deleted. |
+
+### MessageHeaders | Headers
+
+Headers enable attaching extra info to a message. Uses include linking to a relative point in time of a livestream video or flagging this message as important or pinned.
+
+`Record<string, number | string | boolean | null | undefined>`
+
+### MessageMetadata | Metadata
+
+Metadata enables attaching extra info to a message. Uses include animations, effects, or simply to link it to other resources such as images or relative points in time.
+
+`Record<string, unknown>`
+
+### Operation
+
+The details of an operation that modified a message.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `clientId` | The clientId of the user who performed the operation. | String |
+| `description` | A description of the operation. | String |
+| `metadata` | Metadata associated with the operation. | [`MessageOperationMetadata`](#messageoperationmetadata) |
+
+#### MessageOperationMetadata | OperationMetadata
+
+The metadata contained in the `operations` field of a message. It represents the metadata supplied to a message update or deletion request.
+
+Do not use metadata for authoritative information. There is no server-side validation. When reading the metadata, treat it like user input.
+
+`Record<string, unknown>`
+
+### MessageReactions
+
+Represents a summary of all reactions for a message.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `distinct` | Map of reaction to the summary (total and clients) for reactions of type `MessageReactionType.Distinct`. | [`MessageReactionType`](#messagereactiontype) |
+| `multiple` | Map of reaction to the summary (total and clients) for reactions of type `MessageReactionType.Multiple`. | [`MessageReactionType`](#messagereactiontype) |
+| `unique` | Map of reaction to the summary (total and clients) for reactions of type `MessageReactionType.Unique`. | [`MessageReactionType`](#messagereactiontype) |
+
+#### MessageReactionType
+
+An enum that represents the types of reactions for a message.
+
+It has the following members:
+
+| Member | Description | Type |
+| ------ | ----------- | ---- |
+| `Distinct` | Allows for at most one reaction of each type per client per message. It is possible for a client to add multiple reactions to the same message as long as they are different (e.g. different emojis). Duplicates are not counted in the summary. This is similar to reactions on Slack. | `reaction:distinct.v1` |
+| `Multiple` | Allows any number of reactions, including repeats, and they are counted in the summary. The reaction payload also includes a count of how many times each reaction should be counted (defaults to 1 if not set). This is similar to the clap feature on Medium or how room reactions work. | `reaction:multiple.v1` |
+| `Unique` | Allows for at most one reaction per client per message. If a client reacts to a message a second time, only the second reaction is counted in the summary. This is similar to reactions on iMessage, Facebook Messenger or WhatsApp. | `reaction:unique.v1` |
+
+---
+
+## Accessors
+
+| Accessor | Description | Type |
+| -------- | ----------- | ---- |
+| `deletedAt` | The timestamp at which the message was deleted. | Date \| `undefined` |
+| `deletedBy` | The clientId of the user who deleted the message. | String \| `undefined` |
+| `isDeleted` | Indicates if the message has been deleted. | Boolean |
+| `isUpdated` | Indicates if the message has been updated. | Boolean |
+| `updatedAt` | The timestamp at which the message was updated. | Date \| `undefined` |
+| `updatedBy` | The clientId of the user who updated the message. | String \| `undefined` |
+
+---
+
+## Was message created after a given message
+
+`message.after()`
+
+Determines if the message was created after a given message. This comparison is based on global order, so does not necessarily represent the order that messages are received in realtime from the backend.
+
+`after(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if this message was created after the given message, in global order.
+
+Throws an [`ErrorInfo`](LINK) if:
+
+* The `serial` of either message is invalid.
+
+<Code>
+```javascript
+const isAfter = message1.after(message2);
+```
+</Code>
+
+## Was message created before a given message
+
+`message.before()`
+
+Determines if the message was created before a given message. This comparison is based on global order, so does not necessarily represent the order that messages are received in realtime from the backend.
+
+`before(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if this message was created before the given message, in global order.
+
+Throws an [`ErrorInfo`](LINK) if:
+
+* The `serial` of either message is invalid.
+
+<Code>
+```javascript
+const isBefore = message1.before(message2);
+```
+</Code>
+
+### Is message equal to a given message
+
+`message.equal()`
+
+Determines if the message is equal to a given message.
+
+Note that this method compares messages based on `Message.serial` alone. It returns `true` if the two messages represent different versions of the same message.
+
+`equal(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if the two messages are the same message.
+
+<Code>
+```javascript
+const isEqual = message1.equal(message2);
+```
+</Code>
+
+### Is message the same as a given message
+
+`message.isSameAs()`
+
+Alias for [`message.equal()`](LINK).
+
+`isSameAs(message: Message): boolean`
+
+### Is message a newer version of a given message
+
+`message.isNewerVersionOf()`
+
+Determines if a message is a newer version of a given message.
+
+Note that negating this function does not mean that the message is an older version of the same message, as the two may be different messages entirely.
+
+`isNewerVersionOf(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if the two messages are the same message (`isSameAs` returns `true`) and this message is a newer version.
+
+<Code>
+```javascript
+const isNewer = message1.isNewerVersionOf(message2);
+```
+</Code>
+
+### Is message an older version of a given message
+
+`message.isOlderVersionOf()`
+
+Determines if the message is an older version of a given message.
+
+Note that negating this function does not mean that the message is a newer version of the same message, as the two may be different messages entirely.
+
+`isOlderVersionOf(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if the two messages are the same message (`isSameAs` returns true) and this message is an older version.
+
+<Code>
+```javascript
+const isOlder = message1.isOlderVersionOf(message2);
+```
+</Code>
+
+### Is message the same version as a given message
+
+`message.isSameVersionAs()`
+
+Determines if the message is the same version as a given message.
+
+`isSameVersionAs(message: Message): boolean`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `message` | The message to compare against. | [`Message`](#message) |
+
+### Returns
+
+Returns `true` if the two messages are the same message and have the same version.
+
+<Code>
+```javascript
+const isSameVersion = message1.isSameVersionAs(message2);
+```
+</Code>
+
+### Create a copy of a message
+
+`message.copy()`
+
+Creates a copy of the message with fields replaced per the parameters.
+
+`copy(params?: MessageCopyParams): Message`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `params` | *Optional* The parameters to replace in the message. | [`MessageCopyParams`](#messagecopyparams) |
+
+#### MessageCopyParams
+
+The following `MessageCopyParas` can be set:
+
+| Parameters | Description | Type |
+| ---------- | ----------- | ---- |
+| `text` | *Optional* The new text for the message. | String |
+| `metadata` | *Optional* The new metadata for the message. | [`MessageMetadata`](#messagemetadata) |
+| `headers` | *Optional* The new headers for the message. | [`MessageHeaders`](#messageheaders) |
+
+### Returns
+
+Returns the message copy.
+
+<Code>
+```javascript
+const copiedMessage = message.copy({text: 'Updated text'});
+```
+</Code>
+
+### Create a new message with an event applied
+
+`message.with()`
+
+Creates a new message instance with the event applied.
+
+Note: This method will not replace the message reactions if the event is of type `Message`.
+
+`with(event: Message | ChatMessageEvent | MessageReactionSummaryEvent): Message`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `event` | The event to be applied to the returned message. | [`Message`](#message) \| [`ChatMessageEvent`](#chatmessageevent) \| [`MessageReactionSummaryEvent`](#messagereactionsummaryevent) |
+
+#### ChatMessageEvent
+
+The payload of a message event.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `type` | The type of the message event. | [`ChatMessageEventType`](#chatmessageeventtype) |
+| `data` | The message data. | [`Message`](#message) |
+
+#### ChatMessageEventType
+
+An enum that represents the types of message events.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `Created` | Fires when a new message is created. |
+| `Updated` | Fires when a message is updated. |
+| `Deleted` | Fires when a message is deleted. |
+
+#### MessageReactionSummaryEvent
+
+An interface that represents a summary of message reactions. This event aggregates different types of reactions for a specific message.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `type` | The type of the reaction event. | [`MessageReactionEventType`](#messagereactioneventtype) |
+| `data` | The reaction summary data. | [`MessageReactions`](#messagereactions) |
+
+#### MessageReactionEventType
+
+An enum representing the different message reaction events.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `Added` | A reaction was added. |
+| `Removed` | A reaction was removed. |
+
+### Returns
+
+Returns a new message instance with the event applied. If the event is a no-op, such as an event for an old version, the same message is returned (not a copy).
+
+Throws an [`ErrorInfo`](LINK) if:
+
+* The event is for a different message.
+* The event if of the type `ChatMessageEventType.Created`.
+
+<Code>
+```javascript
+const updatedMessage = message.with(messageEvent);
+```
+</Code>

--- a/src/pages/docs/chat/api/javascript/occupancy.mdx
+++ b/src/pages/docs/chat/api/javascript/occupancy.mdx
@@ -1,0 +1,92 @@
+---
+title: Occupancy
+meta_description: ""
+---
+
+The `Occupancy` interface is used to subscribe to occupancy updates and fetch the occupancy metrics of a room.
+
+Access it via `room.occupancy`.
+
+---
+
+## Get the room occupancy
+
+`room.occupancy.get()`
+
+Get the current occupancy of the room.
+
+`get(): Promise<OccupancyEvent>`
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled with an `OccupancyData` object containing the current occupancy metrics. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+#### OccupancyData
+
+An interface that represents an occupancy data of a chat room.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `connections` | The number of connections attached to the channel. | `number` |
+| `presenceMembers` | The number of users entered into the [presence](/docs/chat/api/javascript/presence) set. | `number` |
+
+---
+
+## Get the current room occupancy
+
+`room.occupancy.current()`
+
+Get the latest occupancy data received from realtime events.
+
+`current(): undefined | OccupancyData`
+
+### Returns
+
+The latest occupancy data, or undefined if no realtime events have been received in the room yet.
+
+--
+
+## Subscribe to occupancy
+
+`room.occupancy.subscribe()`
+
+Subscribe the provided listener to occupancy occupancy events.
+
+`subscribe(listener: OccupancyListener): Subscription`
+
+### Parameters
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `listener` | Function called when an occupancy update is received | `OccupancyListener` |
+
+#### OccupancyListener
+
+A listener that listens for occupancy events.
+
+`(event: OccupancyEvent) => void`
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `event` | An occupancy event. | [`OccupancyEvent`](#occupancyevent) |
+
+#### OccupancyEvent
+
+An interface that represents an occupancy event.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `occupancy` | The occupancy data associated with the event. Contains the number of `connections` and `presenceMembers`. | `occupancy: { connections: number; presenceMembers: number }` |
+| `type` | The type of the occupancy event. Will always be `Updated`. ||
+
+### Returns
+
+Returns a [`Subscription`](LINK) object that can be used to unsubscribe the listener.

--- a/src/pages/docs/chat/api/javascript/presence.mdx
+++ b/src/pages/docs/chat/api/javascript/presence.mdx
@@ -1,0 +1,301 @@
+---
+title: Presence
+meta_description: ""
+---
+
+The `Presence` interface is used to enter and subscribe to the presence set of a chat room.
+
+Access it via `room.presence`.
+
+---
+
+## Enter the presence set
+
+`room.presence.enter()`
+
+Enters the client into the presence set. Will emit an `enter` event to all subscribers. Repeat calls will trigger more `enter` events.
+
+`enter(data?: unknown): Promise<void>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `data` | *Optional* The user's data, a JSON serializable object that will be sent to all subscribers. | Unknown |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](LINK).
+
+Throws if:
+
+* The room is not in the `attached` or `attaching` state.
+
+<Code>
+```javascript
+await room.presence.enter({status: 'online', activity: 'viewing'});
+```
+</Code>
+
+---
+
+## Update presence data
+
+`room.presence.update()`
+
+Updates a client's presence `data`. Will emit an `update` event to all subscribers. If the client is not already in the presence set, it will be treated as an [`enter`](LINK) event.
+
+`update(data?: unknown): Promise<void>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `data` | *Optional* The user's data, a JSON serializable object that will be sent to all subscribers. | Unknown |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](LINK).
+
+Throws if:
+
+* The room is not in the `attached` or `attaching` state.
+
+<Code>
+```javascript
+await room.presence.update({status: 'away', lastSeen: new Date()});
+```
+</Code>
+
+---
+
+## Leave the presence set
+
+`room.presence.leave()`
+
+Removes the client from the presence set. Will emit a `leave` event to all subscribers. If the client is not already part of the presence set, it will be treated as a no-op.
+
+`leave(data?: unknown): Promise<void>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `data` | *Optional* The user's data, a JSON serializable object that will be sent to all subscribers. | Unknown |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](LINK).
+
+Throws if:
+
+* The room is not in the `attached` or `attaching` state.
+
+<Code>
+```javascript
+await room.presence.leave({reason: 'User logged out'});
+```
+</Code>
+
+---
+
+## Get current presence members
+
+`room.presence.get()`
+
+Get a list of the current users in the presence set by returning the latest presence message for each.
+
+`get(params?: RealtimePresenceParams): Promise<PresenceMember[]>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `params` | *Optional* Parameters that control how the presence set is retrieved. | [`RealtimePresenceParams`](#realtimepresenceparams) |
+
+#### RealtimePresenceParams
+
+Parameters for retrieving presence members.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `waitForSync` | *Optional* Whether to wait for a full presence set synchronization between Ably and the clients on the channel before returning the results. Synchronization begins as soon as the channel is attached. When set to `true`, the results will be returned as soon as the sync is complete. When set to `false`, the current list of members will be returned without the sync completing. The default is `true`. | Boolean |
+| `clientId` | *Optional* Filters the array of returned presence members for a specific client using its ID. | String |
+| `connectionId` | *Optional* Filters the array of returned presence members for a specific connection. | String |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled with an array of [`PresenceMember`](#presencemember). On failure, the promise is rejected with an [`ErrorInfo`](LINK).
+
+#### PresenceMember
+
+Represents a member in the presence set.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `clientId` | The client ID of the presence member. | String |
+| `data` | The data associated with the presence member. | Unknown |
+| `extras` | The extras associated with the presence member. | Unknown |
+| `updatedAt` | The timestamp when this presence member was last updated. | Number |
+
+<Code>
+```javascript
+const members = await room.presence.get();
+console.log(`${members.length} users present`);
+```
+</Code>
+
+---
+
+## Check if a user is present
+
+`room.presence.isUserPresent()`
+
+Check if a user is part of the presence set using their `clientId`.
+
+`isUserPresent(clientId: string): Promise<boolean>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `clientId` | The client ID to check if it is present in the room. | String |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled with a boolean indicating whether the user is present. On failure, the promise is rejected with an [`ErrorInfo`](LINK).
+
+Throws if:
+
+* The room is not in the `attached` or `attaching` state.
+
+<Code>
+```javascript
+const isPresent = await room.presence.isUserPresent('user123');
+if (isPresent) {
+  console.log('User is currently in the room');
+}
+```
+</Code>
+
+---
+
+### Subscribe to specific presence events
+
+`room.presence.subscribe()`
+
+Subscribe the provided listener to a list of presence events.
+
+Note: This requires presence events to be enabled via the `enableEvents` option in the [`PresenceOptions`](LINK) provided to the room. If this is not enabled, an error will be thrown.
+
+`subscribe(eventOrEvents: PresenceEventType | PresenceEventType[], listener?: PresenceListener): Subscription`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `eventOrEvents` | Single event name or array of events to subscribe to. | [`PresenceEventType`](#presenceeventtype) \| `PresenceEventType`[] |
+| `listener` | *Optional* Listener to register. | [`PresenceListener`](#presencelistener) |
+
+#### PresenceEventType
+
+An enum that represents the types of presence events.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `Enter` | A member has entered the presence set. |
+| `Leave` | A member has left the presence set. |
+| `Update` | A member has updated their presence data. |
+| `Present` | Get the current presence set when subscribing. |
+
+#### PresenceListener
+
+A listener that listens for presence events.
+
+`(event: PresenceEvent) => void`
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `event` | A presence event. | [`PresenceEvent`](#presenceevent) |
+
+#### PresenceEvent
+
+Represents a presence event.
+
+It has the following properties:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `type` | The type of presence event. | [`PresenceEventType`](#presenceeventtype) |
+| `member` | The presence member associated with the event. | [`PresenceMember`](#presencemember) |
+
+### Returns
+
+Returns a [`Subscription`](LINK) object.
+
+Throws an [`ErrorInfo`](LINK) with `code` 40000 if:
+
+* Presence events are not enabled.
+
+<Code>
+```javascript
+const subscription = room.presence.subscribe(['enter', 'leave'], (presenceEvent) => {
+  console.log(`${presenceEvent.member.clientId} ${presenceEvent.type} the room`);
+});
+
+// Unsubscribe when done
+subscription.unsubscribe();
+```
+</Code>
+
+---
+
+### Subscribe to all presence events
+
+`subscribe(listener?: PresenceListener): Subscription`
+
+Subscribe the provided listener to all presence events.
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `listener` | *Optional* Listener to subscribe. | [`PresenceListener`](#presencelistener) |
+
+#### Returns
+
+Returns a [`Subscription`](#subscription) object.
+
+Throws an [`ErrorInfo`](LINK) with code 40000 if:
+
+* Presence events are not enabled.
+
+<Code>
+```javascript
+const subscription = room.presence.subscribe((presenceEvent) => {
+  console.log('Presence event:', presenceEvent.type, presenceEvent.member);
+});
+```
+</Code>

--- a/src/pages/docs/chat/api/javascript/room.mdx
+++ b/src/pages/docs/chat/api/javascript/room.mdx
@@ -1,0 +1,225 @@
+---
+title: Room
+meta_description: ""
+---
+
+The `Room` interface represents a chat room.
+
+Access it via `ChatClient.rooms.get(name)`.
+
+---
+
+## Accessors
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `name` | The unique name of the room. | String |
+| `status` | The current status of the room. | [`RoomStatus`](#roomstatus) |
+| `error` | The current error, if any, that caused the room to enter the current status. | [`ErrorInfo`](LINK) \| `undefined` |
+| `channel` | The underlying Ably realtime channel used for the room. | [`RealtimeChannel`](LINK) |
+| `messages` | Allows you to send, subscribe to, and query messages in the room. | [`Messages`](LINK) |
+| `presence` | Interact with presence events in the room. | [`Presence`](LINK) |
+| `occupancy` | Interact with occupancy metrics for the room. | [`Occupancy`](LINK) |
+| `reactions` | Interact with room-level reactions. | [`RoomReactions`](LINK) |
+| `typing` | Interact with typing events in the room. | [`Typing`](LINK) |
+
+---
+
+## RoomStatus
+
+A `Room` is in one of the following states:
+
+| RoomStatus | Description |
+| ------ | ----------- |
+| `Initializing` | The SDK is initializing the room. |
+| `Initialized` | A temporary state when a room is first initialized. |
+| `Attaching` | The room is attaching to Ably. |
+| `Attached` | The room is attached to Ably. |
+| `Detaching` | The room is detaching from Ably. |
+| `Detached` | The room is detached from Ably. |
+| `Failed` | The room failed to attach to Ably. |
+| `Suspended` | The room is suspended, and automatic reattachment has been temporarily disabled. |
+| `Releasing` | The room is in the process of releasing. |
+| `Released` | The room is released and no longer usable. |
+
+---
+
+## Attach to a room
+
+`room.attach()`
+
+Attaches to the room in order to receive events in realtime.
+
+If a room fails to attach, it will enter either the `Suspended` or `Failed` [state](#roomstatus).
+
+If the room enters the `Failed` state, then the SDK will not automatically retry attaching and intervention is required.
+
+If the room enters the `Suspended` state, then the call to attach will reject with an [`ErrorInfo`](LINK) that caused the suspension. However, the SDK will retry attaching to the room automatically after a delay.
+
+`attach(): Promise<void>`
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled and the room begins receiving real-time events. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+<Code>
+```javascript
+const room = await client.rooms.get('room:general');
+await room.attach();
+```
+</Code>
+
+---
+
+## Detach from a room
+
+`room.detach()`
+
+Detaches from the room to stop receiving events.
+
+`detach(): Promise<void>`
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled and the room stops receiving events. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+<Code>
+```javascript
+await room.detach();
+```
+</Code>
+
+---
+
+## Listen for RoomStatus changes
+
+`room.onStatusChange()`
+
+Registers a listener that is called whenever the [`RoomStatus`](#roomstatus) changes.
+
+`onStatusChange(listener: RoomStatusListener): StatusSubscription`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `listener` | Function called when the room status changes. | [`RoomStatusListener`](#roomstatuslistener) |
+
+#### RoomStatusListener
+
+A function that is called when the [`RoomStatus`](#roomstatus) of a room changes.
+
+`(change: RoomStatusChange) => void`
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `change` | The change in `RoomStatus`. | [`RoomStatusChange`](#roomstatuschange) |
+
+#### RoomStatusChange
+
+An interface that represents a change in the [`RoomStatus`](#roomstatus) of a room.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `previous` | The previous status of the room. | [`RoomStatus`](#roomstatus) |
+| `current` | The current status of the room. | [`RoomStatus`](#roomstatus) |
+| `reason` | *Optional* The error that caused the change. | `ErrorInfo?` |
+| `timestamp` | The time of the change. | `Date` |
+
+### Returns
+
+Returns a `StatusSubscription` object with an `off()` method to remove the listener.
+
+<Code>
+```javascript
+room.onStatusChange((status) => {
+  console.log(`Room status changed to: ${status}`);
+});
+```
+</Code>
+
+#### StatusSubscription
+
+An interface that represents a subscription to status change events. It also provides a method of cleaning up subscriptions that are no longer needed.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `off` | Unsubscribes from the status change events. It will ensure that no further status change events will be sent to the subscriber and that references to the subscriber are cleaned up. | Method |
+
+`off: () => void`
+
+---
+
+## Register a discontinuity handler
+
+`room.onDiscontinuity()`
+
+Registers a handler that is called whenever a discontinuity is detected. Discontinuity occurs when a connection is interrupted and a `Room` cannot be resumed from its previous state.
+
+`onDiscontinuity(handler: DiscontinuityListener): StatusSubscription`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `handler` | Function called when a discontinuity is detected. | `DiscontinuityListener` |
+
+#### DiscontinuityListener
+
+A handler for discontinuity events.
+
+`DiscontinuityListener: (error: ErrorInfo) => void`
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `error` | The error that occurred to cause the discontinuity. | [`ErrorInfo`](LINK) |
+
+### Returns
+
+Returns a `StatusSubscription` object with an `off()` method to remove the handler.
+
+<Code>
+```javascript
+const { off } = room.onDiscontinuity((reason: ErrorInfo) => {
+  // Recover from the discontinuity
+});
+```
+</Code>
+
+#### StatusSubscription
+
+An interface that represents a subscription to status change events. It also provides a method of cleaning up subscriptions that are no longer needed.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `off` | Unsubscribes from the status change events. It will ensure that no further status change events will be sent to the subscriber and that references to the subscriber are cleaned up. | Method |
+
+`off: () => void`
+
+---
+
+## Get RoomOptions
+
+`room.options()`
+
+Returns the [`RoomOptions`](/docs/chat/api/javascript/rooms#roomoptions) used to create the room.
+
+`options(): RoomOptions`
+
+### Returns
+
+Returns a copy of the [`RoomOptions`](/docs/chat/api/room#roomoptions) used to create the room.

--- a/src/pages/docs/chat/api/javascript/rooms.mdx
+++ b/src/pages/docs/chat/api/javascript/rooms.mdx
@@ -1,0 +1,115 @@
+---
+title: Rooms
+meta_description: ""
+---
+
+The `Rooms` interface manages the lifecycle of chat rooms.
+
+Access it via `ChatClient.rooms`.
+
+---
+
+## Create a room
+
+`ChatClient.Rooms.get()`
+
+Create or retrieve `Room` object. Optionally provide custom configuration to the room.
+
+Call [`release()`](#release-a-room) when the `Room` object is no longer needed. If a call to `get()` is made for a room that is currently being released, then the promise will only resolve when the release operation is complete.
+
+If a call to `get()` is made, followed by a subsequent call to `release()` before the promise resolves, then the promise will reject with an error.
+
+`get(name: string, options?: RoomOptions): Promise<Room>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `name` | The name of the room to create or retrieve. | String |
+| `options` | *Optional* Custom configuration options for the room. | [`RoomOptions`](#roomoptions) |
+
+#### RoomOptions
+
+The following `RoomOptions` can be set:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `messages` | *Optional* The configuration for messages in the room. | [`MessageOptions`](#messageoptions) |
+| `occupancy` | *Optional* The configuration for occupancy in the room. | [`OccupancyOptions`](#occupancyoptions) |
+| `presence` | *Optional* The configuration for presence in the room. | [`PresenceOptions`](#presenceoptions) |
+| `typing` | *Optional* The configuration for typing indicators in the room. | [`TypingOptions`](#typingoptions) |
+
+#### MessageOptions
+
+The following `MessageOptions` can be set:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `defaultMessageReactionType` | *Optional* The default type of message reaction. Other types can still be sent by specifying the `type` parameter when reacting to a message. The default value is `distinct`. | [`MessageReactionType`](#messagereactiontype) |
+| `rawMessageReactions` | *Optional* Whether subscribers should receive individual message reactions, rather than just aggregates. The default value is `false`. | Boolean |
+
+#### OccupancyOptions
+
+The following `OccupancyOptions` can be set:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `enableEvents` | *Optional* Sets whether the client should receive [occupancy](#occupancy) events. If enabled, the client will receive messages detailing the changing room occupancy. The default value is `false`. | Boolean |
+
+#### PresenceOptions
+
+The following `PresenceOptions` can be set:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `enableEvents` | *Optional* Sets whether the client should receive [presence](#presence) events. If enabled, the client will presence updates about other clients in the room. Note that even if the client hasn't subscribed to presence, they are still streamed presence events by the server. Clients can also still register their presence in the room without receiving presence events. The default value is `true`. | Boolean |
+
+#### TypingOptions
+
+The following `TypingOptions` can be set:
+
+| Properties | Description | Type |
+| ---------- | ----------- | ---- |
+| `heartbeatThrottleMs` | *Optional* Set the minimum time interval between consecutive `typing.started` events. The interval is reset after a `typing.stopped` event. The default value is `10000`. | Number |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled with the new or existing room object. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo) if a room with the same name but different `options` already exists.
+
+<Code>
+```javascript
+const room = await chatClient.rooms.get('livestream-1', {occupancy: {enableEvents: true}});
+```
+</Code>
+
+---
+
+## Release a room
+
+`ChatClient.Rooms.release()`
+
+Releases a `Room` object, allowing for it to be garbage collected.
+
+This will release the reference to the `Room` object from the `Rooms` collection and detach it from Ably. It does not unsubscribe the client from any events. Call [`Rooms.get()`](LINK) if you want to get the `Room` object back.
+
+`release(name: string): Promise<void>`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `name` | The name of the room to release. | String |
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+<Code>
+```javascript
+await rooms.release('livestream-1');
+```
+</Code>

--- a/src/pages/docs/chat/api/javascript/typing.mdx
+++ b/src/pages/docs/chat/api/javascript/typing.mdx
@@ -1,0 +1,183 @@
+---
+title: Typing
+meta_description: ""
+---
+
+The `Typing` interface is used to send typing events on keystrokes and subscribe to typing events emitted by other users.
+
+Access it via `room.typing`.
+
+---
+
+## Get the users currently typing
+
+`room.typing.current()`
+
+Get the set of users that are currently typing in the room by their `clientId`s.
+
+`current(): Set<string>`
+
+### Returns
+
+Returns the set of `clientId`s of all users that are currently typing.
+
+<Code>
+```javascript
+const currentlyTypingClientIds = room.typing.current();
+```
+</Code>
+
+---
+
+## Start typing
+
+`room.typing.keystroke()`
+
+Send a `typing.started` event to the server. Events are throttled according to the [`heartbeatThrottleMs RoomOption`](/docs/chat/api/javascript/rooms#typingoptions). If an event has already been sent within the configured interval then the operation is a no-op.
+
+Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
+
+* For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute as soon as the first `keystroke()` call completes. All intermediate `keystroke()` calls will be treated as no-ops.
+* The most recent `keystroke()` or `stop()` will always determine the final state, ensuring operations resolve to a consistent and correct state.
+
+`keystroke(): Promise<void>`
+
+#### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+Throws if:
+
+* The `Connection` is not in the `Connected` state.
+* The operation fails to send the event to the server.
+* There is a problem acquiring the mutex that controls serialization.
+
+<Code>
+```javascript
+await room.typing.keystroke();
+```
+</Code>
+
+---
+
+## Stop typing
+
+`room.typing.stop()`
+
+Send a `typing.stopped` event to the server. If an event has already been sent within the configured interval then the operation is a no-op.
+
+Calls to `keystroke()` and `stop()` are serialized and will always resolve in the correct order.
+
+* For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute as soon as the first `keystroke()` call completes. All intermediate `keystroke()` calls will be treated as no-ops.
+* The most recent `keystroke()` or `stop()` will always determine the final state, ensuring operations resolve to a consistent and correct state.
+
+`stop(): Promise<void>`
+
+### Returns
+
+Returns a promise. On success, the promise is fulfilled. On failure, the promise is rejected with an [`ErrorInfo`](#errorinfo).
+
+Throws if:
+
+* The `Connection` is not in the `Connected` state.
+* The operation fails to send the event to the server.
+* There is a problem acquiring the mutex that controls serialization.
+
+<Code>
+```javascript
+await room.typing.stop();
+```
+</Code>
+
+---
+
+## Subscribe to typing events
+
+`room.typing.subscribe()`
+
+Subscribe to all typing events by registering a listener.
+
+`subscribe(listener: TypingListener): Subscription`
+
+### Parameters
+
+Use the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `listener` | Function called when a typing event is received. | `TypingListener` |
+
+#### TypingListener
+
+A listener that listens for typing events.
+
+`(event: TypingSetEvent) => void`
+
+It uses the following parameters:
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| `event` | A typing event. | [`TypingSetEvent`](#typingsetevent) |
+
+#### TypingSetEvent
+
+An interface that represents a change in the state of currently typing users.
+
+It has the following properties:
+
+| Property | Description | Type |
+| -------- | ----------- | ---- |
+| `change` | The change that resulted in the new set of users currently typing. Contains the `clientId` of the user and whether they started or stopped typing. | `change: { clientId: string; type: [TypingEventType](#typingeventtype) }` |
+| `currentlyTyping` | The set of `clientId`s that are currently typing. | `Set<string>` |
+| `type`  | The type of event. | [`TypingSetEventType`](#typingseteventtype) |
+
+The following is an example of a TypingSetEvent:
+
+<Code>
+```json
+{
+  "type": "typing.set.changed",
+  "currentlyTyping": {
+    "clemons",
+    "zoranges",
+  },
+  "change": {
+    "type": "typing.started",
+    "clientId": "clemons"
+  }
+}
+```
+</Code>
+
+#### TypingEventType
+
+An enum that represents the types of events emitted by users typing in a room.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `typing.started` | Sent when a user starts typing. |
+| `typing.stopped` | Sent when a user stops typing. |
+
+#### TypingSetEventType
+
+An enum representing the typing set event types.
+
+It has the following members:
+
+| Member | Description |
+| ------ | ----------- |
+| `SetChanged` | Event triggered when a change occurs in the set of users currently typing. |
+
+### Returns
+
+Returns a [`Subscription`](LINK) object with an `unsubscribe()` method to remove the listener.
+
+<Code>
+```javascript
+const {unsubscribe} = room.typing.subscribe((event) => {
+  console.log(event);
+});
+```
+</Code>


### PR DESCRIPTION
## Description

This is a draft PR looking at converting the JavaScript TypeDoc API references for Chat into MDX. 

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
