### PR TITLE
Add chat message reactions api ref docs

### DIFF
--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -105,6 +105,61 @@ components:
               description: Optional metadata about the operation
               additionalProperties: true
               example: {}
+        reactions:
+          type: object
+          description: Represents a summary of all reactions on a message
+          properties:
+            unique:
+              type: object
+              description: Represents a summary of all unique reactions on a message
+              additionalProperties:
+                $ref: '#/components/schemas/SummaryClientIdList'
+            distinct:
+              type: object
+              description: Represents a summary of all distinct reactions on a message
+              additionalProperties:
+                $ref: '#/components/schemas/SummaryClientIdList'
+            multiple:
+              type: object
+              description: Represents a summary of all multiple reactions on a message
+              additionalProperties:
+                $ref: '#/components/schemas/SummaryClientIdCounts'
+    SummaryClientIdList:
+      type: object
+      description: The summary entry for aggregated reactions for unique and distinct reactions.
+      properties:
+        total:
+          type: integer
+          description: The total number of clients who have published a reaction with this name (or type, depending on context).
+        clientIds:
+          type: array
+          items:
+            type: string
+          description: A list of the clientIds of all clients who have published a reaction with this name (or type, depending on context).
+        clipped:
+          type: boolean
+          description: Whether the list of clientIds has been clipped due to exceeding the maximum size.
+    SummaryClientIdCounts:
+      type: object
+      description: The per-name value for the multiple reactions.
+      properties:
+        total:
+          type: integer
+          description: The sum of the counts from all clients who have published a reaction with this name.
+        clientIds:
+          type: object
+          additionalProperties:
+            type: integer
+          description: A list of the clientIds of all clients who have published a reaction with this name, and the count each of them have contributed.
+        totalUnidentified:
+          type: integer
+          description: The sum of the counts from all unidentified clients who have published a reaction with this name, and so who are not included in the clientIds list.
+        clipped:
+          type: boolean
+          description: Whether the list of clientIds has been clipped due to exceeding the maximum size.
+        totalClientIds:
+          type: integer
+          description: The total number of unique clientIds in the map (equal to length of map if clipped is false).
   parameters:
     ClientIdParam:
       name: clientId


### PR DESCRIPTION
## Description

Chat `Message.reactions` was missing from the Message struct.

https://ably.atlassian.net/browse/CHA-1154

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
