### PR TITLE
[WEB-4460] fix: preserve lang param in content links

### DIFF
--- a/src/components/Markdown/MarkdownProvider.test.tsx
+++ b/src/components/Markdown/MarkdownProvider.test.tsx
@@ -1,12 +1,51 @@
 import React from 'react';
 import { useStaticQuery } from 'gatsby';
+import { useLocation, WindowLocation } from '@reach/router';
 import { render } from '@testing-library/react';
 import { Anchor } from 'src/components/Markdown/MarkdownProvider';
 
+// Mock the hooks
+jest.mock('gatsby', () => ({
+  useStaticQuery: jest.fn(),
+  graphql: jest.fn((query) => query),
+}));
+
+jest.mock('@reach/router', () => ({
+  useLocation: jest.fn(),
+}));
+
+jest.mock('src/components/Link', () => {
+  return function MockLink({ to, children, ...props }: any) {
+    const isExternal = to?.startsWith('http') || to?.startsWith('//');
+    const testId = isExternal ? 'link-external' : 'link-internal';
+
+    return (
+      <a href={to} data-testid={testId} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+const mockUseStaticQuery = useStaticQuery as jest.MockedFunction<typeof useStaticQuery>;
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+
 describe('<Anchor/>', () => {
+  beforeEach(() => {
+    mockUseLocation.mockReturnValue({
+      search: '',
+    } as WindowLocation);
+
+    mockUseStaticQuery.mockReturnValue({
+      site: {
+        assetPrefix: undefined,
+      },
+    });
+  });
+
   describe('with assetPrefix', () => {
     beforeEach(() => {
-      useStaticQuery.mockReturnValue({
+      mockUseStaticQuery.mockReturnValue({
         site: {
           assetPrefix: 'http://example.com',
         },
@@ -29,19 +68,33 @@ describe('<Anchor/>', () => {
   });
 
   describe('without assetPrefix', () => {
-    beforeEach(() => {
-      useStaticQuery.mockReturnValue({
-        site: {
-          assetPrefix: undefined,
-        },
-      });
-    });
-
     it('does nothing to the links from MDX', () => {
       const { getByTestId } = render(<Anchor href="/docs/channels">Example docs</Anchor>);
       const a = getByTestId('link-internal');
 
       expect(a).toHaveAttribute('href', '/docs/channels');
+    });
+  });
+
+  describe('with lang parameter', () => {
+    beforeEach(() => {
+      mockUseLocation.mockReturnValue({
+        search: '?lang=javascript',
+      } as WindowLocation);
+    });
+
+    it('adds lang parameter to internal links', () => {
+      const { getByTestId } = render(<Anchor href="/docs/channels">Example docs</Anchor>);
+      const a = getByTestId('link-internal');
+
+      expect(a).toHaveAttribute('href', '/docs/channels?lang=javascript');
+    });
+
+    it('does not add lang parameter to fragment links', () => {
+      const { getByTestId } = render(<Anchor href="#">Fragment link</Anchor>);
+      const a = getByTestId('link-internal');
+
+      expect(a).toHaveAttribute('href', '#');
     });
   });
 });

--- a/src/components/Markdown/MarkdownProvider.tsx
+++ b/src/components/Markdown/MarkdownProvider.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useLocation } from '@reach/router';
 import { MDXProvider } from '@mdx-js/react';
 import Link from 'src/components/Link';
 import { CodeBlock } from './CodeBlock';
@@ -57,6 +58,7 @@ export const Anchor: FC<JSX.IntrinsicElements['a']> = ({ children, href, ...prop
       }
     }
   `);
+  const location = useLocation();
 
   let cleanHref = href;
   const assetPrefix = site.assetPrefix ?? '';
@@ -64,6 +66,16 @@ export const Anchor: FC<JSX.IntrinsicElements['a']> = ({ children, href, ...prop
 
   if (href?.startsWith(brokenAssetPrefix)) {
     cleanHref = href.slice(brokenAssetPrefix.length);
+  }
+
+  // Add lang param from current URL if available
+  const urlParams = new URLSearchParams(location.search);
+  const langParam = urlParams.get('lang');
+
+  if (langParam && cleanHref && !cleanHref.startsWith('#')) {
+    const url = new URL(cleanHref, 'https://ably.com');
+    url.searchParams.set('lang', langParam);
+    cleanHref = url.pathname + url.search;
   }
 
   return (

--- a/src/components/blocks/external-references/A.tsx
+++ b/src/components/blocks/external-references/A.tsx
@@ -1,13 +1,14 @@
 import React, { ReactElement } from 'react';
+import { useLocation } from '@reach/router';
 import Html from '../Html';
 import { HtmlAttributes, HtmlComponentProps } from '../../html-component-props';
-
 import Img from './Img';
 import { filterAttribsForReact } from 'src/react-utilities';
 import Link from 'src/components/Link';
 
 const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
-  const { href: href, ...props } = attribs ?? {};
+  const { href, ...props } = attribs ?? {};
+  const location = useLocation();
 
   // If there is an image inside the link with src same as href, then nuke <a> and render <img> only
   if (Array.isArray(data)) {
@@ -20,8 +21,18 @@ const A = ({ data, attribs }: HtmlComponentProps<'a'>): ReactElement => {
     }
   }
 
+  const urlParams = new URLSearchParams(location.search);
+  const langParam = urlParams.get('lang');
+
+  let cleanHref = href;
+  if (langParam && cleanHref && !cleanHref.startsWith('#')) {
+    const url = new URL(cleanHref, 'https://ably.com');
+    url.searchParams.set('lang', langParam);
+    cleanHref = url.pathname + url.search;
+  }
+
   return (
-    <Link className="ui-link" to={href} {...props}>
+    <Link className="ui-link" to={cleanHref ?? '#'} {...props}>
       <Html data={data} />
     </Link>
   );


### PR DESCRIPTION
Raised by @m-hulbert.

Links in content in MDX pages need to preserve any active lang params so that we get a consistent language experience between pages.

Review: https://ably-docs-web-4440-pres-2duhlf.herokuapp.com/docs/chat/rooms?lang=react