### PR TITLE
Chat: A how to guide for replies

### DIFF
--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -129,6 +129,10 @@ export default {
           name: 'Livestream chat',
           link: '/docs/guides/chat/build-livestream',
         },
+        {
+          name: 'Replies',
+          link: '/docs/guides/chat/replies',
+        }
       ],
     },
   ],

--- a/src/pages/docs/guides/chat/replies.mdx
+++ b/src/pages/docs/guides/chat/replies.mdx
@@ -10,7 +10,7 @@ As such, we will cover only replies in this guide, but the same principles can b
 
 While cross-room replies are possible, this guide will focus on providing replies within the same room for simplicity.
 
-## Understanding the current limitations
+## Understanding the current limitations <a id="limitations"/>
 
 While Ably Chat doesn't have built-in support for replies or quotes, you can implement this functionality by using the metadata fields that can be sent along with chat messages.
 
@@ -21,7 +21,7 @@ Every message in Ably Chat has:
 
 By storing the serial and creation time of a message you want to quote in the metadata of a new message, you can create a reference between messages that your application can interpret and display accordingly.
 
-## Implementing replies using message metadata
+## Implementing replies using message metadata <a id="implementing-replies"/>
 
 To implement a reply to a message, you'll need to:
 
@@ -29,7 +29,7 @@ To implement a reply to a message, you'll need to:
 2. Include that information in the metadata when sending the reply
 3. Process incoming messages to check for reply metadata
 
-### Step 1: Store information about the message being replied to
+### Step 1: Store information about the message being replied to <a id="store-information"/>
 
 When a user selects a message to reply to, you should store its key information. Extract the following properties from the original message:
 
@@ -42,6 +42,7 @@ Store this information in your application state or pass it to your message inpu
 
 For example, when a user clicks a "Reply" button on a message, you would extract these properties from the message and store them in your application state, perhaps in a variable called `replyingTo`.
 
+<Code>
 ```javascript
 import { Message } from '@ably/chat';
 function prepareReply(originalMessage: Message) {
@@ -57,14 +58,16 @@ function prepareReply(originalMessage: Message) {
   return replyingTo;
 }
 ```
+</Code>
 
-### Step 2: Send a reply message with metadata
+### Step 2: Send a reply message with metadata <a id="send-reply"/>
 
 When sending the reply message, include the original message's information in the metadata.
 Create a metadata object with a "reply" property that contains the original message's serial, timestamp and optionally the clientId and a snippet of the original text.
 
 The structure of your metadata object should look like this:
 
+<Code>
 ```javascript
 // Example metadata structure for a reply message
 const metadata = {
@@ -76,11 +79,13 @@ const metadata = {
   }
 };
 ```
+</Code>
 
