### PR TITLE
EDU-2010: Adds thread safety section

### DIFF
--- a/content/api/realtime-sdk.textile
+++ b/content/api/realtime-sdk.textile
@@ -65,6 +65,19 @@ The "@ClientOptions#token@":#client-options option takes a @token@ string or "@t
 
 Read more on "authentication":/docs/auth.
 
+blang[objc,swift].
+  h3(#thread-safety). Thread safety
+
+  The Cocoa SDK makes the following thread safety guarantees:
+
+  * All public methods and properties can be safely accessed from any thread, both for reading and writing operations.
+  * Objects like @ARTTokenDetails@ and message data returned by the SDK can be safely read from multiple threads. However, you should not modify these objects after they're created.
+  * Objects you pass to the library must not be mutated afterwards. Once passed to the SDK, treat them as immutable. You can safely read from them or pass them again, and the library will never modify them.
+
+  All internal operations are dispatched to a single serial GCD queue to ensure thread safety within the SDK. You can specify a custom queue for this using @ARTClientOptions.internalDispatchQueue@, but it must be serial to maintain thread safety guarantees.
+
+  All callbacks provided by you are dispatched to the main queue by default, allowing you to update UI directly without additional thread switching. You can specify a different queue using @ARTClientOptions.dispatchQueue@. The callback queue must be different from @ARTClientOptions.internalDispatchQueue@ to prevent deadlocks. Using the same queue creates circular dependencies where internal operations wait for callbacks, while callbacks wait for the internal queue.
+
 h2(#properties).
   default: AblyRealtime Properties
   jsall: Ably.Realtime Properties

--- a/content/api/rest-sdk.textile
+++ b/content/api/rest-sdk.textile
@@ -75,6 +75,19 @@ Since tokens are short-lived, it is rarely sufficient to start with a token with
 
 Read more on "authentication":/docs/auth.
 
+blang[objc,swift].
+  h3(#thread-safety). Thread safety
+
+  The Cocoa SDK makes the following thread safety guarantees:
+
+  * All public methods and properties can be safely accessed from any thread, both for reading and writing operations.
+  * Objects like @ARTTokenDetails@ and message data returned by the SDK can be safely read from multiple threads. However, you should not modify these objects after they're created.
+  * Objects you pass to the library must not be mutated afterwards. Once passed to the SDK, treat them as immutable. You can safely read from them or pass them again, and the library will never modify them.
+
+  All internal operations are dispatched to a single serial GCD queue to ensure thread safety within the SDK. You can specify a custom queue for this using @ARTClientOptions.internalDispatchQueue@, but it must be serial to maintain thread safety guarantees.
+
+  All callbacks provided by you are dispatched to the main queue by default, allowing you to update UI directly without additional thread switching. You can specify a different queue using @ARTClientOptions.dispatchQueue@. The callback queue must be different from @ARTClientOptions.internalDispatchQueue@ to prevent deadlocks. Using the same queue creates circular dependencies where internal operations wait for callbacks, while callbacks wait for the internal queue.
+
 h2(#properties).
   default: AblyRest Properties
   jsall: Ably.Rest Properties


### PR DESCRIPTION
This PR:

- Adds a new Thread safety section to the Rest and Realtime sections.
  - This was removed from the Cocoa SDK trim and was not mentioned in the docs.
    - https://github.com/ably/ably-cocoa/pull/2052

Jira:
https://ably.atlassian.net/browse/EDU-2010