### PR TITLE
EDU-2013: Fix Swift safety and add ErrorInfo nesting examples

### DIFF
--- a/content/partials/types/_error_info.textile
+++ b/content/partials/types/_error_info.textile
@@ -17,3 +17,182 @@ h4.
 
 blang[flutter].
   - requestId :=  Request ID with which the error can be identified<br>__Type: @String@__
+
+h4. Error nesting
+
+ErrorInfo objects can contain nested errors through the @cause@ property, allowing you to trace the root cause of failures. When an operation fails due to underlying system errors, the main @ErrorInfo@ provides the high-level failure reason while the nested @cause@ contains more specific details about what went wrong.
+
+One example of ErrorInfo nesting is "80019: Auth server rejecting request":/docs/platform/errors/codes#80019 where the main error indicates token renewal failed, while the nested @cause@ contains the specific HTTP error from the auth server.
+
+blang[javascript,nodejs,ruby,java,swift,objc,csharp,flutter,python,go].
+  The following example demonstrates how to handle nested errors:
+
+blang[javascript].
+  ```[javascript]
+  function handleError(error) {
+      console.log(`Main error: ${error.code} - ${error.message}`);
+
+      // Check for nested error
+      if (error.cause) {
+          console.log(`Root cause: ${error.cause.code} - ${error.cause.message}`);
+
+          // Handle further nesting if needed
+          if (error.cause.cause) {
+              console.log(`Deeper cause: ${error.cause.cause.code} - ${error.cause.cause.message}`);
+          }
+      }
+  }
+  ```
+
+blang[nodejs].
+  ```[javascript]
+  function handleError(error) {
+      console.log(`Main error: ${error.code} - ${error.message}`);
+
+      // Check for nested error
+      if (error.cause) {
+          console.log(`Root cause: ${error.cause.code} - ${error.cause.message}`);
+
+          // Handle further nesting if needed
+          if (error.cause.cause) {
+              console.log(`Deeper cause: ${error.cause.cause.code} - ${error.cause.cause.message}`);
+          }
+      }
+  }
+  ```
+
+blang[swift].
+  ```[swift]
+  func handleError(_ error: ARTErrorInfo) {
+      print("Main error: \(error.code) - \(error.message)")
+
+      if let cause = error.cause {
+          print("Root cause: \(cause.code) - \(cause.message)")
+
+          if let deeperCause = cause.cause {
+              print("Deeper cause: \(deeperCause.code) - \(deeperCause.message)")
+          }
+      }
+  }
+  ```
+
+blang[objc].
+  ```[objc]
+  - (void)handleError:(ARTErrorInfo *)error {
+      NSLog(@"Main error: %ld - %@", (long)error.code, error.message);
+
+      if (error.cause) {
+          NSLog(@"Root cause: %ld - %@", (long)error.cause.code, error.cause.message);
+
+          if (error.cause.cause) {
+              NSLog(@"Deeper cause: %ld - %@", (long)error.cause.cause.code, error.cause.cause.message);
+          }
+      }
+  }
+  ```
+
+blang[flutter].
+  ```[flutter]
+  void handleError(ably.ErrorInfo error) {
+    print('Main error: ${error.code} - ${error.message}');
+
+    if (error.cause != null) {
+      print('Root cause: ${error.cause!.code} - ${error.cause!.message}');
+
+      if (error.cause!.cause != null) {
+        print('Deeper cause: ${error.cause!.cause!.code} - ${error.cause!.cause!.message}');
+      }
+    }
+  }
+  ```
+
+blang[java].
+  ```[java]
+  public void handleError(ErrorInfo error) {
+      System.out.println("Main error: " + error.code + " - " + error.message);
+
+      if (error.cause != null) {
+          System.out.println("Root cause: " + error.cause.code + " - " + error.cause.message);
+
+          if (error.cause.cause != null) {
+              System.out.println("Deeper cause: " + error.cause.cause.code + " - " + error.cause.cause.message);
+          }
+      }
+  }
+  ```
+
+blang[csharp].
+  ```[csharp]
+  void HandleError(ErrorInfo error)
+  {
+      Console.WriteLine($"Main error: {error.Code} - {error.Message}");
+
+      if (error.Cause != null)
+      {
+          Console.WriteLine($"Root cause: {error.Cause.Code} - {error.Cause.Message}");
+
+          if (error.Cause.Cause != null)
+          {
+              Console.WriteLine($"Deeper cause: {error.Cause.Cause.Code} - {error.Cause.Cause.Message}");
+          }
+      }
+  }
+  ```
+
+blang[ruby].
+  ```[ruby]
+  def handle_error(error)
+    puts "Main error: #{error.code} - #{error.message}"
+
+    if error.cause
+      puts "Root cause: #{error.cause.code} - #{error.cause.message}"
+
+      if error.cause.cause
+        puts "Deeper cause: #{error.cause.cause.code} - #{error.cause.cause.message}"
+      end
+    end
+  end
+  ```
+
+
+blang[python].
+  ```[python]
+  def handle_error(error):
+      print(f"Main error: {error.code} - {error.message}")
+
+      if error.cause:
+          print(f"Root cause: {error.cause.code} - {error.cause.message}")
+
+          if error.cause.cause:
+              print(f"Deeper cause: {error.cause.cause.code} - {error.cause.cause.message}")
+  ```
+
+blang[php].
+  ```[php]
+  function handleError($error) {
+      echo "Main error: " . $error->code . " - " . $error->message . "\n";
+
+      if ($error->cause) {
+          echo "Root cause: " . $error->cause->code . " - " . $error->cause->message . "\n";
+
+          if ($error->cause->cause) {
+              echo "Deeper cause: " . $error->cause->cause->code . " - " . $error->cause->cause->message . "\n";
+          }
+      }
+  }
+  ```
+
+blang[go].
+  ```[go]
+  func handleError(err *ErrorInfo) {
+      fmt.Printf("Main error: %d - %s\n", err.Code, err.Message)
+
+      if err.Cause != nil {
+          fmt.Printf("Root cause: %d - %s\n", err.Cause.Code, err.Cause.Message)
+
+          if err.Cause.Cause != nil {
+              fmt.Printf("Deeper cause: %d - %s\n", err.Cause.Cause.Code, err.Cause.Cause.Message)
+          }
+      }
+  }
+  ```

