### PR TITLE
Fixes to local dev experience

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.0.0
+ruby 3.4.5
 nodejs 20.13.1
 yarn 1.22.19

--- a/bin/dev
+++ b/bin/dev
@@ -41,7 +41,8 @@ fi
 echo "🧰  Installing/updating asdf tools from .tool-versions..."
 
 # Check all tools in .tool-versions
-while read -r tool version; do
+# The `|| [[ -n "$tool" ]]` ensures the final line is processed even if the file lacks a trailing newline
+while read -r tool version || [[ -n "$tool" ]]; do
   # Skip empty lines
   [[ -z "$tool" || -z "$version" ]] && continue
   


### PR DESCRIPTION
A couple of fixes from when I tried running `/bin/dev` on my machine for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development startup script now reliably reads all tool versions, even when the configuration file lacks a trailing newline, reducing setup edge cases.

* **Chores**
  * Updated Ruby runtime to 3.4.5 for development and CI environments, aligning with current platform requirements and improving compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->