### PR TITLE
Docs: Improve and expand on webhook signature testing

### DIFF
--- a/src/pages/docs/platform/integrations/webhooks/index.mdx
+++ b/src/pages/docs/platform/integrations/webhooks/index.mdx
@@ -516,10 +516,16 @@ The following steps are required to verify the signature:
 
 ### Sign webhook requests <a id="sign"/>
 
-If you choose to sign your webhook requests, it is recommended that you try the following:
+Webhook signing is the security mechanism where Ably includes a cryptographic signature in each webhook request.
 
-1. Set up your webhook testing/inspection tools:
-   - **Local testing/inspection**: Perform local tunneling with [ngrok](https://ngrok.com/download/linux), paired with [webhook-tester](https://github.com/tarampampam/webhook-tester). You can install webhook-tester [here](https://github.com/tarampampam/webhook-tester?tab=readme-ov-file#-installation). The ngrok CLI tool will generate your **webhook listener URL**.
-   - **Using zero-setup, cloud-based, webhook testing services**: Services like Beeceptor (https://beeceptor.com/webhook-integration/) or Webhook.site (https://webhook.site/) offer a zero-setup, no-login, free webhook testing endpoint for webhook monitoring, payload inspection and signature verification. These services provide you a unique, random endpoint URL, which is your **webhook listener URL**.
-2. [Configure](#configure) your webhook sender (Ably) with the webhook listener URL obtained from **Step 1**. Make sure you choose to [batch](#batched) messages and use a key to sign each webhook request.
-3. Trigger an event using the Dev Console in your app [dashboard](https://ably.com/dashboard/any). This will send a webhook event to your webhook testing/inspection tool via the webhook listener URL. You can, using your preferred choice of webhook testing/inspection tool, monitor requests and confirm that a webhook request was sent, and inspect request headers for signature verification.
+Use the following steps to configure webhook signing and verify it's working correctly:
+
+* Perform local tunneling with [ngrok](https://ngrok.com/download/linux), paired with [webhook-tester](https://github.com/tarampampam/webhook-tester).
+
+  * Install [webhook-tester](https://github.com/tarampampam/webhook-tester?tab=readme-ov-file#-installation). The ngrok CLI tool will generate your webhook listener URL.
+
+* Alternatively, use services like [Beeceptor](https://beeceptor.com/webhook-integration/) or [Webhook.site](https://webhook.site/) which offer zero-setup, no-login, free webhook testing endpoints for webhook monitoring, payload inspection and signature verification. These services provide you a unique, random endpoint URL, which is your webhook listener URL.
+
+* Configure Ably with the webhook listener URL obtained here pre. Make sure you choose to [batch](#batched) messages and use a key to sign each webhook request.
+
+* Use your [Dev console](https://ably.com/accounts/any/apps/any/console) to trigger an event. This will send a webhook event to your webhook testing/inspection tool via the webhook listener URL. You can then monitor requests and confirm that a webhook request was sent, and inspect request headers for signature verification.


### PR DESCRIPTION
## Description
This PR cleans up and expands the documentation on **webhook signature testing** to recommend better, more accessible tools.
Key Changes:
* **Expanded Tooling:** Added a segment for local testing/inspection tools and cloud-based webhook testing services. 
* **New Recommendations:** Replaced RequestBin with **Webhook.site** and **Beeceptor** for instant, zero-setup testing endpoints. RequestBin requires account creation, which adds multiple steps.
* **Clarity:** Improved grammar  to be more descriptive and professional.

That aside, I noticed that the link on step 2 `[Configure](#configure)` points to an anchor URL that doesn't exist. I have left it untouched. 
<!--  An in-depth description of what this PR is adding or updating. Include a link to the related JIRA issue if this exists. -->

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
