### PR TITLE
Message: remove refSerial and refType

### DIFF
--- a/content/partials/types/_message.textile
+++ b/content/partials/types/_message.textile
@@ -71,16 +71,6 @@ blang[jsall].
 
   This message's unique serial (an identifier that will be the same in all future updates of this message).<br>__Type: @String@__
 
-  h6(#ref-serial).
-    default: refSerial
-
-  If this message references another, the serial of that message.<br>__Type: @String@__
-
-  h6(#ref-type).
-    default: refType
-
-  If this message references another, the type of reference that is.<br>__Type: @String@__
-
   h6(#created-at).
     default: createdAt
 


### PR DESCRIPTION
I think this was added by chat team back when they were looking at doing threading based on message references, before the priorities changed. internal concerns have been raised about the naming of the fields so I'm just removing them given that there's no serverside use of these yet.

https://github.com/ably/specification/pull/348