### PR TITLE
Added Python and Go to getting started nav

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -50,6 +50,14 @@ export default {
               link: '/docs/getting-started/swift',
             },
             {
+              name: 'Go',
+              link: '/docs/getting-started/go',
+            },
+            {
+              name: 'Python',
+              link: '/docs/getting-started/python',
+            },
+            {
               name: 'Ruby',
               link: '/docs/getting-started/ruby',
             },

--- a/src/pages/docs/getting-started/index.mdx
+++ b/src/pages/docs/getting-started/index.mdx
@@ -43,6 +43,18 @@ These are your first steps towards building a realtime application that can effo
     link: '/docs/getting-started/swift',
   },
   {
+    title: 'Go',
+    description: 'Start building with Pub/Sub using Ably\'s Go SDK.',
+    image: 'icon-tech-go',
+    link: '/docs/getting-started/go',
+  },
+  {
+    title: 'Python',
+    description: 'Start building with Pub/Sub using Ably\'s Python SDK.',
+    image: 'icon-tech-python',
+    link: '/docs/getting-started/python',
+  },
+  {
     title: 'Ruby',
     description: 'Start building with Pub/Sub using Ably\'s Ruby SDK.',
     image: 'icon-tech-ruby',


### PR DESCRIPTION
## Description

The getting started guides for both Python and Go weren't showing in the navigation or in the overview page. This PR fixes that issue and displays them as expected.


