### PR TITLE
chat: reflect changes in chat-kotlin 0.8.0

### DIFF
--- a/src/data/languages/languageData.ts
+++ b/src/data/languages/languageData.ts
@@ -27,7 +27,7 @@ export default {
     javascript: '0.14',
     react: '0.14',
     swift: '0.6',
-    kotlin: '0.7',
+    kotlin: '0.8',
   },
   spaces: {
     javascript: '0.4',

--- a/src/pages/docs/chat/connect.mdx
+++ b/src/pages/docs/chat/connect.mdx
@@ -108,19 +108,17 @@ for await statusChange in subscription {
 ```
 
 ```kotlin
-val subscription = chatClient.connection.onStatusChange { statusChange: ConnectionStatusChange ->
+val (off) = chatClient.connection.onStatusChange { statusChange: ConnectionStatusChange ->
     println(statusChange.toString())
 }
 ```
 </Code>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `off()` function returned in the `onStatusChange()` response to remove a listener:
 </If>
 
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a listener:
-</If>
+
 
 <If lang="javascript,kotlin">
 <Code>
@@ -129,7 +127,7 @@ off();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+off()
 ```
 </Code>
 </If>
@@ -180,19 +178,17 @@ for await error in subscription {
 ```
 
 ```kotlin
-val subscription = room.onDiscontinuity { reason: ErrorInfo ->
+val (off) = room.onDiscontinuity { reason: ErrorInfo ->
   // Recover from the discontinuity
 }
 ```
 </Code>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `off()` function returned in the `onDiscontinuity()` response to remove a listener:
 </If>
 
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a listener:
-</If>
+
 
 <If lang="javascript,kotlin">
 <Code>
@@ -201,7 +197,7 @@ off();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+off()
 ```
 </Code>
 </If>

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -90,10 +90,10 @@ Note that this is for example purposes only. In production, you should use [toke
 package com.example
 
 import com.ably.chat.*
+import com.ably.chat.json.*
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
 import kotlinx.coroutines.*
-import com.google.gson.JsonObject
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -115,7 +115,7 @@ suspend fun demonstrateMessages() {
     val chatClient = ChatClient(realtimeClient) { logLevel = LogLevel.Info }
 
     // Monitor connection status
-    val subscription = chatClient.connection.onStatusChange { change ->
+    val (off) = chatClient.connection.onStatusChange { change ->
         println("Connection status: ${change.current}")
     }
 
@@ -123,7 +123,7 @@ suspend fun demonstrateMessages() {
 
     // Keep the application running
     delay(5000)
-    subscription.unsubscribe()
+    off()
     realtimeClient.close()
 }
 ```
@@ -161,7 +161,7 @@ suspend fun demonstrateMessages() {
     println("Room '${room.name}' status: ${room.status}")
 
     // Subscribe to messages
-    val subscription = room.messages.subscribe { messageEvent ->
+    val (unsubscribe) = room.messages.subscribe { messageEvent ->
         val message = messageEvent.message
         val timestamp = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(message.timestamp))
         println("[$timestamp] ${message.clientId}: ${message.text}")
@@ -176,7 +176,7 @@ suspend fun demonstrateMessages() {
     delay(30000) // Keep running for 30 seconds
 
     // Clean up
-    subscription.unsubscribe()
+    unsubscribe()
     room.detach()
     realtimeClient.close()
 }
@@ -269,7 +269,7 @@ suspend fun demonstrateHistory() {
     room.attach()
 
     // Subscribe to new messages and get historical messages
-    val subscription = room.messages.subscribe { messageEvent ->
+    val (unsubscribe, subscription) = room.messages.subscribe { messageEvent ->
         println("NEW MESSAGE: ${messageEvent.message.clientId}: ${messageEvent.message.text}")
     }
 
@@ -284,7 +284,7 @@ suspend fun demonstrateHistory() {
     println("=== END HISTORY ===")
 
     delay(10000)
-    subscription.unsubscribe()
+    unsubscribe()
     room.detach()
     realtimeClient.close()
 }
@@ -325,7 +325,7 @@ suspend fun demonstrateTyping() {
     room.attach()
 
     // Subscribe to typing events
-    val subscription = room.typing.subscribe { typingEvent ->
+    val (unsubscribe) = room.typing.subscribe { typingEvent ->
         if (typingEvent.currentlyTyping.isEmpty()) {
             println("No one is currently typing")
         } else {
@@ -343,7 +343,7 @@ suspend fun demonstrateTyping() {
     room.typing.stop()
 
     delay(5000)
-    subscription.unsubscribe()
+    unsubscribe()
     room.detach()
     realtimeClient.close()
 }
@@ -390,7 +390,7 @@ suspend fun demonstratePresence() {
     room.attach()
 
     // Subscribe to presence events
-    val subscription = room.presence.subscribe { presenceEvent ->
+    val (unsubscribe) = room.presence.subscribe { presenceEvent ->
         val member = presenceEvent.member
         when (presenceEvent.type) {
             PresenceEventType.Enter -> {
@@ -410,7 +410,7 @@ suspend fun demonstratePresence() {
 
     // Enter the presence set
     room.presence.enter(
-        JsonObject().apply {
+        jsonObject {
             addProperty("status", "Online")
         },
     )
@@ -427,13 +427,13 @@ suspend fun demonstratePresence() {
 
     // Leave presence before closing
     room.presence.leave(
-        JsonObject().apply {
-            addProperty("status", "Offline")
+        jsonObject {
+            put("status", "Offline")
         },
     )
 
     delay(1000)
-    subscription.unsubscribe()
+    unsubscribe()
     room.detach()
     realtimeClient.close()
 }
@@ -480,7 +480,7 @@ suspend fun demonstrateReactions() {
     room.attach()
 
     // Subscribe to reactions
-    val subscription = room.reactions.subscribe { event ->
+    val (unsubscribe) = room.reactions.subscribe { event ->
         println("${event.reaction.clientId} reacted with: ${event.reaction.name}")
     }
 
@@ -494,7 +494,7 @@ suspend fun demonstrateReactions() {
     }
 
     delay(5000)
-    subscription.unsubscribe()
+    unsubscribe()
     room.detach()
     realtimeClient.close()
 }
@@ -575,8 +575,8 @@ suspend fun fullChatDemo() {
 
         // Enter presence
         room.presence.enter(
-            JsonObject().apply {
-                addProperty("status", "Online")
+            jsonObject {
+                put("status", "Online")
             },
         )
 

--- a/src/pages/docs/chat/rooms/index.mdx
+++ b/src/pages/docs/chat/rooms/index.mdx
@@ -306,20 +306,17 @@ for await status in statusSubscription {
 ```
 
 ```kotlin
-val subscription = room.onStatusChange { statusChange: RoomStatusChange ->
+val (off) = room.onStatusChange { statusChange: RoomStatusChange ->
     println(statusChange.toString())
 }
 ```
 </Code>
 </If>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `off()` function returned in the `onStatusChange()` response to remove a room status listener:
 </If>
 
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a room status listener:
-</If>
 
 <If lang="javascript,kotlin">
 <Code>
@@ -328,7 +325,7 @@ off();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+off()
 ```
 </Code>
 </If>

--- a/src/pages/docs/chat/rooms/messages.mdx
+++ b/src/pages/docs/chat/rooms/messages.mdx
@@ -99,16 +99,12 @@ See [below](#global-ordering) for more information on how to apply deterministic
 
 ### Unsubscribe from messages <a id="unsubscribe"/>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `unsubscribe()` function returned in the `subscribe()` response to remove a chat message listener:
 </If>
 
 <If lang="swift">
 You don't need to handle removing listeners, as this is done automatically by the SDK.
-</If>
-
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a chat message listener:
 </If>
 
 <If lang="react">
@@ -126,7 +122,11 @@ unsubscribe();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+// Initial subscription
+val (unsubscribe) = room.messages.subscribe { event -> println(event.message) }
+
+// To remove the listener
+unsubscribe()
 ```
 </Code>
 </If>
@@ -369,7 +369,7 @@ val messagesSubscription = room.messages.subscribe { event ->
   when (event.type) {
     ChatMessageEventType.Created -> println("Received message: ${event.message}")
     ChatMessageEventType.Updated -> myMessageList.find {
-      event.message.serial == it.serial && event.message.version > it.version
+      event.message.serial == it.serial && event.message.version.serial > it.version.serial
     }?.let { println("Message updated: ${event.message}") }
     else -> {}
   }
@@ -567,7 +567,7 @@ val messagesSubscription = room.messages.subscribe { event ->
   when (event.type) {
     ChatMessageEventType.Created -> println("Received message: ${event.message}")
     ChatMessageEventType.Deleted -> myMessageList.find {
-      event.message.serial == it.serial && event.message.version > it.version
+      event.message.serial == it.serial && event.message.version.serial > it.version.serial
     }?.let { println("Message deleted: ${event.message}") }
     else -> {}
   }

--- a/src/pages/docs/chat/rooms/occupancy.mdx
+++ b/src/pages/docs/chat/rooms/occupancy.mdx
@@ -123,16 +123,12 @@ A user is counted for every device that they are in the room with. For example, 
 
 ### Unsubscribe from room occupancy
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `unsubscribe()` function returned in the `subscribe()` response to remove a room occupancy listener:
 </If>
 
 <If lang="swift">
 You don't need to handle removing listeners, as this is done automatically by the SDK.
-</If>
-
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a room occupancy listener:
 </If>
 
 <If lang="react">
@@ -152,7 +148,13 @@ unsubscribe();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+// Initial subscription
+val (unsubscribe) = room.occupancy.subscribe { event ->
+  println(event)
+}
+
+// To remove the listener
+unsubscribe()
 ```
 </Code>
 </If>

--- a/src/pages/docs/chat/rooms/presence.mdx
+++ b/src/pages/docs/chat/rooms/presence.mdx
@@ -108,16 +108,12 @@ The following are the properties of a presence event:
 
 ## Unsubscribe from presence <a id="unsubscribe"/>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `unsubscribe()` function returned in the `subscribe()` response to remove a presence listener:
 </If>
 
 <If lang="swift">
 You don't need to handle removing listeners, as this is done automatically by the SDK.
-</If>
-
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a presence listener:
 </If>
 
 <If lang="react">
@@ -137,7 +133,13 @@ unsubscribe();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+// Initial subscription
+val (unsubscribe) = room.presence.subscribe { event ->
+  println("${event.member.clientId} entered with data: ${event.member.data}")
+}
+
+// To remove the listener
+unsubscribe()
 ```
 </Code>
 </If>
@@ -193,9 +195,10 @@ try await room.presence.enter(data: ["status": "Online"])
 ```
 
 ```kotlin
+// import com.ably.chat.json.*
 room.presence.enter(
-    JsonObject().apply {
-        addProperty("status", "Online")
+    jsonObject {
+        put("status", "Online")
     },
 )
 ```
@@ -243,9 +246,10 @@ try await room.presence.update(data: ["status": "Busy"])
 ```
 
 ```kotlin
+// import com.ably.chat.json.*
 room.presence.update(
-    JsonObject().apply {
-        addProperty("status", "Busy")
+    jsonObject {
+        put("status", "Busy")
     },
 )
 ```
@@ -293,9 +297,10 @@ try await room.presence.leave(data: ["status": "Be back later!"])
 ```
 
 ```kotlin
+// import com.ably.chat.json.*
 room.presence.leave(
-    JsonObject().apply {
-        addProperty("status", "Be back later!")
+    jsonObject {
+        put("status", "Be back later!")
     },
 )
 ```

--- a/src/pages/docs/chat/rooms/reactions.mdx
+++ b/src/pages/docs/chat/rooms/reactions.mdx
@@ -69,16 +69,12 @@ The following are the properties of a room reaction event:
 
 ### Unsubscribe from room reactions <a id="unsubscribe"/>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `unsubscribe()` function returned in the `subscribe()` response to remove a room reaction listener:
 </If>
 
 <If lang="swift">
 You don't need to handle removing listeners, as this is done automatically by the SDK.
-</If>
-
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a room reaction listener:
 </If>
 
 <If lang="react">
@@ -98,7 +94,13 @@ unsubscribe();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+// Initial subscription
+val (unsubscribe) = room.reactions.subscribe { event ->
+  println("Received a reaction of type ${event.reaction.name}, and metadata ${event.reaction.metadata}")
+}
+
+// To remove the listener
+unsubscribe()
 ```
 </Code>
 </If>
@@ -147,8 +149,9 @@ try await room.reactions.send(params: .init(name: "heart",
 
 ```kotlin
 room.reactions.send(name = "like")
-room.reactions.send(name = "heart", metadata = JsonObject().apply {
-  addProperty("effect", "fireworks")
+// import com.ably.chat.json.*
+room.reactions.send(name = "heart", metadata = jsonObject {
+  put("effect", "fireworks")
 })
 ```
 </Code>

--- a/src/pages/docs/chat/rooms/typing.mdx
+++ b/src/pages/docs/chat/rooms/typing.mdx
@@ -91,16 +91,12 @@ You can use the size of the `currentlyTyping` set to decide whether to display i
 
 ### Unsubscribe from typing events <a id="unsubscribe"/>
 
-<If lang="javascript">
+<If lang="javascript,kotlin">
 Use the `unsubscribe()` function returned in the `subscribe()` response to remove a typing listener:
 </If>
 
 <If lang="swift">
 You don't need to handle removing listeners, as this is done automatically by the SDK.
-</If>
-
-<If lang="kotlin">
-Use the `unsubscribe()` method on the returned subscription to remove a typing listener:
 </If>
 
 <If lang="react">
@@ -121,7 +117,13 @@ unsubscribe();
 ```
 
 ```kotlin
-subscription.unsubscribe()
+// Initial subscription
+val (unsubscribe) = room.typing.subscribe { event ->
+  println("Typing event received: $event")
+}
+
+// To remove the listener
+unsubscribe()
 ```
 </Code>
 </If>

--- a/src/pages/docs/chat/setup.mdx
+++ b/src/pages/docs/chat/setup.mdx
@@ -119,7 +119,7 @@ The Ably Chat SDK is available on the Maven Central Repository. To include the d
 
 <Code>
 ```kotlin
-  implementation("com.ably.chat:chat:0.7.0")
+  implementation("com.ably.chat:chat:0.8.0")
 ```
 </Code>
 
@@ -127,7 +127,7 @@ For groovy:
 
 <Code>
 ```kotlin
-  implementation 'com.ably.chat:chat:0.3.0'
+  implementation 'com.ably.chat:chat:0.8.0'
 ```
 </Code>
 </If>


### PR DESCRIPTION
## Description
Reflect changes in 0.8.0 version of chat-kotlin:

* get rid of Gson in examples
* use destructing syntax for unsubscribe similar to js

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
