### PR TITLE
Create JavaScript and Node.js getting started guides

### DIFF
--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -29,6 +29,10 @@ export default {
               link: '/docs/getting-started/javascript',
             },
             {
+              name: 'Node.js',
+              link: '/docs/getting-started/node',
+            },
+            {
               name: 'React',
               link: '/docs/getting-started/react',
             },

--- a/src/pages/docs/getting-started/index.mdx
+++ b/src/pages/docs/getting-started/index.mdx
@@ -23,6 +23,12 @@ These are your first steps towards building a realtime application that can effo
     link: '/docs/getting-started/javascript',
   },
   {
+    title: 'Node.js',
+    description: 'Start building with Pub/Sub using Ably\'s Node.js SDK',
+    image: 'icon-tech-nodejs',
+    link: '/docs/getting-started/node',
+  },
+  {
     title: 'React',
     description: 'Start building with Pub/Sub using Ably\'s React SDK.',
     image: 'icon-tech-react',

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Getting started: Pub/Sub in JavaScript"
-meta_description: "Get started with Pub/Sub in JavaScript using Ably. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
+meta_description: "Get started with Pub/Sub in vanilla JavaScript using Ably. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
 meta_keywords: "Pub/Sub JavaScript, JavaScript PubSub, Ably JavaScript SDK, realtime messaging JavaScript, publish subscribe JavaScript, Ably Pub/Sub guide, JavaScript realtime communication, Ably tutorial JavaScript, JavaScript message history, presence API JavaScript, Ably Pub/Sub example, realtime Pub/Sub JavaScript, subscribe to channel JavaScript, publish message JavaScript, Ably CLI Pub/Sub"
 ---
 
@@ -16,25 +16,7 @@ You'll establish a realtime connection to Ably and learn to publish and subscrib
 
 3. Your API key will need the `publish`, `subscribe`, `presence` and `history` capabilities.
 
-4. Install [Node.js](https://nodejs.org/en) version 16 or greater.
-
-5. Create a new project in your IDE and install the Ably Pub/Sub JavaScript SDK:
-
-<Code>
-```shell
-npm init -y && npm pkg set type=module
-
-npm install ably
-```
-</Code>
-
-6. Create a `.env` file in your project root and add your API key:
-
-<Code>
-```shell
-echo "ABLY_API_KEY={{API_KEY}}" > .env
-```
-</Code>
+4. Create an HTML file in your project directory where you'll include the Ably JavaScript SDK via a CDN.
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
@@ -68,45 +50,66 @@ Clients establish a connection with Ably when they instantiate an SDK instance. 
 
 Open up the [dev console](https://ably.com/accounts/any/apps/any/console) of your first app before instantiating your client so that you can see what happens.
 
-Create an `index.js` file in your project and add the following function to instantiate the SDK and establish a connection to Ably. At the minimum you need to provide an authentication mechanism. Use an API key for simplicity, but you should use [token authentication](/docs/auth/token#jwt) in a production app. A [`clientId`](/docs/auth/identified-clients) ensures the client is identified, which is required to use certain features, such as presence:
+Create an `index.html` file in your project and add the following HTML to include the Ably JavaScript SDK via CDN and establish a connection to Ably. At the minimum you need to provide an authentication mechanism. Use an API key for simplicity, but you should use [token authentication](/docs/auth/token#jwt) in a production app. A [`clientId`](/docs/auth/identified-clients) ensures the client is identified, which is required to use certain features, such as presence:
 
 <Code>
 ```javascript
-import * as Ably from 'ably';
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ably JavaScript Getting Started</title>
+</head>
+<body>
+    <h1>Ably JavaScript Getting Started</h1>
+    <div id="output"></div>
 
-async function getStarted() {
-  const realtimeClient = new Ably.Realtime({
-    key: process.env.ABLY_API_KEY,
-    clientId: 'my-first-client'
-  });
+    <script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
+    <script>
+        const output = document.getElementById('output');
 
-  await realtimeClient.connection.once('connected');
-  console.log(`Made my first connection!`);
-};
+        function log(message) {
+            output.innerHTML += '<p>' + message + '</p>';
+            console.log(message);
+        }
 
-getStarted();
+        async function getStarted() {
+            const realtimeClient = new Ably.Realtime({
+                key: '{{API_KEY}}',
+                clientId: 'my-first-client'
+            });
+
+            await realtimeClient.connection.once('connected');
+            log('Made my first connection!');
+        }
+
+        getStarted();
+    </script>
+</body>
+</html>
 ```
 </Code>
 
-You can monitor the lifecycle of clients' connections by registering a listener that will emit an event every time the connection state changes. For now, run the function with `node index.js` to log a message to the console to know that the connection attempt was successful. You'll see the message printed to your console, and you can also inspect the connection event in the dev console of your app.
+You can monitor the lifecycle of clients' connections by registering a listener that will emit an event every time the connection state changes. Open the HTML file in your browser to see the connection message, and you can also inspect the connection event in the dev console of your app.
 
 ## Step 2: Subscribe to a channel and publish a message <a id="step-2"/>
 
 Messages contain the data that a client is communicating, such as a short 'hello' from a colleague, or a financial update being broadcast to subscribers from a server. Ably uses channels to separate messages into different topics, so that clients only ever receive messages on the channels they are subscribed to.
 
-Add the following lines to your `getStarted()` function to create a channel instance and register a listener to subscribe to the channel. Then run it with `node index.js`:
+Add the following lines to your `getStarted()` function to create a channel instance and register a listener to subscribe to the channel:
 
 <Code>
 ```javascript
 const channel = realtimeClient.channels.get('my-first-channel');
 
 await channel.subscribe((message) => {
-  console.log(`Received message: ${message.data}`);
+    log(`Received message: ${message.data}`);
 });
 ```
 </Code>
 
-Use the Ably CLI to publish a message to your first channel. The message will be received by the client you've subscribed to the channel, and be logged to the console.
+Use the Ably CLI to publish a message to your first channel. The message will be received by the client you've subscribed to the channel, and be logged to the console and displayed on the page.
 
 <Code>
 ```shell
@@ -122,7 +125,7 @@ ably channels subscribe my-first-channel
 ```
 </Code>
 
-Publish another message using the CLI and you will see that it's received instantly by the client you have running locally, as well as the subscribed terminal instance.
+Publish another message using the CLI and you will see that it's received instantly by the client you have running in your browser, as well as the subscribed terminal instance.
 
 To publish a message in your code, you can add the following line to your `getStarted` method after subscribing to the channel:
 
@@ -136,19 +139,19 @@ await channel.publish('example', 'A message sent from my first client!');
 
 Presence enables clients to be aware of one another if they are present on the same channel. You can then show clients who else is online, provide a custom status update for each, and notify the channel when someone goes offline.
 
-Add the following lines to your `getStarted()` function to subscribe to, and join, the presence set of the channel. Then run it with `node index.js`:
+Add the following lines to your `getStarted()` function to subscribe to, and join, the presence set of the channel:
 
 <Code>
 ```javascript
 await channel.presence.subscribe((member) => {
-  console.log(`Event type: ${member.action} from ${member.clientId} with the data ${JSON.stringify(member.data)}`)
+    log(`Event type: ${member.action} from ${member.clientId} with the data ${JSON.stringify(member.data)}`);
 });
 
 await channel.presence.enter("I'm here!");
 ```
 </Code>
 
-In the [dev console](https://ably.com/accounts/any/apps/any/console) of your first app, attach to `my-first-channel`. Enter a `clientId`, such as `my-dev-console`, and then join the presence set of the channel. You'll see that `my-first-client` is already present in the channel. In the console of your browser or IDE you'll see that an event was received when the dev console client joined the channel.
+In the [dev console](https://ably.com/accounts/any/apps/any/console) of your first app, attach to `my-first-channel`. Enter a `clientId`, such as `my-dev-console`, and then join the presence set of the channel. You'll see that `my-first-client` is already present in the channel. In the console of your browser you'll see that an event was received when the dev console client joined the channel.
 
 You can have another client join the presence set using the Ably CLI:
 
@@ -172,12 +175,16 @@ ably channels publish --count 5 my-first-channel "Message number {{.Count}}"
 ```
 </Code>
 
-Add the following lines to your `getStarted()` function to retrieve any messages that were recently published to the channel. Then run it with `node index.js`:
+Add the following lines to your `getStarted()` function to retrieve any messages that were recently published to the channel:
 
 <Code>
 ```javascript
 const history = await channel.history();
-console.log(history.items.map((message) => message.data));
+const messages = history.items.map((message) => message.data);
+log('Message history:');
+messages.forEach((message, index) => {
+  log(`  ${index + 1}: ${JSON.stringify(message)}`);
+});
 ```
 </Code>
 
@@ -186,11 +193,11 @@ The output will look similar to the following:
 <Code>
 ```json
 [
-  'Message number 5',
-  'Message number 4',
-  'Message number 3',
-  'Message number 2',
-  'Message number 1'
+  "Message number 5",
+  "Message number 4",
+  "Message number 3",
+  "Message number 2",
+  "Message number 1"
 ]
 ```
 </Code>

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -1,0 +1,206 @@
+---
+title: "Getting started: Pub/Sub in Node.js"
+meta_description: "Get started with Pub/Sub in JavaScript using Ably. Learn how to publish, subscribe, track presence, fetch message history, and manage realtime connections."
+meta_keywords: "Pub/Sub Node.js, Node.js PubSub, Ably Node.js SDK, realtime messaging Node.js, publish subscribe Node.js, Ably Pub/Sub guide, Node.js realtime communication, Ably tutorial Node.js, Node.js message history, presence API Node.js, Ably Pub/Sub example, realtime Pub/Sub Node.js, subscribe to channel Node.js, publish message Node.js, Ably CLI Pub/Sub"
+---
+
+This guide will get you started with Ably Pub/Sub in Node.js.
+
+You'll establish a realtime connection to Ably and learn to publish and subscribe to messages. You'll also implement presence to track other online clients, and learn how to retrieve message history.
+
+## Prerequisites <a id="prerequisites"/>
+
+1. [Sign up](https://ably.com/signup) for an Ably account.
+
+2. Create a [new app](https://ably.com/accounts/any/apps/new), and create your first API key in the **API Keys** tab of the dashboard.
+
+3. Your API key will need the `publish`, `subscribe`, `presence` and `history` capabilities.
+
+4. Install [Node.js](https://nodejs.org/en) version 16 or greater.
+
+5. Create a new project in your IDE and install the Ably Pub/Sub JavaScript SDK:
+
+<Code>
+```shell
+npm init -y && npm pkg set type=module
+
+npm install ably
+```
+</Code>
+
+6. Create a `.env` file in your project root and add your API key:
+
+<Code>
+```shell
+echo "ABLY_API_KEY={{API_KEY}}" > .env
+```
+</Code>
+
+### (Optional) Install Ably CLI <a id="install-cli"/>
+
+The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+
+1. Install the Ably CLI:
+
+<Code>
+```shell
+npm install -g @ably/cli
+```
+</Code>
+
+2. Run the following to log in to your Ably account and set the default app and API key:
+
+<Code>
+```shell
+ably login
+```
+</Code>
+
+<If loggedIn={false}>
+  <Aside data-type='note'>
+  The code examples in this guide include a demo API key. If you wish to interact with the Ably CLI and view outputs within your Ably account, ensure that you replace them with your own API key.
+  </Aside>
+</If>
+
+## Step 1: Connect to Ably <a id="step-1"/>
+
+Clients establish a connection with Ably when they instantiate an SDK instance. This enables them to send and receive messages in realtime across channels.
+
+Open up the [dev console](https://ably.com/accounts/any/apps/any/console) of your first app before instantiating your client so that you can see what happens.
+
+Create an `index.js` file in your project and add the following function to instantiate the SDK and establish a connection to Ably. At the minimum you need to provide an authentication mechanism. Use an API key for simplicity, but you should use [token authentication](/docs/auth/token#jwt) in a production app. A [`clientId`](/docs/auth/identified-clients) ensures the client is identified, which is required to use certain features, such as presence:
+
+<Code>
+```nodejs
+import * as Ably from 'ably';
+
+async function getStarted() {
+  const realtimeClient = new Ably.Realtime({
+    key: process.env.ABLY_API_KEY,
+    clientId: 'my-first-client'
+  });
+
+  await realtimeClient.connection.once('connected');
+  console.log(`Made my first connection!`);
+};
+
+getStarted();
+```
+</Code>
+
+You can monitor the lifecycle of clients' connections by registering a listener that will emit an event every time the connection state changes. For now, run the function with `node index.js` to log a message to the console to know that the connection attempt was successful. You'll see the message printed to your console, and you can also inspect the connection event in the dev console of your app.
+
+## Step 2: Subscribe to a channel and publish a message <a id="step-2"/>
+
+Messages contain the data that a client is communicating, such as a short 'hello' from a colleague, or a financial update being broadcast to subscribers from a server. Ably uses channels to separate messages into different topics, so that clients only ever receive messages on the channels they are subscribed to.
+
+Add the following lines to your `getStarted()` function to create a channel instance and register a listener to subscribe to the channel. Then run it with `node index.js`:
+
+<Code>
+```nodejs
+const channel = realtimeClient.channels.get('my-first-channel');
+
+await channel.subscribe((message) => {
+  console.log(`Received message: ${message.data}`);
+});
+```
+</Code>
+
+Use the Ably CLI to publish a message to your first channel. The message will be received by the client you've subscribed to the channel, and be logged to the console.
+
+<Code>
+```shell
+ably channels publish my-first-channel 'Hello!'
+```
+</Code>
+
+In a new terminal tab, subscribe to the same channel using the CLI:
+
+<Code>
+```shell
+ably channels subscribe my-first-channel
+```
+</Code>
+
+Publish another message using the CLI and you will see that it's received instantly by the client you have running locally, as well as the subscribed terminal instance.
+
+To publish a message in your code, you can add the following line to your `getStarted` method after subscribing to the channel:
+
+<Code>
+```nodejs
+await channel.publish('example', 'A message sent from my first client!');
+```
+</Code>
+
+## Step 3: Join the presence set <a id="step-3"/>
+
+Presence enables clients to be aware of one another if they are present on the same channel. You can then show clients who else is online, provide a custom status update for each, and notify the channel when someone goes offline.
+
+Add the following lines to your `getStarted()` function to subscribe to, and join, the presence set of the channel. Then run it with `node index.js`:
+
+<Code>
+```nodejs
+await channel.presence.subscribe((member) => {
+  console.log(`Event type: ${member.action} from ${member.clientId} with the data ${JSON.stringify(member.data)}`)
+});
+
+await channel.presence.enter("I'm here!");
+```
+</Code>
+
+In the [dev console](https://ably.com/accounts/any/apps/any/console) of your first app, attach to `my-first-channel`. Enter a `clientId`, such as `my-dev-console`, and then join the presence set of the channel. You'll see that `my-first-client` is already present in the channel. In the console of your browser or IDE you'll see that an event was received when the dev console client joined the channel.
+
+You can have another client join the presence set using the Ably CLI:
+
+<Code>
+```shell
+ably channels presence enter my-first-channel --data '{"status":"learning about Ably!"}'
+```
+</Code>
+
+## Step 4: Retrieve message history <a id="step-4"/>
+
+You can retrieve previously sent messages using the history feature. Ably stores all messages for 2 minutes by default in the event a client experiences network connectivity issues. You can [extend the storage period](/docs/storage-history/storage) of messages if required.
+
+If more than 2 minutes has passed since you published a regular message (excluding the presence events), then you can publish some more before trying out history. You can use the Pub/Sub SDK, Ably CLI or the dev console to do this.
+
+For example, using the Ably CLI to publish 5 messages:
+
+<Code>
+```shell
+ably channels publish --count 5 my-first-channel "Message number {{.Count}}"
+```
+</Code>
+
+Add the following lines to your `getStarted()` function to retrieve any messages that were recently published to the channel. Then run it with `node index.js`:
+
+<Code>
+```nodejs
+const history = await channel.history();
+console.log(history.items.map((message) => message.data));
+```
+</Code>
+
+The output will look similar to the following:
+
+<Code>
+```json
+[
+  'Message number 5',
+  'Message number 4',
+  'Message number 3',
+  'Message number 2',
+  'Message number 1'
+]
+```
+</Code>
+
+## Next steps <a id="next-steps"/>
+
+Continue to explore the documentation with JavaScript as the selected language:
+
+* Understand [token authentication](/docs/auth/token) before going to production.
+* Understand how to effectively [manage connections](https://ably.com/docs/connect#close?lang=nodejs).
+* Explore more [advanced](/docs/pub-sub/advanced?lang=nodejs) Pub/Sub concepts.
+
+You can also explore the [Ably CLI](https://www.npmjs.com/package/@ably/cli) further, or visit the Pub/Sub [API references](/docs/api/realtime-sdk?lang=nodejs).


### PR DESCRIPTION
## Description

The original JavaScript getting started guide was actually Node.js focused. So this moved the existing guide to node.mdx, then created a new JavaScript getting started guide focused on vanilla JavaScript.
