### PR TITLE
add note about large reaction summaries getting clipped

### DIFF
--- a/src/pages/docs/chat/rooms/message-reactions.mdx
+++ b/src/pages/docs/chat/rooms/message-reactions.mdx
@@ -503,6 +503,20 @@ Summary events are typically created and published immediately after a reaction 
 
 If multiple reactions are sent in a short period of time, multiple reactions may be rolled up and only a single summary event will be published that contains the aggregated results of all reactions. This reduces the number of outbound messages and thus your costs in busy rooms.
 
+
+<If lang="react,javascript">
+#### Large summaries <a id="large-summaries"/>
+
+If many clients send the same reaction to the same message, the list of client IDs in that reaction summary will get clipped in order to keep the event size within the maximum message size.
+
+When a summary is clipped:
+- The `total` property shows the total number of reactions as expected, but the `clientIds` property will contain only a partial list of client IDs.
+- The `clipped` property is set to `true`.
+- For the `multiple` reaction type, use the `totalClientIds` property to determine the total number of clients that have sent the reaction. For the other reaction types this is equal to `total`. 
+
+To determine if a particular client has reacted when the summary is clipped use `room.messages.reactions.clientReactions(message, clientId)`. It returns a custom clipped summary that contains the given clientId's reactions only.
+</If>
+
 ### Subscribing to raw reactions <a id="raw-reactions"/>
 
 Raw individual reactions are published for every reaction, unlike summaries which can be rolled up. Raw reactions are useful for receiving all reaction events, but they are not suitable for the purpose of displaying message reaction counts as their effect on the reactions summary depends on the previous reactions.


### PR DESCRIPTION
## Description

https://ably.atlassian.net/browse/CHA-1098
https://ably.atlassian.net/browse/CHA-1099

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
