### PR TITLE
liveobjects/rest: align openapi error responses

### DIFF
--- a/static/open-specs/liveobjects.yaml
+++ b/static/open-specs/liveobjects.yaml
@@ -105,35 +105,132 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CreateOrUpdateObjectsBadRequest"
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad request (40000)
+                  value:
+                    message: "Bad request"
+                    code: 40000
+                    statusCode: 400
+                    href: "https://help.ably.io/error/40000"
+                    details: null
+                invalidObjectMessage:
+                  summary: Invalid object message (92000)
+                  value:
+                    message: "invalid object message: nonce is required when objectId is specified"
+                    code: 92000
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92000"
+                    details: null
+                objectsLimitExceeded:
+                  summary: Objects limit exceeded (92001)
+                  value:
+                    message: "objects limit max number 100 exceeded"
+                    code: 92001
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92001"
+                    details: null
+                operationOnTombstone:
+                  summary: Operation on tombstone object (92002)
+                  value:
+                    message: "unable to submit operation on tombstone object: root"
+                    code: 92002
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92002"
+                    details: null
+                pathMatchedNoObjects:
+                  summary: Operation path matched no objects (92005)
+                  value:
+                    message: "no objects matched path: votes.missing"
+                    code: 92005
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92005"
+                    details: null
+                missingObjectIdAndPath:
+                  summary: Object ID or path required (92006)
+                  value:
+                    message: "object id or path required"
+                    code: 92006
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92006"
+                    details: null
+                pathNotProcessable:
+                  summary: Path not processable (92007)
+                  value:
+                    message: "path not processable: wildcard paths not supported for counter create"
+                    code: 92007
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92007"
+                    details: null
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AuthError'
-                  - $ref: '#/components/schemas/ClientRestrictionNotSatisfied'
-                  - $ref: '#/components/schemas/InvalidTokenKey'
-                  - $ref: '#/components/schemas/MalformedCredential'
-                  - $ref: '#/components/schemas/OperationObjectSubscribeUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: Unauthorized
+                  value:
+                    message: "Unauthorized"
+                    code: 40100
+                    statusCode: 401
+                    href: "https://help.ably.io/error/40100"
+                    details: null
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/ApplicationDisabled'
-                  - $ref: '#/components/schemas/StateOperationsOnlyAppliedOnRegularChannels'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden:
+                  summary: Forbidden
+                  value:
+                    message: "Forbidden"
+                    code: 40300
+                    statusCode: 403
+                    href: "https://help.ably.io/error/40300"
+                    details: null
         '404':
           description: Not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppNotFound'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                notFound:
+                  summary: Not found
+                  value:
+                    message: "Not found"
+                    code: 40400
+                    statusCode: 404
+                    href: "https://help.ably.io/error/40400"
+                    details: null
+                fetchUnknownObject:
+                  summary: Object not found (92004)
+                  value:
+                    message: "unable to fetch objects tree for not found object: root"
+                    code: 92004
+                    statusCode: 404
+                    href: "https://help.ably.io/error/92004"
+                    details: null
         '429':
           description: Too many requests
-          $ref: '#/components/schemas/RateLimitExceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                rateLimitExceeded:
+                  summary: Rate limit exceeded
+                  value:
+                    message: "Rate limit exceeded"
+                    code: 42900
+                    statusCode: 429
+                    href: "https://help.ably.io/error/42900"
+                    details: null
     get:
       summary: List objects
       description: |
@@ -268,40 +365,112 @@ paths:
                         e02: "01745828651671-000@e025VxXLABoR0C19591332:000"
                       tombstone: false
 
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad request (40000)
+                  value:
+                    message: "Bad request"
+                    code: 40000
+                    statusCode: 400
+                    href: "https://help.ably.io/error/40000"
+                    details: null
+                fetchTombstoneObject:
+                  summary: Unable to fetch tombstone object (92003)
+                  value:
+                    message: "unable to fetch objects tree for tombstone object: root"
+                    code: 92003
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92003"
+                    details: null
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AuthError'
-                  - $ref: '#/components/schemas/ClientRestrictionNotSatisfied'
-                  - $ref: '#/components/schemas/InvalidTokenKey'
-                  - $ref: '#/components/schemas/MalformedCredential'
-                  - $ref: '#/components/schemas/OperationObjectSubscribeUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: Unauthorized
+                  value:
+                    message: "Unauthorized"
+                    code: 40100
+                    statusCode: 401
+                    href: "https://help.ably.io/error/40100"
+                    details: null
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/ApplicationDisabled'
-                  - $ref: '#/components/schemas/StateOperationsOnlyAppliedOnRegularChannels'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden:
+                  summary: Forbidden
+                  value:
+                    message: "Forbidden"
+                    code: 40300
+                    statusCode: 403
+                    href: "https://help.ably.io/error/40300"
+                    details: null
         '404':
           description: Not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppNotFound'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                notFound:
