### PR TITLE
fix: update channel push CLI commands to use push publish --channel flag

### DIFF
--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -554,12 +554,14 @@ You can get your device ID from the device details button (don't confuse it with
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test pushes via channel, subscribe to "Channel 1" in the UI and post a message to the "exampleChannel1"
-with a `push` `extras` field using Ably CLI:
+To test pushes via channel, subscribe to "Channel 1" in the UI and send a push notification to the channel using the Ably CLI:
 
 <Code>
 ```shell
-ably channels publish exampleChannel1 '{"name":"example","data":"Hello from CLI!","extras":{"push":{"notification":{"title":"Ably CLI","body":"Hello from CLI!"},"data":{"foo":"bar"}}}}'
+ably push publish --channel exampleChannel1 \
+  --title "Ably CLI" \
+  --body "Hello from CLI!" \
+  --data '{"foo":"bar"}'
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -276,9 +276,9 @@ func unsubscribeFromChannel(_ channelName: String) {
 
 Sending push notifications using `deviceId` or `clientId` requires the `push-admin` capability for your API key. Use this method for testing purposes. In a production environment, you would typically send push notifications from your backend server (by posting messages with `push` `extras` field to a channel).
 
-To test push notifications in your app, you can use [Ably dashboard](https://ably.com/dashboard), [Apple developer dashboard](https://icloud.developer.apple.com/dashboard/) or Ably CLI.
+To test push notifications in your app, you can use [Ably dashboard](https://ably.com/dashboard), [Apple developer dashboard](https://icloud.developer.apple.com/dashboard/) or [Ably CLI](/docs/platform/tools/cli).
 
-To send to your client ID using Ably CLI paste the following command into your terminal:
+To publish to your client ID using the [Ably CLI](/docs/platform/tools/cli) paste the following command into your terminal:
 
 <Code>
 ```shell
@@ -554,7 +554,7 @@ You can get your device ID from the device details button (don't confuse it with
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test pushes via channel, subscribe to "Channel 1" in the UI and send a push notification to the channel using the Ably CLI:
+To test pushes via channel, subscribe to "Channel 1" in the UI and publish a push notification to the channel using the [Ably CLI](/docs/platform/tools/cli):
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -559,9 +559,9 @@ To test pushes via channel, subscribe to "Channel 1" in the UI and send a push n
 <Code>
 ```shell
 ably push publish --channel exampleChannel1 \
-  --title "Ably CLI" \
-  --body "Hello from CLI!" \
-  --data '{"foo":"bar"}'
+  --title "Hello" \
+  --body "World!" \
+  --message '{"name":"greeting","data":"Hello World!"}'
 ```
 </Code>
 
@@ -991,5 +991,6 @@ Verify that your app receives and handles location push notifications correctly 
 * Learn about [rules](/docs/channels#rules) for channel-based push notifications.
 * Read more about the [Push Admin API](/docs/api/realtime-sdk?lang=swift#push-admin).
 * Check out the [Push Notifications](/docs/push) documentation for advanced use cases.
+* Explore [Ably CLI push commands](/docs/cli/push) for the full list of push CLI options.
 
 You can also explore the [Ably SDK for Swift](https://github.com/ably/ably-cocoa) on GitHub, or visit the [API references](/docs/api/realtime-sdk?lang=swift) for additional functionality.

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -665,9 +665,9 @@ To test push notifications via channel, tap **Subscribe to Channel** in the app 
 <Code>
 ```shell
 ably push publish --channel exampleChannel1 \
-  --title "Ably CLI" \
-  --body "Hello from CLI!" \
-  --data '{"foo":"bar"}'
+  --title "Hello" \
+  --body "World!" \
+  --message '{"name":"greeting","data":"Hello World!"}'
 ```
 </Code>
 
@@ -827,5 +827,6 @@ Build and run your app again. Use the new buttons to send push notifications dir
 * Explore [push notification administration](/docs/push#push-admin) for managing devices and subscriptions.
 * Learn about [rules](/docs/channels#rules) for channel-based push notifications.
 * Read more about the [Push Admin API](/docs/api/realtime-sdk/push-admin).
+* Explore [Ably CLI push commands](/docs/cli/push) for the full list of push CLI options.
 
 You can also explore the [Ably SDK for Android](https://github.com/ably/ably-java) on GitHub, or visit the [API references](/docs/api/realtime-sdk?lang=kotlin) for additional functionality.

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -399,7 +399,7 @@ fun subscribeToRealtime(channelName: String) {
 Sending push notifications using `deviceId` or `clientId` requires the `push-admin` capability for your API key. Use this method for testing purposes. In a production environment, you would typically send push notifications from your backend server (by posting messages with `push` `extras` field to a channel).
 </Aside>
 
-Now use the Ably CLI to test sending a push notification to your client ID:
+Now use the [Ably CLI](/docs/platform/tools/cli) to test publishing a push notification to your client ID:
 
 <Code>
 ```shell
@@ -660,7 +660,7 @@ Build and run your app on an Android device or emulator. Tap **Activate Push** a
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test push notifications via channel, tap **Subscribe to Channel** in the app and then send a push notification to the channel using the Ably CLI:
+To test push notifications via channel, tap **Subscribe to Channel** in the app and then publish a push notification to the channel using the [Ably CLI](/docs/platform/tools/cli):
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -660,11 +660,14 @@ Build and run your app on an Android device or emulator. Tap **Activate Push** a
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test push notifications via channel, tap **Subscribe to Channel** in the app and then publish a message to "exampleChannel1" with a `push` `extras` field using Ably CLI:
+To test push notifications via channel, tap **Subscribe to Channel** in the app and then send a push notification to the channel using the Ably CLI:
 
 <Code>
 ```shell
-ably channels publish exampleChannel1 '{"name":"example","data":"Hello from CLI!","extras":{"push":{"notification":{"title":"Ably CLI","body":"Hello from CLI!"},"data":{"foo":"bar"}}}}'
+ably push publish --channel exampleChannel1 \
+  --title "Ably CLI" \
+  --body "Hello from CLI!" \
+  --data '{"foo":"bar"}'
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/flutter.mdx
+++ b/src/pages/docs/push/getting-started/flutter.mdx
@@ -454,7 +454,7 @@ In the app tap **Activate Push** and wait until the status message displays your
 
 ### Publish directly to your device <a id="step-5-direct"/>
 
-Publish a push notification directly to your client ID (or device ID using `--device-id` instead of `--client-id`) via the Ably CLI:
+Publish a push notification directly to your client ID (or device ID using `--device-id` instead of `--client-id`) via the [Ably CLI](/docs/platform/tools/cli):
 
 <Code fixed="true">
 ```shell
@@ -467,7 +467,7 @@ ably push publish --client-id push-tutorial-client \
 
 ### Publish via a channel <a id="step-5-channel"/>
 
-Tap **Subscribe to Channel** in the app, then publish a push notification to your channel using the Ably CLI:
+Tap **Subscribe to Channel** in the app, then publish a push notification to the channel using the [Ably CLI](/docs/platform/tools/cli):
 
 <Code fixed="true">
 ```shell

--- a/src/pages/docs/push/getting-started/react-native.mdx
+++ b/src/pages/docs/push/getting-started/react-native.mdx
@@ -478,7 +478,7 @@ In the app tap **Activate Push** and wait until the status message displays your
 
 ### Publish directly to your device <a id="step-5-direct"/>
 
-Publish a push notification directly to your client ID (or device ID using `--device-id` instead of `--client-id`) via the Ably CLI:
+Publish a push notification directly to your client ID (or device ID using `--device-id` instead of `--client-id`) via the [Ably CLI](/docs/platform/tools/cli):
 
 <Code fixed="true">
 ```shell
@@ -491,7 +491,7 @@ ably push publish --client-id push-tutorial-client \
 
 ### Publish via a channel <a id="step-5-channel"/>
 
-Tap **Subscribe to Channel** in the app, then publish a push notification to your channel using the Ably CLI:
+Tap **Subscribe to Channel** in the app, then publish a push notification to the channel using the [Ably CLI](/docs/platform/tools/cli):
 
 <Code fixed="true">
 ```shell

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -570,11 +570,14 @@ Try sending push using this `deviceId` or `clientId` as shown earlier.
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test pushes via channel, subscribe to the channel in the UI and post a message to the "exampleChannel1" with a `push` `extras` field using Ably CLI:
+To test pushes via channel, subscribe to the channel in the UI and send a push notification to the channel using the Ably CLI:
 
 <Code>
 ```shell
-ably channels publish exampleChannel1 '{"name":"example","data":"Hello from CLI!","extras":{"push":{"notification":{"title":"Ably CLI","body":"Hello from CLI!"},"data":{"foo":"bar"}}}}'
+ably push publish --channel exampleChannel1 \
+  --title "Ably CLI" \
+  --body "Hello from CLI!" \
+  --data '{"foo":"bar"}'
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -575,9 +575,9 @@ To test pushes via channel, subscribe to the channel in the UI and send a push n
 <Code>
 ```shell
 ably push publish --channel exampleChannel1 \
-  --title "Ably CLI" \
-  --body "Hello from CLI!" \
-  --data '{"foo":"bar"}'
+  --title "Hello" \
+  --body "World!" \
+  --message '{"name":"greeting","data":"Hello World!"}'
 ```
 </Code>
 
@@ -730,5 +730,6 @@ Safari on macOS 13+ supports Web Push, but with some limitations. Notification a
 * Learn about [rules](/docs/channels#rules) for channel-based push notifications.
 * Read more about the [Push Admin API](/docs/api/realtime-sdk/push-admin).
 * Check out the [Web Push Notifications](/docs/push/configure/web) documentation for advanced use cases.
+* Explore [Ably CLI push commands](/docs/cli/push) for the full list of push CLI options.
 
 You can also explore the [Ably JavaScript SDK](https://github.com/ably/ably-js) on GitHub, or visit the [API references](/docs/api/realtime-sdk?lang=javascript) for additional functionality.

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -405,9 +405,9 @@ async function unsubscribeFromChannel() {
 
 Sending push notifications using `deviceId` or `clientId` requires the `push-admin` capability for your API key. Use this method for testing purposes. In a production environment, you would typically send push notifications from your backend server (by posting messages with `push` `extras` field to a channel).
 
-To test push notifications in your app, you can use [Ably dashboard](https://ably.com/dashboard) or Ably CLI.
+To test push notifications in your app, you can use [Ably dashboard](https://ably.com/dashboard) or [Ably CLI](/docs/platform/tools/cli).
 
-To send to your client using Ably CLI paste the following command into your terminal:
+To publish to your client using the [Ably CLI](/docs/platform/tools/cli) paste the following command into your terminal:
 
 <Code>
 ```shell
@@ -570,7 +570,7 @@ Try sending push using this `deviceId` or `clientId` as shown earlier.
 
 ### Send push via channel <a id="step-4-send-channel"/>
 
-To test pushes via channel, subscribe to the channel in the UI and send a push notification to the channel using the Ably CLI:
+To test pushes via channel, subscribe to the channel in the UI and publish a push notification to the channel using the [Ably CLI](/docs/platform/tools/cli):
 
 <Code>
 ```shell


### PR DESCRIPTION
## Summary

- Replace legacy `ably channels publish` with inline JSON extras in APNs, FCM, and web push getting-started guides
- Use the new `ably push publish --channel <name>` flag with `--title`, `--body`, and `--data` options
- Update surrounding text to match the new command style

https://ably.atlassian.net/browse/DX-927