### PR TITLE
Remove -X GET and json content-type from LiveObjects REST docs

### DIFF
--- a/src/pages/docs/liveobjects/rest-api-usage.mdx
+++ b/src/pages/docs/liveobjects/rest-api-usage.mdx
@@ -49,9 +49,8 @@ Fetch a flat list of objects on the channel:
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects" \
+  curl "https://rest.ably.io/channels/my-channel/objects" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -74,9 +73,8 @@ To include values of the objects in the response, set the `values=true` query pa
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects?values=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects?values=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -138,9 +136,8 @@ You can optionally include additional object [metadata](/docs/liveobjects/concep
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects?values=true&metadata=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects?values=true&metadata=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -232,9 +229,8 @@ Use the `limit` query parameter to specify the maximum number of objects to incl
 
 <Code>
 ```shell
-  curl -v -X GET "https://rest.ably.io/channels/my-channel/objects?values=true&limit=2" \
+  curl -v "https://rest.ably.io/channels/my-channel/objects?values=true&limit=2" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -275,9 +271,8 @@ The list objects endpoints returns objects ordered lexicographically by object I
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects?cursor=map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519&limit=2&values=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects?cursor=map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519&limit=2&values=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -327,9 +322,8 @@ To fetch a single object on the channel, specify the object ID in the URL path:
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -356,9 +350,8 @@ To fetch the objects on the channel in a tree structure use the `children` query
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -413,9 +406,8 @@ You can optionally include additional object [metadata](/docs/liveobjects/concep
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root?children=true&metadata=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true&metadata=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -490,9 +482,8 @@ When fetching objects in a tree structure, the response can be paginated using t
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root?children=true&limit=1" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true&limit=1" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -517,9 +508,8 @@ To obtain the next page, make a subsequent query specifying the referenced objec
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519?children=true&limit=1" \
+  curl "https://rest.ably.io/channels/my-channel/objects/map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519?children=true&limit=1" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -568,9 +558,8 @@ The response will handle the cyclic reference by including the `myRoot` key in t
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 
@@ -628,9 +617,8 @@ To fetch the objects on the channel in a tree structure in a concise format:
 
 <Code>
 ```shell
-  curl -X GET "https://rest.ably.io/channels/my-channel/objects/root/compact" \
+  curl "https://rest.ably.io/channels/my-channel/objects/root/compact" \
     -u {{API_KEY}}
-    -H "Content-Type: application/json"
 ```
 </Code>
 


### PR DESCRIPTION
curl makes GET requests by default, so no need to specify `-X GET`, and GET requests don't include a body, so no need to specify a content-type.

## Description

<!--  An in-depth description of what this PR is adding or updating. Include a link to the related JIRA issue if this exists. -->

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
