### PR TITLE
[EDU-2031] - Update ably-ui to 17.6.3 to enable API_KEY rendering in MDX.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.6.2",
+    "@ably/ui": "17.6.3",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.6.2":
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.2.tgz#5d69228242be41b26c9904fea324236a769a6a6a"
-  integrity sha512-GTvr1nFuDMyUkFdQH9oA0g8UdToxu/rtf8id47QM5cjCwC6Dxj4JbiObED7tzN52DXauCIiIF64JIMWOxA2NIA==
+"@ably/ui@17.6.3":
+  version "17.6.3"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.3.tgz#842c37b6721d5abc89162f464ad6dc4d71e8509a"
+  integrity sha512-tNtmUQAGr8zd2PNK+64wjbWJZSe/yH2kPJUaHd5XdtAd5yI/yqYityJV3rG2dyvgMkWjQ3Rl3rYzukBnKB6XbQ==
   dependencies:
     "@heroicons/react" "^2.2.0"
     "@radix-ui/react-accordion" "^1.2.1"


### PR DESCRIPTION
## Description

API_KEY rendering was broken in MDX when using `realtime_` or `rest_` code blocks. This isn't an issue currently in production, but will be fixed with this PR before I release the Pub/Sub MDX migration.