### PR TITLE
update_python_rest_batch_publish_example

### DIFF
--- a/src/pages/docs/messages/batch.mdx
+++ b/src/pages/docs/messages/batch.mdx
@@ -66,9 +66,9 @@ content = {
     }
 }
 
-response = await ably_rest.request('POST', '/messages', 3, body=content)
+response = await ably_rest.request('POST', '/messages', '3', body=content)
 
-if response.is_success:
+if response.success:
     print('Success! status code was', response.status_code)
 else:
     print('An error occurred; err =', response.error_message)


### PR DESCRIPTION
## Description

python batch publish example errors. The signature of request is `request(self, method: str, path: str, version: str, params: Optional[dict] = None, body=None, headers=None)` so version parameter is a string.

Reponse is a `HttpPaginatedResponse` and doesn't have a is_success method but has `success` instead

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
