### PR TITLE
[EDU-2104] Update endpoints from `ably.io` to `ably.net`

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -137,12 +137,12 @@ When we make backwards-incompatible API changes to the API, we release new versi
 
 1. Include the @X-Ably-Version@ header. Example:
 
-bc[sh]. curl https://rest.ably.io/time \
+bc[sh]. curl https://main.realtime.ably.net/time \
  -H "X-Ably-Version: 1.2"
 
 2. Include the version query string param @v@. Example:
 
-bc[sh]. curl https://rest.ably.io/time?v=1.2
+bc[sh]. curl https://main.realtime.ably.net/time?v=1.2
 
 h3(#pagination). Pagination
 
@@ -186,7 +186,7 @@ Specifying @?fields=<field spec>[,<field spec>, ...]@ returns the representation
 h5. Example
 
 ```[sh]
-  curl https://rest.ably.io/stats?fields=channels.peak,intervalId \
+  curl https://main.realtime.ably.net/stats?fields=channels.peak,intervalId \
        -u "{{API_KEY}}"
 
   # Response
@@ -203,7 +203,7 @@ Specifying @?flatten=true@ will result in a flattened representation, with the r
 h5. Example
 
 ```[sh]
-  curl https://rest.ably.io/stats?flatten=true&fields=channels.peak,intervalId \
+  curl https://main.realtime.ably.net/stats?flatten=true&fields=channels.peak,intervalId \
        -u "{{API_KEY}}"
 
   # Response
@@ -222,7 +222,7 @@ The result is a partially-flattened representation, as a map whose keys are the 
 h5. Example
 
 ```[sh]
-  curl https://rest.ably.io/stats?select=*.channels.* \
+  curl https://main.realtime.ably.net/stats?select=*.channels.* \
        -u "{{API_KEY}}"
 
   # Response
@@ -283,14 +283,14 @@ where @<Base64-encoded key>@ is the full application key string obtained through
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/messages \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/messages \
  --header "Authorization: Basic {{API_KEY_BASE64}}"
 
 When using a generic HTTP client library that accepts separate username and password arguments for an HTTP request, the application key can be split at the first colon, with the initial segment being used as the username, and the remaining string (without the leading colon) used as the password.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/messages \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/messages \
  --user "{{API_KEY}}"
 
 h3(#token-authentication). Token Authentication
@@ -307,7 +307,7 @@ The @<Base64-encoded token string>@ is either the @token@ attribute of the Ably 
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/messages \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/messages \
  --header "Authorization: Bearer {{TOKEN_BASE64}}"
 
 h2(#channel). Channel routes
@@ -316,7 +316,7 @@ Routes providing access to the messaging service within a channel scope.
 
 h3(#publish). Publish one or more messages on a channel
 
-h6. POST rest.ably.io/channels/@<channelId>@/messages
+h6. POST main.realtime.ably.net/channels/@<channelId>@/messages
 
 Publish a message on a channel. Note that since the REST API is stateless, publication using this API is outside the context of any specific connection.
 
@@ -343,7 +343,7 @@ A message may be published over REST on behalf of an existing realtime connectio
 
 Example request:
 
-bc[sh]. curl -X POST https://rest.ably.io/channels/rest-example/messages \
+bc[sh]. curl -X POST https://main.realtime.ably.net/channels/rest-example/messages \
  -u "{{API_KEY}}" \
  -H "Content-Type: application/json" \
  --data '{ "name": "publish", "data": "example" }'
@@ -387,7 +387,7 @@ For each underlying transport service (like APNs, FCM, etc.) an object can be pr
 
 Full example of a request publishing a message with a push payload:
 
-bc[sh]. curl -X POST https://rest.ably.io/channels/push-enabled:rest-example/messages \
+bc[sh]. curl -X POST https://main.realtime.ably.net/channels/push-enabled:rest-example/messages \
  -u "{{API_KEY}}" \
  -H "Content-Type: application/json" \
  --data \
@@ -436,13 +436,13 @@ If the @enveloped@ parameter is present and set to @false@, the request body is 
 
 Example json request:
 
-bc[sh]. curl -X POST https://rest.ably.io/channels/rest-example/messages?enveloped=false \
+bc[sh]. curl -X POST https://main.realtime.ably.net/channels/rest-example/messages?enveloped=false \
 -H 'content-type: application/json' --data '{"some":"json"}' \
 -u "{{API_KEY}}"
 
 Example plain text request:
 
-bc[sh]. curl -X POST https://rest.ably.io/channels/rest-example/messages?enveloped=false \
+bc[sh]. curl -X POST https://main.realtime.ably.net/channels/rest-example/messages?enveloped=false \
 -H 'content-type: text/plain' --data 'some plain text' \
 -u "{{API_KEY}}"
 
@@ -466,13 +466,13 @@ When successful, returns an object with @channel@ and @messageId@ properties, in
 
 h3(#message-history). Retrieve message history for a channel
 
-h6. GET rest.ably.io/channels/@<channelId>@/messages
+h6. GET main.realtime.ably.net/channels/@<channelId>@/messages
 
 If a channel is "configured to persist messages":/docs/storage-history/storage, then all messages on that channel, within "your account retention period":https://faqs.ably.com/how-long-are-messages-stored-for, are available via this API endpoint.  If persistence is not configured, then there are no guarantees as to how many historical messages will be available for the channel.  "Find out more about message persistence":https://faqs.ably.com/how-long-are-messages-stored-for.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/messages \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/messages \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -501,13 +501,13 @@ bc[json]. [{
 
 h3(#presence). Retrieve instantaneous presence status for a channel
 
-h6. GET rest.ably.io/channels/@<channelId>@/presence
+h6. GET main.realtime.ably.net/channels/@<channelId>@/presence
 
 Obtain the set of members currently present for a channel.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/presence \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/presence \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -537,13 +537,13 @@ bc[json]. [{
 
 h3(#presence-history). Retrieve presence state history for a channel
 
-h6. GET rest.ably.io/channels/@<channelId>@/presence/history
+h6. GET main.realtime.ably.net/channels/@<channelId>@/presence/history
 
 Obtain the history of presence messages for a channel.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/rest-example/presence/history \
+bc[sh]. curl https://main.realtime.ably.net/channels/rest-example/presence/history \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -593,7 +593,7 @@ After generating these, update your local @DeviceDetails@ object with the new @d
 
 The following API endpoint provided is used to register a device for receiving push notifications:
 
-h6. POST rest.ably.io/push/deviceRegistrations
+h6. POST main.realtime.ably.net/push/deviceRegistrations
 
 The request body contains device and push recipient details, and is an object of the form:
 
@@ -638,7 +638,7 @@ bc[json]. {
 
 Example request:
 
-bc[sh]. curl -X POST https://rest.ably.io/push/deviceRegistrations \
+bc[sh]. curl -X POST https://main.realtime.ably.net/push/deviceRegistrations \
  -u "{{API_KEY}}"
  -H "Content-Type: application/json" \
  --data \
@@ -672,7 +672,7 @@ h3(#update-device-registration). Update a device registration
 
 Device registrations can be either upserted (the existing registration is replaced entirely) with a "@PUT@":#put-device-registration operation, or specific attributes of an existing registration can be updated using a "@PATCH@":#patch-device-registration operation:
 
-h6(#put-device-registration). PUT rest.ably.io/push/deviceRegistrations/@<deviceId>@
+h6(#put-device-registration). PUT main.realtime.ably.net/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration. The @PUT@ operation will replace the existing device registration, however please bear in mind that a registered device in Ably is largely immutable. As such, only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -686,7 +686,7 @@ If you need to make changes to any other fields, you will have to "deregister th
 
 Example request:
 
-bc[sh]. curl -X PUT https://rest.ably.io/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
+bc[sh]. curl -X PUT https://main.realtime.ably.net/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
  -H "Content-Type: application/json" \
  --data \
@@ -719,7 +719,7 @@ A successful request returns the updated device details.
 
 An unsuccessful request returns an error.
 
-h6(#patch-device-registration). PATCH rest.ably.io/push/deviceRegistrations/@<deviceId>@
+h6(#patch-device-registration). PATCH main.realtime.ably.net/push/deviceRegistrations/@<deviceId>@
 
 The body must have the same shape as when "registering the device":#post-device-registration, except only fields to be changed should be provided. Any fields provided replace existing values. Please bear in mind that fields whose values are structured (JSON-like arrays or objects) types will replace existing values as opposed to be merged into existing values. @metadata@ and @push.recipient@ are examples of these types. Currently only the following attributes are currently updatable and any attempt to modify other fields will result in the update failing:
 
@@ -731,7 +731,7 @@ If you need to make changes to any other fields, you will have to "deregister th
 
 Example request:
 
-bc[sh]. curl -X PATCH https://rest.ably.io/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
+bc[sh]. curl -X PATCH https://main.realtime.ably.net/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
  -H "Content-Type: application/json" \
  --data \
@@ -757,13 +757,13 @@ An unsuccessful request returns an error.
 
 h3(#get-device-registration). Get details from a registered device
 
-h6. GET rest.ably.io/push/deviceRegistrations/@<deviceId>@
+h6. GET main.realtime.ably.net/push/deviceRegistrations/@<deviceId>@
 
 Obtain the details for a device registered for receiving push registrations.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
+bc[sh]. curl https://main.realtime.ably.net/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -807,13 +807,13 @@ If Ably could not register the device on behalf of the push notifications provid
 
 h3(#list-device-registrations). List registered devices
 
-h6. GET rest.ably.io/push/deviceRegistrations
+h6. GET main.realtime.ably.net/push/deviceRegistrations
 
 Obtain the details for devices registered for receiving push registrations.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/push/deviceRegistrations \
+bc[sh]. curl https://main.realtime.ably.net/push/deviceRegistrations \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -850,11 +850,11 @@ bc[json]. [{
 
 h3(#reset-update-token). Reset a registered device's update token
 
-h6. POST rest.ably.io/push/deviceRegistrations/@<deviceId>@/resetUpdateToken
+h6. POST main.realtime.ably.net/push/deviceRegistrations/@<deviceId>@/resetUpdateToken
 
 Example request:
 
-bc[sh]. curl -X POST https://rest.ably.io/push/01ARZ3NDEKTSV4RRFFQ69G5FAV/resetUpdateToken \
+bc[sh]. curl -X POST https://main.realtime.ably.net/push/01ARZ3NDEKTSV4RRFFQ69G5FAV/resetUpdateToken \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -872,7 +872,7 @@ A unsuccessful request returns an error.
 
 h3(#delete-device-registration). Unregister a single device for push notifications
 
-h6. DELETE rest.ably.io/push/deviceRegistrations/@<deviceId>@
+h6. DELETE main.realtime.ably.net/push/deviceRegistrations/@<deviceId>@
 
 Unregisters a single device by its device ID. All its subscriptions for receiving push notifications through channels will also be deleted.
 
@@ -881,7 +881,7 @@ Please note that this operation is done asynchronously so immediate requests sub
 Example request:
 
 bc[sh]. curl -X DELETE \
- https://rest.ably.io/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
+ https://main.realtime.ably.net/push/deviceRegistrations/01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -901,7 +901,7 @@ An unsuccessful request returns an error.
 
 h3(#delete-device-registrations). Unregister matching devices for push notifications
 
-h6. DELETE rest.ably.io/push/deviceRegistrations
+h6. DELETE main.realtime.ably.net/push/deviceRegistrations
 
 Unregisters devices. All their subscriptions for receiving push notifications through channels will also be deleted.
 
@@ -910,7 +910,7 @@ Please note that this operation is done asynchronously so immediate requests sub
 Example request:
 
 bc[sh]. curl -X DELETE \
- https://rest.ably.io/push/deviceRegistrations?deviceId=01ARZ3NDEKTSV4RRFFQ69G5FAV \
+ https://main.realtime.ably.net/push/deviceRegistrations?deviceId=01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -933,7 +933,7 @@ h3(#post-channel-subscription). Subscribe to a channel
 
 Subscribe either a single device or all devices associated with a client ID to receive push notifications from messages sent to a channel.
 
-h6. POST rest.ably.io/push/channelSubscriptions
+h6. POST main.realtime.ably.net/push/channelSubscriptions
 
 The request body contains subscription details and is an object of the form:
 
@@ -943,7 +943,7 @@ bc[json]. {
   clientId: <optional, string, must be set when deviceId is empty, cannot be used with deviceId>
 }
 
-bc[sh]. curl -X POST https://rest.ably.io/push/channelSubscriptions \
+bc[sh]. curl -X POST https://main.realtime.ably.net/push/channelSubscriptions \
  -u "{{API_KEY}}"
  -H "Content-Type: application/json" \
  --data \
@@ -970,7 +970,7 @@ A unsuccessful request returns an error.
 
 h3(#delete-channel-subscription). Unsubscribe from push notifications for channels
 
-h6. DELETE rest.ably.io/push/channelSubscriptions
+h6. DELETE main.realtime.ably.net/push/channelSubscriptions
 
 Stop receiving push notifications when push messages are published on the specified channels.
 
@@ -979,7 +979,7 @@ Please note that this operation is done asynchronously so immediate requests sub
 Example request:
 
 bc[sh]. curl -X DELETE \
- https://rest.ably.io/push/channelSubscriptions?deviceId=01ARZ3NDEKTSV4RRFFQ69G5FAV \
+ https://main.realtime.ably.net/push/channelSubscriptions?deviceId=01ARZ3NDEKTSV4RRFFQ69G5FAV \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -1001,13 +1001,13 @@ An unsuccessful request returns an error.
 
 h3(#list-channel-subscriptions). List channel subscriptions
 
-h6. GET rest.ably.io/push/channelSubscriptions
+h6. GET main.realtime.ably.net/push/channelSubscriptions
 
 Get a list of push notification subscriptions to channels.
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/push/channelSubscriptions \
+bc[sh]. curl https://main.realtime.ably.net/push/channelSubscriptions \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -1036,11 +1036,11 @@ bc[json]. [{
 
 h3(#list-channels). List all channels with at least one subscribed device
 
-h6. GET rest.ably.io/push/channels
+h6. GET main.realtime.ably.net/push/channels
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/push/channels \
+bc[sh]. curl https://main.realtime.ably.net/push/channels \
  -u "{{API_KEY}}"
 
 h5. Parameters
@@ -1067,7 +1067,7 @@ If you want to send a push notification to subscribed clients without knowing ab
 
 This direct publish endpoint is designed for use cases where there is a need to push directly to specified recipients, for example where the population of relevant devices is managed outside of Ably, or where it is not appropriate to create a durable association between the device and a channel or topic.
 
-h6. POST rest.ably.io/push/publish
+h6. POST main.realtime.ably.net/push/publish
 
 The request body is an object of the form:
 
@@ -1078,7 +1078,7 @@ bc[json]. {
 
 Example request:
 
-bc[sh]. curl -X POST https://rest.ably.io/push/publish \
+bc[sh]. curl -X POST https://main.realtime.ably.net/push/publish \
  -u "{{API_KEY}}" \
  -H "Content-Type: application/json" \
  --data \
@@ -1158,7 +1158,7 @@ h3(#push-publish-batch). Batch publish directly to specific recipients
 Convenience endpoint to deliver multiple push notification payloads to multiple devices or browsers in a single request by specifying a list of recipients and corresponding payloads.
 Currently, the batch push endpoint allows a maximum of 10,000 notifications per request. Note that each recipient for a given payload counts as a separate notification.
 
-h6. POST rest.ably.io/push/batch/publish
+h6. POST main.realtime.ably.net/push/batch/publish
 
 The request body is an array of objects of the form:
 
@@ -1171,7 +1171,7 @@ Where the recipient and payload fields are the same as those used in the "Publis
 
 Example request:
 
-bc[sh]. curl -X POST https://rest.ably.io/push/admin/batch/publish \
+bc[sh]. curl -X POST https://main.realtime.ably.net/push/admin/batch/publish \
  -u "{{API_KEY}}" \
  -H "Content-Type: application/json" \
  --data \
@@ -1209,13 +1209,13 @@ h3(#request-token). Request an access token
 
 <!-- TODO: Review the suitability of the documentation that describes the token request and the token body response and provide suitable links -->
 
-h6. POST rest.ably.io/keys/@<keyName>@/requestToken
+h6. POST main.realtime.ably.net/keys/@<keyName>@/requestToken
 
 This is the means by which clients obtain access tokens to use the service. The construction of an Ably "@TokenRequest@":/docs/api/token-request-spec is described in the "Authentication Ably TokenRequest spec documentation":/docs/api/token-request-spec. The resulting @token response@ object contains the token properties as defined in "Ably TokenRequest spec":/docs/api/token-request-spec.
 
 Example request:
 
-bc[sh]. curl -X POST "https://rest.ably.io/keys/{{API_KEY_NAME}}/requestToken" \
+bc[sh]. curl -X POST "https://main.realtime.ably.net/keys/{{API_KEY_NAME}}/requestToken" \
  -u "{{API_KEY}}" \
  -H "Content-Type: application/json" \
  --data '{ "keyName": "{{API_KEY_NAME}}", "timestamp": {{MS_SINCE_EPOCH}} }'
@@ -1245,13 +1245,13 @@ bc[json]. {
 
 h3(#revoke-tokens). Revoke tokens
 
-h6. POST rest.ably.io/keys/@<keyName>@/revokeTokens
+h6. POST main.realtime.ably.net/keys/@<keyName>@/revokeTokens
 
 Provides a mechanism to revoke tokens, where @keyName@ is @appId.keyId@.
 
 Example request:
 
-bc[sh]. curl -u "{{API_KEY}}" -X POST https://rest.ably.io/keys/{{API_KEY_NAME}}/revokeTokens \
+bc[sh]. curl -u "{{API_KEY}}" -X POST https://main.realtime.ably.net/keys/{{API_KEY_NAME}}/revokeTokens \
     --header "Accept: application/json" \
     --header "Content-Type: application/json" \
     --data '{"targets": [ "clientId:client1@example.com" ]}'
@@ -1305,11 +1305,11 @@ Routes providing access to the messaging service within an application scope.
 
 h3(#stats). Retrieve usage statistics for an application
 
-h6. GET rest.ably.io/stats
+h6. GET main.realtime.ably.net/stats
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/stats?unit=hour \
+bc[sh]. curl https://main.realtime.ably.net/stats?unit=hour \
  -u "{{API_KEY}}"
 
 The Ably system can be queried to obtain usage statistics for a given application, and results are provided aggregated across all channels in use in the application in the specified period. Stats may be used to track usage against account quotas.
@@ -1344,7 +1344,7 @@ h2(#batch). Batch
 
 h3(#batch-publish). Batch publish
 
-h6. POST rest.ably.io/messages
+h6. POST main.realtime.ably.net/messages
 
 Using this endpoint, you can publish messages to channels in parallel, by passing either a single @BatchSpec@ object or an array of @BatchSpec@ objects in the request body.
 
@@ -1411,7 +1411,7 @@ bc[json]. [
 
 h3(#batch-presence). Batch presence
 
-h6. GET rest.ably.io/presence
+h6. GET main.realtime.ably.net/presence
 
 This endpoint enables you to query the presence states of multiple channels in a single API request. The API retrieves the member presence details of the specified channels in parallel.
 
@@ -1489,13 +1489,13 @@ h2(#utilities). Utilities
 
 h3(#time). Get the service time
 
-h6. GET rest.ably.io/time
+h6. GET main.realtime.ably.net/time
 
 This returns the service time in milliseconds since the epoch. This may be used by clients that do not have local access to a sufficiently accurate time source when generating an Ably "@TokenRequest@":/docs/api/token-request-spec. (Ably "@TokenRequests@":/docs/api/token-request-spec include a timestamp and have a limited validity period to help defend against replay attacks.)
 
 The result is a JSON-encoded array of length 1 containing the time result as a number.
 
-bc[sh]. curl http://rest.ably.io/time
+bc[sh]. curl http://main.realtime.ably.net/time
 
 h5. Parameters
 

--- a/content/api/sse.textile
+++ b/content/api/sse.textile
@@ -14,7 +14,7 @@ redirect_from:
 
 h3(#sse). Server-sent events
 
-h6. GET realtime.ably.io/sse
+h6. GET main.realtime.ably.net/sse
 
 Start a streaming HTTP request that conforms to the "Server-Sent Events":https://www.w3.org/TR/eventsource/ spec, for ease of consuming with an SSE library.
 
@@ -42,7 +42,7 @@ h5. Code example
 
 ```[javascript]
 var apiKey = '{{API_KEY}}';
-var url = 'https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
+var url = 'https://main.realtime.ably.net/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
 var eventSource = new EventSource(url);
 
 eventSource.onmessage = function(event) {
@@ -56,7 +56,7 @@ import json
 import sseclient
 
 api_key='{{API_KEY}}'
-url = "https://realtime.ably.io/sse?channels=myChannel&v=1.2&key=%s" % (api_key)
+url = "https://main.realtime.ably.net/sse?channels=myChannel&v=1.2&key=%s" % (api_key)
 
 def with_urllib3(url):
   import urllib3
@@ -71,7 +71,7 @@ for event in client.events():
 ```
 
 ```[curl]
-curl "https://rest.ably.io/sse?channel=example&v=1.2" \
+curl "https://main.realtime.ably.net/sse?channel=example&v=1.2" \
   --user "{{API_KEY}}"
 ⏎
 id: cbfKayrzgAXDWM:1556806691343-0
@@ -98,7 +98,7 @@ data:{
 
 h3(#event-stream). Plain HTTP event stream
 
-h6. GET realtime.ably.io/event-stream
+h6. GET main.realtime.ably.net/event-stream
 
 Starts a streaming HTTP request. This allows for messages to be easily consumed with any HTTP library that supports streaming. This is similar to the SSE endpoint, but uses JSON envelopes instead of SSE events.
 
@@ -144,7 +144,7 @@ Note that failures on opening the connection (for example, invalid authenticatio
 h5. Code example
 
 ```[curl]
-curl "https://rest.ably.io/event-stream?channel=example&v=1.2" \
+curl "https://main.realtime.ably.net/event-stream?channel=example&v=1.2" \
   --user "{{API_KEY}}"
 
 {
@@ -174,7 +174,7 @@ curl "https://rest.ably.io/event-stream?channel=example&v=1.2" \
 ```[nodejs]
 const request = require('request');
 const apiKey = '{{API_KEY}}';
-const url = 'https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apikey;
+const url = 'https://main.realtime.ably.net/event-stream?channels=myChannel&v=1.2&key=' + apikey;
 
 request
   .get(url)

--- a/content/api/token-request-spec.textile
+++ b/content/api/token-request-spec.textile
@@ -131,7 +131,7 @@ h2(#examples). Example Ably TokenRequests
 
 h3(#unsigned-tokenrequest). Unsigned Ably TokenRequest example
 
-bc[sh]. curl -X POST "https://rest.ably.io/keys/{{API_KEY_NAME}}/requestToken" \
+bc[sh]. curl -X POST "https://main.realtime.ably.net/keys/{{API_KEY_NAME}}/requestToken" \
  --user "{{API_KEY}}" \
  --header "Content-Type: application/json" \
  --data '{
@@ -158,7 +158,7 @@ bc[json]. {
 
 h3(#signed-tokenrequest). Signed Ably TokenRequest example
 
-bc[sh]. curl -X POST "https://rest.ably.io/keys/{{API_KEY_NAME}}/requestToken" \
+bc[sh]. curl -X POST "https://main.realtime.ably.net/keys/{{API_KEY_NAME}}/requestToken" \
  -H "Content-Type: application/json" \
  --data '{{SIGNED_TOKEN_REQUEST_EXAMPLE}}'
 

--- a/content/partials/general/events/_non_enveloped_events.textile
+++ b/content/partials/general/events/_non_enveloped_events.textile
@@ -9,7 +9,7 @@ The payload will contain the "data":/docs/api/realtime-sdk/messages#data of the 
 For example, if you sent the following curl message, which sends a JSON message to the channel @my_channel@:
 
 ```[curl]
-curl -X POST https://rest.ably.io/channels/my_channel/messages \
+curl -X POST https://main.realtime.ably.net/channels/my_channel/messages \
           -u "{{API_KEY}}" \
           -H "Content-Type: application/json" \
           --data '{ "name": "publish", "data": "example" }'

--- a/content/partials/shared/_channel_enumeration.textile
+++ b/content/partials/shared/_channel_enumeration.textile
@@ -4,7 +4,7 @@ This API is intended for occasional use by your servers only; for example, to ge
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels \
+bc[sh]. curl https://main.realtime.ably.net/channels \
  -u "{{API_KEY}}"
 
 This will return either a list of channel names, or a "ChannelDetails":/docs/api/realtime-sdk/channel-metadata#channel-details object depending on what options you've specified.

--- a/content/partials/shared/_channel_metadata.textile
+++ b/content/partials/shared/_channel_metadata.textile
@@ -2,7 +2,7 @@ This returns a "ChannelDetails":/docs/api/realtime-sdk/channel-metadata#channel-
 
 Example request:
 
-bc[sh]. curl https://rest.ably.io/channels/<channelId> \
+bc[sh]. curl https://main.realtime.ably.net/channels/<channelId> \
  -u "{{API_KEY}}"
 
 The credentials presented with the request must include the @channel-metadata@ permission for the channel in question.

--- a/content/partials/types/_push_channel.textile
+++ b/content/partials/types/_push_channel.textile
@@ -66,7 +66,7 @@ bq(definition).
   java,android: "PaginatedResult":#paginated-result<"PushChannelSubscription":#push-channel-subscription> listSubscriptions(String deviceId, String clientId, String deviceClientId, String channel)
   objc,swift:   listSubscriptions(deviceId: String?, clientId: String?, deviceClientId: String?, `channel: String?, callback: ("ARTPaginatedResult":#paginated-result<"PushChannelSubscription":#push-channel-subscription>?, ARTErrorInfo?) -> Void)
 
-Lists push subscriptions on a channel specified by its channel name (@channel@). These subscriptions can be either be a list of client (@clientId@) subscriptions, device (@deviceId@) subscriptions, or if @concatFilters@ is set to @true@, a list of both. This method requires clients to have the "Push Admin capability":push#push-admin. For more information, see @GET rest.ably.io/push/channelSubscriptions@ "Rest API":/docs/api/rest-api.
+Lists push subscriptions on a channel specified by its channel name (@channel@). These subscriptions can be either be a list of client (@clientId@) subscriptions, device (@deviceId@) subscriptions, or if @concatFilters@ is set to @true@, a list of both. This method requires clients to have the "Push Admin capability":push#push-admin. For more information, see @GET main.realtime.ably.net/push/channelSubscriptions@ "Rest API":/docs/api/rest-api.
 
 h4. Parameters
 

--- a/src/pages/docs/chat/moderation/direct/hive-dashboard.mdx
+++ b/src/pages/docs/chat/moderation/direct/hive-dashboard.mdx
@@ -35,7 +35,7 @@ The setup is as follows:
 2. Click "+ Create new"
 3. Ensure that the "Action type" is set to "POST"
 4. Enter a descriptive name for the action, for example "Delete message"
-5. Set the "Endpoint URL" field to `https://rest.ably.io/chat/v4/moderation/hive/delete` (if you have a [dedicated cluster](https://ably.com/docs/platform/account/enterprise-customization#setting-up-a-custom-environment) the domain should be your custom REST domain)
+5. Set the "Endpoint URL" field to `https://main.realtime.ably.net/chat/v4/moderation/hive/delete` (if you have a [dedicated cluster](https://ably.com/docs/platform/account/enterprise-customization#setting-up-a-custom-environment) the domain should be your custom REST domain)
 6. Under "Customize API Request" add the `Authorization` header with the value `Bearer <your Base64 encoded Ably API key>`, make sure to Base64 encode the API key you get from the Ably dashboard.
 7. Under "Request Body" add the following two params:
    * `serial` := `Post ID`

--- a/src/pages/docs/liveobjects/concepts/operations.mdx
+++ b/src/pages/docs/liveobjects/concepts/operations.mdx
@@ -237,7 +237,7 @@ In the [REST API](/docs/liveobjects/rest-api-usage#updating-objects-by-id), this
 
 <Code>
 ```shell
-curl -X POST https://rest.ably.io/channels/my-channel/objects \
+curl -X POST https://main.realtime.ably.net/channels/my-channel/objects \
  -u "{{API_KEY}}"
  -H "Content-Type: application/json" \
  --data \

--- a/src/pages/docs/liveobjects/rest-api-usage.mdx
+++ b/src/pages/docs/liveobjects/rest-api-usage.mdx
@@ -43,13 +43,13 @@ The key in the `data` object indicates the type of the value:
 
 ### List objects <a id="fetching-objects-list"/>
 
-`GET rest.ably.io/channels/<channelName>/objects`
+`GET main.realtime.ably.net/channels/<channelName>/objects`
 
 Fetch a flat list of objects on the channel:
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -75,7 +75,7 @@ To include values of the objects in the response, set the `values=true` query pa
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects?values=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects?values=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -140,7 +140,7 @@ You can optionally include additional object [metadata](/docs/liveobjects/concep
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects?values=true&metadata=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects?values=true&metadata=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -233,7 +233,7 @@ Use the `limit` query parameter to specify the maximum number of objects to incl
 
 <Code>
 ```shell
-  curl -v "https://rest.ably.io/channels/my-channel/objects?values=true&limit=2" \
+  curl -v "https://main.realtime.ably.net/channels/my-channel/objects?values=true&limit=2" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -275,7 +275,7 @@ The list objects endpoints returns objects ordered lexicographically by object I
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects?cursor=map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519&limit=2&values=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects?cursor=map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519&limit=2&values=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -318,7 +318,7 @@ The list objects endpoints returns objects ordered lexicographically by object I
 
 ### Get objects <a id="fetching-objects-get"/>
 
-`GET rest.ably.io/channels/<channelName>/objects/<objectId>`
+`GET main.realtime.ably.net/channels/<channelName>/objects/<objectId>`
 
 #### Get a single object <a id="fetching-objects-get-single"/>
 
@@ -326,7 +326,7 @@ To fetch a single object on the channel, specify the object ID in the URL path:
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -356,7 +356,7 @@ To fetch the objects on the channel in a tree structure use the `children` query
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root?children=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -414,7 +414,7 @@ You can optionally include additional object [metadata](/docs/liveobjects/concep
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true&metadata=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root?children=true&metadata=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -490,7 +490,7 @@ When fetching objects in a tree structure, the response can be paginated using t
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true&limit=1" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root?children=true&limit=1" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -516,7 +516,7 @@ To obtain the next page, make a subsequent query specifying the referenced objec
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519?children=true&limit=1" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/map:ja7cjMUib2LmJKTRdoGAG9pbBYCnkMObAVpmojCOmek@1745828596519?children=true&limit=1" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -551,7 +551,7 @@ For example, if we created a cycle in the object tree by adding a reference to t
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -566,7 +566,7 @@ The response will handle the cyclic reference by including the `myRoot` key in t
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root?children=true" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root?children=true" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -619,13 +619,13 @@ The response will handle the cyclic reference by including the `myRoot` key in t
 
 ### Get a compact view of objects <a id="fetching-objects-compact"/>
 
-`GET rest.ably.io/channels/<channelName>/objects/<objectId>/compact`
+`GET main.realtime.ably.net/channels/<channelName>/objects/<objectId>/compact`
 
 To fetch the objects on the channel in a tree structure in a concise format:
 
 <Code>
 ```shell
-  curl "https://rest.ably.io/channels/my-channel/objects/root/compact" \
+  curl "https://main.realtime.ably.net/channels/my-channel/objects/root/compact" \
     -u {{API_KEY}}
 ```
 </Code>
@@ -672,7 +672,7 @@ Pagination is not currently supported for the compact view of objects.
 
 ## Publishing operations <a id="publishing-operations"/>
 
-`POST rest.ably.io/channels/<channelName>/objects`
+`POST main.realtime.ably.net/channels/<channelName>/objects`
 
 All operations are published to the same endpoint. The request body specifies:
 
@@ -719,7 +719,7 @@ To perform operations on a specific object instance, you need to provide its obj
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -754,7 +754,7 @@ The following example increments the `LiveCounter` instance stored at the `up` k
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -775,7 +775,7 @@ You can use wildcards in paths to target multiple objects at once. To increment 
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -828,7 +828,7 @@ The following example increments the upvote `LiveCounter` instances for all post
 
 <Code>
 ```shell
-  curl -X POST "https://sandbox-rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -843,7 +843,7 @@ If your `LiveMap` keys contain periods, you can escape them with a backslash. Th
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -892,7 +892,7 @@ The following example creates a new `LiveMap` instance and assigns it to the `po
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -935,7 +935,7 @@ Remove a reference to a nested object in a `LiveMap` instance using the `MAP_REM
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -962,7 +962,7 @@ The following example shows how to increment two distinct `LiveCounter` instance
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '[
@@ -986,7 +986,7 @@ Publish operations idempotently in the same way as for [idempotent message publi
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '{
@@ -1002,7 +1002,7 @@ For batch operations, use the format `<baseId>:<index>` where the index is the z
 
 <Code>
 ```shell
-  curl -X POST "https://rest.ably.io/channels/my-channel/objects" \
+  curl -X POST "https://main.realtime.ably.net/channels/my-channel/objects" \
     -u {{API_KEY}} \
     -H "Content-Type: application/json" \
     -d '[

--- a/src/pages/docs/messages/batch.mdx
+++ b/src/pages/docs/messages/batch.mdx
@@ -192,7 +192,7 @@ The following is an example curl request, querying the [REST API](/docs/api/rest
 
 <Code>
 ```shell
-curl -X POST https://rest.ably.io/messages \
+curl -X POST https://main.realtime.ably.net/messages \
     -u "{{API_KEY}}" \
     -H "Content-Type: application/json" \
     --data '{ "channels": [ "test1", "test2"],

--- a/src/pages/docs/metadata-stats/metadata/rest.mdx
+++ b/src/pages/docs/metadata-stats/metadata/rest.mdx
@@ -21,7 +21,7 @@ The following is an example curl request to retrieve metadata from a channel:
 
 <Code>
 ```shell
-curl https://rest.ably.io/channels/<channelId> \
+curl https://main.realtime.ably.net/channels/<channelId> \
  -u "{{API_KEY}}"
 ```
 </Code>
@@ -48,7 +48,7 @@ The following is an example curl request to retrieve metadata from a channel:
 
 <Code>
 ```shell
-curl https://rest.ably.io/channels \
+curl https://main.realtime.ably.net/channels \
  -u "{{API_KEY}}"
 ```
 </Code>

--- a/src/pages/docs/platform/errors/codes.mdx
+++ b/src/pages/docs/platform/errors/codes.mdx
@@ -412,7 +412,7 @@ This error occurs when an app that belongs to a dedicated (private) [cluster](/d
 
 If a request arrives at an unexpected dedicated cluster or incorrect region, the account in that scope may be disabled, triggering this error.
 
-An example of this error is when a client intended for a dedicated environment, such as acme, connects to the default global endpoint (`realtime.ably.io`) instead of the correct dedicated cluster endpoint (`acme-realtime.ably.io`). If the expected environment is not configured, requests may be rejected.
+An example of this error is when a client intended for a dedicated environment, such as acme, connects to the default global endpoint (`main.realtime.ably.net`) instead of the correct dedicated cluster endpoint (`acme.realtime.ably.net`). If the expected environment is not configured, requests may be rejected.
 
 **Resolution:** Verify that all connecting clients are configured with the correct custom environment settings to ensure they are pointing to the intended dedicated cluster.
 

--- a/src/pages/docs/platform/integrations/inbound/webhooks.mdx
+++ b/src/pages/docs/platform/integrations/inbound/webhooks.mdx
@@ -33,7 +33,7 @@ Run the following Curl command to simulate an incoming webhook request:
 
 <Code>
 ```shell
-curl -X POST 'https://rest.ably.io/channels/webhook-test/messages?key={{API_KEY_NAME}}:{{API_KEY_SECRET}}&enveloped=false' \
+curl -X POST 'https://main.realtime.ably.net/channels/webhook-test/messages?key={{API_KEY_NAME}}:{{API_KEY_SECRET}}&enveloped=false' \
      -H 'content-type: application/json' --data '{"some":"json"}'
 ```
 </Code>
@@ -78,7 +78,7 @@ The following example demonstrates how to set a message `name` using the `X-Ably
 
 <Code>
 ```shell
-curl -X POST 'https://rest.ably.io/channels/webhook-test/messages?key=key:secret&enveloped=false' \
+curl -X POST 'https://main.realtime.ably.net/channels/webhook-test/messages?key=key:secret&enveloped=false' \
      -H 'content-type: application/json' --data '{"some":"json"}' \
      -H 'X-Ably-Name: webhook-message'
 ```

--- a/src/pages/docs/platform/integrations/streaming/index.mdx
+++ b/src/pages/docs/platform/integrations/streaming/index.mdx
@@ -147,7 +147,7 @@ For example, if you publish a JSON message to the channel `my_channel` using the
 
 <Code>
 ```shell
-curl -X POST https://rest.ably.io/channels/my_channel/messages \
+curl -X POST https://main.realtime.ably.net/channels/my_channel/messages \
           -u "{{API_KEY}}" \
           -H "Content-Type: application/json" \
           --data '{ "name": "publish", "data": "example" }'

--- a/src/pages/docs/platform/integrations/webhooks/index.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/index.mdx
@@ -444,7 +444,7 @@ For example, if you publish a message to the channel `my_channel` using the foll
 
 <Code>
 ```shell
-curl -X POST https://rest.ably.io/channels/my_channel/messages \
+curl -X POST https://main.realtime.ably.net/channels/my_channel/messages \
           -u "{{API_KEY}}" \
           -H "Content-Type: application/json" \
           --data '{ "name": "publish", "data": "example" }'

--- a/src/pages/docs/presence-occupancy/presence.mdx
+++ b/src/pages/docs/presence-occupancy/presence.mdx
@@ -1010,7 +1010,7 @@ The following is an example curl request, querying the REST API directly:
 
 <Code>
 ```shell
-curl -X GET https://rest.ably.io/presence?channel=quickstart,channel2 \
+curl -X GET https://main.realtime.ably.net/presence?channel=quickstart,channel2 \
     -u "{{API_KEY}}"
 ```
 </Code>

--- a/src/pages/docs/protocols/mqtt.mdx
+++ b/src/pages/docs/protocols/mqtt.mdx
@@ -40,7 +40,7 @@ Our MQTT adapter only supports features supported by both the MQTT protocol and 
 
 To use the Ably MQTT protocol adapter, you'll need to ensure you correctly configure your MQTT client as follows:
 
-* Set the host to "mqtt.ably.io"
+* Set the host to "main.mqtt.ably.net"
 * Set SSL / TLS to true and the port to 8883. (If your MQTT client does not support SSL, you should instead use port 1883, but in this case Ably disallows api-key auth—see [SSL usage note](#ssl) below)
 * Set the keep alive time to somewhere between 15 and 60 seconds. (60s will maximize battery life, 15s will maximize responsiveness to network issues. It must not be any higher than 60s to avoid our load balancer terminating the TCP socket for inactivity)
 * If using an API key, set the username to the part of the API key before the colon, and the password to the part after the colon
@@ -57,7 +57,7 @@ var options = {
   port: 8883
 };
 
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 ```
 </Code>
 
@@ -75,7 +75,7 @@ An example of this with the NodeJS [MQTT package](https://www.npmjs.com/package/
 
 <Code>
 ```javascript
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 client.subscribe('[mqtt]tokenevents');
 
 client.on('message', function(topic, message) {
@@ -89,7 +89,7 @@ client.on('message', function(topic, message) {
       /* reconnect with the new token */
       client.end();
       options.username = newToken;
-      client = mqtt.connect('mqtts:mqtt.ably.io', options);
+      client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
     });
     return;
   }
@@ -113,7 +113,7 @@ var options = {
   port: 8883
 };
 
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 
 client.on('message', function(topic, message) {
   console.log(decoder.decode(message));
@@ -145,7 +145,7 @@ channel.subscribe(function(message) {
 ```nodejs
 const encoding = require('text-encoding');
 var decoder = new encoding.TextDecoder();
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 
 client.on('connect', function () {
   client.subscribe('my_channel');
@@ -194,7 +194,7 @@ Read more in the [delta section](/docs/channels/options/deltas).
     password: '{{API_KEY_SECRET}}', /* API key's secret */
     port: 8883
   };
-  var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+  var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
   var channelName = 'sample-app-mqtt';
   var channelDecoder = new VcdiffDecoder();
 
@@ -237,7 +237,7 @@ var options = {
   password: '{{API_KEY_SECRET}}', /* API key's secret */
   port: 8883
 };
-var client = mqtt.connect('mqtts:mqtt.ably.io', options);
+var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 client.on('connect', () => {
   client.subscribe('[?rewind=1]{{RANDOM_CHANNEL_NAME}}');
 });

--- a/src/pages/docs/protocols/pubnub.mdx
+++ b/src/pages/docs/protocols/pubnub.mdx
@@ -47,7 +47,7 @@ const apiKey = "ablyApiKey";
 const pubnub = PubNub({
   subscribe_key: apiKey,
   publish_key: apiKey,
-  origin: 'pubnub.ably.io',
+  origin: 'main.pubnub.ably.net',
   ssl: true
 });
 ```
@@ -57,8 +57,8 @@ api_key = "ablyApiKey"
 pubnub = Pubnub.new(
   :subscribe_key => api_key,
   :publish_key   => api_key,
-  :origin        => 'pubnub.ably.io',
-  :origins_pool  => ["pubnub.ably.io"],
+  :origin        => 'main.pubnub.ably.net',
+  :origins_pool  => ["main.pubnub.ably.net"],
   :ssl           => true
 )
 ```

--- a/src/pages/docs/protocols/pusher.mdx
+++ b/src/pages/docs/protocols/pusher.mdx
@@ -53,8 +53,8 @@ Initialize your Pusher SDK to connect to Ably. All of Pusher's SDKs are supporte
 <Code>
 ```javascript
 const pusher = new Pusher('appId.keyId', {
-  wsHost: 'realtime-pusher.ably.io',
-  httpHost: 'realtime-pusher.ably.io',
+  wsHost: 'main.pusher.ably.net',
+  httpHost: 'main.pusher.ably.net',
   disableStats: true,
   forceTls: true,
   cluster: 'eu'

--- a/src/pages/docs/protocols/sse.mdx
+++ b/src/pages/docs/protocols/sse.mdx
@@ -45,7 +45,7 @@ The following code sample provides an example of how to use SSE with Ably:
 <Code>
 ```javascript
 var apiKey ='{{API_KEY}}';
-var url ='https://realtime.ably.io/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
+var url ='https://main.realtime.ably.net/event-stream?channels=myChannel&v=1.2&key=' + apiKey;
 var eventSource = new EventSource(url);
 
 eventSource.onmessage = function(event) {
@@ -96,7 +96,7 @@ const connectToAbly = () => {
 
   // establish a connection with that token
   const lastEventParam = lastEvent ? ('&lastEvent=' + lastEvent) : '';
-  eventSource = new EventSource(`https://realtime.ably.io/sse?v=1.1&accessToken=${token}&channels=${channel}${lastEventParam}`);
+  eventSource = new EventSource(`https://main.realtime.ably.net/sse?v=1.1&accessToken=${token}&channels=${channel}${lastEventParam}`);
 
   // handle incoming messages
   eventSource.onmessage = msg => {
@@ -161,7 +161,7 @@ You can subscribe to messages in delta mode, using the SSE transport, as follows
   /* Make sure to include <script src="https://cdn.ably.com/lib/delta-codec.min-1.js"></script> in your head */
   var key = '{{API_KEY}}';
   var channel = '{{RANDOM_CHANNEL_NAME}}';
-  var baseUrl = 'https://realtime.ably.io/event-stream';
+  var baseUrl = 'https://main.realtime.ably.net/event-stream';
   var urlParams = `?channels=${channel}&v=1.1&key=${key}&delta=vcdiff`;
   var url = baseUrl + urlParams;
   var eventSource = new EventSource(url);
@@ -202,7 +202,7 @@ For more information on enveloped and unenveloped SSE, please see the [SSE API](
 
   var key = '{{API_KEY}}';
   var channel = 'sample-app-sse';
-  var baseUrl = 'https://realtime.ably.io/event-stream';
+  var baseUrl = 'https://main.realtime.ably.net/event-stream';
   var urlParams = `?channels=${channel}&v=1.1&key=${key}&delta=vcdiff&enveloped=false`;
   var url = baseUrl + urlParams;
   var eventSource = new EventSource(url);
@@ -235,7 +235,7 @@ You can use the [`rewind`](/docs/channels/options/rewind) channel option to choo
 <Code>
 ```javascript
   var querystring = 'v=1.2&channels={{RANDOM_CHANNEL_NAME}}&rewind=1&key={{API_KEY}}';
-  var eventSource = new EventSource('https://realtime.ably.io/event-stream?' + querystring);
+  var eventSource = new EventSource('https://main.realtime.ably.net/event-stream?' + querystring);
 ```
 </Code>
 
@@ -247,7 +247,7 @@ Or to specify the same parameter but only applying to one channel of two, using 
   var channelTwo = 'channel2';
   var channels = channelOne + ',' + channelTwo;
   var querystring = 'v=1.2&key={{API_KEY}}&channels=' + channels';
-  var eventSource = new EventSource('https://realtime.ably.io/event-stream?' + querystring);
+  var eventSource = new EventSource('https://main.realtime.ably.net/event-stream?' + querystring);
 ```
 </Code>
 
@@ -259,7 +259,7 @@ The following is an example of subscribing to `[meta]stats:minute`:
 
 <Code>
 ```shell
-curl -s -u "{{API_KEY}}" "https://realtime.ably.io/sse?channel=[meta]stats:minute&v=1.2"
+curl -s -u "{{API_KEY}}" "https://main.realtime.ably.net/sse?channel=[meta]stats:minute&v=1.2"
 ```
 </Code>
 
@@ -304,6 +304,6 @@ The following is an example curl command subscribing to `[meta]stats:minute` wit
 
 <Code>
 ```shell
-curl -s -u "{{API_KEY}}" "https://realtime.ably.io/sse?channel=[meta]stats:minute&v=1.2&rewind=1"
+curl -s -u "{{API_KEY}}" "https://main.realtime.ably.net/sse?channel=[meta]stats:minute&v=1.2&rewind=1"
 ```
 </Code>


### PR DESCRIPTION
## Description

This PR updates the listed endpoints from `ably.io` to the new formats;

* `realtime.ably.io` and `rest.ably.io` consolidated to `main.realtime.ably.net`
* `mqtt.ably.io` to `main.mqtt.ably.net`
* `pusher.ably.io` and `realtime-pusher.ably.io` to `main.pusher.ably.net`
* `pubnub.ably.io` to `main.pubnub.ably.net`

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
