### PR TITLE
Remove out-of-date statement about LiveSync Postgres connector development status

### DIFF
--- a/src/pages/docs/livesync/postgres/index.mdx
+++ b/src/pages/docs/livesync/postgres/index.mdx
@@ -24,10 +24,6 @@ The Postgres database connector automatically retries failed publishes while mai
 
 The database connector can be [self-hosted](#self-host).
 
-## Development status <a id="development-status"/>
-
-The Postgres database connector is currently in alpha status. Your [feedback](https://docs.google.com/forms/d/e/1FAIpQLSd00n1uxgXWPGvMjKwMVL1UDhFKMeh3bSrP52j9AfXifoU-Pg/viewform) will help prioritize improvements and fixes for subsequent releases.
-
 ## Integration rule <a id="integration-rule"/>
 
 ### Creating the rule <a id="create"/>


### PR DESCRIPTION

## Description

The LiveSync Postgres connector is a full product and not in alpha release, so remove the misleading out-of-date statement from the docs.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
