### PR TITLE
Incorrect variable name in batch liveobjects codeblock

### DIFF
--- a/src/pages/docs/liveobjects/batch.mdx
+++ b/src/pages/docs/liveobjects/batch.mdx
@@ -100,8 +100,8 @@ await channel.objects.batch((ctx) => {
   const root = ctx.getRoot();
   const tasks = root.get('tasks');
 
-  for (const key of reactions.keys()) {
-    reactions.remove(key);
+  for (const key of tasks.keys()) {
+    tasks.remove(key);
   }
 });
 ```


### PR DESCRIPTION
## Description

This PR fixes an issue raised in [issue #2764](https://github.com/ably/docs/issues/2764). In LiveObjects batch page, Javascript code block, there's an incorrect naming of variables to `reactions` where it should be `tasks`.
