### PR TITLE
chat: remove duplication in the room reaction section

### DIFF
--- a/src/pages/docs/chat/rooms/reactions.mdx
+++ b/src/pages/docs/chat/rooms/reactions.mdx
@@ -54,24 +54,7 @@ val subscription = room.reactions.subscribe { reaction: Reaction ->
 
 ### Room reaction event structure <a id="structure"/>
 
-The following is the structure of a room reaction event:
-
-<Code>
-```json
-{
-  "type": "like",
-  "headers": {},
-  "metadata": {
-    "fireworks": "blue",
-  },
-  "clientId": "R3hegPCqgV3DZoMA2sCT-",
-  "createdAt": "2024-06-12T11:37:59.988Z",
-  "isSelf": true
-}
-```
-</Code>
-
-The following are the properties of a room reaction:
+The following are the properties of a room reaction event:
 
 <If lang="javascript,react">
 


### PR DESCRIPTION
## Description

Right now we do a JSON structure of a reaction event and a table. This is duplication, so remove the JSON and just have a table.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
