### PR TITLE
Go vcdiff delta codec example snippet

### DIFF
--- a/src/pages/docs/channels/options/deltas.mdx
+++ b/src/pages/docs/channels/options/deltas.mdx
@@ -172,6 +172,21 @@ channel.Subscribe(message => {
     Console.WriteLine(message.Data.ToString());
 });
 ```
+
+```realtime_go
+ablyVCDiffPlugin := ably.NewVCDiffPlugin()
+client, err := ably.NewRealtime(
+    ably.WithKey("{{API_KEY}}"),
+    ably.WithVCDiffPlugin(ablyVCDiffPlugin)
+)
+if err != nil {
+    log.Fatal(err)
+}
+channel := client.Channels.Get("{{RANDOM_CHANNEL_NAME}}", ably.ChannelWithVCDiff())
+channel.SubscribeAll(context.Background(), func(msg *ably.Message) {
+    fmt.Printf("Received message: %+v\n", msg)
+})
+```
 </Code>
 
 ## Known limitations <a id="limitations"/>


### PR DESCRIPTION
- Implemented vcdiff encoding for go -> https://github.com/ably/ably-go/pull/690
- Added golang specific code snippet for the same