### PR TITLE
[WEB-4553] Bump ably-ui to 17.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.6.3",
+    "@ably/ui": "17.6.5",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.6.3":
-  version "17.6.3"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.3.tgz#842c37b6721d5abc89162f464ad6dc4d71e8509a"
-  integrity sha512-tNtmUQAGr8zd2PNK+64wjbWJZSe/yH2kPJUaHd5XdtAd5yI/yqYityJV3rG2dyvgMkWjQ3Rl3rYzukBnKB6XbQ==
+"@ably/ui@17.6.5":
+  version "17.6.5"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.5.tgz#b6ad6c47161f8a6c47c09e6cc827df123bd2a587"
+  integrity sha512-9XhInT79I+LGB6lilSFL7iC0FHlUoNQtXL3DbxA0u2TxJN0XisWp+jF7lzmHobrsbUCeW38AZ532rzbFLB6lUg==
   dependencies:
     "@heroicons/react" "^2.2.0"
     "@radix-ui/react-accordion" "^1.2.1"
@@ -15504,16 +15504,7 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
Solves the MDX SDK fallback issue via bumping `ably-ui` to 17.6.5.

Example: https://ably-docs-web-4553-code-qop3gn.herokuapp.com/docs/presence-occupancy/presence