### PR TITLE
[PUB-1667] Update LiveObjects docs to reflect support for JSON-serializable objects as LiveMap values

### DIFF
--- a/src/pages/docs/liveobjects/concepts/objects.mdx
+++ b/src/pages/docs/liveobjects/concepts/objects.mdx
@@ -20,7 +20,7 @@ LiveObjects provides specialized object types to model your application state. T
 [LiveMap](/docs/liveobjects/map) is a key/value data structure similar to a dictionary or JavaScript [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map):
 
 * Keys must be strings
-* Values can be primitive types or [references](#composability) to other objects
+* Values can be primitive types, JSON-serializable objects or arrays, or [references](#composability) to other objects
 * Supports `set` and `remove` operations
 * Concurrent updates to the same key are resolved using last-write-wins (LWW) semantics
 

--- a/src/pages/docs/liveobjects/index.mdx
+++ b/src/pages/docs/liveobjects/index.mdx
@@ -57,7 +57,7 @@ LiveObjects provides specialized object types to model your application state. T
 
 #### LiveMap <a id="map"/>
 
-[LiveMap](/docs/liveobjects/map) is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans and buffers, as well as other objects, enabling [composable data structures](#composability).
+[LiveMap](/docs/liveobjects/map) is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans, buffers, JSON-serializable objects or arrays and other LiveObjects types, enabling [composable data structures](#composability).
 
 ### Composability <a id="composability"/>
 

--- a/src/pages/docs/liveobjects/map.mdx
+++ b/src/pages/docs/liveobjects/map.mdx
@@ -9,7 +9,7 @@ LiveObjects is currently Experimental. Its features are still in development and
 **Building with LiveObjects?** Help shape its future by [sharing your use case](https://44qpp.share.hsforms.com/2fZobHQA1ToyRfB9xqZYQmQ).
 </Aside>
 
-LiveMap is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans and buffers, as well as other objects, [enabling you to build complex, hierarchical object structure](#composability).
+LiveMap is a key/value data structure that synchronizes its state across users in realtime. It enables you to store primitive values, such as numbers, strings, booleans, buffers, JSON-serializable objects or arrays and other LiveObjects types, [enabling you to build complex, hierarchical object structure](#composability).
 
 Conflicts in a LiveMap are automatically resolved with last-write-wins (LWW) semantics. The latest received operation on a key will be applied to the LiveMap and broadcast to all clients.
 
@@ -120,7 +120,7 @@ map.unsubscribeAll();
 
 Set a value for a key in a map by calling `LiveMap.set()`. This operation is synchronized across all clients and triggers data subscription callbacks for the map, including on the client making the request.
 
-Keys in a map can contain numbers, strings, booleans and buffers, as well as other `LiveMap` and `LiveCounter` objects.
+Keys in a map can contain numbers, strings, booleans, buffers, JSON-serializable objects or arrays and other `LiveMap` and `LiveCounter` objects.
 
 This operation is asynchronous, as the client sends the corresponding update operation to the Ably system and waits for acknowledgment of the successful map key update.
 

--- a/src/pages/docs/liveobjects/rest-api-usage.mdx
+++ b/src/pages/docs/liveobjects/rest-api-usage.mdx
@@ -27,11 +27,11 @@ The key in the `data` object indicates the type of the value:
 
 <Code>
 ```json
-{ "data": { "number" : 42 }}
-{ "data": { "string" : "LiveObjects is awesome" }}
-{ "data": { "boolean" : true }}
-{ "data": { "bytes": "TGl2ZU9iamVjdHMgaXMgYXdlc29tZQo=" }}
-{ "data": { "objectId": "counter:JbZYiHnw0ORAyzzLSQahVik31iBDL_ehJNpTEF3qwg8@1745828651669" }}
+{ "data": { "number": 42 } }
+{ "data": { "string": "LiveObjects is awesome" } }
+{ "data": { "boolean": true } }
+{ "data": { "bytes": "TGl2ZU9iamVjdHMgaXMgYXdlc29tZQo=" } }
+{ "data": { "objectId": "counter:JbZYiHnw0ORAyzzLSQahVik31iBDL_ehJNpTEF3qwg8@1745828651669" } }
 ```
 </Code>
 

--- a/src/pages/docs/liveobjects/storage.mdx
+++ b/src/pages/docs/liveobjects/storage.mdx
@@ -51,6 +51,7 @@ The size of a `LiveMap` object is calculated as the sum of the length of all key
 * `number` values are 8 bytes
 * `boolean` values are 1 byte
 * `bytes` values are the length of the byte array
+* JSON-serializable object or array values are equal to the length of their corresponding JSON strings
 
 The maximum allowed size of a single `LiveMap` object is the same as the [message size limit](/docs/platform/pricing/limits#message) for your package. This is because objects are [synchronized](/docs/liveobjects/concepts/synchronization#client-objects) to the client as channel messages.
 


### PR DESCRIPTION
## Description

[PUB-1667](https://ably.atlassian.net/browse/PUB-1667)
ably-js support for this added in https://github.com/ably/ably-js/pull/2052

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


[PUB-1667]: https://ably.atlassian.net/browse/PUB-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