### PR TITLE
Fix broken link in Ruby getting started guide

### DIFF
--- a/content/getting-started/ruby.textile
+++ b/content/getting-started/ruby.textile
@@ -38,7 +38,7 @@ ably apps switch
 ably auth keys switch
 ```
 
-* Install "Ruby":"https://www.ruby-lang.org/en/documentation/installation/ version 2.7 or greater.
+* Install "Ruby":"https://www.ruby-lang.org/en/documentation/installation/" version 2.7 or greater.
 * Create a new project and install the Ably "Pub/Sub Ruby SDK":https://github.com/ably/ably-ruby :
 
 ```[sh]


### PR DESCRIPTION
## Description

The "Install Ruby" instruction in the Ruby getting started guide didn't have the closing ", so it was breaking the link.
