### PR TITLE
feat: Create review app when `review-app` label is used

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -1,0 +1,65 @@
+name: Deploy Review App
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+jobs:
+  manage-review-app:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: read
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'review-app') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'review-app') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'review-app'))
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check if user is an Ably organization member
+        if: github.event.action == 'labeled' && github.event.label.name == 'review-app'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ABLY_ORG_TOKEN }}
+          script: |
+            try {
+              const labelCreator = context.actor;
+              console.log(`Label creator: ${labelCreator}`);
+              
+              // Check if user is a member of the Ably organization
+              const { data: membership } = await github.rest.orgs.getMembershipForUser({
+                org: 'ably',
+                username: labelCreator
+              });
+              
+              console.log(`Membership state: ${membership.state}`);
+              console.log(`Membership role: ${membership.role}`);
+              
+              // Check if user is an active member (not just pending invitation)
+              if (membership.state !== 'active') {
+                core.setFailed(`User ${labelCreator} does not have active membership in the Ably organization`);
+                return;
+              }
+              
+              console.log(`✅ User ${labelCreator} is an active member of the Ably organization`);
+              
+            } catch (error) {
+              // If we get a 404, the user is not a member of the organization
+              if (error.status === 404) {
+                core.setFailed(`User ${context.actor} is not a member of the Ably organization`);
+              } else {
+                core.setFailed(`Failed to check Ably organization membership: ${error.message}`);
+              }
+            }
+
+      - name: Manage Heroku Review App
+        uses: fastruby/manage-heroku-review-app@v1
+        with:
+          action: ${{ (github.event.action == 'labeled' && github.event.label.name == 'review-app' && 'create') || 'destroy' }}
+        env:
+          HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
+          HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,3 +38,31 @@ To ensure proper setup in your local:
 2. Add `DOCS_BASE_URL=http://localhost:9000` to your `.env` file in the root of the Website app.
 3. Ensure that `.env.production` exists in the app root for the Yarn build to function correctly.
 4. You should be able to view the content and toggle between signed in and signed-out states.
+
+## Review Apps
+
+Review apps allow Ably organization members to create temporary deployments of the documentation site for sharing changes with stakeholders without requiring local development setup.
+
+### Creating a Review App
+
+To create a review app:
+
+1. Create a pull request with your changes
+2. Add the `review-app` label to your PR
+3. A Heroku review app will be automatically created and deployed
+4. The deployment will appear in the deployments section of your PR
+
+### Access and Authentication
+
+Review apps are protected with basic authentication. Contact team members for credentials if needed.
+
+### Cleanup
+
+Review apps are automatically cleaned up when:
+- The PR is closed
+- The `review-app` label is removed
+
+### Requirements
+
+- Only members of the Ably organization can create review apps
+- The label creator's organization membership is validated before deployment


### PR DESCRIPTION
## Description


### Copilot Summary

This pull request introduces a new workflow to automate the creation and management of Heroku review apps for pull requests, along with corresponding documentation updates. The workflow ensures that only Ably organization members can trigger these deployments. Below are the key changes:

### Workflow Automation for Review Apps

* Added a new GitHub Actions workflow in `.github/workflows/review-app.yml` to handle the creation and destruction of Heroku review apps based on pull request events (`labeled`, `unlabeled`, `closed`).
* Included a validation step to check if the user triggering the workflow is an active member of the Ably organization. This ensures only authorized users can create review apps.

### Documentation Updates

* Updated the `README.md` file with a new "Review Apps" section, detailing the purpose, creation process, access requirements, and cleanup procedures for review apps. This includes steps for adding the `review-app` label to PRs and notes on basic authentication.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
