### PR TITLE
Add automatic JSON-LD schema generation for docs

### DIFF
--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { JsonLdSchema, serializeJsonLd } from '../utilities/json-ld';
 
 export const Head = ({
   title,
@@ -7,12 +8,14 @@ export const Head = ({
   description,
   metaTitle,
   keywords,
+  jsonLd,
 }: {
   title: string;
   canonical: string;
   description: string;
   metaTitle?: string;
   keywords?: string;
+  jsonLd?: JsonLdSchema | JsonLdSchema[];
 }) => (
   <Helmet>
     <title>{metaTitle || title}</title>
@@ -23,6 +26,18 @@ export const Head = ({
     <meta property="og:description" content={description} />
     <meta name="twitter:description" content={description} />
     {keywords && <meta name="keywords" content={keywords} />}
+
+    {/* JSON-LD Structured Data */}
+    {jsonLd &&
+      (Array.isArray(jsonLd) ? (
+        jsonLd.map((schema, index) => (
+          <script key={`jsonld-${index}`} type="application/ld+json">
+            {serializeJsonLd(schema)}
+          </script>
+        ))
+      ) : (
+        <script type="application/ld+json">{serializeJsonLd(jsonLd)}</script>
+      ))}
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -28,16 +28,19 @@ export const Head = ({
     {keywords && <meta name="keywords" content={keywords} />}
 
     {/* JSON-LD Structured Data */}
-    {jsonLd &&
-      (Array.isArray(jsonLd) ? (
+    {jsonLd && (
+      Array.isArray(jsonLd) ? (
         jsonLd.map((schema, index) => (
           <script key={`jsonld-${index}`} type="application/ld+json">
             {serializeJsonLd(schema)}
           </script>
         ))
       ) : (
-        <script type="application/ld+json">{serializeJsonLd(jsonLd)}</script>
-      ))}
+        <script type="application/ld+json">
+          {serializeJsonLd(jsonLd)}
+        </script>
+      )
+    )}
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -24,7 +24,12 @@ export type Frontmatter = {
   jsonld_date_modified?: string;
   jsonld_author_name?: string;
   jsonld_author_type?: string;
-  [key: string]: unknown; // Allow additional custom JSON-LD fields
+  jsonld_image?: string;
+  jsonld_image_description?: string;
+  jsonld_sdks?: string[];
+  jsonld_faqs?: Array<{ question: string; answer: string }>;
+  jsonld_howto_steps?: Array<{ name: string; text: string }>;
+  [key: string]: unknown;
 };
 
 export type PageContextType = {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -19,6 +19,12 @@ export type Frontmatter = {
   meta_description: string;
   meta_keywords?: string;
   redirect_from?: string[];
+  jsonld_type?: string;
+  jsonld_date_published?: string;
+  jsonld_date_modified?: string;
+  jsonld_author_name?: string;
+  jsonld_author_type?: string;
+  [key: string]: unknown; // Allow additional custom JSON-LD fields
 };
 
 export type PageContextType = {

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -190,6 +190,23 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
     // Extract custom JSON-LD fields from frontmatter
     const customFields: Record<string, unknown> = {};
 
+    // Handle special structured fields
+    if (frontmatter?.jsonld_image) {
+      customFields.image = frontmatter.jsonld_image;
+    }
+    if (frontmatter?.jsonld_image_description) {
+      customFields.imageDescription = frontmatter.jsonld_image_description;
+    }
+    if (frontmatter?.jsonld_sdks) {
+      customFields.sdks = frontmatter.jsonld_sdks;
+    }
+    if (frontmatter?.jsonld_faqs) {
+      customFields.faqs = frontmatter.jsonld_faqs;
+    }
+    if (frontmatter?.jsonld_howto_steps) {
+      customFields.howToSteps = frontmatter.jsonld_howto_steps;
+    }
+
     // Collect any frontmatter fields that start with 'jsonld_custom_'
     Object.entries(frontmatter || {}).forEach(([key, value]) => {
       if (key.startsWith('jsonld_custom_')) {
@@ -235,14 +252,7 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
 
   return (
     <SDKContext.Provider value={{ sdk, setSdk }}>
-      <Head
-        title={title}
-        metaTitle={metaTitle}
-        canonical={canonical}
-        description={description}
-        keywords={keywords}
-        jsonLd={jsonLd}
-      />
+      <Head title={title} metaTitle={metaTitle} canonical={canonical} description={description} keywords={keywords} jsonLd={jsonLd} />
       <Article>
         <MarkdownProvider
           components={{

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -33,7 +33,7 @@ import { useSiteMetadata } from 'src/hooks/use-site-metadata';
 import { ProductName } from 'src/templates/template-data';
 import { getMetaTitle } from '../common/meta-title';
 import UserContext from 'src/contexts/user-context';
-import { generateArticleSchema, inferSchemaTypeFromPath } from 'src/utilities/json-ld';
+import { generateCompleteSchema } from 'src/utilities/json-ld';
 
 type MDXWrapperProps = PageProps<unknown, PageContextType>;
 
@@ -198,15 +198,13 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
       }
     });
 
-    // Infer schema type from path if not explicitly set in frontmatter
-    const schemaType = frontmatter?.jsonld_type || inferSchemaTypeFromPath(location.pathname);
-
-    return generateArticleSchema({
+    return generateCompleteSchema({
       title,
       description,
       url: canonical,
+      pathname: location.pathname,
       keywords,
-      schemaType,
+      schemaType: frontmatter?.jsonld_type,
       datePublished: frontmatter?.jsonld_date_published,
       dateModified: frontmatter?.jsonld_date_modified,
       authorName: frontmatter?.jsonld_author_name,

--- a/src/components/Layout/MDXWrapper.tsx
+++ b/src/components/Layout/MDXWrapper.tsx
@@ -33,6 +33,7 @@ import { useSiteMetadata } from 'src/hooks/use-site-metadata';
 import { ProductName } from 'src/templates/template-data';
 import { getMetaTitle } from '../common/meta-title';
 import UserContext from 'src/contexts/user-context';
+import { generateArticleSchema, inferSchemaTypeFromPath } from 'src/utilities/json-ld';
 
 type MDXWrapperProps = PageProps<unknown, PageContextType>;
 
@@ -184,6 +185,36 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
   const { canonicalUrl } = useSiteMetadata();
   const canonical = canonicalUrl(location.pathname);
 
+  // Generate JSON-LD schema for the page
+  const jsonLd = useMemo(() => {
+    // Extract custom JSON-LD fields from frontmatter
+    const customFields: Record<string, unknown> = {};
+
+    // Collect any frontmatter fields that start with 'jsonld_custom_'
+    Object.entries(frontmatter || {}).forEach(([key, value]) => {
+      if (key.startsWith('jsonld_custom_')) {
+        const schemaKey = key.replace('jsonld_custom_', '');
+        customFields[schemaKey] = value;
+      }
+    });
+
+    // Infer schema type from path if not explicitly set in frontmatter
+    const schemaType = frontmatter?.jsonld_type || inferSchemaTypeFromPath(location.pathname);
+
+    return generateArticleSchema({
+      title,
+      description,
+      url: canonical,
+      keywords,
+      schemaType,
+      datePublished: frontmatter?.jsonld_date_published,
+      dateModified: frontmatter?.jsonld_date_modified,
+      authorName: frontmatter?.jsonld_author_name,
+      authorType: frontmatter?.jsonld_author_type,
+      customFields,
+    });
+  }, [title, description, canonical, keywords, frontmatter, location.pathname]);
+
   // Use the copyable headers hook
   useCopyableHeaders();
 
@@ -206,7 +237,14 @@ const MDXWrapper: React.FC<MDXWrapperProps> = ({ children, pageContext, location
 
   return (
     <SDKContext.Provider value={{ sdk, setSdk }}>
-      <Head title={title} metaTitle={metaTitle} canonical={canonical} description={description} keywords={keywords} />
+      <Head
+        title={title}
+        metaTitle={metaTitle}
+        canonical={canonical}
+        description={description}
+        keywords={keywords}
+        jsonLd={jsonLd}
+      />
       <Article>
         <MarkdownProvider
           components={{

--- a/src/pages/docs/auth/basic.mdx
+++ b/src/pages/docs/auth/basic.mdx
@@ -1,6 +1,41 @@
 ---
 title: Basic auth
 meta_description: "Basic authentication allows you to authenticate a secure server using an Ably API key and secret."
+meta_keywords: "authentication, api key, basic auth, security"
+
+# Image from the page
+jsonld_image: "https://ably.com/docs/images/content/diagrams/Ably-API-Auth1.png"
+jsonld_image_description: "Basic authentication process diagram"
+
+# All SDKs shown in code examples
+jsonld_sdks:
+  - javascript
+  - nodejs
+  - ruby
+  - python
+  - java
+  - swift
+  - objc
+  - csharp
+  - go
+  - flutter
+  - php
+
+# FAQs extracted from "When to use basic auth" section
+jsonld_faqs:
+  - question: "When should I use basic authentication with Ably?"
+    answer: "Basic authentication is recommended only for server-side use. It should be used when authenticating secure servers with Ably. It's more efficient to use the REST interface rather than realtime when the server is used solely for authentication."
+  - question: "Why shouldn't I use basic auth on the client side?"
+    answer: "Basic authentication should not be used client-side because: 1) The secret is passed directly to Ably and can only be used over TLS connections, 2) All configured capabilities of the key are implicitly available which could be abused, 3) Clients can claim any client ID they choose, making client IDs untrustworthy."
+  - question: "Do I need to use the realtime interface for basic authentication?"
+    answer: "No, basic authentication is primarily designed for authenticating secure servers, so it's more efficient to use the REST interface of an Ably SDK to avoid the overhead of maintaining a realtime connection."
+
+# HowTo steps for implementing basic auth
+jsonld_howto_steps:
+  - name: "Obtain API key"
+    text: "Get an API key from your Ably account dashboard"
+  - name: "Initialize SDK with API key"
+    text: "Pass the API key when instancing an Ably SDK using the key parameter in ClientOptions"
 ---
 
 Basic authentication is the simplest way to authenticate with Ably. It requires passing an [API key](/docs/auth#api-key) when instancing an SDK.

--- a/src/utilities/json-ld.ts
+++ b/src/utilities/json-ld.ts
@@ -1,0 +1,135 @@
+/**
+ * JSON-LD Schema Generator for Ably Documentation
+ *
+ * Generates structured data (JSON-LD) for documentation pages to improve SEO
+ * and provide rich snippets in search results.
+ */
+
+export type JsonLdSchema = {
+  '@context': string;
+  '@type': string;
+  [key: string]: unknown;
+};
+
+export interface GenerateArticleSchemaParams {
+  title: string;
+  description: string;
+  url: string;
+  dateModified?: string;
+  datePublished?: string;
+  keywords?: string;
+  schemaType?: string;
+  authorName?: string;
+  authorType?: string;
+  customFields?: Record<string, unknown>;
+}
+
+/**
+ * Generates a JSON-LD schema for documentation pages.
+ * Supports customization through frontmatter fields.
+ *
+ * @param params - The parameters for generating the schema
+ * @returns A JSON-LD schema object
+ */
+export const generateArticleSchema = ({
+  title,
+  description,
+  url,
+  dateModified,
+  datePublished,
+  keywords,
+  schemaType = 'TechArticle',
+  authorName = 'Ably',
+  authorType = 'Organization',
+  customFields = {},
+}: GenerateArticleSchemaParams): JsonLdSchema => {
+  const schema: JsonLdSchema = {
+    '@context': 'https://schema.org',
+    '@type': schemaType,
+    headline: title,
+    description: description,
+    url: url,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Ably',
+      url: 'https://ably.com',
+    },
+    author: {
+      '@type': authorType,
+      name: authorName,
+      ...(authorType === 'Organization' ? { url: 'https://ably.com' } : {}),
+    },
+  };
+
+  // Add optional fields if provided
+  if (dateModified) {
+    schema.dateModified = dateModified;
+  }
+
+  if (datePublished) {
+    schema.datePublished = datePublished;
+  }
+
+  if (keywords) {
+    schema.keywords = keywords.split(',').map((k) => k.trim());
+  }
+
+  // Merge any custom fields from frontmatter
+  Object.entries(customFields).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      schema[key] = value;
+    }
+  });
+
+  return schema;
+};
+
+/**
+ * Generates a BreadcrumbList JSON-LD schema for navigation breadcrumbs.
+ *
+ * @param breadcrumbs - Array of breadcrumb items with name and url
+ * @returns A JSON-LD schema object
+ */
+export const generateBreadcrumbSchema = (breadcrumbs: Array<{ name: string; url: string }>): JsonLdSchema => {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbs.map((crumb, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.url,
+    })),
+  };
+};
+
+/**
+ * Infers the appropriate schema type based on the page URL path.
+ *
+ * @param pathname - The URL pathname of the page
+ * @returns The appropriate schema.org type
+ */
+export const inferSchemaTypeFromPath = (pathname: string): string => {
+  // API documentation and reference pages
+  if (pathname.includes('/api/')) {
+    return 'APIReference';
+  }
+
+  // Tutorial and guide pages
+  if (pathname.includes('/guides/') || pathname.includes('/quickstart') || pathname.includes('/getting-started')) {
+    return 'HowTo';
+  }
+
+  // Default to TechArticle for technical documentation
+  return 'TechArticle';
+};
+
+/**
+ * Serializes a JSON-LD schema object to a JSON string for use in script tags.
+ *
+ * @param schema - The JSON-LD schema object
+ * @returns A JSON string representation
+ */
+export const serializeJsonLd = (schema: JsonLdSchema): string => {
+  return JSON.stringify(schema);
+};


### PR DESCRIPTION
## Description

Implements automatic JSON-LD schema generation for all MDX documentation pages to improve SEO and enable rich search results. Schema types are automatically inferred from URL patterns with manual override support.

Example of /docs/chat/connect:

```
<script type="application/ld+json" data-react-helmet="true">{"@context":"https://schema.org","@type":"TechArticle","headline":"Connections","description":"Manage the realtime connections to Ably.","url":"http://localhost:3000/docs/chat/connect","publisher":{"@type":"Organization","name":"Ably","url":"https://ably.com"},"author":{"@type":"Organization","name":"Ably","url":"https://ably.com"}}</script>
```

Features:
- Automatic schema type detection based on URL patterns:
  * /api/* → APIReference
  * /guides/*, /quickstart → HowTo  
  * Default → TechArticle
 
- Generated schema includes: @context, @type, headline, description, url, publisher, and author
- Manual override via frontmatter (jsonld_type, jsonld_date_*, jsonld_author_*, jsonld_custom_*)
- Support for custom Schema.org fields using jsonld_custom_* prefix
- Renders in <head> as <script type="application/ld+json">

Files added:
- src/utilities/json-ld.ts - Schema generation utilities

Files modified:
- src/components/Head.tsx - Added JSON-LD rendering support
- src/components/Layout/MDXWrapper.tsx - Integrated schema generation
- src/components/Layout/Layout.tsx - Extended Frontmatter type definitions
- src/pages/docs/chat/connect.mdx - Example implementation

Zero configuration required for most pages. Schema automatically generated from existing frontmatter (title, meta_description, meta_keywords).