### PR TITLE
Address comments for LiveObjects pricing docs

### DIFF
--- a/src/pages/docs/liveobjects/counter.mdx
+++ b/src/pages/docs/liveobjects/counter.mdx
@@ -138,7 +138,7 @@ Or decremented by 10:
 ```
 </Code>
 
-Note that subscribing to data updates on a `LiveCounter` does not affect the number of billable messages received by a client. Any client attached to a channel with the `object-subscribe` capability automatically receives all object messages for that channel. Subscribing to updates on an object simply allows the client to react to changes in that object.
+Note that subscribing to data updates on a `LiveCounter` does not affect the number of billable messages received by a client. Any client attached to a channel with the `object-subscribe` capability automatically receives all object messages for that channel. Subscribing to updates on an object simply adds a listener that is called whenever the client receives updates for that object.
 
 ### Unsubscribe from data updates <a id="unsubscribe-data"/>
 

--- a/src/pages/docs/liveobjects/index.mdx
+++ b/src/pages/docs/liveobjects/index.mdx
@@ -91,7 +91,7 @@ When using the realtime client libraries, LiveObjects usage is billed as follows
 
 ### REST API <a id="pricing-rest"/>
 
-When using the [LiveObjects REST API](/docs/liveobjects/rest-api-usage), billing differs slightly from realtime usage:
+When using the [LiveObjects REST API](/docs/liveobjects/rest-api-usage), usage is billed as follows:
 
 * [Fetching objects](/docs/liveobjects/rest-api-usage#fetching-objects): You are billed per object returned in the response.
 * [Publishing operations](/docs/liveobjects/rest-api-usage#publishing-operations): Each published operation is billed as a single message sent. Batch operations are also counted as one message, regardless of the number of operations included.

--- a/src/pages/docs/liveobjects/map.mdx
+++ b/src/pages/docs/liveobjects/map.mdx
@@ -149,7 +149,7 @@ Example structure of an update object when the key `foo` is updated and the key 
 ```
 </Code>
 
-Note that subscribing to data updates on a `LiveMap` does not affect the number of billable messages received by a client. Any client attached to a channel with the `object-subscribe` capability automatically receives all object messages for that channel. Subscribing to updates on an object simply allows the client to react to changes in that object.
+Note that subscribing to data updates on a `LiveMap` does not affect the number of billable messages received by a client. Any client attached to a channel with the `object-subscribe` capability automatically receives all object messages for that channel. Subscribing to updates on an object simply adds a listener that is called whenever the client receives updates for that object.
 
 ### Unsubscribe from data updates <a id="unsubscribe-data"/>
 

--- a/src/pages/docs/liveobjects/rest-api-usage.mdx
+++ b/src/pages/docs/liveobjects/rest-api-usage.mdx
@@ -9,7 +9,7 @@ LiveObjects is currently Experimental. Its features are still in development and
 **Building with LiveObjects?** Help shape its future by [sharing your use case](https://44qpp.share.hsforms.com/2fZobHQA1ToyRfB9xqZYQmQ).
 </Aside>
 
-LiveObjects provides a comprehensive REST API that allows you to directly work with objects without using a client SDK.
+LiveObjects provides a comprehensive REST API that enables you to directly work with objects without using a client SDK.
 
 ## Authentication <a id="authentication"/>
 


### PR DESCRIPTION
## Description

Addresses comments from [1] that were posted after the PR was merged.

[1] https://github.com/ably/docs/pull/2774

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
