### PR TITLE
chat: add missing connection status enum values

### DIFF
--- a/src/pages/docs/chat/connect.mdx
+++ b/src/pages/docs/chat/connect.mdx
@@ -16,6 +16,8 @@ A connection can have any of the following statuses:
 | connected | A connection exists and is active. |
 | disconnected | A temporary failure condition when no current connection exists. The disconnected status is entered if an established connection is dropped, or if a connection attempt is unsuccessful. |
 | suspended | A long term failure condition when no current connection exists because there is no network connectivity or available host. The suspended status is entered after a failed connection attempt if there has then been no connection for a period of two minutes. In the suspended status, an SDK will periodically attempt to open a new connection every 30 seconds. Rooms will be reattached on a successful reconnection, however message history will not be automatically recovered. |
+| closing | An explicit request by the developer to close the connection has been sent to the Ably service. If a reply is not received from Ably within a short period of time, the connection is forcibly terminated and the connection status becomes Closed. |
+| closed | The connection has been explicitly closed by the client. In the closed state, no reconnection attempts are made automatically. No connection state is preserved by the service or the library. |
 | failed | This status is entered if the SDK encounters a failure condition that it cannot recover from. This may be a fatal connection error received from the Ably service, such as an attempt to connect with an incorrect API key, or some local terminal error, such as that the token in use has expired and the SDK does not have any way to renew it. |
 
 <If lang="javascript,swift,kotlin">


### PR DESCRIPTION
## Description

We were missing Closing and Closed.

[CHA-1225]

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).


[CHA-1225]: https://ably.atlassian.net/browse/CHA-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