### PR TITLE
fix: use correct version of ably chat in the examples

### DIFF
--- a/src/components/Examples/ExamplesRenderer.tsx
+++ b/src/components/Examples/ExamplesRenderer.tsx
@@ -41,7 +41,7 @@ const getDependencies = (id: string, products: string[], activeLanguage: Languag
     nanoid: '^5.0.7',
     minifaker: '1.34.1',
     ...(products.includes('auth') ? { cors: '^2.8.5' } : {}),
-    ...(products.includes('chat') ? { '@ably/chat': '^0.9.0' } : {}),
+    ...(products.includes('chat') ? { '@ably/chat': '^0.11.0' } : {}),
     ...(products.includes('spaces') ? { '@ably/spaces': '^0.4.0' } : {}),
     ...(id === 'spaces-component-locking' ? { 'usehooks-ts': '^3.1.0' } : {}),
     ...(activeLanguage === 'react' || products.includes('chat') || products.includes('spaces')


### PR DESCRIPTION
## Description

The examples renderer uses its own version of Chat rather than what's in package.json. This change updates the version to the latest.

https://ably.atlassian.net/browse/CHA-1132
https://ably.atlassian.net/browse/CHA-1133

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
