### PR TITLE
[WEB-4400] chore: revert header logo badge until further decisions on nav revisions

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -102,7 +102,6 @@ const Header: React.FC<HeaderProps> = ({ searchBar = true }) => {
       ]}
       sessionState={sessionState}
       logoHref="/docs"
-      logoBadge="docs"
       location={location}
     />
   );


### PR DESCRIPTION
Added a badge to the header logo [here](https://github.com/ably/docs/pull/2755), had discussions with Jamie W highlighting further changes either to the badge itself, or to the wider header bar (wrt. no logo and other notable changes).

Best thing for now is just to take the logo back off until we formulate a more settled plan for what to update on the nav.