### PR TITLE
Add message/client-summary endpoint docs

### DIFF
--- a/content/api/rest-api.textile
+++ b/content/api/rest-api.textile
@@ -675,6 +675,32 @@ bc[json]. [{
   extras: <optional extras object>,
 }]
 
+h3(#annotations-client-summary). Retrieve annotation summary for a specific clientId
+
+h6. GET rest.ably.io/channels/@<channelId>@/messages/@<messageSerial>@/client-summary
+
+Retrieve the annotation summary for a specific clientId for a specific message identified by its serial.
+
+Example request:
+
+bc[sh]. curl https://rest.ably.io/channels/rest-example/messages/01726585978590-001@abcdefghij:001/client-summary?forClientId=client1 \
+ -u "{{API_KEY}}"
+
+h5. Parameters
+
+- forClientId := _client1_ The clientId to retrieve the annotation summary for. It defaults to the clientId of the authenticated client.
+
+h5. Options
+
+- Accept := @application/json@ by default, or @application/x-msgpack@
+- Auth required := yes ("basic":#basic-authentication or "token":#token-authentication)
+
+h5. Returns
+
+A successful request returns an object containing the annotation summary for the specified message, clipped to only include the summary for the requested clientId.
+
+The summary is an object whose keys are annotation types, and the values are aggregated summaries for that annotation type.
+
 h2(#push). Push
 
 h3(#post-device-registration). Register a device for receiving push notifications


### PR DESCRIPTION
## Description

Add client-summary endpoint docs. https://ably.atlassian.net/browse/CHA-1199

I wasn't sure how to document the response of the summary. It's the just the annotation summary, clipped, and only including the entries that are relevant for the requested clientId. Should I add an example? I just copied the text that describes the summary from the _message_annotations partial.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
