### PR TITLE
Fixed broken in page links where an extra # was being added

### DIFF
--- a/src/pages/docs/api/realtime-sdk/channels.mdx
+++ b/src/pages/docs/api/realtime-sdk/channels.mdx
@@ -1400,7 +1400,7 @@ Checks if a channel is in a given state and returns `null` if it is, else calls 
 Returns a promise. If the channel is already in the given state, the promise will immediately resolve to `null`. If not, it will call [`once()`](#once) to return a promise which resolves the next time the channel transitions to the given state.
 </If>
 
-## Related types <a id="#related-types" />
+## Related types <a id="related-types" />
 
 ### <If lang="javascript,nodejs">ChannelState</If><If lang="objc,swift">ARTRealtimeChannelState</If><If lang="ruby">Channel::STATE Enum</If><If lang="java">io.ably.lib.realtime.ChannelState Enum</If><If lang="csharp">IO.Ably.Realtime.ChannelState Enum</If><If lang="flutter">ably.ChannelState Enum</If>
 
@@ -1995,7 +1995,7 @@ On success, the method returns a complete `ChannelOptions` object. Failure will 
 
 </If>
 
-#### DeriveOptions <a id="#derive-options" />
+#### DeriveOptions <a id="derive-options" />
 
 Properties passed to [`getDerived()`](#get-derived) to filter the messages returned in a subscription to it.
 
@@ -2039,7 +2039,7 @@ public interface CompletionListener {
 </If>
 
 <If lang="csharp">
-### PaginatedRequestParams <a id="#paginated-request-params" />
+### PaginatedRequestParams <a id="paginated-request-params" />
 
 `HistoryRequestParams` is a type that encapsulates the parameters for a history queries. For example usage see [`Channel#History`](/docs/api/realtime-sdk/history#channel-history).
 
@@ -2057,7 +2057,7 @@ public interface CompletionListener {
 
 <If lang="java">
 
-#### io.ably.lib.realtime.Channel.MessageListener <a id="#message-listener" />
+#### io.ably.lib.realtime.Channel.MessageListener <a id="message-listener" />
 
 A `io.ably.lib.realtime.Channel.MessageListener` is an interface allowing a client to be notified when messages are received on a channel using a [channel subscription](/docs/pub-sub#subscribe).
 
@@ -2336,7 +2336,7 @@ channel.history { paginatedResult, error in
 
 <If lang="java">
 
-### io.ably.lib.types.Param <a id="#param" />
+### io.ably.lib.types.Param <a id="param" />
 
 `Param` is a type encapsulating a key/value pair. This type is used frequently in method parameters allowing key/value pairs to be used more flexible, see [`Channel#history`](/docs/api/realtime-sdk/history#channel-history) for an example.
 

--- a/src/pages/docs/api/realtime-sdk/messages.mdx
+++ b/src/pages/docs/api/realtime-sdk/messages.mdx
@@ -8,57 +8,57 @@ redirect_from:
   - /docs/api/versions/v0.8/realtime-sdk/messages
 ---
 
-## <If lang="javascript,nodejs,flutter,csharp,objc,swift">Properties</If><If lang="ruby">Attributes</If><If lang="java">Members</If> <a id="#properties" />
+## <If lang="javascript,nodejs,flutter,csharp,objc,swift">Properties</If><If lang="ruby">Attributes</If><If lang="java">Members</If> <a id="properties" />
 
 A `Message` represents an individual message that is sent to or received from Ably.
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">name</If><If lang="csharp">Name</If> <a id="#name" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">name</If><If lang="csharp">Name</If> <a id="name" />
 
 The event name, if provided. <br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">data</If><If lang="csharp">Data</If> <a id="#data" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">data</If><If lang="csharp">Data</If> <a id="data" />
 
 The message payload, if provided.<br />_Type: <If lang="javascript,nodejs">`String`, `StringBuffer`, `JSON Object`</If><If lang="java">`String`, `ByteArray`, `JSONObject`, `JSONArray`</If><If lang="csharp">`String`, `byte[]`, `plain C# object that can be serialized to JSON`</If><If lang="ruby">`String`, `Binary` (ASCII-8BIT String), `Hash`, `Array`</If><If lang="objc">`NSString *`, `NSData *`, `NSDictionary *`, `NSArray *`</If><If lang="swift">`String`, `NSData`, `Dictionary`, `Array`</If><If lang="flutter">`String`, `Map`, `List`</If>_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">extras</If><If lang="csharp">Extras</If> <a id="#extras" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">extras</If><If lang="csharp">Extras</If> <a id="extras" />
 
 Metadata and/or ancillary payloads, if provided. Valid payloads include [`push`](/docs/push/publish#payload), [`headers`](/docs/channels#metadata) (a map of strings to strings for arbitrary customer-supplied metadata), [`ephemeral`](/docs/pub-sub/advanced#ephemeral), and [`privileged`](/docs/platform/integrations/webhooks#skipping).<br />_Type: <If lang="java">`JSONObject`, `JSONArray`</If><If lang="csharp">plain C# object that can be converted to JSON</If><If lang="javascript,nodejs">`JSON Object`</If><If lang="ruby">`Hash`, `Array`</If><If lang="swift">`Dictionary`, `Array`</If><If lang="objc">`NSDictionary *`, `NSArray *`</If>_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">id</If><If lang="csharp">Id</If> <a id="#id" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">id</If><If lang="csharp">Id</If> <a id="id" />
 
 A Unique ID assigned by Ably to this message.<br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,java">clientId</If><If lang="csharp">ClientId</If><If lang="ruby,python">client_id</If> <a id="#client-id" />
+### <If lang="javascript,nodejs,flutter,objc,swift,java">clientId</If><If lang="csharp">ClientId</If><If lang="ruby,python">client_id</If> <a id="client-id" />
 
 The client ID of the publisher of this message.<br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,java">connectionId</If><If lang="csharp">ConnectionId</If><If lang="ruby,python">connection_id</If> <a id="#connection-id" />
+### <If lang="javascript,nodejs,flutter,objc,swift,java">connectionId</If><If lang="csharp">ConnectionId</If><If lang="ruby,python">connection_id</If> <a id="connection-id" />
 
 The connection ID of the publisher of this message.<br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,java">connectionKey</If><If lang="csharp,go">ConnectionKey</If><If lang="ruby,python">connection_key</If> <a id="#connection-key" />
+### <If lang="javascript,nodejs,flutter,objc,swift,java">connectionKey</If><If lang="csharp,go">ConnectionKey</If><If lang="ruby,python">connection_key</If> <a id="connection-key" />
 
 A connection key, which can optionally be included for a REST publish as part of the [publishing on behalf of a realtime client functionality](/docs/pub-sub/advanced#publish-on-behalf).<br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">timestamp</If><If lang="csharp">Timestamp</If> <a id="#timestamp" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">timestamp</If><If lang="csharp">Timestamp</If> <a id="timestamp" />
 
 Timestamp when the message was first received by the Ably, as <If lang="javascript,nodejs,flutter,swift,csharp,objc,java">milliseconds since the epoch</If><If lang="ruby">a `Time` object</If>.<br />_Type: <If lang="javascript,nodejs,flutter">`Integer`</If><If lang="java">`Long Integer`</If><If lang="csharp">`DateTimeOffset`</If><If lang="ruby">`Time`</If><If lang="objc,swift">`NSDate`</If>_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">encoding</If><If lang="csharp">Encoding</If> <a id="#encoding" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">encoding</If><If lang="csharp">Encoding</If> <a id="encoding" />
 
 This will typically be empty as all messages received from Ably are automatically decoded client-side using this value. However, if the message encoding cannot be processed, this attribute will contain the remaining transformations not applied to the `data` payload.<br />_Type: `String`_
 
 <If lang="javascript,nodejs">
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">action</If> <a id="#action" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">action</If> <a id="action" />
 
 The action type of the message, one of the [`MessageAction`](/docs/api/realtime-sdk/types#message-action) enum values.<br />_Type: `int enum { MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, META, MESSAGE_SUMMARY }`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">serial</If> <a id="#serial" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">serial</If> <a id="serial" />
 
 A server-assigned identifier that will be the same in all future updates of this message. It  can be used to add annotations to a message. Serial will only be set if you enable annotations in [channel rules](/docs/channels#rules).<br />_Type: `String`_
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">annotations</If> <a id="#annotations" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">annotations</If> <a id="annotations" />
 
 An object containing information about annotations that have been made to the object.<br />_Type: [`MessageAnnotations`](/docs/api/realtime-sdk/types#message-annotations)_
 
@@ -66,7 +66,7 @@ An object containing information about annotations that have been made to the ob
 
 ### Message constructors <a id="constructors" />
 
-#### <If lang="javascript,nodejs,flutter,csharp,objc,swift,ruby,java">Message.fromEncoded</If> <a id="#message-from-encoded" />
+#### <If lang="javascript,nodejs,flutter,csharp,objc,swift,ruby,java">Message.fromEncoded</If> <a id="message-from-encoded" />
 
 `Message.fromEncoded(Object encodedMsg, ChannelOptions channelOptions?) -> Message`
 
@@ -83,7 +83,7 @@ A static factory method to create a [`Message`](/docs/api/realtime-sdk/types#mes
 
 A [`Message`](/docs/api/realtime-sdk/types#message) object
 
-#### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">Message.fromEncodedArray</If> <a id="#message-from-encoded-array" />
+#### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">Message.fromEncodedArray</If> <a id="message-from-encoded-array" />
 
 `Message.fromEncodedArray(Object[] encodedMsgs, ChannelOptions channelOptions?) -> Message[]`
 
@@ -100,7 +100,7 @@ A static factory method to create an array of [`Messages`](/docs/api/realtime-sd
 
 An `Array` of [`Message`](/docs/api/realtime-sdk/types#message) objects
 
-## MessageAnnotations <a id="#message-annotations" />
+## MessageAnnotations <a id="message-annotations" />
 
 #### <If lang="javascript,nodejs,flutter,objc,csharp,swift">Properties</If><If lang="java">Members</If><If lang="ruby">Attributes</If>
 

--- a/src/pages/docs/api/realtime-sdk/presence.mdx
+++ b/src/pages/docs/api/realtime-sdk/presence.mdx
@@ -24,11 +24,11 @@ redirect_from:
   - /docs/api/versions/v0.8/realtime-sdk/presence
 ---
 
-## <If lang="javascript,nodejs,flutter">Presence Properties</If><If lang="objc,swift">ARTPresence Properties</If><If lang="ruby">Ably::Realtime::Presence Attributes</If><If lang="java">io.ably.lib.realtime.Presence Members</If><If lang="csharp">IO.Ably.Realtime.Presence Properties</If> <a id="#properties" />
+## <If lang="javascript,nodejs,flutter">Presence Properties</If><If lang="objc,swift">ARTPresence Properties</If><If lang="ruby">Ably::Realtime::Presence Attributes</If><If lang="java">io.ably.lib.realtime.Presence Members</If><If lang="csharp">IO.Ably.Realtime.Presence Properties</If> <a id="properties" />
 
 The `Presence` object exposes the following public <If lang="javascript,nodejs,flutter,csharp,objc,swift">properties</If><If lang="ruby">attributes</If><If lang="java">members</If>:
 
-### <If lang="javascript,nodejs,flutter,objc,swift,java">syncComplete</If><If lang="ruby">sync_complete?</If><If lang="csharp">SyncComplete</If> <a id="#sync-complete" />
+### <If lang="javascript,nodejs,flutter,objc,swift,java">syncComplete</If><If lang="ruby">sync_complete?</If><If lang="csharp">SyncComplete</If> <a id="sync-complete" />
 
 A `boolean` field indicating whether the presence member set is synchronized with server after a channel attach.
 
@@ -36,7 +36,7 @@ When a channel is attached, the Ably service immediately synchronizes the presen
 
 ## Methods
 
-### <If lang="javascript,nodejs,objc,swift,java,ruby">enter</If><If lang="csharp">EnterAsync</If> <a id="#enter" />
+### <If lang="javascript,nodejs,objc,swift,java,ruby">enter</If><If lang="csharp">EnterAsync</If> <a id="enter" />
 
 In order to enter and be present on a channel, the client must [be identified by having a client ID](https://faqs.ably.com/authenticated-and-identified-clients), [have permission to be present](https://faqs.ably.com/using-capabilities-to-manage-client-access-privileges-on-channels), and be attached to the channel. For simplicity, the library will implicitly attach to a channel when entering. Entering when already entered is treated as an [update](#update).
 
@@ -161,7 +161,7 @@ On successfully entering the channel, the registered success blocks for the [Def
 
 </If>
 
-### <If lang="javascript,nodejs,objc,java,swift,flutter,ruby">leave</If><If lang="csharp">Leave</If> <a id="#leave" />
+### <If lang="javascript,nodejs,objc,java,swift,flutter,ruby">leave</If><If lang="csharp">Leave</If> <a id="leave" />
 
 In order to leave the presence set of a channel, the client must have already [entered and been present](#enter).
 
@@ -382,7 +382,7 @@ On successfully updating the data, the registered success blocks for the [Deferr
 
 </If>
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">get</If><If lang="csharp">Get</If> <a id="#get" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">get</If><If lang="csharp">Get</If> <a id="get" />
 
 Get the current presence member set for this channel. Typically, this method returns the member set immediately as the member set is retained in memory by the client. However, by default this method will wait until the presence member set is synchronized, so if the synchronization is not yet complete following a channel being attached, this method will wait until the presence member set is synchronized.
 
@@ -500,7 +500,7 @@ Failure to retrieve the current presence member set will trigger the `errback` c
 
 </If>
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">history</If><If lang="csharp">History</If> <a id="#history" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">history</If><If lang="csharp">History</If> <a id="history" />
 
 <If lang="flutter">
 
@@ -608,7 +608,7 @@ Failure to retrieve the message history will trigger the `errback` callbacks of 
 
 </If>
 
-### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">subscribe</If><If lang="csharp">Subscribe</If> <a id="#subscribe" />
+### <If lang="javascript,nodejs,flutter,objc,swift,ruby,java">subscribe</If><If lang="csharp">Subscribe</If> <a id="subscribe" />
 
 There are overloaded versions of this method:
 
@@ -736,7 +736,7 @@ Returns a promise. On successful channel attachment, the promise is resolved. On
 * The registered <If lang="flutter,javascript,nodejs,java,swift,objc">listener</If><If lang="ruby">block</If><If lang="csharp">handler</If> remains active on the presence channel regardless of the underlying channel state. For example, if you call `subscribe` when the underlying channel is `attached` and it later becomes `detached` or even `failed`, when the channel is reattached and a presence message is received, the <If lang="flutter,javascript,nodejs,java,swift,objc">listeners</If><If lang="ruby">blocks</If><If lang="csharp">handlers</If> originally registered will still be invoked. Listeners are only removed when calling [unsubscribe](#unsubscribe) or when the underlying channel is `released` using the <If lang="flutter,javascript,nodejs,java,swift,objc">`Realtime.channels.release(name)`</If><If lang="csharp">`Realtime.Channels.Release(name)`</If> method
 * If an exception is thrown in the subscribe listener and bubbles up to the event emitter, it will be caught and logged at `error` level, so as not to affect other listeners for the same event
 
-### <If lang="flutter,javascript,nodejs,ruby,java,swift,objc">unsubscribe</If><If lang="csharp">Unsubscribe</If> <a id="#unsubscribe" />
+### <If lang="flutter,javascript,nodejs,ruby,java,swift,objc">unsubscribe</If><If lang="csharp">Unsubscribe</If> <a id="unsubscribe" />
 
 There are <If lang="javascript,nodejs">six</If><If lang="flutter,ruby,java,swift,objc,csharp">three</If> overloaded versions of this method:
 
@@ -822,7 +822,7 @@ Unsubscribe all listeners for all presence actions in the array.
 
 </If>
 
-<a id="#unsubscribe-all" />
+<a id="unsubscribe-all" />
 
 <If lang="flutter,javascript,nodejs,ruby">
 
@@ -868,7 +868,7 @@ Unsubscribes all listeners to presence message events on this channel. This remo
 
 </If>
 
-### <If lang="javascript,nodejs,java,objc,swift">enterClient</If><If lang="ruby">enter_client</If><If lang="csharp">EnterClientAsync</If> <a id="#enter-client" />
+### <If lang="javascript,nodejs,java,objc,swift">enterClient</If><If lang="ruby">enter_client</If><If lang="csharp">EnterClientAsync</If> <a id="enter-client" />
 
 Enter this presence channel for the given <If lang="flutter,javascript,nodejs,java,swift,objc">`clientId`</If><If lang="ruby">`client_id`</If><If lang="csharp">`ClientId`</If>. This method is provided to support typically server instances that act on behalf of multiple client IDs. See [Managing multiple client IDs](/docs/presence-occupancy/presence#presence-multiple-client-id) for more info. In order to be able to publish presence changes for arbitrary client IDs, the client library must have been instantiated either with an [API key](/docs/auth#api-keys,) or with a [token bound to a wildcard client ID](https://faqs.ably.com/can-a-client-emulate-any-client-id-i.e.-authenticate-using-a-wildcard-client-id.)
 
@@ -998,7 +998,7 @@ On successfully entering the channel, the registered success blocks for the [Def
 
 </If>
 
-### <If lang="flutter,javascript,nodejs,java,objc,swift">leaveClient</If><If lang="ruby">leave_client</If><If lang="csharp">LeaveClientAsync</If> <a id="#leave-client" />
+### <If lang="flutter,javascript,nodejs,java,objc,swift">leaveClient</If><If lang="ruby">leave_client</If><If lang="csharp">LeaveClientAsync</If> <a id="leave-client" />
 
 Leave this presence channel for the given <If lang="flutter,javascript,nodejs,java,swift,objc">`clientId`</If><If lang="ruby">`client_id`</If><If lang="csharp">`ClientId`</If>. This method is provided to support typically server instances that act on behalf of multiple client IDs. See [Managing multiple client IDs](/docs/presence-occupancy/presence#presence-multiple-client-id) for more info. In order to leave the presence set of a channel, the client must have already [entered and been present](#enter-client.)
 
@@ -1123,7 +1123,7 @@ On successfully leaving the channel, the registered success blocks for the [Defe
 
 </If>
 
-### <If lang="flutter,javascript,nodejs,java,objc,swift">updateClient</If><If lang="ruby">update_client</If><If lang="csharp">UpdateClientAsync</If> <a id="#update-client" />
+### <If lang="flutter,javascript,nodejs,java,objc,swift">updateClient</If><If lang="ruby">update_client</If><If lang="csharp">UpdateClientAsync</If> <a id="update-client" />
 
 Clients can update the member data on behalf of the given <If lang="flutter,javascript,nodejs,java,swift,objc">`clientId`</If><If lang="ruby">`client_id`</If><If lang="csharp">`ClientId`</If> which will trigger a broadcast of this update to all presence subscribers. This method is provided to support typically server instances that act on behalf of multiple client IDs. See [Managing multiple client IDs](/docs/presence-occupancy/presence#presence-multiple-client-id) for more info. If an attempt to update is made before the member has entered the channel, the update is treated as an enter.
 
@@ -1225,9 +1225,9 @@ On successfully updating the data, the registered success blocks for the [Deferr
 
 </If>
 
-## Related types <a id="#related-types" />
+## Related types <a id="related-types" />
 
-## <If lang="flutter,javascript,nodejs">PresenceMessage</If><If lang="swift,objc">ARTPresenceMessage</If><If lang="ruby">Ably::Models::PresenceMessage</If><If lang="java">io.ably.lib.types.PresenceMessage</If><If lang="csharp">IO.Ably.PresenceMessage</If> <a id="#presence-message" />
+## <If lang="flutter,javascript,nodejs">PresenceMessage</If><If lang="swift,objc">ARTPresenceMessage</If><If lang="ruby">Ably::Models::PresenceMessage</If><If lang="java">io.ably.lib.types.PresenceMessage</If><If lang="csharp">IO.Ably.PresenceMessage</If> <a id="presence-message" />
 
 A `PresenceMessage` represents an individual presence update that is sent to or received from Ably.
 
@@ -1246,7 +1246,7 @@ A `PresenceMessage` represents an individual presence update that is sent to or 
 
 ### PresenceMessage constructors
 
-#### PresenceMessage.fromEncoded <a id="#presence-from-encoded" />
+#### PresenceMessage.fromEncoded <a id="presence-from-encoded" />
 
 `PresenceMessage.fromEncoded(Object encodedPresMsg, ChannelOptions channelOptions?) -> PresenceMessage`
 
@@ -1263,7 +1263,7 @@ A static factory method to create a [`PresenceMessage`](/docs/api/realtime-sdk/t
 
 A [`PresenceMessage`](/docs/api/realtime-sdk/types#presence-message) object
 
-#### PresenceMessage.fromEncodedArray <a id="#presence-from-encoded-array" />
+#### PresenceMessage.fromEncodedArray <a id="presence-from-encoded-array" />
 
 `PresenceMessage.fromEncodedArray(Object[] encodedPresMsgs, ChannelOptions channelOptions?) -> PresenceMessage[]`
 
@@ -1280,7 +1280,7 @@ A static factory method to create an array of [`PresenceMessages`](/docs/api/rea
 
 An `Array` of [`PresenceMessage`](/docs/api/realtime-sdk/types#presence-message) objects
 
-## <If lang="flutter,javascript,nodejs">Presence action</If><If lang="swift,objc">ARTPresenceAction</If><If lang="java">io.ably.lib.types.PresenceMessage.Action</If><If lang="ruby">Ably::Models::PresenceMessage::ACTION</If><If lang="csharp">IO.Ably.PresenceAction</If> <a id="#presence-action" />
+## <If lang="flutter,javascript,nodejs">Presence action</If><If lang="swift,objc">ARTPresenceAction</If><If lang="java">io.ably.lib.types.PresenceMessage.Action</If><If lang="ruby">Ably::Models::PresenceMessage::ACTION</If><If lang="csharp">IO.Ably.PresenceAction</If> <a id="presence-action" />
 
 <If lang="javascript,nodejs">
 
@@ -1417,7 +1417,7 @@ enum ARTPresenceAction : UInt {
 
 <If lang="csharp">
 
-## PaginatedRequestParams <a id="#paginated-request-params" />
+## PaginatedRequestParams <a id="paginated-request-params" />
 
 `HistoryRequestParams` is a type that encapsulates the parameters for a history queries. For example usage see [`Channel#History`](/docs/api/realtime-sdk/history#channel-history.)
 
@@ -1435,7 +1435,7 @@ enum ARTPresenceAction : UInt {
 
 <If lang="java">
 
-## io.ably.lib.realtime.CompletionListener <a id="#completion-listener" />
+## io.ably.lib.realtime.CompletionListener <a id="completion-listener" />
 
 A `io.ably.lib.realtime.CompletionListener` is an interface allowing a client to be notified of the outcome of an asynchronous operation.
 
@@ -1453,7 +1453,7 @@ public interface CompletionListener {
 
 </If>
 
-## <If lang="flutter,javascript,nodejs">PaginatedResult</If><If lang="swift,objc">ARTPaginatedResult</If><If lang="ruby">Ably::Models::PaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If><If lang="csharp">IO.Ably.PaginatedResult</If> <a id="#paginated-result" />
+## <If lang="flutter,javascript,nodejs">PaginatedResult</If><If lang="swift,objc">ARTPaginatedResult</If><If lang="ruby">Ably::Models::PaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If><If lang="csharp">IO.Ably.PaginatedResult</If> <a id="paginated-result" />
 
 A `PaginatedResult` is a type that represents a page of results for all message and presence history, stats and REST presence requests. The response from a [Ably REST API paginated query](/docs/api/rest-api/#pagination) is accompanied by metadata that indicates the relative queries available to the `PaginatedResult` object.
 
@@ -1597,7 +1597,7 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 
 <If lang="javascript,nodejs">
 
-#### current <a id="#current" />
+#### current <a id="current" />
 
 `current(): Promise<PaginatedResult>`
 
@@ -1605,7 +1605,7 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 
 </If>
 
-#### Example <a id="#paginated-result-example" />
+#### Example <a id="paginated-result-example" />
 
 <If lang="javascript">
 <Code>
@@ -1724,7 +1724,7 @@ channel.history { paginatedResult, error in
 </If>
 
 <If lang="java">
-### io.ably.lib.types.Param <a id="#param" />
+### io.ably.lib.types.Param <a id="param" />
 
 `Param` is a type encapsulating a key/value pair. This type is used frequently in method parameters allowing key/value pairs to be used more flexible, see [`Channel#history`](/docs/api/realtime-sdk/history#channel-history) for an example.
 
@@ -1737,7 +1737,7 @@ Please note that `key` and `value` attributes are always strings. If an `Integer
 | key | The key value | `String` |
 | value | The value associated with the `key` | `String` |
 
-### io.ably.lib.realtime.PresenceListener <a id="#presence-listener" />
+### io.ably.lib.realtime.PresenceListener <a id="presence-listener" />
 
 A `io.ably.lib.realtime.Presence.PresenceListener` is an interface allowing a client to be notified when presence message events are received on a presence channel using a [presence subscription](/docs/presence-occupancy/presence.)
 

--- a/src/pages/docs/api/realtime-sdk/push.mdx
+++ b/src/pages/docs/api/realtime-sdk/push.mdx
@@ -12,13 +12,13 @@ redirect_from:
   - /docs/api/versions/v1.1/realtime-sdk/push
 ---
 
-## Push Device object <a id="#push-object" />
+## Push Device object <a id="push-object" />
 
 This object is accessible through `client.push` and provides to [push-compatible devices](/docs/push) :
 
 ### Methods
 
-#### activate <a id="#activate" />
+#### activate <a id="activate" />
 
 <If lang="javascript,nodejs">
 
@@ -58,7 +58,7 @@ Returns a promise. On successful device activation, the promise resolves. On fai
 
 </If>
 
-#### deactivate <a id="#deactivate" />
+#### deactivate <a id="deactivate" />
 
 <If lang="javascript,nodejs">
 
@@ -113,9 +113,9 @@ The following table explains how to receive location push notifications:
 
 </If>
 
-## Related types <a id="#related-types" />
+## Related types <a id="related-types" />
 
-### <If lang="javascript,nodejs,java">DeviceDetails</If><If lang="objc,swift">ARTDeviceDetails</If> <a id="#device-details" />
+### <If lang="javascript,nodejs,java">DeviceDetails</If><If lang="objc,swift">ARTDeviceDetails</If> <a id="device-details" />
 
 A `DeviceDetails` is a type encapsulating attributes of a device registered for push notifications.
 
@@ -133,7 +133,7 @@ A `DeviceDetails` is a type encapsulating attributes of a device registered for 
 | push.state | The current state of the push device being either <If lang="java,objc,swift">`Active`, `Failing` or `Failed`</If><If lang="javascript,nodejs">`ACTIVE`, `FAILING` or `FAILED`</If> | `String` |
 | <If lang="java,objc,swift">push.errorReason</If><If lang="javascript,nodejs">push.error</If> | When the device's state is failing or failed, this attribute contains the reason for the most recent failure | [`ErrorInfo`](/docs/api/realtime-sdk/types#error-info) |
 
-### LocalDevice <a id="#local-device" />
+### LocalDevice <a id="local-device" />
 
 <If lang="java,objc,swift">
 
@@ -181,13 +181,13 @@ Returns a promise. On success, the promise is fulfilled with a [PaginatedResult]
 
 </If>
 
-### PushChannel <a id="#push-channel" />
+### PushChannel <a id="push-channel" />
 
 A `PushChannel` is a property of a [`RealtimeChannel`](/docs/api/realtime-sdk/channels#properties) or [`RestChannel`](/docs/api/rest-sdk/channels#properties). It provides [push devices](/docs/push) the ability to subscribe and unsubscribe to push notifications on channels.
 
 #### Methods
 
-##### subscribeDevice <a id="#subscribe-device" />
+##### subscribeDevice <a id="subscribe-device" />
 
 <If lang="javascript,nodejs">
 
@@ -210,7 +210,7 @@ Returns a promise. On success, the promise resolves. On failure, the promise is 
 
 </If>
 
-#### subscribeClient <a id="#subscribe-client" />
+#### subscribeClient <a id="subscribe-client" />
 
 <If lang="javascript,nodejs">
 
@@ -233,7 +233,7 @@ Returns a promise. On success, the promise resolves. On failure, the promise is 
 
 </If>
 
-#### unsubscribeDevice <a id="#unsubscribe-device" />
+#### unsubscribeDevice <a id="unsubscribe-device" />
 
 <If lang="javascript,nodejs">
 
@@ -256,7 +256,7 @@ Returns a promise. On success, the promise resolves. On failure, the promise is 
 
 </If>
 
-#### unsubscribeClient <a id="#unsubscribe-client" />
+#### unsubscribeClient <a id="unsubscribe-client" />
 
 <If lang="javascript,nodejs">
 
@@ -279,7 +279,7 @@ Returns a promise. On success, the promise resolves. On failure, the promise is 
 
 </If>
 
-#### listSubscriptions <a id="#list-subscriptions" />
+#### listSubscriptions <a id="list-subscriptions" />
 
 <If lang="javascript,nodejs">
 
@@ -359,7 +359,7 @@ Failure to retrieve the message history will raise an [`AblyException`](/docs/ap
 
 </If>
 
-### <If lang="javascript,nodejs">PushChannelSubscription</If><If lang="java">ChannelSubscription</If><If lang="objc,swift">ARTPushChannelSubscription</If> <a id="#push-channel-subscription" />
+### <If lang="javascript,nodejs">PushChannelSubscription</If><If lang="java">ChannelSubscription</If><If lang="objc,swift">ARTPushChannelSubscription</If> <a id="push-channel-subscription" />
 
 A `PushChannelSubscription` is a type encapsulating the subscription of a device or group of devices sharing a [client identifier](/docs/auth/identified-clients) to a channel in order to receive push notifications.
 
@@ -375,7 +375,7 @@ A `PushChannelSubscription` is a type encapsulating the subscription of a device
 
 ### PushChannelSubscription constructors
 
-#### PushChannelSubscription.forDevice <a id="#push-channel-subscription-for-device" />
+#### PushChannelSubscription.forDevice <a id="push-channel-subscription-for-device" />
 
 `PushChannelSubscription.forDevice(String channel, String deviceId) -> PushChannelSubscription`
 
@@ -392,7 +392,7 @@ A static factory method to create a `PushChannelSubscription` object for a chann
 
 A [`PushChannelSubscription`](/docs/api/realtime-sdk/types#push-channel-subscription) object
 
-#### PushChannelSubscription.forClient <a id="#push-channel-subscription-for-client-id" />
+#### PushChannelSubscription.forClient <a id="push-channel-subscription-for-client-id" />
 
 `PushChannelSubscription.forClient(String channel, String clientId) -> PushChannelSubscription`
 
@@ -411,7 +411,7 @@ A `PushChannelSubscription` object
 
 </If>
 
-### <If lang="javascript,nodejs">PaginatedResult</If><If lang="objc,swift">ARTPaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If> <a id="#paginated-result" />
+### <If lang="javascript,nodejs">PaginatedResult</If><If lang="objc,swift">ARTPaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If> <a id="paginated-result" />
 
 A `PaginatedResult` is a type that represents a page of results for all message and presence history, stats and REST presence requests. The response from an [Ably REST API paginated query](/docs/api/rest-api/#pagination) is accompanied by metadata that indicates the relative queries available to the `PaginatedResult` object.
 
@@ -472,13 +472,13 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 
 Returns `true` if there are more pages available by calling `next` and returns `false` if this page is the last page available.
 
-##### isLast <a id="#is-last" />
+##### isLast <a id="is-last" />
 
 `Boolean isLast()`
 
 Returns `true` if this page is the last page and returns `false` if there are more pages available by calling `next`.
 
-##### next <a id="#next" />
+##### next <a id="next" />
 
 <If lang="javascript,nodejs">
 
@@ -505,7 +505,7 @@ Returns a new `PaginatedResult` loaded with the next page of results. If there a
 
 Returns a promise. On success, the promise is fulfilled with a new `PaginatedResult` loaded with the next page of results. If there are no further pages, then `null` is returned. On failure, the promise is rejected with an [`ErrorInfo`](/docs/api/realtime-sdk/types#error-info) object that details the reason why it was rejected.
 
-##### current <a id="#current" />
+##### current <a id="current" />
 
 `current(): Promise<PaginatedResult>`
 
@@ -513,7 +513,7 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 
 </If>
 
-##### Example <a id="#paginated-result-example" />
+##### Example <a id="paginated-result-example" />
 
 <If lang="javascript">
 

--- a/src/pages/docs/api/realtime-sdk/statistics.mdx
+++ b/src/pages/docs/api/realtime-sdk/statistics.mdx
@@ -8,7 +8,7 @@ redirect_from:
   - /docs/api/versions/v0.8/realtime-sdk/statistics
 ---
 
-## Methods <a id="#methods" />
+## Methods <a id="methods" />
 
 ### stats <a id="stats" />
 

--- a/src/pages/docs/api/rest-sdk/authentication.mdx
+++ b/src/pages/docs/api/rest-sdk/authentication.mdx
@@ -23,11 +23,11 @@ redirect_from:
 
 This is the Authentication API Reference.
 
-## Tokens <a id="#tokens" />
+## Tokens <a id="tokens" />
 
 In the documentation, references to Ably-compatible tokens typically refer either to an Ably Token, or an [Ably JWT](#ably-jwt). For Ably Tokens, this can either be referring to the `TokenDetails` object that contain the `token` string or the token string itself. `TokenDetails` objects are obtained when [requesting an Ably Token](#request-token) from the Ably service and contain not only the `token` string in the `token` attribute, but also contain attributes describing the properties of the Ably Token. For [Ably JWT](#ably-jwt), this will be simply referring to a JWT which has been signed by an Ably private API key.
 
-## Auth object <a id="#auth-object" />
+## Auth object <a id="auth-object" />
 
 The principal use-case for the `Auth` object is to create Ably [`TokenRequest`](#token-request) objects with [`createTokenRequest`](#create-token-request) or obtain [Ably Tokens](#token-details) from Ably with [`requestToken`](#request-token), and then issue them to other "less trusted" clients. Typically, your servers should be the only devices to have a [private API key](/docs/auth#api-key), and this private API key is used to securely sign Ably [`TokenRequest`](#token-request) objects or request [Ably Tokens](#token-details) from Ably. Clients are then issued with these short-lived [Ably Tokens](#token-details) or Ably [`TokenRequest`](#token-request) objects, and the libraries can then use these to authenticate with Ably. If you adopt this model, your private API key is never shared with clients directly.
 
@@ -35,17 +35,17 @@ A subsidiary use-case for the `Auth` object is to preemptively trigger renewal o
 
 The Auth object is available as the <If lang="java">[`auth` field](/docs/api/rest-sdk#auth)</If><If lang="javascript,nodejs,php,python,objc,swift,go">[`auth` property](/docs/api/rest-sdk#auth)</If><If lang="csharp">[`Auth` property](/docs/api/rest-sdk#auth)</If><If lang="ruby">[`auth` attribute](/docs/api/rest-sdk#auth)</If> of an [Ably REST client instance](/docs/api/rest-sdk#constructor).
 
-## <If lang="javascript,nodejs,csharp,go">Auth Properties</If><If lang="php">Ably\Auth Properties</If><If lang="java">io.ably.lib.rest.Auth Members</If><If lang="ruby">Ably::Auth Attributes</If><If lang="python">Auth Attributes</If><If lang="objc,swift">ARTAuth Properties</If> <a id="#properties" />
+## <If lang="javascript,nodejs,csharp,go">Auth Properties</If><If lang="php">Ably\Auth Properties</If><If lang="java">io.ably.lib.rest.Auth Members</If><If lang="ruby">Ably::Auth Attributes</If><If lang="python">Auth Attributes</If><If lang="objc,swift">ARTAuth Properties</If> <a id="properties" />
 
 The <If lang="objc,swift">`ART`</If>`Auth` object exposes the following public <If lang="javascript,nodejs,csharp,go,php">properties</If><If lang="ruby,python">attributes</If><If lang="java">members</If>:
 
-### <If lang="javascript,nodejs,php,java,objc,swift">clientId</If><If lang="ruby,python">client_id</If><If lang="csharp">ClientId</If><If lang="go">ClientID</If> <a id="#client-id" />
+### <If lang="javascript,nodejs,php,java,objc,swift">clientId</If><If lang="ruby,python">client_id</If><If lang="csharp">ClientId</If><If lang="go">ClientID</If> <a id="client-id" />
 
 The client ID string, if any, configured for this client connection. See [identified clients](#identified-clients) for more information on trusted client identifiers.
 
-## <If lang="javascript,nodejs,csharp,python,go">Auth Methods</If><If lang="java">io.ably.lib.rest.Auth Methods</If><If lang="ruby">Ably::Auth Methods</If><If lang="php">Ably\Auth Methods</If><If lang="objc,swift">ARTAuth Methods</If> <a id="#methods" />
+## <If lang="javascript,nodejs,csharp,python,go">Auth Methods</If><If lang="java">io.ably.lib.rest.Auth Methods</If><If lang="ruby">Ably::Auth Methods</If><If lang="php">Ably\Auth Methods</If><If lang="objc,swift">ARTAuth Methods</If> <a id="methods" />
 
-### <If lang="javascript,nodejs,php,java,ruby,python,objc,swift">authorize</If><If lang="csharp,go">Authorize</If> <a id="#authorise" />
+### <If lang="javascript,nodejs,php,java,ruby,python,objc,swift">authorize</If><If lang="csharp,go">Authorize</If> <a id="authorise" />
 
 <If lang="javascript,nodejs">
 
@@ -296,7 +296,7 @@ fmt.Println(token)
 
 </If>
 
-### <If lang="javascript,nodejs,php,java,objc,swift">createTokenRequest</If><If lang="csharp,go">CreateTokenRequest</If><If lang="ruby,python">create_token_request</If> <a id="#create-token-request" />
+### <If lang="javascript,nodejs,php,java,objc,swift">createTokenRequest</If><If lang="csharp,go">CreateTokenRequest</If><If lang="ruby,python">create_token_request</If> <a id="create-token-request" />
 
 <If lang="javascript,nodejs">
 
@@ -535,7 +535,7 @@ fmt.Println(tokenRequest)
 
 </If>
 
-### <If lang="javascript,nodejs,php,java,objc,swift">requestToken</If><If lang="ruby,python">request_token</If><If lang="csharp,go">RequestToken</If> <a id="#request-token" />
+### <If lang="javascript,nodejs,php,java,objc,swift">requestToken</If><If lang="ruby,python">request_token</If><If lang="csharp,go">RequestToken</If> <a id="request-token" />
 
 <If lang="javascript,nodejs">
 
@@ -794,7 +794,7 @@ fmt.Println(token)
 
 <If lang="javascript,nodejs">
 
-### revokeTokens <a id="#revoke-tokens" />
+### revokeTokens <a id="revoke-tokens" />
 
 `revokeTokens(TokenRevocationTargetSpecifier[] specifiers, TokenRevocationOptions options?): Promise<BatchResult<TokenRevocationSuccessResult | TokenRevocationFailureResult>>`
 
@@ -849,9 +849,9 @@ try {
 </If>
 </If>
 
-## Related types <a id="#related-types" />
+## Related types <a id="related-types" />
 
-### <If lang="javascript,nodejs,csharp,objc,php,python,swift,go">AuthOptions Object</If><If lang="ruby">AuthOptions Hash</If><If lang="java">io.ably.lib.rest.Auth.AuthOptions</If> <a id="#auth-options" />
+### <If lang="javascript,nodejs,csharp,objc,php,python,swift,go">AuthOptions Object</If><If lang="ruby">AuthOptions Hash</If><If lang="java">io.ably.lib.rest.Auth.AuthOptions</If> <a id="auth-options" />
 
 <If lang="javascript,nodejs">
 `AuthOptions` is a plain JavaScript object and is used when making [authentication](/docs/auth) requests. If passed in, an `authOptions` object will be used instead of (as opposed to supplementing or being merged with) the default values given when the library was instantiated. The following attributes are supported:
@@ -891,7 +891,7 @@ try {
 | <If lang="javascript,nodejs,java,objc,php,swift">queryTime</If><If lang="csharp,go">QueryTime</If><If lang="ruby">:query_time</If><If lang="python">query_time</If> | _false_ If true, the library will query the Ably servers for the current time when [issuing TokenRequests](/docs/auth/token) instead of relying on a locally-available time of day. Knowing the time accurately is needed to create valid signed Ably [TokenRequests](/docs/auth/token), so this option is useful for library instances on auth servers where for some reason the server clock cannot be kept synchronized through normal means, such as an [NTP daemon](https://en.wikipedia.org/wiki/Ntpd). The server is queried for the current time once per client library instance (which stores the offset from the local clock), so if using this option you should avoid instancing a new version of the library for each request. | `Boolean` |
 | <If lang="javascript,nodejs,java,objc,php,swift">token</If><If lang="csharp,go">Token</If><If lang="ruby">:token</If><If lang="python">token</If> | An authenticated token. This can either be a [`TokenDetails`](/docs/api/realtime-sdk/types#token-details) object, a [`TokenRequest`](/docs/api/realtime-sdk/types#token-request) object, or token string (obtained from the <If lang="javascript,nodejs,java,objc,php,swift">token</If><If lang="csharp,go">Token</If><If lang="python">token</If><If lang="ruby">token</If> property of a [`TokenDetails`](/docs/api/realtime-sdk/types#token-details) component of an Ably TokenRequest response, or a [JSON Web Token](https://tools.ietf.org/html/rfc7519) satisfying [the Ably requirements for JWTs](/docs/auth/token#jwt)). This option is mostly useful for testing: since tokens are short-lived, in production you almost always want to use an authentication method that allows the client library to renew the token automatically when the previous one expires, such as <If lang="javascript,nodejs,java,objc,php,swift">authUrl</If><If lang="csharp,go">AuthUrl</If><If lang="ruby">:auth_url</If><If lang="python">auth_url</If> or <If lang="javascript,nodejs,java,objc,php,swift">authCallback</If><If lang="csharp,go">AuthCallback</If><If lang="python">auth_callback</If><If lang="ruby">:auth_callback</If>. Read more about [Token authentication](/docs/auth/token) | `String`, `TokenDetails` or `TokenRequest` |
 
-### <If lang="javascript,nodejs,csharp,php,python,go">TokenDetails Object</If><If lang="objc,swift">ARTTokenDetails</If><If lang="java">io.ably.lib.types.TokenDetails</If><If lang="ruby">Ably::Models::TokenDetails</If> <a id="#token-details" />
+### <If lang="javascript,nodejs,csharp,php,python,go">TokenDetails Object</If><If lang="objc,swift">ARTTokenDetails</If><If lang="java">io.ably.lib.types.TokenDetails</If><If lang="ruby">Ably::Models::TokenDetails</If> <a id="token-details" />
 
 `TokenDetails` is a type providing details of Ably Token string and its associated metadata.
 
@@ -934,7 +934,7 @@ try {
 
 ### TokenDetails constructors
 
-#### <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">TokenDetails.fromJson</If><If lang="ruby">TokenDetails.from_json</If> <a id="#token-details-from-json" />
+#### <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">TokenDetails.fromJson</If><If lang="ruby">TokenDetails.from_json</If> <a id="token-details-from-json" />
 
 <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">
 `TokenDetails.fromJson(String json) -> TokenDetails`
@@ -956,7 +956,7 @@ A static factory method to create a [`TokenDetails`](/docs/api/realtime-sdk/type
 
 A [`TokenDetails`](/docs/api/realtime-sdk/types#token-details) object
 
-### <If lang="javascript,nodejs,csharp,php,python,go">TokenParams Object</If><If lang="objc,swift">ARTTokenParams</If><If lang="ruby">TokenParams Hash</If><If lang="java">io.ably.lib.rest.Auth.TokenParams</If> <a id="#token-params" />
+### <If lang="javascript,nodejs,csharp,php,python,go">TokenParams Object</If><If lang="objc,swift">ARTTokenParams</If><If lang="ruby">TokenParams Hash</If><If lang="java">io.ably.lib.rest.Auth.TokenParams</If> <a id="token-params" />
 
 <If lang="javascript,nodejs">
 `TokenParams` is a plain JavaScript object and is used in the parameters of [token authentication](/docs/auth/token) requests, corresponding to the desired attributes of the [Ably Token](/docs/api/realtime-sdk/authentication#token-details). The following attributes can be defined on the object:
@@ -992,7 +992,7 @@ A [`TokenDetails`](/docs/api/realtime-sdk/types#token-details) object
 | <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">timestamp</If><If lang="csharp,go">Timestamp</If><If lang="ruby">:timestamp</If> | <If lang="javascript,nodejs,java,objc,php,python,go">The timestamp (in milliseconds since the epoch)</If><If lang="ruby,objc,swift,csharp">The timestamp</If> of this request. `timestamp`, in conjunction with the `nonce`, is used to prevent requests for [Ably Token](/docs/api/realtime-sdk/authentication#token-details) from being replayed. | <If lang="javascript,nodejs,php,python,go">`Integer`</If><If lang="java">`Long Integer`</If><If lang="ruby">`Time`</If><If lang="objc,swift">`NSDate`</If><If lang="csharp">`DateTimeOffset`</If> |
 | <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">ttl</If><If lang="csharp,go">Ttl</If><If lang="ruby">:ttl</If> | _1 hour_ Requested time to live for the [Ably Token](/docs/api/realtime-sdk/authentication#token-details) being created <If lang="javascript,nodejs,java,objc,php,python,go">in milliseconds</If><If lang="ruby">in seconds</If><If lang="objc,swift">as a `NSTimeInterval`</If><If lang="csharp,go">as a `TimeSpan`.</If> When omitted, the Ably REST API default of 60 minutes is applied by Ably | <If lang="javascript,nodejs,php,python,go">`Integer` (milliseconds)</If><If lang="ruby">`Integer` (seconds)</If><If lang="objc,swift">`NSTimeInterval`</If><If lang="java">`Long Integer`</If><If lang="csharp">`TimeSpan`</If> |
 
-### <If lang="javascript,nodejs,csharp,php,python,go">TokenRequest Object</If><If lang="objc,swift">ARTTokenRequest</If><If lang="ruby">Ably::Models::TokenRequest</If><If lang="java">io.ably.lib.rest.Auth.TokenRequest</If> <a id="#token-request" />
+### <If lang="javascript,nodejs,csharp,php,python,go">TokenRequest Object</If><If lang="objc,swift">ARTTokenRequest</If><If lang="ruby">Ably::Models::TokenRequest</If><If lang="java">io.ably.lib.rest.Auth.TokenRequest</If> <a id="token-request" />
 
 `TokenRequest` is a type containing parameters for an Ably `TokenRequest`. [Ably Tokens](/docs/api/realtime-sdk/authentication#token-details) are requested using <If lang="javascript,nodejs,java,objc,php,python,swift,csharp,go">[Auth#requestToken](/docs/api/rest-sdk/authentication#request-token)</If><If lang="ruby">[Auth#request_token](/docs/api/rest-sdk/authentication#request-token)</If>
 
@@ -1010,7 +1010,7 @@ A [`TokenDetails`](/docs/api/realtime-sdk/types#token-details) object
 
 ### TokenRequest constructors
 
-#### <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">TokenRequest.fromJson</If><If lang="ruby">TokenRequest.from_json</If> <a id="#token-request-from-json" />
+#### <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">TokenRequest.fromJson</If><If lang="ruby">TokenRequest.from_json</If> <a id="token-request-from-json" />
 
 <If lang="javascript,nodejs,java,csharp,objc,php,python,swift,go">
 `TokenRequest.fromJson(String json) -> TokenRequest`
@@ -1032,7 +1032,7 @@ A static factory method to create a [`TokenRequest`](/docs/api/realtime-sdk/type
 
 A [`TokenRequest`](/docs/api/realtime-sdk/types#token-request) object
 
-### Ably JWT <a id="#ably-jwt" />
+### Ably JWT <a id="ably-jwt" />
 
 An Ably JWT is not strictly an Ably construct, rather it is a [JWT](https://jwt.io/) which has been constructed to be compatible with Ably. The JWT must adhere to the following to ensure compatibility:
 
@@ -1109,7 +1109,7 @@ The following is an example of creating an Ably JWT:
 </If>
 <If lang="javascript,nodejs">
 
-### BatchResult <a id="#batch-result" />
+### BatchResult <a id="batch-result" />
 
 A `BatchResult` contains information about the results of a batch operation.
 
@@ -1123,7 +1123,7 @@ A `BatchResult` contains information about the results of a batch operation.
 
 <If lang="javascript,nodejs">
 
-### TokenRevocationTargetSpecifier <a id="#token-revocation-target-specifier" />
+### TokenRevocationTargetSpecifier <a id="token-revocation-target-specifier" />
 
 A `TokenRevocationTargetSpecifier` describes which tokens should be affected by a token revocation request.
 
@@ -1138,7 +1138,7 @@ A `TokenRevocationTargetSpecifier` describes which tokens should be affected by 
 
 <If lang="javascript,nodejs">
 
-### TokenRevocationOptions <a id="#token-revocation-options" />
+### TokenRevocationOptions <a id="token-revocation-options" />
 
 A `TokenRevocationOptions` describes the additional options accepted by revoke tokens request.
 
@@ -1153,7 +1153,7 @@ A `TokenRevocationOptions` describes the additional options accepted by revoke t
 
 <If lang="javascript,nodejs">
 
-### TokenRevocationSuccessResult <a id="#token-revocation-success-result" />
+### TokenRevocationSuccessResult <a id="token-revocation-success-result" />
 
 A `TokenRevocationSuccessResult` contains information about the result of a successful token revocation request for a single target specifier.
 
@@ -1169,7 +1169,7 @@ A `TokenRevocationSuccessResult` contains information about the result of a succ
 
 <If lang="javascript,nodejs">
 
-### TokenRevocationFailureResult <a id="#token-revocation-failure-result" />
+### TokenRevocationFailureResult <a id="token-revocation-failure-result" />
 
 A `TokenRevocationFailureResult` contains information about the result of an unsuccessful token revocation request for a single target specifier.
 

--- a/src/pages/docs/api/rest-sdk/presence.mdx
+++ b/src/pages/docs/api/rest-sdk/presence.mdx
@@ -16,7 +16,7 @@ redirect_from:
 
 ## Methods
 
-### <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">get</If><If lang="csharp,go">Get</If> <a id="#get" />
+### <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">get</If><If lang="csharp,go">Get</If> <a id="get" />
 
 Get the current presence member set for this channel.  In the REST client library this method directly queries [Ably's REST presence API](/docs/api/rest-api#presence)
 
@@ -137,7 +137,7 @@ Failure to retrieve the current presence member, the `error` contains an [`Error
 
 </If>
 
-### <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">history</If><If lang="csharp,go">History</If> <a id="#history" />
+### <If lang="javascript,nodejs,java,objc,php,python,ruby,swift">history</If><If lang="csharp,go">History</If> <a id="history" />
 
 <If lang="javascript,nodejs">
 
@@ -243,9 +243,9 @@ Upon failure to retrieve the message history, the `error` contains an [`ErrorInf
 
 </If>
 
-## Related types <a id="#related-types" />
+## Related types <a id="related-types" />
 
-### <If lang="javascript,nodejs,php,python,go,flutter">PresenceMessage</If><If lang="swift,objc">ARTPresenceMessage</If><If lang="ruby">Ably::Models::PresenceMessage</If><If lang="java">io.ably.lib.types.PresenceMessage</If><If lang="csharp">IO.Ably.PresenceMessage</If> <a id="#presence-message" />
+### <If lang="javascript,nodejs,php,python,go,flutter">PresenceMessage</If><If lang="swift,objc">ARTPresenceMessage</If><If lang="ruby">Ably::Models::PresenceMessage</If><If lang="java">io.ably.lib.types.PresenceMessage</If><If lang="csharp">IO.Ably.PresenceMessage</If> <a id="presence-message" />
 
 A `PresenceMessage` represents an individual presence update that is sent to or received from Ably.
 
@@ -264,7 +264,7 @@ A `PresenceMessage` represents an individual presence update that is sent to or 
 
 ### PresenceMessage constructors
 
-#### PresenceMessage.fromEncoded <a id="#presence-from-encoded" />
+#### PresenceMessage.fromEncoded <a id="presence-from-encoded" />
 
 `PresenceMessage.fromEncoded(Object encodedPresMsg, ChannelOptions channelOptions?) -> PresenceMessage`
 
@@ -281,7 +281,7 @@ A static factory method to create a [`PresenceMessage`](/docs/api/realtime-sdk/t
 
 A [`PresenceMessage`](/docs/api/realtime-sdk/types#presence-message) object
 
-#### PresenceMessage.fromEncodedArray <a id="#presence-from-encoded-array" />
+#### PresenceMessage.fromEncodedArray <a id="presence-from-encoded-array" />
 
 `PresenceMessage.fromEncodedArray(Object[] encodedPresMsgs, ChannelOptions channelOptions?) -> PresenceMessage[]`
 
@@ -298,7 +298,7 @@ A static factory method to create an array of [`PresenceMessages`](/docs/api/rea
 
 An `Array` of [`PresenceMessage`](/docs/api/realtime-sdk/types#presence-message) objects
 
-### <If lang="javascript,nodejs,php,go,flutter">Presence action</If><If lang="python">PresenceAction</If><If lang="swift,objc">ARTPresenceAction</If><If lang="java">io.ably.lib.types.PresenceMessage.Action</If><If lang="ruby">Ably::Models::PresenceMessage::ACTION</If><If lang="csharp">IO.Ably.PresenceAction</If> <a id="#presence-action" />
+### <If lang="javascript,nodejs,php,go,flutter">Presence action</If><If lang="python">PresenceAction</If><If lang="swift,objc">ARTPresenceAction</If><If lang="java">io.ably.lib.types.PresenceMessage.Action</If><If lang="ruby">Ably::Models::PresenceMessage::ACTION</If><If lang="csharp">IO.Ably.PresenceAction</If> <a id="presence-action" />
 
 <If lang="javascript,nodejs">
 
@@ -518,7 +518,7 @@ const (
 
 <If lang="csharp">
 
-### PaginatedRequestParams <a id="##paginated-request-params" />
+### PaginatedRequestParams <a id="paginated-request-params" />
 
 `HistoryRequestParams` is a type that encapsulates the parameters for a history queries. For example usage see [`Channel#History`](/docs/api/realtime-sdk/history#channel-history).
 
@@ -534,7 +534,7 @@ const (
 
 </If>
 
-### <If lang="javascript,nodejs,php,python,go,flutter">PaginatedResult</If><If lang="swift,objc">ARTPaginatedResult</If><If lang="ruby">Ably::Models::PaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If><If lang="csharp">IO.Ably.PaginatedResult</If> <a id="#paginated-result" />
+### <If lang="javascript,nodejs,php,python,go,flutter">PaginatedResult</If><If lang="swift,objc">ARTPaginatedResult</If><If lang="ruby">Ably::Models::PaginatedResult</If><If lang="java">io.ably.lib.types.PaginatedResult</If><If lang="csharp">IO.Ably.PaginatedResult</If> <a id="paginated-result" />
 
 A `PaginatedResult` is a type that represents a page of results for all message and presence history, stats and REST presence requests. The response from a [Ably REST API paginated query](/docs/api/rest-api/#pagination) is accompanied by metadata that indicates the relative queries available to the `PaginatedResult` object.
 
@@ -740,7 +740,7 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 </If>
 <If lang="javascript,nodejs">
 
-##### current <a id="#current" />
+##### current <a id="current" />
 
 `current(): Promise<PaginatedResult>`
 
@@ -748,7 +748,7 @@ Returns a promise. On success, the promise is fulfilled with a new `PaginatedRes
 
 </If>
 
-#### Example <a id="#paginated-result-example" />
+#### Example <a id="paginated-result-example" />
 
 <If lang="javascript">
 
@@ -919,7 +919,7 @@ fmt.Println("Last page? %s\n", page1.IsLast())
 </If>
 <If lang="java">
 
-### io.ably.lib.types.Param <a id="#param" />
+### io.ably.lib.types.Param <a id="param" />
 
 `Param` is a type encapsulating a key/value pair. This type is used frequently in method parameters allowing key/value pairs to be used more flexible, see [`Channel#history`](/docs/api/realtime-sdk/history#channel-history) for an example.
 

--- a/src/pages/docs/api/rest-sdk/statistics.mdx
+++ b/src/pages/docs/api/rest-sdk/statistics.mdx
@@ -181,7 +181,7 @@ Please note that most attributes of the `Stats` type below contain references to
 
 <If lang="csharp">
 
-### IO.Ably.StatsRequestParams <a id="#stats-request-params" />
+### IO.Ably.StatsRequestParams <a id="stats-request-params" />
 
 `StatsRequestParams` is a type that encapsulates the parameters for a stats query. For example usage see [`Realtime#Stats`](/docs/metadata-stats/stats).
 
@@ -292,7 +292,7 @@ Please note that most attributes of the `Stats` type below contain references to
 
 <If lang="java">
 
-### io.ably.lib.types.Param <a id="#param" />
+### io.ably.lib.types.Param <a id="param" />
 
 `Param` is a type encapsulating a key/value pair. This type is used frequently in method parameters allowing key/value pairs to be used more flexible, see [`Channel#history`](/docs/api/realtime-sdk/history#channel-history) for an example.
 


### PR DESCRIPTION
## Description

There was an issue in the migration of api pages where in page links were prepended with a #. This with the MDX caused a double ## which then caused issues where the browser wasn't redirecting to the required part of the page.