### PR TITLE
[WEB-4765] chore: add sandpack to nginx CORS origin list

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -77,6 +77,7 @@ http {
     ~*https://ably-docs-[a-z0-9\-]*\.herokuapp\.com $http_origin;
     ~http://localhost:\d+ $http_origin;
     ~https?://ably\.test $http_origin;
+    ~^https?://[a-zA-Z0-9\-]+\-sandpack\.codesandbox\.io $http_origin;
   }
 
   # Further down in the configs where we can expect CORS requests we combine


### PR DESCRIPTION
Whitelists Sandpack URLs in the CORS origin list, i.e. `https://2-19-8-sandpack.codesandbox.io/`, for use with auth examples.