### PR TITLE
fix: remove pricing calculator reference from livestream chat

### DIFF
--- a/src/pages/docs/guides/chat/build-livestream.mdx
+++ b/src/pages/docs/guides/chat/build-livestream.mdx
@@ -285,7 +285,7 @@ Livestreams can be a high-churn affair, with many users coming and going through
 
 If you have an audience that is relatively consistent, for example a number of people sign up for an event and then stay for the duration, Ably also offers a competitive MAU pricing model in addition to the traditional consumption-based model for these scenarios.
 
-A full breakdown of pricing, as well as a cost estimator for your scenario, can be found on the [pricing page](/pricing).
+A full breakdown of Ably's pricing can be found on the [pricing page](/pricing).
 
 ### Server-side message batching <a id="server-side-batching"/>
 


### PR DESCRIPTION
## Description

This PR removes reference to the pricing calculator from the Livestream guide, as it no longer exists.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
