### PR TITLE
Update stats to reflect sent messages includes recevied

### DIFF
--- a/src/pages/docs/metadata-stats/stats.mdx
+++ b/src/pages/docs/metadata-stats/stats.mdx
@@ -373,10 +373,10 @@ All messages metrics include all messages types, such as those sent and received
 
 | Metric | Description |
 | --- | --- |
-| **messages.all.all.count** | Total number of messages that were successfully sent, summed over all message types and transports. |
-| **messages.all.all.billableCount** | Total number of billable messages that were successfully sent, summed over all message types and transports. |
-| **messages.all.all.data** | Total message size of all messages that were successfully sent, summed over all message types and transports. |
-| **messages.all.all.uncompressedData** | Total uncompressed message size, excluding delta compression. |
+| **messages.all.all.count** | Total number of messages that were successfully received and sent by Ably, summed over all message types and transports. |
+| **messages.all.all.billableCount** | Total number of billable messages that were successfully received and sent by Ably, summed over all message types and transports. |
+| **messages.all.all.data** | Total data in messages successfully received and sent by Ably, summed over all message types and transports. |
+| **messages.all.all.uncompressedData** | Total data in messages successfully received and sent by Ably, excluding savings provided by delta compression. |
 | **messages.all.all.failed** | Total number of messages that failed. These are messages which did not succeed for some reason other than Ably explicitly refusing them, such as they were rejected by an external integration target, or a service issue on Ably's side. |
 | **messages.all.all.refused** | Total number of messages that were refused by Ably. For example, due to [rate limiting](/docs/platform/pricing/limits), malformed messages, or incorrect client permissions.|
 | **messages.all.messages.count** | Total message count, excluding presence and object messages. |


### PR DESCRIPTION
The copy previously made it sounds like only messages sent were counted, which could be confusing for users who think this is messages sent to Ably, or sent from Ably, but not both.

See somewhat related [Slack message](https://ably-real-time.slack.com/archives/CF7GGBF2N/p1753425019299029) which surfaced this.