### PR TITLE
chat: remove [chat] qualifier from documentation

### DIFF
--- a/src/pages/docs/chat/setup.mdx
+++ b/src/pages/docs/chat/setup.mdx
@@ -33,10 +33,13 @@ API keys and tokens have a set of [capabilities](/docs/auth/capabilities) assign
 | Typing indicators | `publish`, `subscribe` |
 | Room reactions | `publish`, `subscribe` |
 
-When setting the capabilities for Chat, you need to apply them to either a wildcard resource, or a wildcard resource prefixed with the chat namespace, for example:
+When setting the capabilities for Chat, you can apply them to specific chat rooms, a group of chat rooms in a common namespace, or all chat rooms:
 
-* `[chat]*` or
-* `[*]*`
+* `my-chat-room` or
+* `dms:*` or
+* `*`
+
+For more guidance, see the [capabilities documentation](/docs/auth/capabilities).
 
 ## Install <a id="install"/>
 

--- a/src/pages/docs/guides/chat/build-livestream.mdx
+++ b/src/pages/docs/guides/chat/build-livestream.mdx
@@ -93,7 +93,7 @@ const currentTime = Math.round(Date.now() / 1000);
 const claims = {
     "iat": currentTime, /* current time in seconds */
     "exp": currentTime + 14400, /* time of expiration in seconds */
-    "x-ably-capability": "{\"[chat]foo\":[\"publish\", \"subscribe\"]}",
+    "x-ably-capability": "{\"foo\":[\"publish\", \"subscribe\"]}",
     "x-ably-clientId": "your-client-id",
 }
 


### PR DESCRIPTION
## Description

Using the `[chat]` qualifier has recently been deprecated. This change removes it from the docs.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
