### PR TITLE
chat: direct users to normal contact form for history retention

### DIFF
--- a/src/pages/docs/chat/rooms/history.mdx
+++ b/src/pages/docs/chat/rooms/history.mdx
@@ -3,7 +3,7 @@ title: Message storage and history
 meta_description: "Retrieve previously sent messages from history."
 ---
 
-The history feature enables users to retrieve messages that have been previously sent in a room. Ably stores chat messages for 30 days by default. You can extend this up to 365 days by [contacting us](https://forms.gle/SmCLNFoRrYmkbZSf8).
+The history feature enables users to retrieve messages that have been previously sent in a room. Ably stores chat messages for 30 days by default. You can extend this up to 365 days by [contacting us](https://ably.com/support).
 
 ## Retrieve previously sent messages <a id="history"/>
 


### PR DESCRIPTION
## Description

We were directing people to a chat features/feedback form, whereas it should go via the usual support channels if requesting package changes.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
