### PR TITLE
Update title of Pub/Sub getting started index page

### DIFF
--- a/src/pages/docs/getting-started/index.mdx
+++ b/src/pages/docs/getting-started/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Index of Pub/Sub getting started guides"
 meta_description: "Get started with Ably Pub/Sub in your language or framework of choice. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
 meta_keywords: "Pub/Sub, Ably SDKs, realtime messaging, publish subscribe, getting started guides, realtime communication, Ably tutorial, message history, presence API, Ably CLI Pub/Sub"
 ---


### PR DESCRIPTION
The structure of the nav for getting started guides for Pub/Sub was recently changed, in this PR https://github.com/ably/docs/pull/2718

The title was not. This PR fixes that.