### PR TITLE
chat: remove experimental notice from message reactions documentation

### DIFF
--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -3,10 +3,6 @@ title: Message reactions
 meta_description: "React to chat messages"
 ---
 
-<Aside data-type='experimental'>
-The message reactions feature is currently Experimental. It is still in development and subject to rapid change.
-</Aside>
-
 Add, remove and display message reactions in a chat room. Users can react to messages, typically with emojis but can be any string, and others can see the reactions to the message. Message reactions can be added and removed and a summary of the reactions is persisted with the message.
 
 The reaction `name` represents the reaction itself, for example an emoji. Reactions are aggregated by `name` and the aggregation method including how many reactions a user can place for a message is controlled by the reaction `type`. The `count` is an optional parameter that can be set when adding a reaction of type `Multiple`.


### PR DESCRIPTION
## Description

Message reactions is now generally available, remove the experimental flag.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
