### PR TITLE
[WEB-4400] chore: update ably-ui to 17.6.2, add and make room for docs badge in header logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.6.1",
+    "@ably/ui": "17.6.2",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",
@@ -149,5 +149,6 @@
     "ts-node": "^10.9.2",
     "undici": "^5.29.0",
     "v8-profiler-next": "^1.9.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -88,7 +88,7 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
           />
         ) : null
       }
-      headerCenterClassName="max-w-[17.5rem]"
+      headerCenterClassName="flex-none w-52 lg:w-[17.5rem]"
       headerLinks={[
         {
           href: '/docs/sdks',
@@ -102,6 +102,7 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
       ]}
       sessionState={sessionState}
       logoHref="/docs"
+      logoBadge="docs"
       location={location}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.6.1":
-  version "17.6.1"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.1.tgz#74b9b55bd1e63173bc4a4a9bf3b93bbab68d6a3b"
-  integrity sha512-AJZLUvOYqLftQw/sslrWG2+hREW/ZKRl2wBqERxQj6AO8PScp83OvXhNCM/PQq4y1qTIqw6PxZ54cg0r6UX/gQ==
+"@ably/ui@17.6.2":
+  version "17.6.2"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.2.tgz#5d69228242be41b26c9904fea324236a769a6a6a"
+  integrity sha512-GTvr1nFuDMyUkFdQH9oA0g8UdToxu/rtf8id47QM5cjCwC6Dxj4JbiObED7tzN52DXauCIiIF64JIMWOxA2NIA==
   dependencies:
     "@heroicons/react" "^2.2.0"
     "@radix-ui/react-accordion" "^1.2.1"
@@ -15504,7 +15504,16 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
Adds a custom badge to the header logo.

Review link: https://ably-docs-web-4400-cust-g08ltt.herokuapp.com/docs

### Word of bot
This pull request includes a minor dependency update and some layout improvements for the header component. The most notable changes are the update of the `@ably/ui` package, adjustments to the header's center alignment, and the addition of a badge to the logo in the header.

**Dependency update:**

* Updated the `@ably/ui` package to version `17.6.2` in `package.json` for improved features or bug fixes.

**Header layout and UI enhancements:**

* Modified the `headerCenterClassName` in `Header.tsx` to use fixed width classes (`flex-none w-52 lg:w-[17.5rem]`) for better layout consistency across screen sizes.
* Added a `logoBadge="docs"` prop to the `Header` component, which displays a "docs" badge next to the logo for clearer section identification.