### PR TITLE
[EDU-2057] Update request method to include version in requests

### DIFF
--- a/src/pages/docs/auth/revocation.mdx
+++ b/src/pages/docs/auth/revocation.mdx
@@ -99,6 +99,7 @@ const requestBody = { targets: ['clientId:client1@example.com'] };
 const revocationResponse = await ablyRest.request(
   'post',
   '/keys/{{API_KEY_NAME}}/revokeTokens',
+  3,
   null,
   requestBody
 );
@@ -117,7 +118,7 @@ request_body = {
     'targets': ['clientId:client1@example.com']
 }
 
-response = await rest.request('POST', '/keys/{{API_KEY_NAME}}/revokeTokens', body=request_body)
+response = await rest.request('POST', '/keys/{{API_KEY_NAME}}/revokeTokens', 3, body=request_body)
 
 if not response.is_success:
     print('An error occurred; err = ' + response.error_message)
@@ -176,6 +177,7 @@ const requestBody = { targets: ['revocationKey:users.group1@example.com'] };
 const revocationResponse = await ablyRest.request(
   'post',
   '/keys/{{API_KEY_NAME}}/revokeTokens',
+  3,
   null,
   requestBody,
   null
@@ -195,7 +197,7 @@ request_body = {
     'targets': ['revocationKey:users.group1@example.com']
 }
 
-response = await rest.request('POST', '/keys/{{API_KEY_NAME}}/revokeTokens', body=request_body)
+response = await rest.request('POST', '/keys/{{API_KEY_NAME}}/revokeTokens', 3, body=request_body)
 
 if not response.is_success:
     print('An error occurred; err = ' + response.error_message)

--- a/src/pages/docs/messages/batch.mdx
+++ b/src/pages/docs/messages/batch.mdx
@@ -51,7 +51,7 @@ The following is an example of a batch publish request using the [`request()`](/
 ```rest_javascript
 const ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 const content = { 'channels': [ 'test1', 'test2' ], 'messages': { 'data': 'myData' } }
-const batchPublish = await ablyRest.request('post', '/messages', null, content, null);
+const batchPublish = await ablyRest.request('post', '/messages', 3, null, content, null);
 
 console.log('Success! status code was ' + batchPublish.statusCode)
 ```
@@ -66,7 +66,7 @@ content = {
     }
 }
 
-response = await ably_rest.request('POST', '/messages', body=content)
+response = await ably_rest.request('POST', '/messages', 3, body=content)
 
 if response.is_success:
     print('Success! status code was', response.status_code)
@@ -130,6 +130,7 @@ content := Content{
 response, err := rest.Request(
   "POST",
   "/messages",
+  3,
   ably.RequestWithBody(content)).Pages(context.Background())
 
 if err != nil {

--- a/src/pages/docs/presence-occupancy/presence.mdx
+++ b/src/pages/docs/presence-occupancy/presence.mdx
@@ -934,7 +934,7 @@ The following is an example of a batch presence request using the [`request()`](
 ```rest_javascript
 const ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 const content = { 'channel': 'channel1,channel2' }
-const presenceSets = await ablyRest.request('GET', '/presence', null, content, null);
+const presenceSets = await ablyRest.request('GET', '/presence', 3, null, content, null);
 console.log('Success! status code was ' + presenceSets.statusCode);
 ```
 
@@ -975,7 +975,7 @@ The following is an example of a batch presence request using the [`request()`](
 ```rest_javascript
 var ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 const content = { 'channel': 'quickstart,channel2' }
-const presenceSets = await rest.request('GET', '/presence', content, null, null);
+const presenceSets = await rest.request('GET', '/presence', 3, content, null, null);
 console.log('Success! status code was ' + presenceSets.statusCode);
 ```
 
@@ -1123,7 +1123,7 @@ The following is an example of handling the various responses:
 ```rest_javascript
 var ablyRest = new Ably.Rest({ key: '{{API_KEY}}' })
 const content = { 'channel': 'channel1,channel2' }
-const presenceSets = await ablyRest.request('GET', '/presence', null, content, null);
+const presenceSets = await ablyRest.request('GET', '/presence', 3, null, content, null);
 console.log(presenceSets.success);
 console.log(presenceSets.errorCode);
 

--- a/src/pages/docs/push/publish.mdx
+++ b/src/pages/docs/push/publish.mdx
@@ -821,7 +821,7 @@ The following example shows how to publish multiple push notifications in one re
 
 <Code>
 ```rest_javascript
-await rest.request('POST', '/push/batch/publish', null, [
+await rest.request('POST', '/push/batch/publish', 3, null, [
   {
     recipient: {
       deviceId: 'xxxxxxxxxxx'
@@ -847,7 +847,7 @@ await rest.request('POST', '/push/batch/publish', null, [
 ```
 
 ```rest_nodejs
-await rest.request('POST', '/push/batch/publish', null, [
+await rest.request('POST', '/push/batch/publish', 3, null, [
   {
     recipient: {
       deviceId: 'xxxxxxxxxxx'


### PR DESCRIPTION
## Description

This PR fixes all occurrences of the `request()` method where a version parameter was missing after the update to v2. Note that the upgrade to v2 did not include this fix for all SDKs; so this doesn't change any examples for Java, Cocoa, PHP, Flutter or Ruby. 

Originally reported in: https://github.com/ably/docs/pull/2492 

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
