### PR TITLE
Add redirect from /docs/liveobjects/quickstart/ to /docs/liveobjects/quickstart/javascript

### DIFF
--- a/src/pages/docs/liveobjects/quickstart/javascript.mdx
+++ b/src/pages/docs/liveobjects/quickstart/javascript.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Getting started: LiveObjects in JavaScript"
 meta_description: "A getting started guide to learn the basics of integrating the Ably LiveObjects product into your JavaScript application."
+redirect_from:
+  - /docs/liveobjects/quickstart/
 ---
 
 <Aside data-type='experimental'>


### PR DESCRIPTION
In Slack, @zknill  raised a concern. When Googling LiveObjects, the top result was /docs/liveobjects/quickstart, which was just doing an infinite redirect loop (it was 404ing).

Add a redirect in the Javascript getting started for LiveObjects.
We don’t currently have a getting started landing page, possibly something we should look at in the future.