+                  summary: Not found
+                  value:
+                    message: "Not found"
+                    code: 40400
+                    statusCode: 404
+                    href: "https://help.ably.io/error/40400"
+                    details: null
+                fetchUnknownObject:
+                  summary: Object not found (92004)
+                  value:
+                    message: "unable to fetch objects tree for not found object: root"
+                    code: 92004
+                    statusCode: 404
+                    href: "https://help.ably.io/error/92004"
+                    details: null
         '429':
-          description: Too Many Requests
-          $ref: '#/components/schemas/RateLimitExceeded'
-        '500':
-          description: Internal server error.
+          description: Too many requests
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/error'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                rateLimitExceeded:
+                  summary: Rate limit exceeded
+                  value:
+                    message: "Rate limit exceeded"
+                    code: 42900
+                    statusCode: 429
+                    href: "https://help.ably.io/error/42900"
+                    details: null
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                internalError:
+                  summary: Internal server error
+                  value:
+                    message: "Internal server error"
+                    code: 50000
+                    statusCode: 500
+                    href: "https://help.ably.io/error/50000"
+                    details: null
   /channels/{channelName}/objects/{objectId}:
     get:
       summary: Get objects
@@ -423,36 +592,97 @@ paths:
                     siteTimeserials:
                       e02: "01745828596522-000@e025VxXLABoR0C19591332:001"
                     tombstone: false
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad request (40000)
+                  value:
+                    message: "Bad request"
+                    code: 40000
+                    statusCode: 400
+                    href: "https://help.ably.io/error/40000"
+                    details: null
+                fetchTombstoneObject:
+                  summary: Unable to fetch tombstone object (92003)
+                  value:
+                    message: "unable to fetch objects tree for tombstone object: root"
+                    code: 92003
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92003"
+                    details: null
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AuthError'
-                  - $ref: '#/components/schemas/ClientRestrictionNotSatisfied'
-                  - $ref: '#/components/schemas/InvalidTokenKey'
-                  - $ref: '#/components/schemas/MalformedCredential'
-                  - $ref: '#/components/schemas/OperationObjectSubscribeUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: Unauthorized
+                  value:
+                    message: "Unauthorized"
+                    code: 40100
+                    statusCode: 401
+                    href: "https://help.ably.io/error/40100"
+                    details: null
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/ApplicationDisabled'
-                  - $ref: '#/components/schemas/StateOperationsOnlyAppliedOnRegularChannels'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden:
+                  summary: Forbidden
+                  value:
+                    message: "Forbidden"
+                    code: 40300
+                    statusCode: 403
+                    href: "https://help.ably.io/error/40300"
+                    details: null
         '404':
           description: Not found
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AppNotFound'
-                  - $ref: '#/components/schemas/ObjectNotFound'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                notFound:
+                  summary: Not found
+                  value:
+                    message: "Not found"
+                    code: 40400
+                    statusCode: 404
+                    href: "https://help.ably.io/error/40400"
+                    details: null
+                fetchUnknownObject:
+                  summary: Object not found (92004)
+                  value:
+                    message: "unable to fetch objects tree for not found object: root"
+                    code: 92004
+                    statusCode: 404
+                    href: "https://help.ably.io/error/92004"
+                    details: null
         '429':
           description: Too many requests
-          $ref: '#/components/schemas/RateLimitExceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                rateLimitExceeded:
+                  summary: Rate limit exceeded
+                  value:
+                    message: "Rate limit exceeded"
+                    code: 42900
+                    statusCode: 429
+                    href: "https://help.ably.io/error/42900"
+                    details: null
   /channels/{channelName}/objects/{objectId}/compact:
     get:
       summary: Get a compact view of objects
@@ -498,37 +728,95 @@ paths:
                         objectId: "root"
         '400':
           description: Bad request
-          $ref: '#/components/schemas/TombstoneObjectError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                badRequest:
+                  summary: Bad request (40000)
+                  value:
+                    message: "Bad request"
+                    code: 40000
+                    statusCode: 400
+                    href: "https://help.ably.io/error/40000"
+                    details: null
+                fetchTombstoneObject:
+                  summary: Unable to fetch tombstone object (92003)
+                  value:
+                    message: "unable to fetch objects tree for tombstone object: root"
+                    code: 92003
+                    statusCode: 400
+                    href: "https://help.ably.io/error/92003"
+                    details: null
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AuthError'
-                  - $ref: '#/components/schemas/ClientRestrictionNotSatisfied'
-                  - $ref: '#/components/schemas/InvalidTokenKey'
-                  - $ref: '#/components/schemas/MalformedCredential'
-                  - $ref: '#/components/schemas/OperationObjectSubscribeUnauthorized'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: Unauthorized
+                  value:
+                    message: "Unauthorized"
+                    code: 40100
+                    statusCode: 401
+                    href: "https://help.ably.io/error/40100"
+                    details: null
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/ApplicationDisabled'
-                  - $ref: '#/components/schemas/StateOperationsOnlyAppliedOnRegularChannels'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden:
+                  summary: Forbidden
+                  value:
+                    message: "Forbidden"
+                    code: 40300
+                    statusCode: 403
+                    href: "https://help.ably.io/error/40300"
+                    details: null
         '404':
           description: Not found
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/AppNotFound'
-                  - $ref: '#/components/schemas/ObjectNotFound'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                notFound:
+                  summary: Not found
+                  value:
+                    message: "Not found"
+                    code: 40400
+                    statusCode: 404
+                    href: "https://help.ably.io/error/40400"
+                    details: null
+                fetchUnknownObject:
+                  summary: Object not found (92004)
+                  value:
+                    message: "unable to fetch objects tree for not found object: root"
+                    code: 92004
+                    statusCode: 404
+                    href: "https://help.ably.io/error/92004"
+                    details: null
         '429':
           description: Too many requests
-          $ref: '#/components/schemas/RateLimitExceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                rateLimitExceeded:
+                  summary: Rate limit exceeded
+                  value:
+                    message: "Rate limit exceeded"
+                    code: 42900
+                    statusCode: 429
+                    href: "https://help.ably.io/error/42900"
+                    details: null
 
 components:
   schemas:
@@ -961,608 +1249,9 @@ components:
             - "counter:iVji62_MW_j4dShuJbr2fmsP2D8MyCs6tFqON9-xAkc@1745828645269"
 
     # Errors
