### PR TITLE
Fix lang param to default to first supported language on page

### DIFF
--- a/src/contexts/layout-context.tsx
+++ b/src/contexts/layout-context.tsx
@@ -37,7 +37,7 @@ const determineActiveLanguage = (
   const params = new URLSearchParams(location);
   const langParam = params.get('lang') as LanguageKey;
 
-  if (langParam && Object.keys(languageInfo).includes(langParam)) {
+  if (langParam && Object.keys(languageInfo).includes(langParam) && activeLanguages.includes(langParam)) {
     return langParam;
   } else if (activeLanguages.length > 0 && product) {
     const relevantLanguages = activeLanguages.filter((lang) => Object.keys(languageData[product]).includes(lang));


### PR DESCRIPTION
## Description

Fixes a bug where unsupported language query parameters cause all language-specific content to be displayed simultaneously on MDX pages.

## Problem

When a user visits an MDX page with a `?lang=` query parameter for a language that exists globally but isn't supported on that specific page (e.g., `?lang=python` on the statistics page which only supports JavaScript, Ruby, Java, etc.), the following occurred:

1. `determineActiveLanguage()` would validate the language parameter against the global `languageInfo` object
2. If the language existed globally, it would return that language even though the page doesn't support it
3. The layout context would then set `language: null` because the language wasn't in the page's `activeLanguages` array
4. The `<If>` component checks `if (lang !== undefined && language)` - when `language` is `null`, this condition becomes false
5. With the language check skipped entirely, `shouldShow` remains `true` for all `<If>` blocks
6. **Result:** All language-specific content renders simultaneously, creating a confusing mess
