### PR TITLE
Add React Native setup instructions for encrypted channels

### DIFF
--- a/src/pages/docs/channels/options/encryption.mdx
+++ b/src/pages/docs/channels/options/encryption.mdx
@@ -58,6 +58,24 @@ Other attributes of messages and presence messages, such as event `name` and `cl
 
 The key that's in use at any given time is known by the SDK. The Ably service only knows that a given message payload was encrypted, not the key used to encrypt it. When accessing messages using the history feature, it is the caller's responsibility to ensure that the correct key is configured for the channel before the history request is made.
 
+<If lang="javascript">
+  <Aside data-type='note'>
+    To use encrypted channels in a React Native project, you’ll need to complete several additional setup steps.
+
+     React Native does **not** provide cryptographic primitives out of the box. Ably relies on the well-documented **WebCrypto** interfaces instead. In particular, Ably uses:
+
+     - `crypto.subtle.importKey`
+     - `crypto.subtle.encrypt`
+     - `crypto.subtle.decrypt`
+
+     Ably also depends on `TextDecoder` (Expo provides this by default; for bare React Native you’ll need to install it manually, e.g. [text-encoding](https://www.npmjs.com/package/text-encoding)) and `randomBytes`.
+
+     We recommend the following polyfills:
+     - `@react-native-module/randombytes` — for `randomBytes`
+     - `react-native-quick-crypto` — for WebCrypto (`crypto.subtle`)
+  </Aside>
+</If>
+
 ## Encrypt a channel <a id="encrypt"/>
 
 Set the `cipher` property to enable message encryption by passing a [`CipherParams`](/docs/api/realtime-sdk/encryption#cipher-params) object that contains at least a secret `key`.


### PR DESCRIPTION
## Description

Based on internal customer feedback: https://ably-real-time.slack.com/archives/C07RGGVHQ7L/p1761225328497749

Add React Native setup instructions for encrypted channels
- Documented the use of WebCrypto APIs (`crypto.subtle` methods) and additional dependencies for React Native.
- Provided a list of recommended polyfills for cryptographic primitives and text decoding in React Native.

### Checklist

- [x] Commits have been rebased.
- [] Linting has been run against the changed file(s).
- [] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
