### PR TITLE
chat: fix fromSerial in REST API docs

### DIFF
--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -283,7 +283,7 @@ paths:
           schema:
             type: integer
             example: 50
-        - name: serial
+        - name: fromSerial
           in: query
           required: false
           description: The serial value to start fetching messages from, this must be URI encoded. If omitted, messages are retrieved from the beginning or end depending on the `orderBy` parameter.


### PR DESCRIPTION
## Description

Fixes the `fromSerial` parameter in the Chat REST docs.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
