### PR TITLE
Fix typo in fromEncoded

### DIFF
--- a/src/pages/docs/api/realtime-sdk/channels.mdx
+++ b/src/pages/docs/api/realtime-sdk/channels.mdx
@@ -1881,7 +1881,7 @@ A static factory method to create a [`Message`](/docs/api/realtime-sdk/types#mes
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedMsg | a `Message`-like deserialized object | `Object` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data | `Object` |
 
 ##### Returns
 
@@ -1898,7 +1898,7 @@ A static factory method to create an array of [`Messages`](/docs/api/realtime-sd
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedMsgs | an array of `Message`-like deserialized objects | `Array` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data | `Object` |
 
 ##### Returns
 

--- a/src/pages/docs/api/realtime-sdk/messages.mdx
+++ b/src/pages/docs/api/realtime-sdk/messages.mdx
@@ -77,7 +77,7 @@ A static factory method to create a [`Message`](/docs/api/realtime-sdk/types#mes
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedMsg | A `Message`-like deserialized object. | `Object` |
-| channelOptions | An optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | An optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 ##### Returns
 
@@ -94,7 +94,7 @@ A static factory method to create an array of [`Messages`](/docs/api/realtime-sd
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedMsgs | An array of `Message`-like deserialized objects. | `Array` |
-| channelOptions | An optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | An optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 ##### Returns
 

--- a/src/pages/docs/api/realtime-sdk/presence.mdx
+++ b/src/pages/docs/api/realtime-sdk/presence.mdx
@@ -1257,7 +1257,7 @@ A static factory method to create a [`PresenceMessage`](/docs/api/realtime-sdk/t
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedPresMsg | a `PresenceMessage`-like deserialized object. | `Object` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 #### Returns
 
@@ -1274,7 +1274,7 @@ A static factory method to create an array of [`PresenceMessages`](/docs/api/rea
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedPresMsgs | an array of `PresenceMessage`-like deserialized objects. | `Array` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 #### Returns
 

--- a/src/pages/docs/api/rest-sdk/messages.mdx
+++ b/src/pages/docs/api/rest-sdk/messages.mdx
@@ -75,7 +75,7 @@ A static factory method to create a [`Message`](/docs/api/realtime-sdk/types#mes
 | Name | Description | Type |
 |------|-------------|------|
 | encodedMsg | a `Message`-like deserialized object. | `Object` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object`t
 
 #### Returns
 
@@ -92,7 +92,7 @@ A static factory method to create an array of [`Messages`](/docs/api/realtime-sd
 | Name | Description | Type |
 |------|-------------|------|
 | encodedMsgs | an array of `Message`-like deserialized objects. | `Array` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object`t
 
 #### Returns
 

--- a/src/pages/docs/api/rest-sdk/presence.mdx
+++ b/src/pages/docs/api/rest-sdk/presence.mdx
@@ -275,7 +275,7 @@ A static factory method to create a [`PresenceMessage`](/docs/api/realtime-sdk/t
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedPresMsg | a `PresenceMessage`-like deserialized object. | `Object` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 #### Returns
 
@@ -292,7 +292,7 @@ A static factory method to create an array of [`PresenceMessages`](/docs/api/rea
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | encodedPresMsgs | an array of `PresenceMessage`-like deserialized objects. | `Array` |
-| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library can decrypt the data. | `Object` |
+| channelOptions | an optional [`ChannelOptions`](/docs/api/realtime-sdk/types#channel-options). If you have an encrypted channel, use this to allow the library to decrypt the data. | `Object` |
 
 #### Returns
 


### PR DESCRIPTION
## Description

In https://github.com/ably/docs/pull/2938 Vlad raised a PR to fix a typo in the textile partials for the string "use this to allow to library can decrypt the data" 

So replacing the `can` to `to`. The partials are very soon to be removed in the work to migrate textile to mdx. I've already released some mdx conversions, this PR fixes those. The other PRs already in place have the typo fixed.