### PR TITLE
Add instructions for installing and using the `vcdiff` decoder in Python

### DIFF
--- a/src/pages/docs/channels/options/deltas.mdx
+++ b/src/pages/docs/channels/options/deltas.mdx
@@ -78,6 +78,20 @@ The vcdiff decoder library exports the following function for manual delta decod
 * `source`: The original message to apply the delta to.
 </If>
 
+<If lang="python">
+## Install vcdiff decoder <a id="vcdiff"/>
+
+The vcdiff decoder is written in pure Python and enables clients to reconstruct full messages from the small "diffs" sent by Ably.
+
+### Installation from pip as ably package extras <a id="install"/>
+
+<Code fixed="true">
+```shell
+pip install ably[vcdiff]
+```
+</Code>
+</If>
+
 ## Subscribe using delta <a id="subscribe"/>
 
 Set the `delta` property of `params` to `vcdiff` in order to enable deltas when subscribing to a channel.
@@ -186,6 +200,22 @@ channel := client.Channels.Get("{{RANDOM_CHANNEL_NAME}}", ably.ChannelWithVCDiff
 channel.SubscribeAll(context.Background(), func(msg *ably.Message) {
     fmt.Printf("Received message: %+v\n", msg)
 })
+```
+
+```realtime_python
+from ably import AblyRealtime, AblyVCDiffDecoder
+from ably.realtime.realtime_channel import ChannelOptions
+
+ably = AblyRealtime("{{API_KEY}}", vcdiff_decoder=AblyVCDiffDecoder())
+
+channel = client.channels.get("{{RANDOM_CHANNEL_NAME}}", ChannelOptions(params={
+ 'delta': 'vcdiff'
+}))
+
+def on_message(message):
+    print(f"Received message: {message.data}")
+
+await channel.subscribe(on_message);
 ```
 </Code>
 


### PR DESCRIPTION
## Description

- Added installation guide for `vcdiff` via pip extras.
- Provided code example for subscribing to channels with delta support in Python.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
