### PR TITLE
[INF-5971] Add latency architecture page

### DIFF
--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -43,6 +43,10 @@ export default {
           link: '/docs/platform/architecture/performance',
         },
         {
+          name: 'Latency',
+          link: '/docs/platform/architecture/latency',
+        },
+        {
           name: 'Platform scalability',
           link: '/docs/platform/architecture/platform-scalability',
         },

--- a/src/pages/docs/platform/architecture/latency.mdx
+++ b/src/pages/docs/platform/architecture/latency.mdx
@@ -1,0 +1,94 @@
+---
+title: Latency
+meta_description: "Understand Ably's latency performance metrics and how they ensure consistent, low-latency message delivery across the global platform."
+---
+
+Latency is the most critical performance metric for realtime messaging platforms.
+
+That doesn't mean just hitting a one-off figure to advertise. It's about providing **consistently low latencies** to all regions, for all use cases, all the time.
+
+Ably's platform achieves this by providing the lowest latencies of any Pub/Sub WebSockets platform, with a **global median latency of 37ms**.
+
+Understand how Ably optimizes its transit latency to consistently provide your users with the best possible realtime experience.
+
+## Why latency matters
+
+In realtime applications, latency directly impacts user experience and application responsiveness. Whether it's live chat, collaborative editing, multiplayer gaming, or financial trading, your users expect near-instantaneous message delivery. Even a small increase in latency can significantly degrade the perceived quality of your application.
+
+## Latency metrics
+
+Ably measures and optimizes for two latency metrics to ensure consistent performance across the platform:
+
+### Round-trip latency
+
+Round-trip latency measures the total time it takes for a message to travel from a publisher, through Ably's infrastructure, to a subscriber, and back again.
+
+#### Round-trip latency - Last 7 days
+
+<iframe src="https://ably.metabaseapp.com/public/question/ede4320e-08f6-4660-9303-33a7331ba112#bordered=false&titled=false&downloads=false" width="100%" height="350"></iframe>
+
+### Message delivery latency
+
+Message delivery latency measures the time taken from when a message is published to Ably until it is delivered to a subscriber.
+
+This metric focuses on the core messaging performance without including the return path.
+
+#### Message delivery - Median latency - Last 7 days
+
+<iframe src="https://ably.metabaseapp.com/public/question/ad2e9f79-7a20-4f5e-b25b-b1b5b9587fcf#bordered=false&titled=false&downloads=false" width="100%" height="350"></iframe>
+
+#### Message delivery - P90 latency - Last 7 days
+
+<iframe src="https://ably.metabaseapp.com/public/question/107d2855-2946-4582-86f9-629ce66fad2c#bordered=false&titled=false&downloads=false" width="100%" height="350"></iframe>
+
+## How latency is measured
+
+Ably employs rigorous measurement methodologies to ensure latency performance is accurately captured across its global platform.
+
+Latency measurements are taken continuously at the following rates:
+
+* 70 measurements per second.
+* 4,200 measurements per minute.
+* 252,000 measurements per hour.
+* 6,048,000 measurements per day.
+
+### Round-trip latency measurement
+
+Round-trip latency is measured using real browser monitoring through Uptrends Real Browser Monitoring. This approach provides:
+
+* **Real browser simulation**: Measurements are conducted using actual browser instances, ensuring realistic network conditions.
+* **Global coverage**: Monitoring points are distributed across the globe using a third party service.
+* **Pub/sub simulation**: Real browsers publish messages and measure the complete round-trip time.
+* **Continuous monitoring**: Measurements are conducted continuously to capture performance across different time periods and load conditions.
+
+This methodology ensures that round-trip latency measurements reflect the actual experience of end-users accessing Ably through web browsers.
+
+### Message delivery latency measurement
+
+Message delivery latency is measured using Ably's internal quality of service (QOS) application. The measurement process includes:
+
+* **Continuous message publishing**: Messages are sent continuously to a common Ably channel at a rate of 5 messages per second, per region.
+* **Payload inclusion**: Each message contains a payload with region information and precise publish timestamp.
+* **Delivery tracking**: Subscribers across different regions receive and timestamp the messages.
+* **Latency calculation**: Delivery latency is calculated by subtracting the publish timestamp from the delivery timestamp.
+* **Statistical sampling**: The 5 messages per second rate ensures statistically relevant sample sizes across all regions.
+
+This methodology provides comprehensive coverage of Ably's global infrastructure and ensures that latency measurements reflect real-world conditions across all datacenters and regions.
+
+### Measurement infrastructure
+
+Both measurement systems operate continuously to provide realtime insights into Ably's latency performance. They include:
+
+* **Automated collection**: Measurements are collected automatically without manual intervention
+* **Realtime analysis**: Latency data is processed and analyzed in real-time
+* **Alerting**: Performance thresholds trigger alerts when latency exceeds targets
+* **Historical tracking**: Long-term trends are maintained for performance optimization
+
+### Statistical analysis
+
+Latency data is analyzed across multiple percentiles to ensure comprehensive performance reporting:
+
+* **P50 (median)**: Represents typical performance under normal conditions.
+* **P90**: Ensures 90% of messages meet performance targets.
+
+This multi-percentile approach ensures that Ably's latency performance is consistent and predictable across all load conditions.

--- a/src/pages/docs/platform/architecture/performance.mdx
+++ b/src/pages/docs/platform/architecture/performance.mdx
@@ -23,10 +23,7 @@ The first objective is minimizing latency and latency variance for message deliv
 
 The second objective is maximizing single-channel throughput in terms of both message rate and bandwidth. This ensures that even when a channel handles high volumes of traffic, such as during live events or peak usage periods, the system can efficiently process and distribute messages without degradation.
 
-The latency metrics that matter most to Ably include:
-
-- Round-trip latency where publisher and subscriber are connected to the same site, measuring the time taken for a message to travel from a publisher to Ably and back to a subscriber within the same region.
-- Round-trip latency generally, including messages transiting between different sites, which measures the end-to-end time for messages that must travel between different geographic regions.
+Ably achieves a [**global mean latency of 37ms**](/docs/platform/architecture/latency) to provide the best possible realtime experience to your users.
 
 Beyond average latency, Ably focuses on the performance of the slowest percentiles of messages (p95, p99, p99.9) to ensure consistent performance for all messages. These tail latencies often reveal performance issues that might be hidden by average measurements.
 


### PR DESCRIPTION
## Description

WIP: Add Latency page to the platform architecture documentation. Images will be swapped out for embedded Metabase reports in due course.

- https://ably-metabase.herokuapp.com/dashboard/1346-latencies-cross-region
- https://ably-metabase.herokuapp.com/dashboard/1347-latencies-real-browser

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
