### PR TITLE
Add ably as a library install when running npm install in chat javascript getting started

### DIFF
--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -55,7 +55,7 @@ npm init -y
 
 <Code>
 ```shell
-npm install @ably/chat typescript ts-node
+npm install @ably/chat ably typescript ts-node
 ```
 </Code>
 


### PR DESCRIPTION
## Description

The Chat JS getting started guide only instructs to install @ably/chat not ably JS SDK too. Which isn't an issue when NPM version is 7. However any versions below will still require ably JS SDK to be installed manually.