### PR TITLE
fix history response type including pagination links as headers

### DIFF
--- a/static/open-specs/chat.yaml
+++ b/static/open-specs/chat.yaml
@@ -305,35 +305,19 @@ paths:
       responses:
         '200':
           description: A paginated list of messages retrieved from the room.
+          headers:
+            Link:
+              description: If the response contains multiple pages, links shall be provided to navigate through the pages using the Link header. rel values used are `current`, `next`, and `first`.
+              schema:
+                type: string
+              example: '<./messages?direction=backwards&limit=100>; rel="current", <./messages?cursor=01741782820772-000%40cbf5P0_1gBmlrl73660839%3A000&direction=backwards&limit=100>; rel="next", <./messages?direction=backwards&limit=100>; rel="first"'
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  messages:
-                    type: array
-                    description: A list of retrieved messages. Each message contains the following fields
-                    items:
-                      $ref: '#/components/schemas/Message'
-                  links:
-                    type: object
-                    description: If the response contains multiple pages, links shall be provided to navigate through the pages.
-                    properties:
-                      current:
-                        type: string
-                        format: uri
-                        description: URI link to the current page of messages.
-                        example: <./messages?direction=backwards&limit=100>; rel="current"
-                      next:
-                        type: string
-                        format: uri
-                        description: URI link to the next page of messages, if it exists.
-                        example: <./messages?cursor=01741782820772-000%40cbf5P0_1gBmlrl73660839%3A000&direction=backwards&limit=100>; rel="previous"
-                      first:
-                        type: string
-                        format: uri
-                        description: URI link to the first page of messages.
-                        example: <./messages?direction=backwards&limit=100>; rel="first"
+                type: array
+                description: A list of retrieved messages. Each message contains the following fields
+                items:
+                  $ref: '#/components/schemas/Message'
         '400':
           description: Invalid query parameters
           content:


### PR DESCRIPTION
We actually return a plain array and links are in headers.


https://ably.atlassian.net/browse/CHA-1155