-Then use the `room.messages.send()` method to send the message with this metadata. The method takes an object with `text` and `metadata` properties.
+Then use the [`room.messages.send()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#send) method to send the message with this metadata. The method takes an object with `text` and `metadata` properties.
 
 In your `text` property, include the reply text that the user is sending. The `metadata` property should contain the metadata object you created earlier.
 
+<Code>
 ```javascript
 // Function to send a reply message
 import {Message} from '@ably/chat';
@@ -118,9 +123,11 @@ const replyText = "I'm responding to your message!";
 
 await sendReply(messageToReplyTo, replyText);
 ```
+</Code>
 
 To test this out, you can try sending a message to a room, and then sending a reply to that message using the `sendReply` function. Make sure to replace `messageToReplyTo` with the actual message object you want to reply to.
 
+<Code>
 ```ts
 const originalMessage = await room.messages.send({
   text: "Hello, this is the original message!"
@@ -130,12 +137,13 @@ const replyText = "This is a reply to the original message!";
 
 await sendReply(originalMessage, replyText);
 ```
+</Code>
 
-## Handling received messages with reply metadata
+## Handling received messages with reply metadata <a id="handling-received-messages"/>
 
 When receiving messages, you need to check if they contain reply metadata and display them accordingly. Here's how to do it:
 
-1. Subscribe to messages in the room using `room.messages.subscribe()`.
+1. Subscribe to messages in the room using [`room.messages.subscribe()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#subscribe).
 2. In the callback function, examine each incoming message.
 3. Check if the message has a `metadata.reply` property.
 4. If it does, extract the reply information (serial, createdAt, clientId, etc.).
@@ -143,6 +151,7 @@ When receiving messages, you need to check if they contain reply metadata and di
 6. If the original message is found, display the message as a reply with context from the original message.
 7. If the original message is not found, you might want to fetch it (see next section) or display a simplified version.
 
+<Code>
 ```javascript
 // Subscribe to messages and handle replies
 const messageSubscription = room.messages.subscribe((messageEvent) => {
@@ -169,12 +178,14 @@ function displayReply(replyMessage, originalMessage, replyData) {
   console.log(`Reply text: ${replyMessage.text}`);
 }
 ```
+</Code>
 
 Your message subscription logic should check for the reply metadata and handle it appropriately.
 When displaying a reply message, you might want to show a preview of the original message, the name of the original sender, or a visual indication that it's a reply.
 
 You can try sending a message and then sending a reply to it, and see how the reply is displayed in your application.
 
+<Code>
 ```ts
 import { Message } from '@ably/chat';
 
@@ -190,18 +201,20 @@ const replyText = "This is a reply to the original message!";
 
 await sendReply(originalMessage, replyText);
 ```
+</Code>
 
-## Finding quoted messages that aren't in local state
+## Finding quoted messages that aren't in local state <a id="finding-quoted-messages"/>
 
 If a reply references a message that isn't in your local state (for example, if a user just joined the chat), you can use the history methods to find it. Here's how:
 
 1. Extract the serial and createdAt from the reply metadata.
 2. Use the exact createdAt time from the metadata to query messages, as start and end params are inclusive.
-3. Use `room.messages.history()` to query messages at that specific timestamp.
+3. Use [`room.messages.history()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.Messages.html#history) to query messages at that specific timestamp.
 4. When you receive the results, find the message with the matching serial.
 5. If found, add it to your local state and update your UI to show the reply with context.
 6. You may need to handle pagination to find the right message.
 
+<Code>
 ```javascript
 // Function to fetch the original message referenced in a reply
 async function fetchOriginalMessage(replyData) {
@@ -222,14 +235,15 @@ async function fetchOriginalMessage(replyData) {
     }
 }
 ```
+</Code>
 
 Here we use the exact timestamp to narrow down the search, reducing the number of messages to check. Since the start and end parameters are inclusive, you can set both to the exact timestamp of the original message.
 
 If many messages are sent around the same time, you might need to increase the limit or handle pagination to ensure you find the original message.
 
-## Using historyBeforeSubscribe
+## Using historyBeforeSubscribe <a id="using-history-before-subscribe"/>
 
-The `historyBeforeSubscribe` method is useful because it allows you to search backwards from the point you attach to a room. You can use this to paginate back through history, and if you see any messages that are replies, you can keep paginating back until you have no replies without their original messages. This approach has the added bonus of backfilling your chat at the same time.
+The [`historyBeforeSubscribe`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-js.SubscribeMessagesResponse.html#historyBeforeSubscribe) method is useful because it allows you to search backwards from the point you attach to a room. You can use this to paginate back through history, and if you see any messages that are replies, you can keep paginating back until you have no replies without their original messages. This approach has the added bonus of backfilling your chat at the same time.
 
 Here's how to use it:
 
@@ -242,6 +256,7 @@ Here's how to use it:
 
 Of course, if you have a lot of history and the reply came much later, it might be better to use the `history` function to load only the specific message you care about, as shown in the previous section.
 
+<Code>
 ```javascript
 const { historyBeforeSubscribe } = room.messages.subscribe((messageEvent) => {
   console.log('New message received:', messageEvent.message);
@@ -276,9 +291,10 @@ function processMessages(messages) {
     .filter(reply => !bySerial.has(reply.metadata.reply.serial));
 }
 ```
+</Code>
 
 
-## Complete example
+## Complete example <a id="complete-example"/>
 
 This guide was meant to show the basic principles of implementing replies and quotes in Ably Chat using metadata. In a more complete example, you would expect to:
 
@@ -291,7 +307,8 @@ This guide was meant to show the basic principles of implementing replies and qu
 
 Here's a simple React component that demonstrates how to implement a chat interface with basic reply functionality using the `useMessages` hook:
 
-```tsx
+<Code>
+```react
 import React, { useState } from 'react';
 import { useMessages } from '@ably/chat/react';
 import { Message, ChatMessageEventType } from '@ably/chat';
@@ -489,10 +506,12 @@ export const ChatWithReplies: React.FC = () => {
   );
 };
 ```
+</Code>
 
 To use this component, you would need to wrap it with the necessary providers:
 
-```tsx
+<Code>
+```react
 import * as Ably from 'ably';
 import { ChatClient } from '@ably/chat';
 import { ChatClientProvider } from '@ably/chat/react';
@@ -517,6 +536,7 @@ const App = () => {
   )
 };
 ```
+</Code>
 
 This component demonstrates the core concepts of implementing replies with Ably Chat:
 
@@ -529,7 +549,7 @@ This component demonstrates the core concepts of implementing replies with Ably 
 Remember that Ably Chat doesn't provide built-in UI components or reply functionality **yet**, so you'll need to implement these aspects yourself using the metadata approach described in this guide. The steps outlined in the previous sections provide the foundation for building a complete reply system in your application.
 
 
-## Limitations and considerations
+## Limitations and considerations <a id="limitations-and-considerations"/>
 
 When implementing replies and quotes using metadata, keep these considerations in mind:
 
@@ -548,7 +568,7 @@ When implementing replies and quotes using metadata, keep these considerations i
 7. **Nested replies**: Implementing nested replies (replies to replies) in this fashion can be potentially expensive and error-prone. You may have to query history multiple times to fetch all nested replies, and either:
     - Store the reply metadata for all of a child's parents in its own metadata field, or
     - Do a new history fetch for each message as you make your way up the reply tree.
-## Next steps
+## Next steps <a id="next-steps"/>
 
 Now that you've implemented basic reply functionality, you might want to:
 
@@ -561,4 +581,3 @@ For more information on working with Ably Chat, refer to:
 * [Messages](/docs/chat/rooms/messages?lang=javascript)
 * [Message history](/docs/chat/rooms/history?lang=javascript)
 * [Setup](/docs/chat/setup?lang=javascript)
-

--- a/src/pages/docs/guides/chat/replies.mdx
+++ b/src/pages/docs/guides/chat/replies.mdx
@@ -1,0 +1,564 @@
+---
+title: "Implementing Replies and Quotes with Chat"
+meta_description: "Learn how to implement message replies and quotes in your Ably Chat applications using TypeScript. This guide shows how to use metadata to create quote and reply functionality."
+meta_keywords: "ably chat, message replies, message quotes, chat replies, chat quotes, javascript chat replies, typescript chat replies, chat metadata, ably chat metadata, realtime chat replies"
+---
+
+This guide will show you how you could implement a simple solution for things like replies and quotes in your Ably Chat application.
+While the two features have different applications, they share the same fundamental principle of referencing other messages in the chat.
+As such, we will cover only replies in this guide, but the same principles can be applied to quotes.
+
+While cross-room replies are possible, this guide will focus on providing replies within the same room for simplicity.
+
+## Understanding the current limitations
+
+While Ably Chat doesn't have built-in support for replies or quotes, you can implement this functionality by using the metadata fields that can be sent along with chat messages.
+
+Every message in Ably Chat has:
+- A `serial` field (a UUID that uniquely identifies the message)
+- A `createdAt` field (when the message was created)
+- A `metadata` field (key-value store for custom data)
+
+By storing the serial and creation time of a message you want to quote in the metadata of a new message, you can create a reference between messages that your application can interpret and display accordingly.
+
+## Implementing replies using message metadata
+
+To implement a reply to a message, you'll need to:
+
+1. Store the original message's information when a user wants to reply to it
+2. Include that information in the metadata when sending the reply
+3. Process incoming messages to check for reply metadata
+
+### Step 1: Store information about the message being replied to
+
+When a user selects a message to reply to, you should store its key information. Extract the following properties from the original message:
+
+- `serial`: The unique identifier of the message
+- `createdAt`: The creation time of the message (use `createdAt.getTime()`)
+- `clientId`: The ID of the user who sent the message (optional, but useful for context and lazy loading)
+- `text`: A snippet of the message text (optional, but useful for context and lazy loading)
+
+Store this information in your application state or pass it to your message input component.
+
+For example, when a user clicks a "Reply" button on a message, you would extract these properties from the message and store them in your application state, perhaps in a variable called `replyingTo`.
+
+```javascript
+import { Message } from '@ably/chat';
+function prepareReply(originalMessage: Message) {
+  // Extract key information from the original message
+  const replyingTo = {
+    serial: originalMessage.serial,
+    createdAt: originalMessage.createdAt.getTime(),
+    clientId: originalMessage.clientId,
+    previewText: originalMessage.text.length > 140
+      ? originalMessage.text.substring(0, 140) + '...'
+      : originalMessage.text
+  };
+  return replyingTo;
+}
+```
+
+### Step 2: Send a reply message with metadata
+
+When sending the reply message, include the original message's information in the metadata.
+Create a metadata object with a "reply" property that contains the original message's serial, timestamp and optionally the clientId and a snippet of the original text.
+
+The structure of your metadata object should look like this:
+
+```javascript
+// Example metadata structure for a reply message
+const metadata = {
+  reply: {
+    serial: "original-message-serial",
+    createdAt: 1634567890123,
+    clientId: "original-sender-id",
+    previewText: "Snippet of the original message..."
+  }
+};
+```
+
+Then use the `room.messages.send()` method to send the message with this metadata. The method takes an object with `text` and `metadata` properties.
+
+In your `text` property, include the reply text that the user is sending. The `metadata` property should contain the metadata object you created earlier.
+
+```javascript
+// Function to send a reply message
+import {Message} from '@ably/chat';
+
+async function sendReply(replyToMessage: Message, replyText: string) {
+  try {
+    // Create metadata object with reply information
+    const metadata = {
+      reply: {
+        serial: replyToMessage.serial,
+        timestamp: replyToMessage.createdAt.getTime(),
+        clientId: replyToMessage.clientId,
+        previewText: replyToMessage.text.length > 140
+          ? replyToMessage.text.substring(0, 140) + '...'
+          : replyToMessage.text
+      }
+    };
+
+    // Send the message with reply metadata
+    const message = await room.messages.send({
+      text: replyText,
+      metadata: metadata
+    });
+
+    console.log('Reply sent successfully:', message);
+    return message;
+  } catch (error) {
+    console.error('Failed to send reply:', error);
+    throw error;
+  }
+}
+
+// Example usage
+const replyText = "I'm responding to your message!";
+
+await sendReply(messageToReplyTo, replyText);
+```
+
+To test this out, you can try sending a message to a room, and then sending a reply to that message using the `sendReply` function. Make sure to replace `messageToReplyTo` with the actual message object you want to reply to.
+
+```ts
+const originalMessage = await room.messages.send({
+  text: "Hello, this is the original message!"
+});
+
+const replyText = "This is a reply to the original message!";
+
+await sendReply(originalMessage, replyText);
+```
+
+## Handling received messages with reply metadata
+
+When receiving messages, you need to check if they contain reply metadata and display them accordingly. Here's how to do it:
+
+1. Subscribe to messages in the room using `room.messages.subscribe()`.
+2. In the callback function, examine each incoming message.
+3. Check if the message has a `metadata.reply` property.
+4. If it does, extract the reply information (serial, createdAt, clientId, etc.).
+5. Find the original message in your local state using the serial stored in the metadata.
+6. If the original message is found, display the message as a reply with context from the original message.
+7. If the original message is not found, you might want to fetch it (see next section) or display a simplified version.
+
+```javascript
+// Subscribe to messages and handle replies
+const messageSubscription = room.messages.subscribe((messageEvent) => {
+  const message = messageEvent.message;
+
+  // Check if this is a reply message
+  if (message.metadata && message.metadata.reply) {
+    const replyData = message.metadata.reply;
+
+    // Find the original message in your local state
+    const originalMessage = localMessages.find(msg => msg.serial === replyData.serial);
+
+    // Display the reply message
+    displayReply(message, originalMessage, replyData);
+  }
+});
+
+function displayReply(replyMessage, originalMessage, replyData) {
+  if (originalMessage) {
+    console.log(`Reply from ${replyMessage.clientId} to ${originalMessage.clientId}'s message: "${originalMessage.text}"`);
+  } else {
+    console.log(`Reply from ${replyMessage.clientId} to a message by ${replyData.clientId}`);
+  }
+  console.log(`Reply text: ${replyMessage.text}`);
+}
+```
+
+Your message subscription logic should check for the reply metadata and handle it appropriately.
+When displaying a reply message, you might want to show a preview of the original message, the name of the original sender, or a visual indication that it's a reply.
+
+You can try sending a message and then sending a reply to it, and see how the reply is displayed in your application.
+
+```ts
+import { Message } from '@ably/chat';
+
+room.messages.subscribe((messageEvent) => {
+  // ... subscription logic as shown above
+});
+
+const originalMessage = await room.messages.send({
+  text: "Hello, this is the original message!"
+});
+
+const replyText = "This is a reply to the original message!";
+
+await sendReply(originalMessage, replyText);
+```
+
+## Finding quoted messages that aren't in local state
+
+If a reply references a message that isn't in your local state (for example, if a user just joined the chat), you can use the history methods to find it. Here's how:
+
+1. Extract the serial and createdAt from the reply metadata.
+2. Use the exact createdAt time from the metadata to query messages, as start and end params are inclusive.
+3. Use `room.messages.history()` to query messages at that specific timestamp.
+4. When you receive the results, find the message with the matching serial.
+5. If found, add it to your local state and update your UI to show the reply with context.
+6. You may need to handle pagination to find the right message.
+
+```javascript
+// Function to fetch the original message referenced in a reply
+async function fetchOriginalMessage(replyData) {
+    const timestamp = replyData.createdAt;
+    try {
+        // Query messages at this specific timestamp
+        const result = await room.messages.history({
+            start: timestamp,
+            end: timestamp,
+            limit: 20
+        });
+
+        // Find the message with the matching serial
+        return result.items.find(msg => msg.serial === replyData.serial);
+    } catch (error) {
+        console.error('Error fetching original message:', error);
+         // Handle error appropriately in your application
+    }
+}
+```
+
+Here we use the exact timestamp to narrow down the search, reducing the number of messages to check. Since the start and end parameters are inclusive, you can set both to the exact timestamp of the original message.
+
+If many messages are sent around the same time, you might need to increase the limit or handle pagination to ensure you find the original message.
+
+## Using historyBeforeSubscribe
+
+The `historyBeforeSubscribe` method is useful because it allows you to search backwards from the point you attach to a room. You can use this to paginate back through history, and if you see any messages that are replies, you can keep paginating back until you have no replies without their original messages. This approach has the added bonus of backfilling your chat at the same time.
+
+Here's how to use it:
+
+1. Subscribe to messages in the room using `room.messages.subscribe()`.
+2. The subscription returns an object that includes the `historyBeforeSubscribe` method.
+3. Call this method with a limit parameter (e.g., `{ limit: 50 }`) to get recent history.
+4. Process the results to identify any reply messages without their original messages.
+5. If you find replies without originals, paginate back further using the `next()` method on the result.
+6. Continue this process until all replies have their original messages or no more history is available.
+
+Of course, if you have a lot of history and the reply came much later, it might be better to use the `history` function to load only the specific message you care about, as shown in the previous section.
+
+```javascript
+const { historyBeforeSubscribe } = room.messages.subscribe((messageEvent) => {
+  console.log('New message received:', messageEvent.message);
+});
+
+async function initializeChat(room) {
+  // Load message history before the subscription point
+  let result = await historyBeforeSubscribe({ limit: 200 });
+  let allMessages = [...result.items];
+  // Process messages and check for replies without originals
+  let repliesWithoutOriginals = processMessages(allMessages);
+
+  // Continue paginating back until we have no replies without originals or no more history
+  while (repliesWithoutOriginals.length > 0 && result.hasNext()) {
+    // Load the next page of history
+    result = await result.next();
+
+    // Add new messages to our collection
+    allMessages = [...allMessages, ...result.items];
+
+    // Process the updated collection and check again for replies without originals
+    repliesWithoutOriginals = processMessages(allMessages);
+  }
+
+  return allMessages;
+}
+
+function processMessages(messages) {
+  const bySerial = new Map(messages.map(m => [m.serial, m]));
+  return messages
+    .filter(m => m.metadata?.reply)
+    .filter(reply => !bySerial.has(reply.metadata.reply.serial));
+}
+```
+
+
+## Complete example
+
+This guide was meant to show the basic principles of implementing replies and quotes in Ably Chat using metadata. In a more complete example, you would expect to:
+
+1. Create UI components for displaying regular messages and replies differently
+2. Implement a message selection mechanism to allow users to choose which message to reply to
+3. Set up local state management to store messages and their relationships
+4. Handle edge cases like missing original messages or pagination of history
+5. Implement error handling for failed message sends or history queries
+6. Add visual indicators for when a message is a reply and which message it's replying to
+
+Here's a simple React component that demonstrates how to implement a chat interface with basic reply functionality using the `useMessages` hook:
+
+```tsx
+import React, { useState } from 'react';
+import { useMessages } from '@ably/chat/react';
+import { Message, ChatMessageEventType } from '@ably/chat';
+import type { ChatMessageEvent } from '@ably/chat';
+
+interface ReplyMetadata {
+  serial: string;
+  timestamp: number;
+  clientId: string;
+  previewText: string;
+}
+
+interface MessageWithReply extends Message {
+  metadata: {
+    reply?: ReplyMetadata;
+    [key: string]: unknown;
+  };
+}
+
+export const ChatWithReplies: React.FC = () => {
+  const [messages, setMessages] = useState<MessageWithReply[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [replyingTo, setReplyingTo] = useState<MessageWithReply | null>(null);
+
+  const { send } = useMessages({
+    listener: (event: ChatMessageEvent) => {
+      if (event.type === ChatMessageEventType.Created) {
+        setMessages(prev => [...prev, event.message as MessageWithReply]);
+      }
+    }
+  });
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputText.trim()) return;
+
+    try {
+      const messageParams: any = { text: inputText };
+
+      // Add reply metadata if replying to a message
+      if (replyingTo) {
+        messageParams.metadata = {
+          reply: {
+            serial: replyingTo.serial,
+            timestamp: replyingTo.createdAt.getTime(),
+            clientId: replyingTo.clientId,
+            previewText: replyingTo.text.length > 100
+              ? replyingTo.text.substring(0, 100) + '...'
+              : replyingTo.text
+          }
+        };
+      }
+
+      await send(messageParams);
+      setInputText('');
+      setReplyingTo(null);
+    } catch (error) {
+      console.error('Failed to send message:', error);
+    }
+  };
+
+  const handleReply = (message: MessageWithReply) => {
+    setReplyingTo(message);
+  };
+
+  const cancelReply = () => {
+    setReplyingTo(null);
+  };
+
+  const getOriginalMessage = (replyMessage: MessageWithReply): MessageWithReply | null => {
+    if (!replyMessage.metadata?.reply) return null;
+    return messages.find(msg => msg.serial === replyMessage.metadata.reply!.serial) || null;
+  };
+
+  const isReply = (message: MessageWithReply): boolean => {
+    return !!message.metadata?.reply;
+  };
+
+  return (
+    <div className="min-h-screen w-screen bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center p-4">
+      <div className="w-full max-w-3xl bg-white rounded-2xl shadow-2xl overflow-hidden">
+        {/* Messages Container */}
+        <div className="h-96 overflow-y-auto p-6 space-y-4 bg-gray-50">
+          {messages.length === 0 ? (
+            <div className="text-center text-gray-500 mt-20">
+              <div className="text-4xl mb-2">💬</div>
+              <p className="text-lg">No messages yet. Start the conversation!</p>
+            </div>
+          ) : (
+            messages.map((message) => {
+              const originalMessage = isReply(message) ? getOriginalMessage(message) : null;
+
+              return (
+                <div key={message.serial} className="group">
+                  {/* Reply Context */}
+                  {originalMessage && (
+                    <div className="ml-6 mb-3 p-3 bg-indigo-50 border-l-4 border-indigo-400 rounded-r-lg">
+                      <div className="text-xs text-indigo-600 font-medium mb-1 flex items-center">
+                        <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                        Replying to {originalMessage.clientId}
+                      </div>
+                      <div className="text-sm text-gray-700 truncate">
+                        {originalMessage.text}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Main Message */}
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center shadow-lg">
+                      <span className="text-white text-sm font-bold">
+                        {message.clientId.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center space-x-2 mb-2">
+                        <span className="text-sm font-semibold text-gray-900">
+                          {message.clientId}
+                        </span>
+                      </div>
+
+                      <div className="bg-white rounded-2xl px-4 py-3 shadow-sm border border-gray-200 max-w-md">
+                        <p className="text-gray-800 break-words leading-relaxed">
+                          {message.text}
+                        </p>
+                      </div>
+
+                      {/* Reply Button */}
+                      <button
+                        onClick={() => handleReply(message)}
+                        className="mt-2 text-xs text-gray-500 hover:text-indigo-600 opacity-0 group-hover:opacity-100 transition-all duration-200 font-medium hover:bg-indigo-50 px-2 py-1 rounded-full"
+                      >
+                        Reply
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Input Area */}
+        <div className="border-t border-gray-200 p-6 bg-white">
+          {/* Reply Preview */}
+          {replyingTo && (
+            <div className="mb-4 p-3 bg-gradient-to-r from-indigo-50 to-purple-50 border border-indigo-200 rounded-xl">
+              <div className="flex items-center justify-between">
+                <div className="flex-1 min-w-0">
+                  <div className="text-xs text-indigo-600 font-semibold mb-1 flex items-center">
+                    <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                    Replying to {replyingTo.clientId}
+                  </div>
+                  <div className="text-sm text-gray-700 truncate">
+                    {replyingTo.text}
+                  </div>
+                </div>
+                <button
+                  onClick={cancelReply}
+                  className="ml-3 p-1 text-gray-400 hover:text-gray-600 hover:bg-white rounded-full transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Message Input */}
+          <form onSubmit={handleSendMessage} className="flex space-x-3">
+            <input
+              type="text"
+              value={inputText}
+              onChange={(e) => setInputText(e.target.value)}
+              placeholder={replyingTo ? "Type your reply..." : "Type a message..."}
+              className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+            />
+            <button
+              type="submit"
+              disabled={!inputText.trim()}
+              className="px-6 py-3 bg-gradient-to-r from-indigo-600 to-purple-600 text-white font-semibold rounded-xl hover:from-indigo-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-lg disabled:shadow-none"
+            >
+              Send
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+```
+
+To use this component, you would need to wrap it with the necessary providers:
+
+```tsx
+import * as Ably from 'ably';
+import { ChatClient } from '@ably/chat';
+import { ChatClientProvider } from '@ably/chat/react';
+import './index.css';
+import { AblyProvider } from 'ably/react';
+
+// Initialize Ably client
+const client = new Ably.Realtime({
+  key: 'your-api-key',
+  clientId: 'user-123'
+});
+const chatClient = new ChatClient(realtimeClient);
+const App = () => {
+  return (
+    <AblyProvider client={realtimeClient}>
+      <ChatClientProvider client={chatClient}>
+        <ChatRoomProvider name={'room-with-replies'}>
+          <ChatWithReplies />
+        </ChatRoomProvider>
+      </ChatClientProvider>
+    </AblyProvider>
+  )
+};
+```
+
+This component demonstrates the core concepts of implementing replies with Ably Chat:
+
+1. It uses the `useMessages` hook to subscribe to new messages and send messages
+2. It maintains a local state of messages
+3. It allows users to reply to messages by clicking on them
+4. When sending a reply, it includes the original message's information in the metadata
+5. When displaying a reply, it shows the original message's context if available
+
+Remember that Ably Chat doesn't provide built-in UI components or reply functionality **yet**, so you'll need to implement these aspects yourself using the metadata approach described in this guide. The steps outlined in the previous sections provide the foundation for building a complete reply system in your application.
+
+
+## Limitations and considerations
+
+When implementing replies and quotes using metadata, keep these considerations in mind:
+
+1. **No built-in UI**: You'll need to build your own UI components to display replies and quotes.
+
+2. **Message availability**: If a quoted message is very old, it might not be available in history anymore, depending on your Ably account's message retention settings.
+
+3. **Message updates**: Because messages can be updated (including the metadata), it's possible to accidentally remove the quoted message reference. Be careful when updating messages that are part of a reply chain.
+
+4. **No server-side validation**: Since metadata is not validated by the server, you should ensure that your application logic correctly handles cases where the metadata might be malformed or missing.
+
+5. **Local state management**: Maintaining a local state of messages will improve performance by reducing the need to query history.
+
+6. **Tracking replies**: There isn't an easy way to know if a message has been replied to, other than to see its replies in history. This is why the historyBeforeSubscribe method is useful to ensure you have the full context of messages in your room.
+
+7. **Nested replies**: Implementing nested replies (replies to replies) in this fashion can be potentially expensive and error-prone. You may have to query history multiple times to fetch all nested replies, and either:
+    - Store the reply metadata for all of a child's parents in its own metadata field, or
+    - Do a new history fetch for each message as you make your way up the reply tree.
+## Next steps
+
+Now that you've implemented basic reply functionality, you might want to:
+
+* Explore the [Ably Chat documentation](/docs/chat) for API details.
+* Play around with the [Ably Chat examples](/examples?product=chat).
+* Try out the [livestream chat demo](https://ably-livestream-chat-demo.vercel.app).
+* Read the [JavaScript / TypeScript](/docs/chat/getting-started/javascript) or [React](/docs/chat/getting-started/react) getting started guides.
+
+For more information on working with Ably Chat, refer to:
+* [Messages](/docs/chat/rooms/messages?lang=javascript)
+* [Message history](/docs/chat/rooms/history?lang=javascript)
+* [Setup](/docs/chat/setup?lang=javascript)
+


### PR DESCRIPTION
## Context

Chat currently doesn't have native support for things like replies and quotes, so we need a short guide to give users an idea as to how they might implement a solution with the Chat SDK in the mean time.

[CHA-1016](https://ably.atlassian.net/browse/CHA-1016)

## Description

This PR adds a guide that covers a basic replies setup, using the Chat SDK, and sending message reply metadata in the metadata field of a chat message.

