### PR TITLE
Add If loggedIn filter to API guest keys in getting started CLI section.

### DIFF
--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -62,7 +62,7 @@ Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.en
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/kotlin.mdx
+++ b/src/pages/docs/chat/getting-started/kotlin.mdx
@@ -47,7 +47,7 @@ implementation("com.ably.chat:chat-extensions-compose:<latest-version>")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -66,7 +66,7 @@ cd ios && pod install && cd ..
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react-ui-components.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-components.mdx
@@ -69,7 +69,7 @@ That's all the setup you need—the kit's CSS is automatically bundled by Vite a
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -65,7 +65,7 @@ Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.en
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -29,7 +29,7 @@ It will take you through the following steps:
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -42,7 +42,7 @@ dotnet add package ably.io
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -166,7 +166,7 @@ Initialize the Ably service at the application level to prevent it from being re
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -35,7 +35,7 @@ go get -u github.com/ably/ably-go/ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -53,7 +53,7 @@ It will take you through the following steps:
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -49,7 +49,7 @@ Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.en
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -32,7 +32,7 @@ implementation("io.ably:ably-java:<latest-version>")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -47,7 +47,7 @@ https://github.com/ably/ably-cocoa
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -44,7 +44,7 @@ composer require ably/ably-php
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -42,7 +42,7 @@ pip install ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -148,7 +148,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -152,7 +152,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -40,7 +40,7 @@ The realtime interface of the Ruby SDK must be run within an [EventMachine](http
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -39,7 +39,7 @@ dependencies: [
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
 
 1. Install the Ably CLI:
 


### PR DESCRIPTION

## Description

If the user is logged in they won't see the note that a guest key is used in the getting started guide. This is because if you're logged in the code blocks give your own API key. Where as if you're not, you'll see a demo API key, which you won't get from your dashboard when setting up the CLI.

It's difficult to replicate this locally as you need to have the docs and website set up together to test. If you want to test this and don't have it set up, please let me know and I can walk you through it.

Screenshot of CLI section of getting started guide when someone is logged in.
<img width="789" height="367" alt="Screenshot 2025-09-05 at 10 08 22" src="https://github.com/user-attachments/assets/4bc72fc4-c5cb-459d-bea4-75300e317f80" />

Screenshot of CLI section of getting started guide when someone is **not** logged in.
<img width="778" height="600" alt="Screenshot 2025-09-05 at 10 08 28" src="https://github.com/user-attachments/assets/53aec913-ac61-4ddc-923a-86da659338b4" />
