### PR TITLE
[EDU-2090] - Add description to cli section of getting started guides

### DIFF
--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -40,7 +40,7 @@ implementation("com.ably.chat:chat-extensions-compose:<latest-version>")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -56,7 +56,7 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -53,7 +53,7 @@ implementation("org.slf4j:slf4j-nop:2.0.17")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -47,7 +47,7 @@ cd ios && pod install && cd ..
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react-ui-components.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-components.mdx
@@ -59,7 +59,7 @@ That's all the setup you need—the kit's CSS is automatically bundled by Vite a
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -54,7 +54,7 @@ echo "VITE_ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -19,7 +19,7 @@ You'll learn how to create chat rooms, send and edit messages, and implement rea
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -35,7 +35,7 @@ dotnet add package ably.io
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -161,7 +161,7 @@ Initialize the Ably service at the application level to prevent it from being re
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -28,7 +28,7 @@ go get -u github.com/ably/ably-go/ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -46,7 +46,7 @@ You'll establish a realtime connection to Ably and learn to publish and subscrib
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -20,7 +20,7 @@ You'll establish a realtime connection to Ably and learn to publish and subscrib
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -25,7 +25,7 @@ implementation("io.ably:ably-java:<latest-version>")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/laravel.mdx
+++ b/src/pages/docs/getting-started/laravel.mdx
@@ -44,7 +44,7 @@ npm run dev
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably Pub/Sub and Chat applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -38,7 +38,7 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -40,7 +40,7 @@ https://github.com/ably/ably-cocoa
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -38,7 +38,7 @@ composer require ably/ably-php
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -35,7 +35,7 @@ pip install ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -139,7 +139,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -147,7 +147,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -33,7 +33,7 @@ The realtime interface of the Ruby SDK must be run within an [EventMachine](http
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -29,10 +29,9 @@ dependencies: [
 ```
 </Code>
 
-
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-The [Ably CLI](https://github.com/ably/cli) provides a command-line interface for managing your Ably applications directly from your terminal.
+Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
 1. Install the Ably CLI:
 


### PR DESCRIPTION
## Description

This PR updates the Ably CLI descriptions across all getting started guides to give context as to why it would be useful to sue the CLI while following the guide.