### PR TITLE
[EDU-2056] Add webhook concurrency limit

### DIFF
--- a/src/pages/docs/platform/pricing/limits.mdx
+++ b/src/pages/docs/platform/pricing/limits.mdx
@@ -126,7 +126,7 @@ Integration limits relate to the rate and concurrency of [webhooks](/docs/platfo
 | Integration limit | Free | Standard | Pro | Enterprise |
 | ----------------- | ---- | -------- | --- | ---------- |
 | **Integration rate (per second)**<p>*the maximum rate at which integrations can be executed, or streamed*</p> | 250 | 250 | 1,000 | Custom |
-| **Integration concurrency (Google Functions and Azure)**<p>*the maximum number of integrations that can run at the same time*</p> | 25 | 25 | 100 | Custom |
+| **Webhook concurrency**<p>*the maximum number of unbatched webhook requests that can be in-flight at any one time from a given source*</p> | 25 | 25 | 100 | Custom |
 | **Webhook batch size**<p>*the maximum number of webhook events that can be sent per batch*</p> | 50 | 100 | 100 | 100 |
 | **Webhook batch concurrency**<p>*the maximum number of webhook batches that can be processed at the same time*</p> | 1 | 1 | 1 | 1 |
 | **Max number of queues (per account)**<p>*the maximum number of queues that can be created per account*</p> | 5 | 10 | 50 | 100+ |


### PR DESCRIPTION
## Description

This PR adds a missing limit for webhook concurrency to the limits page.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
