### PR TITLE
Fix naming of outbound streaming overview

### DIFF
--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -194,7 +194,7 @@ export default {
           name: 'Outbound streaming',
           pages: [
             {
-              name: 'Overview',
+              name: 'Firehose overview',
               link: '/docs/integrations/streaming',
               index: true,
             },


### PR DESCRIPTION
The outbound streaming header has an "overview" where the page title is "Firehose overview", but we haven't mentioned firehose before.

Align the nav and page titles.