### PR TITLE
Update /contact links to be /support where needed

### DIFF
--- a/content/api/realtime-sdk/authentication.textile
+++ b/content/api/realtime-sdk/authentication.textile
@@ -531,7 +531,7 @@ The following is an example of creating an Ably JWT:
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 
-*Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party. If this is something you'd be interested in, please "get in touch":https://ably.com/contact.
+*Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party.
 
 h3(#batch-result).
   jsall: BatchResult

--- a/content/api/rest-sdk/authentication.textile
+++ b/content/api/rest-sdk/authentication.textile
@@ -564,7 +564,7 @@ The following is an example of creating an Ably JWT:
   var ablyJwt = base64Header + "." + base64Claims + "." + signature;
 ```
 
-*Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party. If this is something you'd be interested in, please "get in touch":https://ably.com/contact.
+*Note:* At present Ably does not support asymmetric signatures based on a keypair belonging to a third party.
 
 h3(#batch-result).
   jsall: BatchResult

--- a/src/components/Article/ArticleFooter.tsx
+++ b/src/components/Article/ArticleFooter.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { contactUsClickTracker, supportClickTracker } from 'src/external-scripts/google-tag-manager/events';
+import { supportClickTracker } from 'src/external-scripts/google-tag-manager/events';
 import { InArticleBanner, InArticleBannerCopy, InArticleOptions } from './InArticleBanner';
 
 export const ArticleFooter = () => (
@@ -20,9 +19,6 @@ export const ArticleFooter = () => (
       primaryOptionLabel="Support &amp; Help"
       primaryOptionDestination="/support"
       primaryTracker={supportClickTracker}
-      secondaryOptionLabel="Contact Us"
-      secondaryOptionDestination="/contact"
-      secondaryTracker={contactUsClickTracker}
     />
   </InArticleBanner>
 );

--- a/src/components/Article/InArticleBanner/InArticleOptions.tsx
+++ b/src/components/Article/InArticleBanner/InArticleOptions.tsx
@@ -12,16 +12,10 @@ export const InArticleOptions = ({
   primaryOptionLabel,
   primaryOptionDestination,
   primaryTracker,
-  secondaryOptionLabel,
-  secondaryOptionDestination,
-  secondaryTracker,
 }: {
   primaryOptionLabel: string;
   primaryOptionDestination: string;
   primaryTracker: () => void;
-  secondaryOptionLabel: string;
-  secondaryOptionDestination: string;
-  secondaryTracker: () => void;
 }) => (
   <div className="flex flex-row mt-4 gap-4">
     <a
@@ -30,13 +24,6 @@ export const InArticleOptions = ({
       className="ui-button-primary"
     >
       {primaryOptionLabel}
-    </a>
-    <a
-      onClick={linkClickWithTracker(secondaryTracker, secondaryOptionDestination)}
-      href={secondaryOptionDestination}
-      className="ui-button-secondary"
-    >
-      {secondaryOptionLabel}
     </a>
   </div>
 );

--- a/src/components/Examples/ExamplesNoResults.tsx
+++ b/src/components/Examples/ExamplesNoResults.tsx
@@ -19,7 +19,7 @@ const ExamplesNoResults = () => {
       </div>
       <p className="mt-4 ui-text-p3 text-neutral-1000">
         or{' '}
-        <Link to="/contact" className="ui-link">
+        <Link to="/support" className="ui-link">
           Suggest an example
         </Link>
       </p>

--- a/src/pages/docs/liveobjects/storage.mdx
+++ b/src/pages/docs/liveobjects/storage.mdx
@@ -14,7 +14,7 @@ LiveObjects is currently Experimental. Its features are still in development and
 Ably durably stores all objects on a channel for a retention period that is configured to 90 days by default. If the data is not updated within the retention period, it will automatically expire. After expiry, the channel is reset to its initial state and only includes an empty [root object](/docs/liveobjects/concepts/objects#root-object).
 
 <Aside data-type='note'>
-If you're interested in a configurable default object storage duration, please [get in touch](https://ably.com/contact) with your requirements.
+If you're interested in a configurable default object storage duration, please [get in touch](https://ably.com/support) with your requirements.
 </Aside>
 
 ## Store objects outside of Ably <a id="outside-persistence"/>
@@ -24,7 +24,7 @@ You can store your objects outside of Ably by obtaining the channel objects via 
 In order to receive notifications when the objects on a channel are updated, use [inband objects](/docs/liveobjects/inband-objects) to receive updates as regular channel messages.
 
 <Aside data-type='note'>
-If you're interested in exporting objects to your own systems using [integration rules](/docs/platform/integrations/webhooks), please [get in touch](https://ably.com/contact) with your requirements.
+If you're interested in exporting objects to your own systems using [integration rules](/docs/platform/integrations/webhooks), please [get in touch](https://ably.com/support) with your requirements.
 </Aside>
 
 ## Operation storage <a id="operation-persistence"/>
@@ -40,7 +40,7 @@ Operations themselves are not included in the [history](/docs/storage-history/hi
 There is a maximum number of objects that can be stored on a [channel](/docs/platform/pricing/limits#channel), which is configured to 100 objects by default.
 
 <Aside data-type='note'>
-If you're interested storing a larger number of objects on a channel, please [get in touch](https://ably.com/contact) with your requirements.
+If you're interested storing a larger number of objects on a channel, please [get in touch](https://ably.com/support) with your requirements.
 </Aside>
 
 A `LiveCounter` is a double-precision floating-point number and has a size of 8 bytes.

--- a/src/pages/docs/platform/account/organizations.mdx
+++ b/src/pages/docs/platform/account/organizations.mdx
@@ -13,7 +13,7 @@ Organizations enable the [primary](#primary) account to assign and adjust the ro
 You can separate accounts within an organization to create isolated environments, such as production, staging, and development. Assign each environment a [package](/docs/pricing#packages) that meets its specific needs. For example, production may need high capacity with an **Enterprise** package, staging might use a **Standard** package, and development a **Free** package.
 
 <Aside data-type='note'>
-An [Enterprise](/docs/platform/pricing/enterprise) account is required to use organizations. [Contact us](https://ably.com/contact) to enable organizations for your account.
+An [Enterprise](/docs/platform/pricing/enterprise) account is required to use organizations. [Contact us](https://ably.com/support) to enable organizations for your account.
 </Aside>
 
 ## Primary account <a id="primary"/>

--- a/src/pages/docs/platform/account/sso.mdx
+++ b/src/pages/docs/platform/account/sso.mdx
@@ -10,7 +10,7 @@ Single sign-on (SSO) enables your users to authenticate via any SAML-compatible 
 
 ## Configure <a id="configure"/>
 
-Single sign-on is restricted to Enterprise customers only and must be enabled on a per-account basis by [contacting Ably](https://ably.com/contact). Only [account owners](/docs/platform/account/users) can configure SSO for an account.
+Single sign-on is restricted to Enterprise customers only and must be enabled on a per-account basis by [contacting Ably](https://ably.com/support). Only [account owners](/docs/platform/account/users) can configure SSO for an account.
 
 Any SAML-compatible identity provider can be used to enable SSO.
 

--- a/src/pages/docs/platform/pricing/faqs.mdx
+++ b/src/pages/docs/platform/pricing/faqs.mdx
@@ -80,7 +80,7 @@ No. This is not necessary as Ably's online Terms incorporate everything that is 
 
 ### Is Ably compliant with HIPAA (Health Insurance Portability and Accountability Act)? <a id="hipaa"/>
 
-The following information outlines Ably's compliance with the US HIPAA Security Rule. If you require further information then [contact us](https://ably.com/contact) to find out more.
+The following information outlines Ably's compliance with the US HIPAA Security Rule. If you require further information then [contact us](https://ably.com/support) to find out more.
 
 #### Is Ably a 'covered entity' which is required to comply with the HIPAA Security Rule?
 

--- a/src/pages/docs/protocols/mqtt.mdx
+++ b/src/pages/docs/protocols/mqtt.mdx
@@ -161,7 +161,7 @@ In the above example, `command` will now contain the message in its original str
 
 ## SSL/TLS <a id="ssl-tls"/>
 
-Ably supports both SSL and non-SSL connections (the latter uses a different port, see above), but strongly recommends using SSL wherever possible. If you are not using SSL, note that the same restrictions apply as if you were using an Ably client without SSL. That is, [connection attempts using Basic Authentication (i.e. an API key) are disallowed](/docs/auth/basic), and any [namespaces which you've enabled 'require TLS' on](/docs/channels) will be inaccessible. [Contact us](https://ably.com/contact) if this is a problem for you.
+Ably supports both SSL and non-SSL connections (the latter uses a different port, see above), but strongly recommends using SSL wherever possible. If you are not using SSL, note that the same restrictions apply as if you were using an Ably client without SSL. That is, [connection attempts using Basic Authentication (i.e. an API key) are disallowed](/docs/auth/basic), and any [namespaces which you've enabled 'require TLS' on](/docs/channels) will be inaccessible. [Contact us](https://ably.com/support) if this is a problem for you.
 
 ## Channel options <a id="channel-options"/>
 


### PR DESCRIPTION
## Description

Some of the /contact links aren't necessarily for sales any, but instead for support. So updated these links from /contact to /support.

WEB-4728