### PR TITLE
[WEB-4489] chore: disable personal keys on examples

### DIFF
--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -103,18 +103,22 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
   // Use the copyable headers hook
   useCopyableHeaders();
 
-  const apiKeys = useMemo(
-    () =>
-      userContext.apps && userContext.apps.length > 0 && userContext.apps[0].apiKeys.length > 0
-        ? userContext.apps
-            .filter(({ demo }) => !demo)
-            .flatMap(({ name, apiKeys }) => ({
-              app: name,
-              keys: apiKeys.map((apiKey) => ({ name: apiKey.name, key: apiKey.whole_key })),
-            }))
-        : [{ app: 'demo', keys: [{ name: 'demo', key: 'demokey:123456' }] }],
-    [userContext.apps],
-  );
+  const apiKeys = useMemo(() => {
+    const apps =
+      userContext.apps && userContext.apps.length > 0 && userContext.apps[0].apiKeys.length > 0 ? userContext.apps : [];
+
+    // Check if there are any non-demo apps
+    const hasNonDemo = apps.some(({ demo }) => !demo);
+
+    const filteredApps = hasNonDemo ? apps.filter(({ demo }) => !demo) : apps;
+
+    return filteredApps.length > 0
+      ? filteredApps.flatMap(({ name, apiKeys, demo }) => ({
+          app: demo ? 'demo' : name,
+          keys: apiKeys.map((apiKey) => ({ name: apiKey.name, key: apiKey.whole_key })),
+        }))
+      : [{ app: 'demo', keys: [{ name: 'demo', key: 'demokey:123456' }] }];
+  }, [userContext.apps]);
 
   return (
     <SDKContext.Provider value={{ sdk, setSdk }}>

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -105,10 +105,14 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
 
   const apiKeys = useMemo(
     () =>
-      userContext.apps?.flatMap(({ name, apiKeys }) => ({
-        app: name,
-        keys: apiKeys.map((apiKey) => ({ name: apiKey.name, key: apiKey.whole_key })),
-      })),
+      userContext.apps && userContext.apps.length > 0 && userContext.apps[0].apiKeys.length > 0
+        ? userContext.apps
+            .filter(({ demo }) => !demo)
+            .flatMap(({ name, apiKeys }) => ({
+              app: name,
+              keys: apiKeys.map((apiKey) => ({ name: apiKey.name, key: apiKey.whole_key })),
+            }))
+        : [{ app: 'demo', keys: [{ name: 'demo', key: 'demokey:123456' }] }],
     [userContext.apps],
   );
 

--- a/src/components/blocks/software/Code/ApiKeyMenu.tsx
+++ b/src/components/blocks/software/Code/ApiKeyMenu.tsx
@@ -23,7 +23,8 @@ export type APIKeyMenuProps = {
 };
 
 const APIKeyMenu = ({ apps, setActiveApiKey }: APIKeyMenuProps) => {
-  const initialApiKeyOption = findFirstApiKey(apps);
+  const appsWithoutDemo = apps.length > 0 ? apps.filter(({ demo }) => !demo) : apps;
+  const initialApiKeyOption = findFirstApiKey(appsWithoutDemo);
 
   const [value, setValue] = useState<ReactSelectOption>(
     initialApiKeyOption
@@ -34,7 +35,7 @@ const APIKeyMenu = ({ apps, setActiveApiKey }: APIKeyMenuProps) => {
       : errorOption,
   );
 
-  const options = apps.map((app) => ({
+  const options = appsWithoutDemo.map((app) => ({
     label: app.name,
     options: app.apiKeys.map((appApiKey) => ({
       label: makeLabel(appApiKey),

--- a/src/contexts/user-context.ts
+++ b/src/contexts/user-context.ts
@@ -69,6 +69,7 @@ export type App = {
   name: string;
   url: string;
   apiKeys: AppApiKey[];
+  demo: boolean;
 };
 
 export type UserDetails = {

--- a/src/redux/api-key/remote-api-key-data.ts
+++ b/src/redux/api-key/remote-api-key-data.ts
@@ -24,37 +24,48 @@ const safelyInvokeApiKeyRetrievalTrigger = () => {
   }
 };
 
-const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>) => {
-  if (payload.error || !payload.data || !isArray(payload.data)) {
-    const tempApiKeyResponse = await fetch(WEB_API_TEMP_KEY_ENDPOINT, { cache: DEFAULT_CACHE_STRATEGY });
-    const tempApiKey = await tempApiKeyResponse.text();
+const fetchDemoApiKey = async () => {
+  const tempApiKeyResponse = await fetch(WEB_API_TEMP_KEY_ENDPOINT, { cache: DEFAULT_CACHE_STRATEGY });
+  const tempApiKey = await tempApiKeyResponse.text();
 
-    if (window.ably?.docs && !window.ably.docs.DOCS_API_KEY) {
-      window.ably.docs.DOCS_API_KEY = tempApiKey;
-      safelyInvokeApiKeyRetrievalTrigger();
-    }
+  if (window.ably?.docs && !window.ably.docs.DOCS_API_KEY) {
+    window.ably.docs.DOCS_API_KEY = tempApiKey;
+    safelyInvokeApiKeyRetrievalTrigger();
+  }
+
+  return {
+    name: 'Demo Only',
+    demo: true,
+    url: WEB_API_TEMP_KEY_ENDPOINT,
+    apiKeys: [
+      {
+        name: 'Demo Only',
+        whole_key: tempApiKey,
+      },
+    ],
+  };
+};
+
+const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>) => {
+  // Always fetch the demo key
+  const demoApiKey = await fetchDemoApiKey();
+
+  // If there's no valid payload, return only the demo key
+  if (payload.error || !payload.data || !isArray(payload.data)) {
     return {
-      data: [
-        {
-          name: 'Demo Only',
-          url: WEB_API_TEMP_KEY_ENDPOINT,
-          apiKeys: [
-            {
-              name: 'Demo Only',
-              whole_key: tempApiKey,
-            },
-          ],
-        },
-      ],
+      data: [demoApiKey],
     };
   }
+
+  // Fetch actual API keys from the payload
   const apiKeyData = await Promise.all(
     payload.data.map(async (value: ApiKeyValue) => {
       const apiKeysRaw = await getJsonResponse(value.url, 'api-key-retrieval');
       const apiKeys = apiKeysRaw.map(pick(['name', 'whole_key']));
-      return { ...value, apiKeys };
+      return { ...value, apiKeys, demo: false };
     }),
   );
+
   /**
    * Supporting ad hoc scripts; the following lines can be removed when ad hoc scripts are.
    */
@@ -65,9 +76,11 @@ const retrieveApiKeyDataFromApiKeyUrl = async (payload: Record<string, unknown>)
   /**
    * Supporting ad hoc scripts; the preceding lines can be removed when ad hoc scripts are.
    */
+
+  // Return both actual keys and demo key
   return {
     ...payload,
-    data: apiKeyData,
+    data: [demoApiKey, ...apiKeyData],
   };
 };
 

--- a/src/templates/examples.tsx
+++ b/src/templates/examples.tsx
@@ -60,7 +60,8 @@ const Examples = ({ pageContext }: { pageContext: { example: ExampleWithContent 
   const meta_title = example.metaTitle || `Ably Examples | ${example.name}`;
   const meta_description = example.metaDescription || example.description;
   const userData = useContext(UserContext);
-  const apiKey = getApiKey(userData);
+  const apiKey = getApiKey(userData, true);
+
   const isFirstRender = useRef(true);
   const [activeLanguage, setActiveLanguage] = React.useState<LanguageKey>(() => {
     // Get all available language keys from the example

--- a/src/utilities/update-ably-connection-keys.test.ts
+++ b/src/utilities/update-ably-connection-keys.test.ts
@@ -1,0 +1,155 @@
+import { getApiKey } from './update-ably-connection-keys';
+import type { AppApiKey, UserDetails } from 'src/contexts';
+
+// Mock environment variables
+const originalEnv = process.env;
+
+// Test fixtures
+const createMockAppApiKey = (whole_key: string): AppApiKey => ({
+  whole_key,
+  ui_compatible_capabilities: true,
+  capability: {},
+  revocableTokens: true,
+  paas_linked: false,
+  is_webhook: false,
+  webhook_url: '',
+  created: '2023-01-01',
+  name: 'Test Key',
+  id: 'test-id',
+});
+
+const createUserDataWithBothApps = (): UserDetails => ({
+  sessionState: {},
+  apps: [
+    {
+      name: 'Demo App',
+      url: 'https://demo.example.com',
+      apiKeys: [createMockAppApiKey('demo-key-456')],
+      demo: true,
+    },
+    {
+      name: 'Real App',
+      url: 'https://real.example.com',
+      apiKeys: [createMockAppApiKey('real-key-789')],
+      demo: false,
+    },
+  ],
+});
+
+const createUserDataWithOnlyRealApp = (): UserDetails => ({
+  sessionState: {},
+  apps: [
+    {
+      name: 'Real App',
+      url: 'https://real.example.com',
+      apiKeys: [createMockAppApiKey('real-key-789')],
+      demo: false,
+    },
+  ],
+});
+
+const createUserDataWithEmptyApiKeys = (): UserDetails => ({
+  sessionState: {},
+  apps: [
+    {
+      name: 'Demo App',
+      url: 'https://demo.example.com',
+      apiKeys: [],
+      demo: true,
+    },
+  ],
+});
+
+const createUserDataWithMultipleApiKeys = (): UserDetails => ({
+  sessionState: {},
+  apps: [
+    {
+      name: 'Demo App',
+      url: 'https://demo.example.com',
+      apiKeys: [createMockAppApiKey('demo-key-1'), createMockAppApiKey('demo-key-2')],
+      demo: true,
+    },
+  ],
+});
+
+describe('getApiKey', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('development environment with GATSBY_VITE_ABLY_KEY', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+      process.env.GATSBY_VITE_ABLY_KEY = 'dev-key-123';
+    });
+
+    it('returns the development key regardless of demoOnly parameter', () => {
+      const userData = createUserDataWithBothApps();
+
+      expect(getApiKey(userData, true)).toBe('dev-key-123');
+      expect(getApiKey(userData, false)).toBe('dev-key-123');
+    });
+  });
+
+  describe('production environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.GATSBY_VITE_ABLY_KEY;
+    });
+
+    it('returns demo key when demoOnly is true', () => {
+      const userData = createUserDataWithBothApps();
+
+      expect(getApiKey(userData, true)).toBe('demo-key-456');
+    });
+
+    it('returns real key when demoOnly is false', () => {
+      const userData = createUserDataWithBothApps();
+
+      expect(getApiKey(userData, false)).toBe('real-key-789');
+    });
+
+    it('returns undefined when no matching app is found', () => {
+      const userData = createUserDataWithOnlyRealApp();
+
+      expect(getApiKey(userData, true)).toBeUndefined();
+    });
+
+    it('returns undefined when app has no apiKeys', () => {
+      const userData = createUserDataWithEmptyApiKeys();
+
+      expect(getApiKey(userData, true)).toBeUndefined();
+    });
+
+    it('returns undefined when userData has no apps', () => {
+      const userData: UserDetails = {
+        sessionState: {},
+        apps: [],
+      };
+
+      expect(getApiKey(userData, true)).toBeUndefined();
+      expect(getApiKey(userData, false)).toBeUndefined();
+    });
+
+    it('returns undefined when userData.apps is undefined', () => {
+      const userData: UserDetails = {
+        sessionState: {},
+        apps: [],
+      };
+
+      expect(getApiKey(userData, true)).toBeUndefined();
+      expect(getApiKey(userData, false)).toBeUndefined();
+    });
+
+    it('returns the first apiKey when multiple are present', () => {
+      const userData = createUserDataWithMultipleApiKeys();
+
+      expect(getApiKey(userData, true)).toBe('demo-key-1');
+    });
+  });
+});

--- a/src/utilities/update-ably-connection-keys.ts
+++ b/src/utilities/update-ably-connection-keys.ts
@@ -10,23 +10,6 @@ export const getApiKey = (userData: UserDetails, demoOnly = false) => {
   return app?.apiKeys?.[0]?.whole_key;
 };
 
-/**
- * Redacts an API key by showing only the part before the first colon, followed by asterisks
- */
-export const redactApiKey = (apiKey: string): string => {
-  if (!apiKey) {
-    return apiKey;
-  }
-
-  const colonIndex = apiKey.indexOf(':');
-  if (colonIndex === -1) {
-    // If no colon found, show first 4 characters followed by asterisks
-    return apiKey.substring(0, 4) + '*****';
-  }
-
-  return apiKey.substring(0, colonIndex + 1) + '*****';
-};
-
 export const updateAblyConnectionKey = (
   files: Record<string, string>,
   apiKey: string,
@@ -34,7 +17,6 @@ export const updateAblyConnectionKey = (
 ) => {
   const ablyEnvironment = process.env.GATSBY_ABLY_ENVIRONMENT ?? 'production';
   const names = Object.keys(files);
-  const redactedApiKey = redactApiKey(apiKey);
 
   return names.reduce(
     (acc, name: string) => {
@@ -51,14 +33,13 @@ export const updateAblyConnectionKey = (
         });
       }
 
-      // API Key - use redacted version
-      content = content.replaceAll(/import\.meta\.env\.VITE_ABLY_KEY/g, `"${redactedApiKey}"`);
+      // API Key
+      content = content.replaceAll(/import\.meta\.env\.VITE_ABLY_KEY/g, `"${apiKey}"`);
 
-      // Additional keys - also redact these if they look like API keys
+      // Additional keys
       if (additionalKeys) {
         Object.entries(additionalKeys).forEach(([key, value]) => {
-          const redactedValue = redactApiKey(value);
-          content = content.replaceAll(`import.meta.env.VITE_${key}`, `"${redactedValue}"`);
+          content = content.replaceAll(`import.meta.env.VITE_${key}`, `"${value}"`);
         });
       }
 

--- a/src/utilities/update-ably-connection-keys.ts
+++ b/src/utilities/update-ably-connection-keys.ts
@@ -1,9 +1,14 @@
 import { UserDetails } from 'src/contexts';
 
-export const getApiKey = (userData: UserDetails) =>
-  process.env.NODE_ENV === 'development' && process.env.GATSBY_VITE_ABLY_KEY
-    ? process.env.GATSBY_VITE_ABLY_KEY
-    : userData.apps?.[0]?.apiKeys?.[0]?.whole_key;
+export const getApiKey = (userData: UserDetails, demoOnly = false) => {
+  if (process.env.NODE_ENV === 'development' && process.env.GATSBY_VITE_ABLY_KEY) {
+    return process.env.GATSBY_VITE_ABLY_KEY;
+  }
+
+  const apps = userData.apps ?? [];
+  const app = apps.find((a) => a.demo === demoOnly);
+  return app?.apiKeys?.[0]?.whole_key;
+};
 
 export const updateAblyConnectionKey = (
   files: Record<string, string>,


### PR DESCRIPTION
This pull request refactors the handling of API keys in the `examples` page template and removes unused code related to user context and API key retrieval. The changes simplify the codebase by replacing dynamic API key logic with a static environment variable and removing unnecessary imports and functions.

Review app (it's a random website dependabot env, but it points to the right docs - log in as normal): https://website-dependabot-npm--7ueyw3.herokuapp.com/examples

Acceptance: it should work and say it's using the demo key in the Sandpack window footer

### Refactoring API key handling:

* Replaced the dynamic API key retrieval logic using `UserContext` and `getApiKey` with a static demo key sourced from the `GATSBY_VITE_ABLY_KEY` environment variable in `src/templates/examples.tsx`. This is a temporary solution until a better approach is implemented.

### Code cleanup:

* Removed the unused `UserContext` import and the `getApiKey` function from `src/templates/examples.tsx`.
* Deleted the `getApiKey` function and its related import from `src/utilities/update-ably-connection-keys.ts`, as it is no longer used.
* Removed the unused `useContext` import from `src/templates/examples.tsx`.