### PR TITLE
[DX-144] Update control API spec for missing fields

### DIFF
--- a/src/pages/docs/platform/account/control-api.mdx
+++ b/src/pages/docs/platform/account/control-api.mdx
@@ -36,7 +36,7 @@ Note that the Control API has certain [limits](/docs/platform/pricing/limits#api
 
 ## OpenAPI document <a id="open-api"/>
 
-The OpenAPI document for this API can be found in the Ably OpenAPI Documents [GitHub repository](https://github.com/ably/open-specs). It is not required in order to use Control API, but is provided to you so you may optionally generate your own documentation in the tool of your choice, or use mocking tools such as [Prism](https://stoplight.io/open-source/prism/) to assist in developing your clients.
+The OpenAPI document for this API can be found in the Ably OpenAPI Documents [GitHub repository](https://github.com/ably/docs/tree/main/static/open-specs). It is not required in order to use Control API, but is provided to you so you may optionally generate your own documentation in the tool of your choice, or use mocking tools such as [Prism](https://stoplight.io/open-source/prism/) to assist in developing your clients.
 
 In the [testing with Postman](#postman) section you learn how to import this OpenAPI document into Postman, to enable you to quickly try out Control API.
 
@@ -819,7 +819,7 @@ A convenient way to try out the Control API is by importing the OpenAPI document
 
 ![Postman import dialog](../../../../images/content/screenshots/control-api/postman-import-dialog.png)
 
-3. Click the **Link** tab, and paste in the following URL: `https://raw.githubusercontent.com/ably/open-specs/main/definitions/control-v1.yaml`, then click **Continue**:
+3. Click the **Link** tab, and paste in the following URL: `https://raw.githubusercontent.com/ably/docs/refs/heads/main/static/open-specs/control-v1.yaml`, then click **Continue**:
 
 ![Link to OpenAPI document](../../../../images/content/screenshots/control-api/postman-link.png)
 

--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -4878,9 +4878,10 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         batchingInterval:
           type: integer
           default: 20
-          description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
+          description: The batching interval in milliseconds, configurable from 20ms to 1s. Temporarily holds and aggregates incoming messages, which are then combined and delivered as a single batch once the interval elapses or a size limit is reached.
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false
@@ -4900,6 +4901,25 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           type: boolean
           default: false
           description: If `true`, messages received on a channel will contain a unique `timeserial` that can be referenced by later messages for use with message interactions.
+        mutableMessages:
+          type: boolean
+          default: false
+          description: If `true`, messages received on a channel can be updated or deleted after publishing using message interactions. When `mutableMessages` is `true`, `persisted` must also be set to `true`.
+          example: false
+        populateChannelRegistry:
+          type: boolean
+          default: false
+          description: If `true`, channels within this namespace will be populated in the channel registry, enabling enumeration of channels.
+          example: false
+        batchingPolicy:
+          type: string
+          default: simple
+          description: The batching policy to use for channels within this namespace.
+          example: simple
+        batchingConflationKey:
+          type: string
+          nullable: true
+          description: The conflation key used for batching. When set, messages with the same conflation key are merged during batching.
       required:
       - id
     namespace_patch:
@@ -4934,9 +4954,10 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         batchingInterval:
           type: integer
           default: 20
-          description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
+          description: The batching interval in milliseconds, configurable from 20ms to 1s. Temporarily holds and aggregates incoming messages, which are then combined and delivered as a single batch once the interval elapses or a size limit is reached.
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false
@@ -4955,10 +4976,33 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         exposeTimeserial:
           type: boolean
           description: If `true`, messages received on a channel will contain a unique `timeserial` that can be referenced by later messages for use with message interactions.
+        mutableMessages:
+          type: boolean
+          default: false
+          description: If `true`, messages received on a channel can be updated or deleted after publishing using message interactions. When `mutableMessages` is `true`, `persisted` must also be set to `true`.
+          example: false
+        populateChannelRegistry:
+          type: boolean
+          default: false
+          description: If `true`, channels within this namespace will be populated in the channel registry, enabling enumeration of channels.
+          example: false
+        batchingPolicy:
+          type: string
+          default: simple
+          description: The batching policy to use for channels within this namespace.
+          example: simple
+        batchingConflationKey:
+          type: string
+          nullable: true
+          description: The conflation key used for batching. When set, messages with the same conflation key are merged during batching.
     namespace_response:
       type: object
       additionalProperties: false
       properties:
+        appId:
+          type: string
+          description: The ID of the application that the namespace belongs to.
+          example: 28AB6c
         authenticated:
           type: boolean
           default: false
@@ -4999,9 +5043,10 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         batchingInterval:
           type: integer
           default: 20
-          description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
+          description: The batching interval in milliseconds, configurable from 20ms to 1s. Temporarily holds and aggregates incoming messages, which are then combined and delivered as a single batch once the interval elapses or a size limit is reached.
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false
@@ -5020,6 +5065,25 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
         exposeTimeserial:
           type: boolean
           description: If `true`, messages received on a channel will contain a unique `timeserial` that can be referenced by later messages for use with message interactions.
+        mutableMessages:
+          type: boolean
+          default: false
+          description: If `true`, messages received on a channel can be updated or deleted after publishing using message interactions. When `mutableMessages` is `true`, `persisted` must also be set to `true`.
+          example: false
+        populateChannelRegistry:
+          type: boolean
+          default: false
+          description: If `true`, channels within this namespace will be populated in the channel registry, enabling enumeration of channels.
+          example: false
+        batchingPolicy:
+          type: string
+          default: simple
+          description: The batching policy to use for channels within this namespace.
+          example: simple
+        batchingConflationKey:
+          type: string
+          nullable: true
+          description: The conflation key used for batching. When set, messages with the same conflation key are merged during batching.
     app_post:
       type: object
       additionalProperties: false
@@ -5183,6 +5247,11 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
             description: An array of strings setting the capability operations for the resource.
             items:
               type: string
+        revocableTokens:
+          description: If `true`, tokens issued by this key will be revocable. This enables the use of the token revocation API to invalidate tokens issued by this key.
+          type: boolean
+          default: false
+          example: false
       example:
         name: My key name
         capability:
@@ -5210,6 +5279,11 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
             description: An array of strings setting the capability operations for the resource.
             items:
               type: string
+        revocableTokens:
+          description: If `true`, tokens issued by this key will be revocable. This enables the use of the token revocation API to invalidate tokens issued by this key.
+          type: boolean
+          default: false
+          example: false
       example:
         name: My key name
         capability:
@@ -5262,6 +5336,11 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           type: integer
           description: Unix timestamp representing the date and time of the last modification of the key.
           example: 1614679682091
+        revocableTokens:
+          description: If `true`, tokens issued by this key are revocable. This enables the use of the token revocation API to invalidate tokens issued by this key.
+          type: boolean
+          default: false
+          example: false
     me:
       type: object
       additionalProperties: false


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/DX-144
- Updated missing fields for `mutableMessages`, `batchingPolicy`, `batchingConflationKey` etc
- Related to https://ably.atlassian.net/browse/DX-789

TODOs

- [x] (Optional) Update `src/pages/docs/platform/account/control-api.mdx` for newly added fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Control API OpenAPI and Postman import references to the new docs location.

* **New Features**
  * Added namespace-level configuration options: mutableMessages, populateChannelRegistry, batchingPolicy, and batchingConflationKey.
  * Added revocable token support for keys (revocableTokens) and related response fields.
  * Renamed and clarified several fields (e.g., exposeTimeSerial) and refined batching descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->