### PR TITLE
Add Tile component

### DIFF
--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -16,6 +16,7 @@ import { HtmlComponentPropsData } from '../html-component-props';
 import { languageData } from 'src/data/languages';
 import { ActivePage } from './utils/nav';
 import { Table, TableHead, TableBody, TableRow, TableHeader, TableCell } from './mdx/tables';
+import { Tiles } from './mdx/tiles';
 import { Head } from '../Head';
 import { useSiteMetadata } from 'src/hooks/use-site-metadata';
 import { ProductName } from 'src/templates/template-data';
@@ -126,6 +127,7 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
             tr: TableRow,
             th: TableHeader,
             td: TableCell,
+            Tiles,
           }}
         >
           <PageTitle>{title}</PageTitle>

--- a/src/components/Layout/mdx/tiles.tsx
+++ b/src/components/Layout/mdx/tiles.tsx
@@ -1,0 +1,43 @@
+import Link from 'src/components/Link';
+import Icon from '@ably/ui/core/Icon';
+import { IconName } from '@ably/ui/core/Icon/types';
+
+type TileProps = {
+  title?: string;
+  description?: string;
+  image?: IconName;
+  link?: string;
+};
+
+const Tile = ({ title, description, image, link = '/docs' }: TileProps) => {
+  return (
+    <Link to={link} className="block no-underline">
+      <section
+        className="flex items-start gap-4 p-4 bg-neutral-100 dark:bg-neutral-1200 rounded-lg border border-neutral-300 dark:border-neutral-1000
+        transition-colors hover:bg-neutral-200 dark:hover:bg-neutral-1100 hover:border-neutral-400 dark:hover:border-neutral-900 min-h-[112px]"
+      >
+        <div className="w-12 h-12 bg-neutral-000 dark:bg-neutral-1300 rounded-xl p-2.5 flex items-center justify-center flex-shrink-0">
+          {image && <Icon name={image} size="2rem" />}
+        </div>
+        <div className="flex-1 max-w-66">
+          <h3 className="text-lg font-bold leading-tight tracking-tight mb-2 text-neutral-1300">{title}</h3>
+          <p className="text-sm font-medium leading-relaxed tracking-normal text-neutral-800 dark:text-neutral-500 max-h-11 overflow-hidden">
+            {description}
+          </p>
+        </div>
+      </section>
+    </Link>
+  );
+};
+
+export const Tiles = ({ children }: { children: TileProps[] }) => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pb-40">
+      {children
+        .filter((item) => item.title && item.description)
+        .map((item: TileProps) => (
+          <Tile key={`${item.title}${item.description}`} {...item} />
+        ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

The first step to creating a landing page for Pub/Sub and other products getting started guides. This is the component which can be used by Getting started guides, but on other pages throughout the docs. You'll be able to pass the array of objects you wish to render through the riles. 

To access this page, go to `/docs/test` in your browser.

Once the PR is approved, I'll fixup a commit to remove the test page, which is:

```---
title: "Test page"
meta_description: "A page created with the sole purpose of testing a new MDX component"
meta_keywords: "No need"
---

The content below is the new component we're creating:

<Tiles>
{[
  {
    title: 'Test 1',
    description: 'Here is a description for this first option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
  {
    title: 'Test 2',
    description: 'Here is a description for this second option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
  {
    title: 'Test 3',
    description: 'Here is a description for this third option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
  {
    title: 'Test 4',
    description: 'Here is a description for this fourth option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
  {
    title: 'Test 5',
    description: 'Here is a description for this fifth option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
  {
    title: 'Test 6',
    description: 'Here is a description for this sixth option',
    image: 'icon-tech-ably',
    link: '/docs/',
  },
]}
</Tiles>
```

<img width="1728" alt="Screenshot 2025-07-07 at 16 25 58" src="https://github.com/user-attachments/assets/418b0fdc-23b2-43e2-a8fe-13351d2493e7" />