-    ApplicationDisabled:
-      title: Application disabled
+    ErrorResponse:
       type: object
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Application disabled."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 403
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          nullable: true
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          nullable: true
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-    AuthError:
-      title: Auth error
-      type: object
-      properties:
-        code:
-          type: integer
-          example: 401
-        message:
-          type: string
-          example: "Token expired, token revoked, or client restriction not satisfied."
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          nullable: true
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          nullable: true
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-    AppNotFound:
-      title: App not found
-      type: object
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Application not found."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 404
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          nullable: true
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          nullable: true
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-    ClientRestrictionNotSatisfied:
-      description: Client restriction not satisfied.
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Client restriction not satisfied."
-        code:
-          type: integer
-          example: 401
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 40160
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/40160
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-    ClientSpecifiedMessageIdInvalid:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Client-specified message ID cannot be empty or does not match the required format for batches."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 40031
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/40031
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    CreateOrUpdateObjectsBadRequest:
-      oneOf:
-      - $ref: '#/components/schemas/FailureDecodingRequestBody'
-      - $ref: '#/components/schemas/InvalidObjectId'
-      - $ref: '#/components/schemas/InvalidObjectMessage'
-      - $ref: '#/components/schemas/NoOperationsInRequest'
-      - $ref: '#/components/schemas/ObjectIdOrPathRequired'
-      - $ref: '#/components/schemas/UnknownOperationType'
-      - $ref: '#/components/schemas/OperationPathNotProcessable'
-      - $ref: '#/components/schemas/ClientSpecifiedMessageIdInvalid'
-      - $ref: '#/components/schemas/FailedToUnmarshalOperationData'
-      - $ref: '#/components/schemas/NoObjectsMatchedPath'
-      - $ref: '#/components/schemas/UnableToUnquoteJsonData'
-      - $ref: '#/components/schemas/ObjectsLimitExceeded'
-      discriminator:
-        propertyName: statusCode
-        mapping:
-          'Failure decoding request body': '#/components/schemas/FailureDecodingRequestBody'
-          'Failed to unmarshal operation data': '#/components/schemas/FailedToUnmarshalOperationData'
-          'No operations in request': '#/components/schemas/NoOperationsInRequest'
-          'Operation Id or path required': '#/components/schemas/ObjectIdOrPathRequired'
-          'No objects matched path': '#/components/schemas/NoObjectsMatchedPath'
-          'Unknown operation type': '#/components/schemas/UnknownOperationType'
-          'Unable to unquote json data': '#/components/schemas/UnableToUnquoteJsonData'
-          'Invalid object message': '#/components/schemas/InvalidObjectMessage'
-          'Invalid object id': '#/components/schemas/InvalidObjectId'
-          'Client specified message Id invalid': '#/components/schemas/ClientSpecifiedMessageIdInvalid'
-          'Objects limit exceeded': '#/components/schemas/ObjectsLimitExceeded'
-          'Operation path not processable': '#/components/schemas/OperationPathNotProcessable'
-    FailureDecodingRequestBody:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Failure decoding request body."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92001
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92001"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    FailedToUnmarshalOperationData:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Failed to unmarshal operation data."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92002
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92002"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    InvalidObjectMessage:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Invalid object message."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92000
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/92000
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    InvalidObjectId:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Invalid object ID."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92000
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/92000
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    InvalidTokenKey:
-      title: Token expired or revoked, or key revoked, expired, or removed.
-      type: object
-      properties:
-        code:
-          type: integer
-          example: 401
-        message:
-          type: string
-          example: "Token expired"
-    MalformedCredential:
-      title: Malformed credential or invalid request.
-      type: object
-      properties:
-        code:
-          type: integer
-          example: 401
-        message:
-          type: string
-          example: "Malformed credential or unknown operation type."
-    NoObjectsMatchedPath:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "(92005) No objects matched path."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92005
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92005"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    NoOperationsInRequest:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "No operations in request."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92003
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92003"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    ObjectIdOrPathRequired:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "(92006) Object ID or path required."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92006
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92006"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    ObjectNotFound:
-      title: Object not found
-      type: object
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Object not found."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 404
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92004
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92004"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    ObjectsLimitExceeded:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Objects limit max number exceeded."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 32001
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/32001
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    OperationPathNotProcessable:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Operation path not processable."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92007
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/92007
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    OperationObjectSubscribeUnauthorized:
-      title: Operation object-subscribe unauthorized on channel.
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Operation object-subscribe unauthorized on channel."
-        code:
-          type: integer
-          example: 401
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 40160
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: https://help.ably.io/error/40160
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    RateLimitExceeded:
-      description: Rate limit exceeded.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: integer
-                example: 429
-              message:
-                type: string
-                example: "Rate limit exceeded."
-    StateOperationsOnlyAppliedOnRegularChannels:
-      title: State operations only applied on regular channels
-      type: object
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "State operations only applied on regular channels (e.g., not [meta], [chat], etc channels)."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 403
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          nullable: true
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          nullable: true
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-    TombstoneObjectError:
-      type: object
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Unable to fetch objects tree for tombstone object."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92003
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92003"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    UnknownOperationType:
-      type: object
-      additionalProperties: false
-      properties:
-        message:
-          type: string
-          description: The error message.
-          example: "Unknown operation type."
-        code:
-          type: integer
-          description: The HTTP status code returned.
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          example: 92007
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          example: "https://help.ably.io/error/92007"
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-      - statusCode
-      - href
-    UnableToUnquoteJsonData:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Unable to unquote JSON encoded data field."
-        code:
-          type: integer
-          example: 400
-        statusCode:
-          type: integer
-          description: The Ably error code.
-          nullable: true
-        href:
-          type: string
-          description: The URL to documentation about the error code.
-          nullable: true
-        details:
-          type: object
-          nullable: true
-          description: Any additional details about the error message.
-      required:
-      - message
-      - code
-    error:
-      type: object
-      additionalProperties: false
+      description: Base error response structure used by all API errors.
       properties:
         message:
           type: string
@@ -1573,15 +1262,16 @@ components:
         statusCode:
           type: integer
           description: The Ably error code.
+          nullable: true
         href:
           type: string
           description: The URL to documentation about the error code.
+          nullable: true
         details:
           type: object
           nullable: true
           description: Any additional details about the error message.
       required:
-      - message
-      - code
-      - statusCode
-      - href
+        - message
+        - code
+


### PR DESCRIPTION
Updates the OpenAPI spec for the LiveObjects REST API to correctly reflect the error codes returned from the endpoints.

Defines error response examples inline on the endpoints to avoid generated docs from including a oneOf selector in the "Responses" section and instead preferring to show specific examples for error responses in the right hand pane.

## Description

<!--  An in-depth description of what this PR is adding or updating. Include a link to the related JIRA issue if this exists. -->

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
