### PR TITLE
Fix formatting in IFTTT webhooks documentation

### DIFF
--- a/src/pages/docs/platform/integrations/webhooks/ifttt.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/ifttt.mdx
@@ -40,7 +40,7 @@ The following settings are available when creating an IFTTT integration:
 
 IFTTT has limitations on the data it can process. All payloads must be `JSON` and use only the keys `value1`, `value2`, or `value3`. Any other format or additional keys will not be processed.
 
-As a result, [enveloping](/docs/platform/integrations/webhooks#enveloped), "batching":/docs/platform/integrations/webhooks#batching are not supported. Additionally, protocols that require decoding such as [MQTT](/docs/protocols/mqtt), are not supported with IFTTT.
+As a result, [enveloping](/docs/platform/integrations/webhooks#enveloped) and [batching](/docs/platform/integrations/webhooks#batching) are not supported. Additionally, protocols that require decoding such as [MQTT](/docs/protocols/mqtt), are not supported with IFTTT.
 
 To ensure data is processed by IFTTT, it must match the required IFTTT structure. The following example shows the headers and payload sent to IFTTT when a message is sent to a channel:
 


### PR DESCRIPTION
## Description

Fix link formatting in IFTTT webhooks documentation page.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
