### PR TITLE
Fix bullet point numbering issue in chat getting started guides

### DIFF
--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -30,7 +30,7 @@ npm install @ably/chat typescript -D @types/node
 ```
 </Code>
 
-1. Create a default TypeScript configuration in your project
+5. Create a default TypeScript configuration in your project
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -43,7 +43,7 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 ```
 </Code>
 
-1. For iOS, install the native dependencies:
+4. For iOS, install the native dependencies:
 
 <Code>
 ```shell


### PR DESCRIPTION
## Description

Two bullet points were incorrectly numbered in two of the Chat getting started guides. This PR fixes them.