### PR TITLE
Update python push publish

### DIFF
--- a/src/pages/docs/push/publish.mdx
+++ b/src/pages/docs/push/publish.mdx
@@ -1163,7 +1163,7 @@ extras = {
 message = Message(name='event', data='message', extras=extras)
 
 channel = realtime.channels.get('pushenabled:foo')
-channel.publish(message);
+channel.publish(message)
 ```
 
 ```realtime_csharp


### PR DESCRIPTION
## Description

Updating the Python example for sending a push via a channel publish. Note this works for the async version of the SDK currently but not the sync version see https://github.com/ably/ably-python/issues/632 so not sure if we need to wait to see the outcome of that or add a note. 

The current example errors with `Unexpected type <class 'dict'>`

Please make any necessary changes

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
