### PR TITLE
Fix link formatting in moderation documentation

### DIFF
--- a/src/pages/docs/chat/moderation/custom/index.mdx
+++ b/src/pages/docs/chat/moderation/custom/index.mdx
@@ -79,4 +79,4 @@ After publish moderation is where your moderation logic is invoked after a messa
 
 There isn't currently a chat-specific custom API for after publish moderation.
 
-However, you can still use standard Ably "integration rules"/docs/platform/integrations to send chat messages to your infrastructure and then remove any offending content with the REST API.
+However, you can still use standard Ably [integration rules](/docs/platform/integrations) to send chat messages to your infrastructure and then remove any offending content with the REST API.


### PR DESCRIPTION
## Description

Fix broken link formatting

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../writing-style-guide.md) and [contribution guide](../CONTRIBUTING.md).
