### PR TITLE
Added each language getting started to a collapsible menu in nav bar

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -23,8 +23,41 @@ export default {
       pages: [
         {
           name: 'Guides',
-          link: '/docs/getting-started',
-          index: true,
+          pages: [
+            {
+              name: 'Index',
+              link: '/docs/getting-started',
+              index: true,
+            },
+            {
+              name: 'JavaScript',
+              link: '/docs/getting-started/javascript',
+            },
+            {
+              name: 'React',
+              link: '/docs/getting-started/react',
+            },
+            {
+              name: 'React Native',
+              link: '/docs/getting-started/react-native',
+            },
+            {
+              name: 'Kotlin',
+              link: '/docs/getting-started/kotlin',
+            },
+            {
+              name: 'Swift',
+              link: '/docs/getting-started/swift',
+            },
+            {
+              name: 'Ruby',
+              link: '/docs/getting-started/ruby',
+            },
+            {
+              name: 'PHP',
+              link: '/docs/getting-started/php',
+            },
+          ],
         },
         {
           name: 'SDK setup',


### PR DESCRIPTION
With the release of an index page showing the getting started guides, this introduced a small bug with the existing code, where if the page isn't in the nav, it doesn't pick up the language, so all code blocks are showing an error that it's not the language you're expecting. This fixes that issue.