### PR TITLE
Add Java examples for message annotations in docs

### DIFF
--- a/src/pages/docs/messages/annotations.mdx
+++ b/src/pages/docs/messages/annotations.mdx
@@ -228,6 +228,27 @@ await channel.annotations.publish(message.serial, {
   name: 'delivered'
 });
 ```
+
+```java
+// Create an Ably Realtime client specifying the clientId that will
+// be associated with annotations published by this client
+ClientOptions options = new ClientOptions("{{API_KEY}}");
+options.clientId = "my-client-id";
+AblyRealtime realtime = new AblyRealtime(options);
+
+// Create a channel in a namespace called `annotations`
+// which has message annotations enabled
+Channel channel = realtime.channels.get("annotations:example");
+
+// Publish an annotation for a message that flags it as delivered
+Annotation annotation = new Annotation();
+annotation.type = "receipts:flag.v1";
+annotation.name = "delivered";
+channel.annotations.publish(message, annotation);
+
+// You can also use a message's `serial`
+channel.annotations.publish(message.serial, annotation);
+```
 </Code>
 
 In the case of the `distinct`, `unique`, or `multiple` aggregation types, you should also specify a `name`. For these types, each different name will be aggregated separately in the [annotation summary](#annotation-summaries).
@@ -249,6 +270,15 @@ await channel.annotations.publish(message.serial, {
   name: 'stars',
   count: 4
 });
+```
+
+```java
+Annotation annotation = new Annotation();
+annotation.type = "rating:multiple.v1";
+annotation.name = "stars";
+annotation.count = 4;
+
+channel.annotations.publish(message.serial, annotation);
 ```
 </Code>
 
@@ -296,6 +326,24 @@ await channel.annotations.delete(message.serial, {
   name: 'delivered'
 });
 ```
+
+```java
+// Create an Ably Realtime client specifying the clientId that will
+// be associated with annotations published by this client
+ClientOptions options = new ClientOptions("{{API_KEY}}");
+options.clientId = "my-client-id";
+AblyRealtime realtime = new AblyRealtime(options);
+
+// Create a channel in a namespace called `annotations`
+// which has message annotations enabled
+Channel channel = realtime.channels.get("annotations:example");
+
+// Delete a 'delivered' annotation
+Annotation annotation = new Annotation();
+annotation.type = "receipts:flag.v1";
+annotation.name = "delivered";
+channel.annotations.delete(message.serial, annotation);
+```
 </Code>
 
 ## Subscribe to annotation summaries <a id="subscribe" />
@@ -339,6 +387,24 @@ const channel = realtime.channels.get('annotations:example');
 await channel.subscribe((message) => {
   if (message.action === 'message.summary') {
     console.log(message.annotations.summary);
+  }
+});
+```
+
+```java
+// Create an Ably Realtime client specifying the clientId that will
+// be associated with annotations published by this client
+ClientOptions options = new ClientOptions("{{API_KEY}}");
+options.clientId = "my-client-id";
+AblyRealtime realtime = new AblyRealtime(options);
+
+// Create a channel in a namespace called `annotations`
+// which has message annotations enabled
+Channel channel = realtime.channels.get("annotations:example");
+
+channel.subscribe(message -> {
+  if (message.action == MessageAction.MESSAGE_SUMMARY) {
+    System.out.println(message.annotations.summary);
   }
 });
 ```
@@ -471,6 +537,30 @@ await channel.annotations.subscribe((annotation) => {
     console.log(`New ${annotation.type} annotation with name ${annotation.name} from ${annotation.clientId}`);
   } else if (annotation.action === 'annotation.delete') {
     console.log(`${annotation.clientId} deleted a ${annotation.type} annotation with name ${annotation.name}`);
+  }
+});
+```
+
+```java
+// Create an Ably Realtime client specifying the clientId that will
+// be associated with annotations published by this client
+ClientOptions options = new ClientOptions("{{API_KEY}}");
+options.clientId = "my-client-id";
+AblyRealtime realtime = new AblyRealtime(options);
+
+// Create a channel in a namespace called `annotations`
+// which has message annotations enabled
+Channel channel = realtime.channels.get("annotations:example");
+
+channel.annotations.subscribe(annotation -> {
+  if (annotation.action == AnnotationAction.ANNOTATION_CREATE) {
+    System.out.println(
+      String.format("New %s annotation with name %s from %s", annotation.type, annotation.name, annotation.clientId)
+    );
+  } else if (annotation.action == AnnotationAction.ANNOTATION_DELETE) {
+    System.out.println(
+      String.format("%s deleted a %s annotation with name %s", annotation.clientId, annotation.type, annotation.name)
+    );
   }
 });
 ```


### PR DESCRIPTION


## Description

Add Java examples for message annotations in docs

- Included Java code snippets for creating, publishing, deleting, and subscribing to annotations.
- Updated documentation to demonstrate usage of annotations API with Java examples.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
