### PR TITLE
[WEB-4691] chore: update inkeep support link to /support

### DIFF
--- a/src/external-scripts/inkeep.ts
+++ b/src/external-scripts/inkeep.ts
@@ -157,13 +157,10 @@ const aiChatSettings = () => ({
       isPinnedToToolbar: true,
     },
     {
-      name: 'Chat with support',
+      name: 'Get support',
       action: {
-        type: 'invoke_callback',
-        callback: () => {
-          openHubSpotConversations();
-        },
-        shouldCloseModal: true,
+        type: 'open_link',
+        url: '/support',
       },
       isPinnedToToolbar: true,
     },


### PR DESCRIPTION
Addresses 1) here https://ably.atlassian.net/jira/software/projects/WEB/boards/172?jql=assignee%20%3D%20712020%3A73c2b278-c45e-41aa-b656-78a09f53eae4&selectedIssue=WEB-4691.

Updates the "Chat with support" link in the Inkeep modal to "Get support" and points it to our own support page.

<img width="743" height="503" alt="Screenshot 2025-10-09 at 16 45 31" src="https://github.com/user-attachments/assets/8d800761-2d39-43a3-838c-402db79bbdf3" />
