### PR TITLE
chat: rename kotlin getting started guide to android

### DIFF
--- a/src/data/nav/chat.ts
+++ b/src/data/nav/chat.ts
@@ -32,8 +32,8 @@ export default {
               link: '/docs/chat/getting-started/react-native',
             },
             {
-              name: 'Kotlin',
-              link: '/docs/chat/getting-started/kotlin',
+              name: 'Kotlin (Android)',
+              link: '/docs/chat/getting-started/android',
             },
             {
               name: 'Swift',

--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Getting started: Chat with Kotlin"
+title: "Getting started: Chat with Android"
 meta_description: "A getting started guide for Ably Chat Android that steps through some of the key features using Jetpack Compose."
 meta_keywords: "Ably, realtime, quickstart, getting started, basics, Chat, Android, Kotlin, Jetpack Compose"
 ---

--- a/src/pages/docs/chat/index.mdx
+++ b/src/pages/docs/chat/index.mdx
@@ -13,7 +13,7 @@ The Chat SDK contains a set of purpose-built APIs that abstract away the complex
 * [Getting started: Chat in React](/docs/chat/getting-started/react)
 * [Getting started: Chat UI Kits in React](/docs/chat/getting-started/react-ui-components)
 * [Getting started: Chat in React Native](/docs/chat/getting-started/react-native)
-* [Getting started: Chat in Kotlin](/docs/chat/getting-started/kotlin)
+* [Getting started: Chat in Android](/docs/chat/getting-started/android)
 * [Getting started: Chat in Swift](/docs/chat/getting-started/swift)
 
 ## Chat features <a id="features"/>


### PR DESCRIPTION
## Description

Now the SDK is available for the JVM at large, we should differentiate getting started guides.

This change renames it to be explicitly Android.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
