### PR TITLE
chat: add soft delete clarification

### DIFF
--- a/src/pages/docs/chat/rooms/messages.mdx
+++ b/src/pages/docs/chat/rooms/messages.mdx
@@ -547,7 +547,7 @@ The following is the structure of a deleted message:
 {
   "serial": "01726232498871-001@abcdefghij:001",
   "clientId": "basketLover014",
-  "text": "What a shot!",
+  "text": "",
   "headers": {},
   "metadata": {},
   "createdAt": new Date("2024-06-12T11:37:59.988Z"),
@@ -571,6 +571,9 @@ The deleted message response is identical to the structure of a message, with th
 | version | Set to the serial of the deletion action. |
 | timestamp | Set to the time the message was deleted. |
 | operation | Set to the details the actioning client provided in the request. |
+| text | Set to the empty string. |
+| metadata | Set to the empty object. |
+| headers | Set to the empty object. |
 
 ## Ordering chat message events <a id="global-ordering"/>
 


### PR DESCRIPTION
## Description

We're updating chat so that soft-deleted messages don't have data anymore. This change adds detail to that effect.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
