### PR TITLE
Add landing page for Pub/Sub getting started guides

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -22,45 +22,9 @@ export default {
       name: 'Getting started',
       pages: [
         {
-          name: 'Overview',
+          name: 'Guides',
           link: '/docs/getting-started',
           index: true,
-        },
-        {
-          name: 'JavaScript',
-          link: '/docs/getting-started/javascript',
-        },
-        {
-          name: 'React',
-          link: '/docs/getting-started/react',
-        },
-        {
-          name: 'React Native',
-          link: '/docs/getting-started/react-native',
-        },
-        {
-          name: 'Kotlin',
-          link: '/docs/getting-started/kotlin',
-        },
-        {
-          name: 'Swift',
-          link: '/docs/getting-started/swift',
-        },
-        {
-          name: 'Ruby',
-          link: '/docs/getting-started/ruby',
-        },
-        {
-          name: 'Python',
-          link: '/docs/getting-started/python',
-        },
-        {
-          name: 'Go',
-          link: '/docs/getting-started/go',
-        },
-        {
-          name: 'Quickstart guide',
-          link: '/docs/getting-started/quickstart',
         },
         {
           name: 'SDK setup',

--- a/src/pages/docs/getting-started/index.mdx
+++ b/src/pages/docs/getting-started/index.mdx
@@ -1,48 +1,50 @@
 ---
 title: "Overview"
-meta_description: "Get started with Pub/Sub in various languages or frameworks using Ably. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
+meta_description: "Get started with Ably Pub/Sub in your language or framework of choice. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
 meta_keywords: "Pub/Sub, Ably SDKs, realtime messaging, publish subscribe, getting started guides, realtime communication, Ably tutorial, message history, presence API, Ably CLI Pub/Sub"
 ---
 
-Ably is a realtime experience infrastructure provider that powers synchronized digital experiences in realtime. Our platform provides APIs and SDKs to help developers build realtime features like live chat, data broadcast, notifications, and collaborative experiences. With Ably's Pub/Sub messaging, you can publish messages to channels and have them delivered instantly to millions of subscribers across any device, anywhere in the world.
+Get started with Ably Pub/Sub by choosing your language or framework.
 
-Choose from the following list of getting started guides to build an application using the Pub/Sub product. Each guide is tailored for different programming languages or frameworks and provides step-by-step instructions and code examples to help you integrate Pub/Sub into your application.
+You'll learn the basics, such as how to connect to Ably, publish and subscribe to messages, and manage the status of clients with presence. You'll also be introduced to the Ably CLI and your Ably dashboard to interact with, and manage your apps.
+
+These are your first steps towards building a realtime application that can effortlessly scale to serve millions of users.
 
 <Tiles>
 {[
   {
     title: 'JavaScript',
-    description: 'Start building with Pub/Sub using our JavaScript SDK',
+    description: 'Start building with Pub/Sub using Ably\'s JavaScript SDK',
     image: 'icon-tech-javascript',
     link: '/docs/getting-started/javascript',
   },
   {
-    title: 'React guide',
-    description: 'Start building with Pub/Sub using our React SDK.',
+    title: 'React',
+    description: 'Start building with Pub/Sub using Ably\'s React SDK.',
     image: 'icon-tech-react',
     link: '/docs/getting-started/react',
   },
   {
-    title: 'React Native guide',
-    description: 'Start building with Pub/Sub using our React Native SDK.',
+    title: 'React Native',
+    description: 'Start building with Pub/Sub using Ably\'s React Native SDK.',
     image: 'icon-tech-reactnative',
     link: '/docs/getting-started/react-native',
   },
   {
-    title: 'Kotlin guide',
-    description: 'Start building with Pub/Sub using our Kotlin SDK.',
+    title: 'Kotlin',
+    description: 'Start building with Pub/Sub using Ably\'s Kotlin SDK.',
     image: 'icon-tech-kotlin',
     link: '/docs/getting-started/kotlin',
   },
   {
-    title: 'Swift guide',
-    description: 'Start building with Pub/Sub using our Swift SDK.',
+    title: 'Swift',
+    description: 'Start building with Pub/Sub using Ably\'s Swift SDK.',
     image: 'icon-tech-swift',
     link: '/docs/getting-started/swift',
   },
   {
-    title: 'Ruby guide',
-    description: 'Start building with Pub/Sub using our Ruby SDK.',
+    title: 'Ruby',
+    description: 'Start building with Pub/Sub using Ably\'s Ruby SDK.',
     image: 'icon-tech-ruby',
     link: '/docs/getting-started/ruby',
   },


### PR DESCRIPTION
## Description

Added a page in Pub/Sub that lists the existing tiles of getting started guides. This is to reduce the size of the nav bar usage.
Also removed items from nav bar for the existing getting started guides as they're linked to in the new page

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
