### PR TITLE
Chore: bump @ably/chat to 1.1.0 and @ably/chat-react-ui-kit to 0.3.0

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -102,8 +102,8 @@
     "spaces-member-location-react": "yarn workspace spaces-member-location-react dev"
   },
   "dependencies": {
-    "@ably/chat": "^1.0.0",
-    "@ably/chat-react-ui-kit": "^0.2.0",
+    "@ably/chat": "^1.1.0",
+    "@ably/chat-react-ui-kit": "^0.3.0",
     "@ably/spaces": "^0.4.0",
     "ably": "^2.14.0",
     "cors": "^2.8.5",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@ably/chat-react-ui-kit@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@ably/chat-react-ui-kit/-/chat-react-ui-kit-0.2.0.tgz#292b7a06053baf08c15ec868848ac896c96f0960"
-  integrity sha512-SBqJhY7CKzjDIPGcuDmc302+QRID+4oqq4+RIdHxAF0fOlNJGooHEiEzzG/lenKnITDuLuSMIAkR8HSKATrfog==
+"@ably/chat-react-ui-kit@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@ably/chat-react-ui-kit/-/chat-react-ui-kit-0.3.0.tgz#4439cfd3df4521738c105f504cb6d14e5f1f34fe"
+  integrity sha512-1Fbn0Np3oNIM/R/ISs/snsVNfVF0hX3nUxc494YTdX+gHep1L4GP1xJCUkMaosKv6ixsIcphosXyxD1Ni0gf1A==
   dependencies:
     clsx "^2.1.1"
 
-"@ably/chat@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ably/chat/-/chat-1.0.0.tgz#46fee649c9908cc90c278b3b973982050e1424ae"
-  integrity sha512-001+DfhCFWTAD6CAZSltdIR9TMaznWsHOMyDN23vhPoFVGmM1nlXl9uTh3OE695pHfOrTuD/AqGC5J4qWYrrmA==
+"@ably/chat@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ably/chat/-/chat-1.1.0.tgz#c78162e6dda753ee5e289b6aea8363b823d113a1"
+  integrity sha512-3aPMSYdwhUnd7RMITnzByeM08yxD9ho/znX/S01tcDIpVoCf6xmP9RcYZZ3+miU9Mh6+2gbVjS4QC5RNGmYqTQ==
   dependencies:
     async-mutex "^0.5.0"
     dequal "^2.0.3"

--- a/src/components/Examples/ExamplesRenderer.tsx
+++ b/src/components/Examples/ExamplesRenderer.tsx
@@ -43,7 +43,7 @@ const getDependencies = (id: string, products: string[], activeLanguage: Languag
     'franken-ui': '^2.0.0',
     ...(products.includes('auth') ? { cors: '^2.8.5' } : {}),
     ...(products.includes('chat')
-      ? { '@ably/chat': '^1.0.0', '@ably/chat-react-ui-kit': '^0.2.0', clsx: '^2.1.1' }
+      ? { '@ably/chat': '^1.1.0', '@ably/chat-react-ui-kit': '^0.3.0', clsx: '^2.1.1' }
       : {}),
     ...(products.includes('spaces') ? { '@ably/spaces': '^0.4.0' } : {}),
     ...(id === 'spaces-component-locking' ? { 'usehooks-ts': '^3.1.0' } : {}),

--- a/src/data/languages/languageData.ts
+++ b/src/data/languages/languageData.ts
@@ -24,8 +24,8 @@ export default {
     laravel: '1.0',
   },
   chat: {
-    javascript: '1.0',
-    react: '1.0',
+    javascript: '1.1',
+    react: '1.1',
     swift: '1.0',
     kotlin: '1.0',
   },


### PR DESCRIPTION
## Description

Bump chat-js and chat-react-ui-kit to latest versions. 

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
