### PR TITLE
Update pubsub nav to match chat

### DIFF
--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -16,13 +16,8 @@ export default {
           link: '/docs/chat',
           index: true,
         },
-      ],
-    },
-    {
-      name: 'Getting started',
-      pages: [
         {
-          name: 'Quickstarts',
+          name: 'Getting started',
           pages: [
             {
               name: 'JavaScript',
@@ -46,6 +41,11 @@ export default {
           name: 'SDK setup',
           link: '/docs/chat/setup',
         },
+      ],
+    },
+    {
+      name: 'Concepts',
+      pages: [
         {
           name: 'Connections',
           link: '/docs/chat/connect',

--- a/src/data/nav/liveobjects.ts
+++ b/src/data/nav/liveobjects.ts
@@ -16,13 +16,8 @@ export default {
           link: '/docs/liveobjects',
           index: true,
         },
-      ],
-    },
-    {
-      name: 'Getting started',
-      pages: [
         {
-          name: 'Quickstart',
+          name: 'Getting started',
           link: '/docs/liveobjects/quickstart',
         },
       ],

--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -16,13 +16,8 @@ export default {
           link: '/docs/basics',
           index: true,
         },
-      ],
-    },
-    {
-      name: 'Getting started',
-      pages: [
         {
-          name: 'Quickstarts',
+          name: 'Getting started',
           pages: [
             {
               name: 'Overview',

--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -22,7 +22,7 @@ export default {
       name: 'Getting started',
       pages: [
         {
-          name: 'Guides',
+          name: 'Quickstarts',
           pages: [
             {
               name: 'Overview',

--- a/src/data/nav/spaces.ts
+++ b/src/data/nav/spaces.ts
@@ -16,11 +16,6 @@ export default {
           link: '/docs/spaces',
           index: true,
         },
-      ],
-    },
-    {
-      name: 'Get started',
-      pages: [
         {
           name: 'SDK setup',
           link: '/docs/spaces/setup',

--- a/src/pages/docs/liveobjects/quickstart.mdx
+++ b/src/pages/docs/liveobjects/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
-title: Quickstart
-meta_description: "A quickstart guide to learn the basics of integrating the Ably LiveObjects product into your application."
+title: "Getting started: LiveObjects in JavaScript"
+meta_description: "A getting started guide to learn the basics of integrating the Ably LiveObjects product into your application."
 ---
 
 <Aside data-type='experimental'>


### PR DESCRIPTION
Pubsub uses "Getting started" -> "Guides", and Chat uses "Getting started" -> "Quickstarts".

<img width="231" height="230" alt="image" src="https://github.com/user-attachments/assets/9143244d-40df-4624-8e29-0a8fcbe4414c" />
<img width="235" height="188" alt="image" src="https://github.com/user-attachments/assets/a02240f4-6503-4224-8014-bd3fd5aab0d6" />
<img width="234" height="189" alt="image" src="https://github.com/user-attachments/assets/186b302d-6f9c-47a2-8ba1-f4bfbfba77f7" />
