### PR TITLE
Fixed issues with getting started guide for Chat JS

### DIFF
--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -27,24 +27,31 @@ It will take you through the following steps:
 
 <Code>
 ```shell
-npm init -y
+npm init -y && npm pkg set type=module
 ```
 </Code>
 
-4. Install [typescript](https://www.npmjs.com/package/typescript) to compile TypeScript files.
-5. Install [ts-node](https://www.npmjs.com/package/ts-node) to execute TypeScript files directly.
+4. Install [@ably/chat](https://github.com/ably/ably-chat-js), [typescript](https://www.npmjs.com/package/typescript) to compile TypeScript files and make Ably Chat connections.
 
 <Code>
 ```shell
-npm install @ably/chat typescript ts-node
+npm install @ably/chat typescript -D @types/node
 ```
 </Code>
 
-6. Create a default TypeScript configuration in your project
+1. Create a default TypeScript configuration in your project
 
 <Code>
 ```shell
 npx tsc --init
+```
+</Code>
+
+6. Update `tsconfig.json` to have `types` containing `node`:
+
+<Code>
+```json
+   "types": ["node"],
 ```
 </Code>
 
@@ -95,11 +102,16 @@ Create an `index.ts` file in your project and add the following function to inst
 <Code>
 ```javascript
 import * as Ably from 'ably';
-import { ChatClient, ChatMessageEvent, Message } from '@ably/chat';
+import { ChatClient } from '@ably/chat';
+import type { ChatMessageEvent  } from '@ably/chat';
 
 async function getStarted() {
+  const apiKey = process.env.ABLY_API_KEY;
+  if (!apiKey) {
+    throw new Error('ABLY_API_KEY environment variable is required');
+  }
 
-  const realtimeClient = new Ably.Realtime({ key: process.env.ABLY_API_KEY, clientId: 'my-first-client' });
+  const realtimeClient = new Ably.Realtime({ key: apiKey, clientId: 'my-first-client' });
 
   const chatClient = new ChatClient(realtimeClient);
 
@@ -111,13 +123,13 @@ getStarted();
 ```
 </Code>
 
-You can monitor the lifecycle of clients' connections by registering a listener that will emit an event every time the connection state changes. For now, run the function with `npx ts-node index.ts` to log a message to the console to know that the connection attempt was successful. You'll see a message saying `Connection status is currently connected!` printed to your console.
+You can monitor the lifecycle of clients' connections by registering a listener that will emit an event every time the connection state changes. For now, run the function with `npx tsx --env-file=.env index.ts` to log a message to the console to know that the connection attempt was successful. You'll see a message saying `Connection status is currently connected!` printed to your console.
 
 ## Step 2: Create a room and send a message <a id="step-2"/>
 
 Messages are how your clients interact with one another. Use rooms to separate and organize clients and messages into different topics, or 'chat rooms'. Rooms are the entry object into Chat, providing access to all of its features, such as messages, presence and reactions.
 
-Add the following lines to your `getStarted()` function to create an instance of a room, attach to the room instance, and then register a listener to subscribe to messages sent to the room. You then also send your first message. Afterwards, run it with `npx ts-node index.ts`:
+Add the following lines to your `getStarted()` function to create an instance of a room, attach to the room instance, and then register a listener to subscribe to messages sent to the room. You then also send your first message. Afterwards, run it with `npx tsx --env-file=.env index.ts`:
 
 <Code>
 ```javascript
@@ -145,11 +157,12 @@ ably rooms messages send my-first-room 'Hello!'
 
 If your client makes a typo, or needs to update their original message then they can edit it.
 
-Add the following line to your `getStarted()` function. Now, when you run the function again and send another message, that message will be updated and you should see both in your terminal. Run it with `npx ts-node index.ts`.
+Add the following line to your `getStarted()` function. Now, when you run the function again and send another message, that message will be updated and you should see both in your terminal. Run it with `npx tsx --env-file=.env index.ts`.
 
 <Code>
 ```javascript
-await room.messages.update(myFirstMessage.serial, { text: 'My 2nd message! (edited)' });
+const updatedMessage = myFirstMessage.copy({text: "My 2nd message! (edited)"})
+await room.messages.update(myFirstMessage.serial, updatedMessage);
 ```
 </Code>
 
@@ -165,7 +178,7 @@ ably rooms messages send my-first-room 'Old message #1'
 ```
 </Code>
 
-Create a new `clientTwo.ts` file in your project, and run the following in a separate terminal instance. It imitates a second client, `my-second-client` joining the room and receiving the context of the previous 10 messages. Run it with `npx ts-node clientTwo.ts`
+Create a new `clientTwo.ts` file in your project, and run the following in a separate terminal instance. It imitates a second client, `my-second-client` joining the room and receiving the context of the previous 10 messages. Run it with `npx tsx --env-file=.env clientTwo.ts`
 
 <Code>
 ```javascript
@@ -173,10 +186,13 @@ import * as Ably from 'ably';
 import { ChatClient } from '@ably/chat';
 
 async function getStartedLate() {
+  const apiKey = process.env.ABLY_API_KEY;
+  if (!apiKey) {
+    throw new Error('ABLY_API_KEY environment variable is required');
+  }
 
-  const realtimeClient = new Ably.Realtime({ key: process.env.ABLY_API_KEY, clientId: 'my-second-client' });
+  const realtimeClient = new Ably.Realtime({ key: apiKey, clientId: 'my-second-client' });
   const chatClient = new ChatClient(realtimeClient);
-
 
   const room = await chatClient.rooms.get('my-first-room');
 
@@ -200,7 +216,7 @@ getStartedLate();
 
 Typing indicators enable you to display messages to clients when someone is currently typing. An event is emitted when someone starts typing, when they press a keystroke, and then another event is emitted after a configurable amount of time has passed without a key press.
 
-In practice the `typing.keystroke()` method would be called on keypress, however for demonstration purposes we will call it and wait for the default period of time to pass for a stop event to be emitted. Using your original client, add the following lines to `getStarted()` to subscribe to typing events and emit one, then run it with `npx ts-node index.ts`:
+In practice the `typing.keystroke()` method would be called on keypress, however for demonstration purposes we will call it and wait for the default period of time to pass for a stop event to be emitted. Using your original client, add the following lines to `getStarted()` to subscribe to typing events and emit one, then run it with `npx tsx --env-file=.env index.ts`:
 
 <Code>
 ```javascript
@@ -230,7 +246,7 @@ ably rooms typing subscribe my-first-room
 
 Display the online status of clients using the presence feature. This enables clients to be aware of one another if they are present in the same room. You can then show clients who else is online, provide a custom status update for each, and notify the room when someone enters it, or leaves it, such as by going offline.
 
-Add the following lines to your `getStarted()` function to subscribe to, and join, the presence set of the room. It also sets a short wait before leaving the presence set. Run it with `npx ts-node index.ts`:
+Add the following lines to your `getStarted()` function to subscribe to, and join, the presence set of the room. It also sets a short wait before leaving the presence set. Run it with `npx tsx --env-file=.env index.ts`:
 
 <Code>
 ```javascript
@@ -258,7 +274,7 @@ ably rooms presence enter my-first-room --data '{"status":"learning about Ably!"
 
 Clients can send an ephemeral reaction to a room to show their sentiment for what is happening, such as a point being scored in a sports game.
 
-Add the following lines to your `getStarted()` function to subscribe to room reactions. Then run it with `npx ts-node index.ts`:
+Add the following lines to your `getStarted()` function to subscribe to room reactions. Then run it with `npx tsx --env-file=.env index.ts`:
 
 <Code>
 ```javascript
@@ -282,7 +298,7 @@ Connections are automatically closed approximately 2 minutes after no heartbeat 
 
 Connections to Ably are handled by the underlying Pub/Sub SDK. To close the connection you need to call `connection.close()` on the original realtime client instance.
 
-Add the following to `getStarted()` to close the connection after a simulated 10 seconds. Run it with `npx ts-node index.ts`:
+Add the following to `getStarted()` to close the connection after a simulated 10 seconds. Run it with `npx tsx --env-file=.env index.ts`:
 
 <Code>
 ```javascript


### PR DESCRIPTION
## Description

While running through the Chat JS getting started guide, I found several issues along the way. One was introduced by my usage of env variables for the Ably API key. But the others wouldn't let me proceed until I fixed them. This PR fixes those issues:

- Fixed usage of env variables without the dotenv library. 
- Set package type to module when running `npm init`. 
- Added `@types/node` as a dependency as without this was throwing issues in the imports of the @ably/chat SDK.
