### PR TITLE
[WEB-4311] Use latest action version

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -56,7 +56,7 @@ jobs:
             }
 
       - name: Manage Heroku Review App
-        uses: fastruby/manage-heroku-review-app@v1
+        uses: fastruby/manage-heroku-review-app@v1.3
         with:
           action: ${{ (github.event.action == 'labeled' && github.event.label.name == 'review-app' && 'create') || 'destroy' }}
         env:


### PR DESCRIPTION
## Description

Noticed while monitoring the use of the `review-app` label, that the deployment section was temperamental at listing the deployments. Bumping the review app action fixes this as the plugin correctly uses `GITHUB_TOKEN` during the review app creation.

### Testing
The deployment section of this PR is correctly updated. Feel free to remove and re-add the label to test

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
