### PR TITLE
examples: use new ably-js endpoint option

### DIFF
--- a/src/utilities/update-ably-connection-keys.ts
+++ b/src/utilities/update-ably-connection-keys.ts
@@ -15,21 +15,21 @@ export const updateAblyConnectionKey = (
   apiKey: string,
   additionalKeys?: Record<string, string>,
 ) => {
-  const ablyEnvironment = process.env.GATSBY_ABLY_ENVIRONMENT ?? 'production';
+  const ablyEndpoint = process.env.GATSBY_ABLY_ENVIRONMENT ?? 'main';
   const names = Object.keys(files);
 
   return names.reduce(
     (acc, name: string) => {
       let content = files[name];
 
-      // Environment
-      if (ablyEnvironment !== 'production') {
+      // Endpoint
+      if (ablyEndpoint !== 'main') {
         content = content.replaceAll(/new Ably\.(Realtime|Rest)\(\{/g, (_match, type) => {
-          return `new Ably.${type}({\n  environment: '${ablyEnvironment}',`;
+          return `new Ably.${type}({\n  endpoint: '${ablyEndpoint}',`;
         });
 
         content = content.replaceAll(/new (Realtime|Rest)\(\{/g, (_match, type) => {
-          return `new ${type}({\n  environment: '${ablyEnvironment}',`;
+          return `new ${type}({\n  endpoint: '${ablyEndpoint}',`;
         });
       }
 


### PR DESCRIPTION
## Description

environment is now deprecated (and for some reason isn't working with Sandbox on demo apps).

This change migrates to the new `endpoint` option.

NOTE: The preview apps will need to have their `GATSBY_ABLY_ENVIRONMENT` changed to `nonprod:sandbox`. If set, the main docs site will need to set `main` or leave empty.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
