### PR TITLE
chat: add message reactions for Swift/Kotlin

### DIFF
--- a/src/pages/docs/chat/rooms/history.mdx
+++ b/src/pages/docs/chat/rooms/history.mdx
@@ -50,7 +50,7 @@ const MyComponent = () => {
 ```
 
 ```swift
-let paginatedResult = try await room.messages.get(options: .init(orderBy: .newestFirst))
+let paginatedResult = try await room.messages.history(options: .init(orderBy: .newestFirst))
 print(paginatedResult.items)
 if let next = try await paginatedResult.next {
     print(next.items)
@@ -60,7 +60,7 @@ if let next = try await paginatedResult.next {
 ```
 
 ```kotlin
-var historicalMessages = room.messages.get(orderBy = OrderBy.NewestFirst)
+var historicalMessages = room.messages.history(orderBy = OrderBy.NewestFirst)
 println(historicalMessages.items.toString())
 
 // historical messages are paginated, so we can iterate through
@@ -143,7 +143,7 @@ const MyComponent = () => {
 
 ```swift
 let messagesSubscription = try await room.messages.subscribe()
-let paginatedResult = try await messagesSubscription.getPreviousMessages(params: .init(limit: 50)) // `orderBy` here is ignored and always `newestFirst`
+let paginatedResult = try await messagesSubscription.historyBeforeSubscribe(params: .init(limit: 50)) // `orderBy` here is ignored and always `newestFirst`
 print(paginatedResult.items)
 if let next = try await paginatedResult.next {
     print(next.items)
@@ -157,7 +157,7 @@ val subscription = room.messages.subscribe {
     println("New message received")
 }
 
-var historicalMessages = subscription.getPreviousMessages(limit = 50)
+var historicalMessages = subscription.historyBeforeSubscribe(limit = 50)
 println(historicalMessages.items.toString())
 
 while (historicalMessages.hasNext()) {

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -43,6 +43,50 @@ await room.messages.reactions.send(message, {
     count: 100,
 });
 ```
+
+```swift
+// Add a 👍 reaction using the default type
+await room.messages.reactions.send(to: message.serial, params: .init(name: "👍"))
+
+// The reaction can be anything, not just UTF-8 emojis:
+await room.messages.reactions.send(to: message.serial, params: .init(name: ":like:"))
+await room.messages.reactions.send(to: message.serial, params: .init(name: "+1"))
+
+// Add a :love: reaction using the Unique type
+await room.messages.reactions.send(to: message.serial, params: .init(
+  reaction: ":love:",
+  type: .unique
+))
+
+// Add a ❤️ reaction with count 100 using the Multiple type
+await room.messages.reactions.send(to: message.serial, params: .init(
+  reaction: "❤️",
+  type: .multiple,
+  count: 100
+))
+```
+
+```kotlin
+// Add a 👍 reaction using the default type
+room.messages.reactions.send(message, name = "👍")
+
+// The reaction can be anything, not just UTF-8 emojis:
+room.messages.reactions.send(message, name = ":like:"))
+room.messages.reactions.send(message, name = "+1"))
+
+// Add a :love: reaction using the Unique type
+room.messages.reactions.send(message,
+  name = ":love:",
+  type = MessageReactionType.Unique,
+)
+
+// Add a ❤️ reaction with count 100 using the Multiple type
+room.messages.reactions.send(message,
+  name = "❤️",
+  type = MessageReactionType.Multiple,
+  count = 100,
+)
+```
 </Code>
 
 The `annotation-publish` capability is required for adding reactions.
@@ -72,6 +116,23 @@ const room = await ablyChatClient.rooms.get('room1', {
         defaultMessageReactionType: MessageReactionType.Unique,
     },
 });
+```
+
+```swift
+let room = try await ablyChatClient.rooms.get(
+    name: "room1",
+    options: .init(
+        messages: .init(defaultMessageReactionType: .unique)
+    )
+)
+```
+
+```kotlin
+val room = ablyChatClient.rooms.get("room1") {
+    messages {
+        defaultMessageReactionType = MessageReactionType.Unique
+    }
+}
 ```
 </Code>
 
@@ -128,6 +189,17 @@ room.messages.reactions.subscribe((event) => {
     console.log("received reactions summary event", event);
 });
 ```
+```swift
+room.messages.reactions.subscribe { event in
+    print("received reactions summary event: \(event)")
+}
+```
+
+```kotlin
+room.messages.reactions.subscribe { event ->
+    println("received reactions summary event: $event")
+}
+```
 </Code>
 
 The event is of type `reaction.summary`. `event.summary` is the received reactions summary and contains the following properties:
@@ -160,6 +232,33 @@ room.messages.reactions.subscribe((event) => {
     messages[idx] = messages[idx].with(event);
 });
 ```
+
+```swift
+// init messages, in practice this should be updated with a message subscription
+var messages = (await room.messages.history(options: .init(limit: 50))).items
+
+// subscribe to message reactions summary events
+room.messages.reactions.subscribe { event in
+    if let idx = messages.lastIndex(where: { $0.serial == event.summary.messageSerial }) {
+        messages[idx] = messages[idx].with(summaryEvent: event)
+    }
+}
+```
+
+```kotlin
+// init messages, in practice this should be updated with a message subscription
+val messages = room.messages.history(limit = 50).items.toMutableList()
+
+// subscribe to message reactions summary events
+room.messages.reactions.subscribe { event ->
+    // find the relevant message (in practice: use binary search or a map for lookups)
+    val idx = messages.indexOfLast { msg -> msg.serial == event.summary.messageSerial }
+    if (idx != -1) {
+        // update message
+        messages[idx] = messages[idx].with(event)
+    }
+}
+```
 </Code>
 
 ### Summary events are sent efficiently at scale <a id="throttle"/>
@@ -182,6 +281,23 @@ const room = await ablyChatClient.rooms.get('room1', {
     },
 });
 ```
+
+```swift
+let room = try await ablyChatClient.rooms.get(
+    name: "room1",
+    options: .init(
+        messages: .init(rawMessageReactions: true)
+    )
+)
+```
+
+```kotlin
+val room = ablyChatClient.rooms.get("room1") {
+    messages {
+        rawMessageReactions = true
+    }
+}
+```
 </Code>
 
 Then you can receive raw reactions using the `room.messages.reactions.subscribeRaw()` method:
@@ -195,6 +311,26 @@ room.messages.reactions.subscribeRaw((event) => {
         console.log("reaction removed", event.reaction);
     }
 });
+```
+
+```swift
+room.messages.reactions.subscribeRaw { event in
+    if (event.type == .create) {
+        print("new reaction: \(event.reaction)")
+    } else if (event.type == .delete) {
+        print("reaction removed: \(event.reaction)")
+    }
+}
+```
+
+```kotlin
+room.messages.reactions.subscribeRaw { event ->
+    if (event.type == MessageReactionEventType.Create) {
+        println("new reaction: ${event.reaction}")
+    } else if (event.type == MessageReactionEventType.Delete) {
+        println("reaction removed: ${event.reaction}")
+    }
+}
 ```
 </Code>
 

--- a/src/pages/docs/chat/rooms/messages.mdx
+++ b/src/pages/docs/chat/rooms/messages.mdx
@@ -49,7 +49,7 @@ for await message in messagesSubscription {
 ```
 
 ```kotlin
-val subscription = room.messages.subscribe { messageEvent: MessageEvent ->
+val subscription = room.messages.subscribe { messageEvent: ChatMessageEvent ->
     println(messageEvent.message.toString())
 }
 ```
@@ -330,8 +330,8 @@ for await message in messagesSubscription {
 val myMessageList: List<Messages>
 val messagesSubscription = room.messages.subscribe { event ->
   when (event.type) {
-    MessageEventType.Created -> println("Received message: ${event.message}")
-    MessageEventType.Updated -> myMessageList.find {
+    ChatMessageEventType.Created -> println("Received message: ${event.message}")
+    ChatMessageEventType.Updated -> myMessageList.find {
       event.message.serial == it.serial && event.message.version > it.version
     }?.let { println("Message updated: ${event.message}") }
     else -> {}
@@ -526,8 +526,8 @@ for await message in messagesSubscription {
 val myMessageList: List<Messages>
 val messagesSubscription = room.messages.subscribe { event ->
   when (event.type) {
-    MessageEventType.Created -> println("Received message: ${event.message}")
-    MessageEventType.Deleted -> myMessageList.find {
+    ChatMessageEventType.Created -> println("Received message: ${event.message}")
+    ChatMessageEventType.Deleted -> myMessageList.find {
       event.message.serial == it.serial && event.message.version > it.version
     }?.let { println("Message deleted: ${event.message}") }
     else -> {}

--- a/src/pages/docs/chat/rooms/occupancy.mdx
+++ b/src/pages/docs/chat/rooms/occupancy.mdx
@@ -48,13 +48,14 @@ const MyComponent = () => {
 ```swift
 let occupancySubscription = room.occupancy.subscribe()
 for await event in occupancySubscription {
-  occupancyInfo = "Connections: \(event.presenceMembers) (\(event.connections))"
+  occupancyInfo = "Connections: \(event.occupancy.presenceMembers) (\(event.occupancy.connections))"
 }
 ```
 
 ```kotlin
 val subscription = room.occupancy.subscribe { event: OccupancyEvent ->
-    println(event.toString())
+    println("Number of users connected is: ${event.occupancy.connections}")
+    println("Number of members present is: ${event.occupancy.presenceMembers}")
 }
 ```
 </Code>

--- a/src/pages/docs/chat/rooms/presence.mdx
+++ b/src/pages/docs/chat/rooms/presence.mdx
@@ -55,13 +55,13 @@ const MyComponent = () => {
 ```swift
 let presenceSubscription = room.presence.subscribe(events: [.enter, .leave, .update])
 for await event in presenceSubscription {
-    print("Presence event `\(event.action)` from `\(event.clientId)` with data `\(event.data)`")
+    print("Presence event `\(event.type)` from `\(event.member.clientId)` with data `\(event.member.data)`")
 }
 ```
 
 ```kotlin
 val subscription = room.presence.subscribe { event: PresenceEvent ->
-    println("Presence event ${event.action} from ${event.clientId} with data: ${event.data}")
+    println("Presence event ${event.type} from ${event.member.clientId} with data: ${event.member.data}")
 }
 ```
 </Code>

--- a/src/pages/docs/chat/rooms/reactions.mdx
+++ b/src/pages/docs/chat/rooms/reactions.mdx
@@ -40,14 +40,14 @@ const MyComponent = () => {
 
 ```swift
 let reactionSubscription = room.reactions.subscribe()
-for await reaction in reactionSubscription {
-  print("Received a reaction of type \(reaction.type), and metadata \(reaction.metadata)")
+for await event in reactionSubscription {
+  print("Received a reaction of type \(event.reaction.type), and metadata \(event.reaction.metadata)")
 }
 ```
 
 ```kotlin
-val subscription = room.reactions.subscribe { reaction: Reaction ->
-    println("received a ${reaction.type} with metadata ${reaction.metadata}")
+val subscription = room.reactions.subscribe { event: RoomReactionEvent ->
+    println("received a ${event.reaction.type} with metadata ${event.reaction.metadata}")
 }
 ```
 </Code>


### PR DESCRIPTION
## Description

 Add message reactions for Swift/Kotlin

Also updated docs to reflect last API changes:

- Changed `get` to `history` in message history retrieval to improve clarity.
- Updated reaction and presence examples to incorporate new event type and structure adjustments.


<!--  An in-depth description of what this PR is adding or updating. Include a link to the related JIRA issue if this exists. -->

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
