### PR TITLE
chat: update bodyguard documentation link

### DIFF
--- a/src/pages/docs/chat/moderation/index.mdx
+++ b/src/pages/docs/chat/moderation/index.mdx
@@ -61,7 +61,7 @@ Tisane also offers an [on-premises solution](https://tisane.ai/) for organizatio
 
 ### Bodyguard <a id="bodyguard"/>
 
-Bodyguard provides content moderation through their [API solution](https://bamboo.bodyguard.ai/api). The service performs contextual analysis of messages to detect and categorize inappropriate content based on configurable criteria. Each analysis provides detailed information about the content, enabling you to implement appropriate moderation actions in your chat room.
+Bodyguard provides content moderation through their [API solution](https://www.bodyguard.ai/docs/api). The service performs contextual analysis of messages to detect and categorize inappropriate content based on configurable criteria. Each analysis provides detailed information about the content, enabling you to implement appropriate moderation actions in your chat room.
 
 The platform is accessed through a REST API and is integrated with Ably to provide automated content moderation for your chat rooms.
 


### PR DESCRIPTION
## Description

Fix the link to Bodyguard's documentation in the chat moderation docs.