### PR TITLE
chat: update adding reactions to send

### DIFF
--- a/src/data/examples/index.ts
+++ b/src/data/examples/index.ts
@@ -36,12 +36,12 @@ export const examples: Example[] = [
   {
     id: 'chat-room-reactions',
     name: 'Room reactions',
-    description: 'Add emoji reactions to messages in chat rooms.',
+    description: 'Send emoji reactions to messages in chat rooms.',
     products: ['chat'],
     layout: 'double-vertical',
     visibleFiles: ['src/script.ts', 'App.tsx', 'index.tsx'],
     metaTitle: `Build chat room reactions with Ably’s Chat SDK`,
-    metaDescription: `Add realtime chat room reactions using Ably’s Chat SDK. Enable instant emoji responses and seamless updates for engaging user experiences.`,
+    metaDescription: `Send realtime chat room reactions using Ably’s Chat SDK. Enable instant emoji responses and seamless updates for engaging user experiences.`,
   },
   {
     id: 'chat-typing-indicator',

--- a/src/pages/docs/chat/index.mdx
+++ b/src/pages/docs/chat/index.mdx
@@ -37,7 +37,7 @@ Each room can represent a 1:1 chat between an agent and a customer, a private me
 
 ### Message reactions <a id="message-reactions"/>
 
-[Message reactions](/docs/chat/rooms/message-reactions) enable users to add reactions to messages, such as 👍 or ❤. Users can also see which other users reacted to a message.
+[Message reactions](/docs/chat/rooms/message-reactions) enable users to send reactions to messages, such as 👍 or ❤. Users can also see which other users reacted to a message.
 
 ### Typing indicators <a id="typing"/>
 

--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -3,23 +3,23 @@ title: Message reactions
 meta_description: "React to chat messages"
 ---
 
-Add, remove and display message reactions in a chat room. Users can react to messages, typically with emojis but can be any string, and others can see the reactions to the message. Message reactions can be added and removed and a summary of the reactions is persisted with the message.
+Send, remove and display message reactions in a chat room. Users can react to messages, typically with emojis but can be any string, and others can see the reactions to the message. Message reactions can be sent and removed and a summary of the reactions is persisted with the message.
 
-The reaction `name` represents the reaction itself, for example an emoji. Reactions are aggregated by `name` and the aggregation method including how many reactions a user can place for a message is controlled by the reaction `type`. The `count` is an optional parameter that can be set when adding a reaction of type `Multiple`.
+The reaction `name` represents the reaction itself, for example an emoji. Reactions are aggregated by `name` and the aggregation method including how many reactions a user can place for a message is controlled by the reaction `type`. The `count` is an optional parameter that can be set when sending a reaction of type `Multiple`.
 
 The reaction `name` can be any string. Summaries are aggregated based on unique `name` values. UTF-8 emojis are a common use case, but any string can be used as long as they are consistent across all front-ends of your app. Examples of common reaction names are `👍`, `❤️`, `:like:`, `like`, `+1`, and so on. How those are presented to the user is entirely up to the app.
 
 ## Types of message reactions <a id="types-of-reactions"/>
 
-Ably Chat supports three types of message reactions. They differ in how they are aggregated and what are the rules for adding and removing them.
+Ably Chat supports three types of message reactions. They differ in how they are aggregated and what are the rules for sending and removing them.
 
 | Type | Description | Example | Similar to |
 | ---- | ----------- | ------- | --------- |
-| `Unique` | Users can add a single reaction per message. If they react again, their previous reaction is replaced with the new one. | A user can add a 👍, but adding a ❤️ will replace the 👍. | iMessage, WhatsApp, Facebook Messenger |
-| `Distinct` | Users can add each type of reaction once per message. Multiple different reactions are allowed, but duplicates are not. | A user can add both 👍 and ❤️, but cannot add a second 👍. | Slack |
-| `Multiple` | Users can add unlimited reactions, including duplicates. A count parameter specifies how many reactions to add at once. Each new reaction adds to the total count. | A user can add 10 👍 reactions and 100 ❤️ reactions to the same message. | Claps on Medium |
+| `Unique` | Users can send a single reaction per message. If they react again, their previous reaction is replaced with the new one. | A user can send a 👍, but sending a ❤️ will replace the 👍. | iMessage, WhatsApp, Facebook Messenger |
+| `Distinct` | Users can send each type of reaction once per message. Multiple different reactions are allowed, but duplicates are not. | A user can send both 👍 and ❤️, but cannot send a second 👍. | Slack |
+| `Multiple` | Users can send unlimited reactions, including duplicates. A count parameter specifies how many reactions to send at once. Each new reaction adds to the total count. | A user can send 10 👍 reactions and 100 ❤️ reactions to the same message. | Claps on Medium |
 
-Note that if adding two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
+Note that if sending two identical reactions of type `Distinct`, the second one will be accepted and broadcast as a raw reaction, but it will be ignored in the summary (aggregate). Similarly, when removing a reaction that doesn't exist (of any type), the operation will be accepted and broadcast as a raw reaction, but it will have no effect on the summary.
 
 ### Configure the default reaction type <a id="default-type"/>
 
@@ -79,17 +79,17 @@ const MyComponent = () => {
 ```
 </Code>
 
-## Adding a message reaction <a id="adding-reactions"/>
+## Sending a message reaction <a id="sending-reactions"/>
 
 <If lang="javascript,swift,kotlin">
-To add a message reaction use `room.messages.reactions.send(message, params)`. This method takes the following parameters:
-* `message` - The message to add the reaction to. Can be either a Message object or a string containing the message serial.
+To send a message reaction use `room.messages.reactions.send(message, params)`. This method takes the following parameters:
+* `message` - The message to send the reaction to. Can be either a Message object or a string containing the message serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
 <If lang="react">
-Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to add a reaction to a message. This method takes the following parameters:
-* `message` - The message to add the reaction to. Can be either a Message object or a string containing the message serial.
+Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#sendReaction) method available from the response of the `useMessages` hook to send a reaction to a message. This method takes the following parameters:
+* `message` - The message to send the reaction to. Can be either a Message object or a string containing the message serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
@@ -97,20 +97,20 @@ Use the [`sendReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/ty
 ```javascript
 import { MessageReactionType } from '@ably/chat';
 
-// Add a 👍 reaction using the default type
+// Send a 👍 reaction using the default type
 await room.messages.reactions.send(message, { name: '👍' });
 
 // The reaction can be anything, not just UTF-8 emojis:
 await room.messages.reactions.send(message, { name: ':like:' });
 await room.messages.reactions.send(message, { name: '+1' });
 
-// Add a :love: reaction using the Unique type
+// Send a :love: reaction using the Unique type
 await room.messages.reactions.send(message, {
     name: ':love:',
     type: MessageReactionType.Unique,
 });
 
-// Add a ❤️ reaction with count 100 using the Multiple type
+// Send a ❤️ reaction with count 100 using the Multiple type
 await room.messages.reactions.send(message, {
     name: '❤️',
     type: MessageReactionType.Multiple,
@@ -119,20 +119,20 @@ await room.messages.reactions.send(message, {
 ```
 
 ```swift
-// Add a 👍 reaction using the default type
+// Send a 👍 reaction using the default type
 await room.messages.reactions.send(to: message.serial, params: .init(name: "👍"))
 
 // The reaction can be anything, not just UTF-8 emojis:
 await room.messages.reactions.send(to: message.serial, params: .init(name: ":like:"))
 await room.messages.reactions.send(to: message.serial, params: .init(name: "+1"))
 
-// Add a :love: reaction using the Unique type
+// Send a :love: reaction using the Unique type
 await room.messages.reactions.send(to: message.serial, params: .init(
   reaction: ":love:",
   type: .unique
 ))
 
-// Add a ❤️ reaction with count 100 using the Multiple type
+// Send a ❤️ reaction with count 100 using the Multiple type
 await room.messages.reactions.send(to: message.serial, params: .init(
   reaction: "❤️",
   type: .multiple,
@@ -141,20 +141,20 @@ await room.messages.reactions.send(to: message.serial, params: .init(
 ```
 
 ```kotlin
-// Add a 👍 reaction using the default type
+// Send a 👍 reaction using the default type
 room.messages.reactions.send(message, name = "👍")
 
 // The reaction can be anything, not just UTF-8 emojis:
 room.messages.reactions.send(message, name = ":like:"))
 room.messages.reactions.send(message, name = "+1"))
 
-// Add a :love: reaction using the Unique type
+// Send a :love: reaction using the Unique type
 room.messages.reactions.send(message,
   name = ":love:",
   type = MessageReactionType.Unique,
 )
 
-// Add a ❤️ reaction with count 100 using the Multiple type
+// Send a ❤️ reaction with count 100 using the Multiple type
 room.messages.reactions.send(message,
   name = "❤️",
   type = MessageReactionType.Multiple,
@@ -169,35 +169,35 @@ import { useMessages } from '@ably/chat/react';
 const MyComponent = () => {
   const { sendReaction } = useMessages();
 
-  const handleAddReaction = async (message) => {
+  const handleSendReaction = async (message) => {
     try {
-      // Add a 👍 reaction using the default type
+      // Send a 👍 reaction using the default type
       await sendReaction(message, { name: '👍' });
 
       // The reaction can be anything, not just UTF-8 emojis:
       await sendReaction(message, { name: ':like:' });
       await sendReaction(message, { name: '+1' });
 
-      // Add a :love: reaction using the Unique type
+      // Send a :love: reaction using the Unique type
       await sendReaction(message, {
         name: ':love:',
         type: MessageReactionType.Unique,
       });
 
-      // Add a ❤️ reaction with count 100 using the Multiple type
+      // Send a ❤️ reaction with count 100 using the Multiple type
       await sendReaction(message, {
         name: '❤️',
         type: MessageReactionType.Multiple,
         count: 100,
       });
     } catch (error) {
-      console.error('Error adding reaction:', error);
+      console.error('Error sending reaction:', error);
     }
   };
 
   return (
     <div>
-      <button onClick={() => handleAddReaction(message)}>Add Reaction</button>
+      <button onClick={() => handleSendReaction(message)}>Send Reaction</button>
     </div>
   );
 };
@@ -205,20 +205,20 @@ const MyComponent = () => {
 </Code>
 
 <Aside data-type='note'>
-The `annotation-publish` capability is required for adding reactions.
+The `annotation-publish` capability is required for sending reactions.
 </Aside>
 
 ## Removing a message reaction <a id="removing-reactions"/>
 
 <If lang="javascript,swift,kotlin">
 To remove a message reaction use `room.messages.reactions.delete(message, params)`. This method takes the following parameters:
-* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
+* `message` - The message to remove the reaction from. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
 <If lang="react">
 Use the [`deleteReaction()`](https://sdk.ably.com/builds/ably/ably-chat-js/main/typedoc/interfaces/chat-react.UseMessagesResponse.html#deleteReaction) method available from the response of the `useMessages` hook to remove a reaction from a message. This method takes the following parameters:
-* `message` - The message to add the reaction to. This can be a Message object, or just the string serial.
+* `message` - The message to remove the reaction from. This can be a Message object, or just the string serial.
 * `params` - Set the `name`, and optionally override the `type` or set a `count`.
 </If>
 
@@ -499,9 +499,9 @@ const MyComponent = () => {
 
 ### Summary events are sent efficiently at scale <a id="throttle"/>
 
-Summary events are typically created and published immediately after a reaction is added or removed. If the reaction is a no-op (for example, when removing a reaction that didn't exist), then there will be no summary event.
+Summary events are typically created and published immediately after a reaction is sent or removed. If the reaction is a no-op (for example, when removing a reaction that didn't exist), then there will be no summary event.
 
-If multiple reactions are added in a short period of time, multiple reactions may be rolled up and only a single summary event will be published that contains the aggregated results of all reactions. This reduces the number of outbound messages and thus your costs in busy rooms.
+If multiple reactions are sent in a short period of time, multiple reactions may be rolled up and only a single summary event will be published that contains the aggregated results of all reactions. This reduces the number of outbound messages and thus your costs in busy rooms.
 
 ### Subscribing to raw reactions <a id="raw-reactions"/>
 
@@ -620,8 +620,8 @@ The `annotation-subscribe` capability is required for receiving individual react
 You should be aware of the following limitations:
 
 * Deleting a reaction succeeds even if it did not initially exist. It is a no-op in regards to the summary but the delete event is still broadcast.
-* Adding a reaction succeeds and is broadcast, even if it has no effect on the summary (for example, when double-adding a reaction with the same name of type `Distinct` or `Unique`).
-* Adding a reaction of type `Unique` may remove another reaction, but no delete event will be broadcast.
+* Sending a reaction succeeds and is broadcast, even if it has no effect on the summary (for example, when double-sending a reaction with the same name of type `Distinct` or `Unique`).
+* Sending a reaction of type `Unique` may remove another reaction, but no delete event will be broadcast.
 * It is not recommended to use raw reactions for displaying counts, instead use the summary events.
 * Keeping a local summary updated based on raw reactions is not recommended as it may become out-of-sync with server-generated summaries.
 

--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -716,11 +716,11 @@ paths:
                   href: "https://help.ably.io/error/50001"
   /chat/{version}/rooms/{roomName}/messages/{serial}/reactions:
     post:
-      summary: Add a reaction to a message
+      summary: Send a reaction to a message
       description: |
-        Adds a reaction to a specified message in a room.
+        Sends a reaction to a specified message in a room.
 
-        A successful request returns the serial identifier of the newly added reaction. This will also broadcast the reaction to all subscribing members of the room.
+        A successful request returns the serial identifier of the newly sent reaction. This will also broadcast the reaction to all subscribing members of the room.
       tags:
         - rooms
       parameters:
@@ -735,7 +735,7 @@ paths:
           in: path
           required: true
           description: |
-            The unique identifier of the room containing the message you wish to add a reaction to.
+            The unique identifier of the room containing the message you wish to send a reaction to.
             The `roomName` must be URI-encoded.
           schema:
             type: string
@@ -743,7 +743,7 @@ paths:
           in: path
           required: true
           description: |
-            The unique identifier of the message you wish to add a reaction to.
+            The unique identifier of the message you wish to send a reaction to.
             The `serial` must be URI-encoded.
           schema:
             type: string
@@ -752,7 +752,7 @@ paths:
         - $ref: '#/components/parameters/AuthorizationHeader'
         - $ref: '#/components/parameters/AcceptHeader'
       requestBody:
-        description: The reaction details to add to the specified message.
+        description: The reaction details to send to the specified message.
         required: true
         content:
           application/json:
@@ -763,9 +763,9 @@ paths:
                   type: string
                   description: |
                     The type of reaction. Must be one of the supported reaction types:
-                    - `unique`: Each user can add only one reaction of this type with a specific name.
-                    - `distinct`: Each user can add only one reaction of each name.
-                    - `multiple`: Users can add multiple reactions with counts.
+                    - `unique`: Each user can have only one reaction of this type with a specific name (WhatsApp, iMessage style).
+                    - `distinct`: Each user can have only one reaction of each name (Slack style).
+                    - `multiple`: Users can have multiple reactions with counts (Medium style).
                   example: "unique"
                   enum:
                     - "unique"
@@ -791,7 +791,7 @@ paths:
       responses:
         '201':
           description: |
-            Successfully added the reaction to the message.
+            Successfully sent the reaction to the message.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Description

Updated a few areas where we use "add" instead of "send" for message reactions

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
