### PR TITLE
Fix chat-swift guidance for when app returns from background

### DIFF
--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -1213,14 +1213,15 @@ struct ContentView: View {
         }
     }
 
-    private func handleScenePhaseChange(_ phase: ScenePhase) async {
+    private func handleScenePhaseChange(_ phase: ScenePhase) async throws {
         switch phase {
         case .background:
             // Disconnect when app goes to background
             chatClient.realtime.connection.close()
         case .active:
-            // Reconnect when app becomes active
+            // Reconnect and reattach the room when app becomes active
             chatClient.realtime.connection.connect()
+            try await room?.attach()
         case .inactive:
             // Handle inactive state if needed
             break


### PR DESCRIPTION
We had a user report in https://github.com/ably/ably-chat-swift/issues/461 that our guidance is not working (that the room does not reattach). This is because closing the connection puts the channel into `DETACHED`, so the user needs to explicitly reattach the room later.