### PR TITLE
EDU-2092: Adds Generic HTTP webhooks page

### DIFF
--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -165,6 +165,10 @@ export default {
               index: true,
             },
             {
+              name: 'Generic HTTP Webhooks',
+              link: '/docs/platform/integrations/webhooks/generic',
+            },
+            {
               name: 'Lambda Functions',
               link: '/docs/platform/integrations/webhooks/lambda',
             },

--- a/src/pages/docs/platform/integrations/webhooks/azure.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/azure.mdx
@@ -34,7 +34,7 @@ The following settings are available when creating an Azure Function integration
 | Function Name | The name of your Azure Function. |
 | Headers | Allows the inclusion of additional information in key-value format. |
 | Request Mode | Choose between **Single Request** or **Batch Request**. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Azure Functions. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Azure Functions. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 | [Enveloped](/docs/platform/integrations/webhooks#enveloped) | Checkbox to set whether messages should be enveloped or not. Enveloped is the default. Only available when `Request Mode` is set to `Single`. |

--- a/src/pages/docs/platform/integrations/webhooks/cloudflare.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/cloudflare.mdx
@@ -33,7 +33,7 @@ The following settings are available when creating a Cloudflare Worker integrati
 | URL | The URL of the Cloudflare Worker to POST a summary of events to. |
 | Headers | Allows the inclusion of additional information in key-value format. |
 | Request Mode | Choose between **Single Request** or **Batch Request**. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Cloudflare Workers. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Cloudflare Workers. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 | Sign with key | Payloads will be signed with an API key so they can be validated by your servers. Only available when `Request Mode` is set to `Batched`. |

--- a/src/pages/docs/platform/integrations/webhooks/gcp-function.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/gcp-function.mdx
@@ -35,7 +35,7 @@ The following settings are available when creating a Google Function integration
 | Function | The name of your Google Function. |
 | Headers | Allows the inclusion of additional information in key-value format. |
 | Request Mode | Choose between **Single Request** or **Batch Request**. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to your Google Function. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to your Google Function. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 | [Enveloped](/docs/platform/integrations/webhooks#enveloped) | Checkbox to set whether messages should be enveloped or not. Enveloped is the default. Only available when `Request Mode` is set to `Single`. |

--- a/src/pages/docs/platform/integrations/webhooks/generic.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/generic.mdx
@@ -1,0 +1,121 @@
+---
+title: Generic HTTP webhooks
+meta_description: "Configure generic HTTP webhooks to trigger HTTP endpoints and notify external services when events occur in Ably."
+meta_keywords: "ably webhooks, http webhooks, webhook integration, generic webhooks, webhook endpoints, event notifications, realtime webhooks"
+redirect_from:
+  - /docs/integrations/webhooks/generic
+---
+
+Generic HTTP webhooks enable you to trigger HTTP endpoints and notify external services when events occur in Ably. Events include when messages are published, presence events occur, changes in channel occupancy, and when channels are created or discarded. Data can be delivered individually or in batches to any HTTP endpoint.
+
+## Create a generic HTTP webhook integration
+
+To create a generic HTTP webhook integration in your [dashboard](https://ably.com/dashboard/any):
+
+1. Login and select the application you wish to integrate with an HTTP endpoint.
+2. Click the **Integrations** tab.
+3. Click the **New Integration Rule** button.
+4. Choose **Webhook**.
+5. Choose **Generic HTTP Webhook**.
+6. Configure the webhook [settings](#settings).
+7. Click **Create**.
+
+You can also create a generic HTTP webhook integration using the [Control API](/docs/platform/account/control-api).
+
+## Settings
+
+The following settings are available when creating a generic HTTP webhook integration:
+
+| Setting | Description |
+|---------|-------------|
+| URL | The HTTP/HTTPS endpoint URL where webhook requests will be sent. Ably strongly recommends using HTTPS for security. |
+| Headers | Optional HTTP headers to include with each request. Use the format `key:value`, for example, `X-Custom-Header:my-value`. Each header should be on a new line. |
+| Request Mode | Choose between **Single request** (sends each event individually) or **Batch request** (groups multiple events into a single request). |
+| Source | Choose which event types trigger the webhook: `channel.message`, `channel.presence`, `channel.lifecycle`, or `channel.occupancy`. |
+| [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
+| [Enveloped](/docs/platform/integrations/webhooks#enveloped) | When enabled (default), messages are wrapped in additional metadata. When disabled, only the raw message data is sent. |
+
+## Webhook request format
+
+There are two webhook request formats: single request and batch request.
+
+### Single request mode
+
+When **Single request** mode is selected, a separate HTTP POST request is sent for each event. This is useful when your endpoint processes one event at a time or when you need immediate notification of each event.
+
+The following example demonstrates request headers:
+
+```
+POST /webhook HTTP/1.1
+Host: your-endpoint.com
+Content-Type: application/json
+X-Ably-Message-Id: hKJ7FjEQh@1519124010003-0
+X-Ably-Message-Source: channel.message
+X-Ably-Message-Action: message
+User-Agent: Ably/1.0
+```
+
+The following example is an enveloped payload:
+
+```json
+{
+  "source": "channel.message",
+  "appId": "aBCdEf",
+  "channel": "channel-name",
+  "site": "eu-central-1-A",
+  "ruleId": "1-a2Bc",
+  "messages": [{
+    "id": "ABcDefgHIj:1:0",
+    "clientId": "user-123",
+    "connectionId": "ABcDefgHIj",
+    "timestamp": 1582270137276,
+    "data": "Hello World",
+    "name": "greeting"
+  }]
+}
+```
+
+The following example is a non-enveloped payload:
+
+```
+Hello World
+```
+
+### Batch request mode
+
+When **Batch request** mode is selected, multiple events occurring within a short timeframe are grouped into a single HTTP POST request. This reduces the number of requests and is more efficient for high-throughput scenarios.
+
+The following example is a batched payload:
+```json
+{
+  "items": [{
+    "webhookId": "ABcDEf",
+    "source": "channel.message",
+    "serial": "a7bcdEFghAbcDef123456789:4",
+    "timestamp": 1562124922426,
+    "name": "channel.message",
+    "data": {
+      "channelId": "chat-channel-4",
+      "site": "eu-west-1-A",
+      "messages": [{
+        "id": "ABcDefgHIj:1:0",
+        "clientId": "user-3",
+        "connectionId": "ABcDefgHIj",
+        "timestamp": 1123145678900,
+        "data": "the message data",
+        "name": "a message name"
+      }]
+    }
+  }]
+}
+```
+
+## Next steps
+
+For more advanced webhook configuration options and security features, see the [Outbound webhooks overview](/docs/platform/integrations/webhooks).
+
+You may also want to explore other integration options:
+- [Lambda Functions](/docs/platform/integrations/webhooks/lambda) for AWS Lambda integration
+- [Azure Functions](/docs/platform/integrations/webhooks/azure) for Microsoft Azure integration  
+- [Message Queues](/docs/platform/integrations/queues) for reliable message processing
+- [Streaming integrations](/docs/platform/integrations/streaming) for data pipeline integration

--- a/src/pages/docs/platform/integrations/webhooks/ifttt.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/ifttt.mdx
@@ -32,7 +32,7 @@ The following settings are available when creating an IFTTT integration:
 | ------- | ----------- |
 | IFTTT Webhook key | The webhook key for your IFTTT account. |
 | Event name | The name used to identify the IFTTT applet. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to IFTTT. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to IFTTT. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 

--- a/src/pages/docs/platform/integrations/webhooks/lambda.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/lambda.mdx
@@ -36,7 +36,7 @@ The following settings are available when creating an AWS Lambda integration:
 | AWS Credentials | If using AWS credentials, enter the values in `key:value` format. |
 | ARN of an assumable role | If using ARN of an assumable role, enter the ARN of the role that Ably can assume to access your AWS Lambada function. |
 | Qualifier | The qualifier of your Lambda function, if set. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to your AWS Lambda function. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to your AWS Lambda function. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 | [Enveloped](/docs/platform/integrations/webhooks#enveloped) | Checkbox to set whether messages should be enveloped or not. Enveloped is the default. |

--- a/src/pages/docs/platform/integrations/webhooks/zapier.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/zapier.mdx
@@ -34,7 +34,7 @@ The following settings are available when creating a Zapier integration:
 | URL | The Zapier webhook URL to POST a summary of events to. |
 | Headers | Allows the inclusion of additional information in key-value format. |
 | Request Mode | Choose between **Single Request** or **Batch Request**. |
-| [Source](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Zapier. |
+| [Event types](/docs/platform/integrations/webhooks#sources) | Specifies the event types being sent to Zapier. |
 | [Channel filter](/docs/platform/integrations/webhooks#filter) | Filters the source channels based on a regular expression. |
 | Encoding | Specifies the encoding format of messages. Either JSON or MsgPack. |
 | [Enveloped](/docs/platform/integrations/webhooks#enveloped) | Checkbox to set whether messages should be enveloped or not. Enveloped is the default. Only available when `Request Mode` is set to `Single`. |


### PR DESCRIPTION
This PR:

  - Adds Generic HTTP Webhooks integration page under "outbound webhooks".
  - Changes "Source" to "Event types" across all the webhook pages.

https://ably.atlassian.net/browse/EDU-2071