### PR TITLE
Update JS based getting started guides to display {{API_KEY}} in shell code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "validate-llms-txt": "ts-node bin/validate-llms.txt.ts"
   },
   "dependencies": {
-    "@ably/ui": "17.6.5",
+    "@ably/ui": "17.7.2",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@gfx/zopfli": "^1.0.15",

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -59,13 +59,9 @@ npx tsc --init
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
-
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -48,15 +48,11 @@ npm install @ably/chat ably
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
 
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
-
-4. For iOS, install the native dependencies:
+1. For iOS, install the native dependencies:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-ui-components.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-components.mdx
@@ -57,13 +57,9 @@ Follow the Tailwind Vite guide to configure the generated files.
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
-
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
 
 That's all the setup you need—the kit's CSS is automatically bundled by Vite alongside the rest of your styles.
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -55,13 +55,9 @@ npm install @ably/chat ably
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
-
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -39,13 +39,9 @@ npm install ably
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
-
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -84,13 +84,9 @@ Create a `.env` file in your project root and add your API key:
 
 <Code>
 ```shell
-echo "ABLY_API_KEY=<YOUR_ABLY_API_KEY>" > .env
+echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
-
-<Aside data-type='note'>
-Replace `<YOUR_ABLY_API_KEY>` with your actual API key from step 2, and add `.env` to your `.gitignore` file to avoid committing your API key to version control.
-</Aside>
 
 ### Set up AblyProvider <a id="prerequisites-setup-ably-provider"/>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ably/ui@17.6.5":
-  version "17.6.5"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.6.5.tgz#b6ad6c47161f8a6c47c09e6cc827df123bd2a587"
-  integrity sha512-9XhInT79I+LGB6lilSFL7iC0FHlUoNQtXL3DbxA0u2TxJN0XisWp+jF7lzmHobrsbUCeW38AZ532rzbFLB6lUg==
+"@ably/ui@17.7.2":
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-17.7.2.tgz#002922354a34ee705c80886da22eef26243e5e23"
+  integrity sha512-NxolftnHIO/yhFKD/FtrWRHe78VtLjorW45PI7o6SZsMRcIXIMUncYzCLH4TgY4sLvmbx+tBHnx3Q7KKM2XhhQ==
   dependencies:
     "@heroicons/react" "^2.2.0"
     "@radix-ui/react-accordion" "^1.2.1"
@@ -21,10 +21,10 @@
     array-flat-polyfill "^1.0.1"
     clsx "^2.1.1"
     dompurify "^3.2.4"
+    es-toolkit "^1.39.10"
     highlight.js "^11.11.1"
     highlightjs-curl "^1.3.0"
     js-cookie "^3.0.5"
-    lodash.throttle "^4.1.1"
     react "^18.2.0"
     react-dom "^18.3.1"
     redux "^4.0.5"
@@ -7406,6 +7406,11 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
+
+es-toolkit@^1.39.10:
+  version "1.39.10"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.10.tgz#513407af73e79f9940e7ec7650f2e6dceeaf1d81"
+  integrity sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==
 
 es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14, es5-ext@~0.10.2:
   version "0.10.64"


### PR DESCRIPTION
## Description

`{{API_KEY}}` in code blocks wasn't being replaced with an actual API key. An update to make this functional was released in [Ably-UI](https://github.com/ably/ably-ui/pull/903). 

The code blocks in question have been updated in this PR as well as bumping Ably-ui version.