--- a/content/partials/types/_paginated_result.textile
+++ b/content/partials/types/_paginated_result.textile
@@ -110,7 +110,7 @@ console.log('Page 1 item 1: ' + nextPage.items[1].data);
 console.log('Last page?: ' + nextPage.isLast());
 ```
 
-```[java,android]
+```[java]
 PaginatedResult firstPage = channel.history();
 System.out.println("Page 0 item 0:" + firstPage.items[0].data);
 if (firstPage.hasNext) {
@@ -185,10 +185,16 @@ if ($firstPage->hasNext()) {
 
 ```[swift]
 channel.history { paginatedResult, error in
-    let paginatedResult = paginatedResult!
+    guard let paginatedResult = paginatedResult else {
+        print("No results available")
+        return
+    }
     print("Page 0 item 0: \((paginatedResult.items[0] as! ARTMessage).data)")
     paginatedResult.next { nextPage, error in
-        let nextPage = nextPage!
+        guard let nextPage = nextPage else {
+            print("No next page available")
+            return
+        }
         print("Page 1 item 1: \((nextPage.items[1] as! ARTMessage).data)")
         print("Last page? \(nextPage.isLast())")
     }
@@ -202,3 +208,5 @@ channel.history { paginatedResult, error in
   fmt.Println("Page. 1 item 1: %s\n", page1.Messages[1].Data)
   fmt.Println("Last page? %s\n", page1.IsLast())
 ```
+
+


### PR DESCRIPTION
This PR: 

This PR addresses issue #2662, fixing unsafe Swift code patterns and adding docs for `ErrorInfo` nesting functionality.

-  `content/partials/types/_paginated_result` (PaginatedResult swift code update)

- `/partials/types/_error_info` (Nested error explanation)

https://ably.atlassian.net/browse/EDU-2013

