### PR TITLE
 Rewind param: stop making the non-ably-sdk fallback method the first thing we tell people about

### DIFF
--- a/src/pages/docs/channels/options/index.mdx
+++ b/src/pages/docs/channels/options/index.mdx
@@ -608,15 +608,15 @@ await channel.setOptions(channelOptions);
 
 The `cipher` property can be used to enable message [encryption](/docs/channels/options/encryption). This ensures that message payloads are opaque and can only only be decrypted by other clients that share your secret key.
 
-## Channel options without Ably SDK support <a id="other-sdks"/>
+## Channel params without Ably SDK support <a id="other-sdks"/>
 
-For any Ably SDKs that do not currently expose the channel options API, a set of channel options can be expressed by including a query string with standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
+For any Ably SDKs that do not currently expose the channel options API, a set of channel params can be expressed by including a query string with standard URL query syntax and encoding, within the qualifier part of a channel name. The qualifier part is in square brackets at the start of the channel name.
 
-To specify the channel option `foo` with value `bar` on channel `baz`, the qualified channel name would be `[?foo=bar]baz`. If the channel name already has a qualifier, such as `[meta]log`, then the query string follows the existing qualifier, as in `[meta?foo=bar]log`.
+To specify the channel param `foo` with value `bar` on channel `baz`, the qualified channel name would be `[?foo=bar]baz`. If the channel name already has a qualifier, such as `[meta]log`, then the query string follows the existing qualifier, as in `[meta?foo=bar]log`.
 
-Using this syntax with a non-supported Ably SDK means that channel options are specified for the lifetime of the `Channel` instance. In order to reference the same channel, but with different options, it is necessary to get a new `Channel` instance, using a qualified name that includes the new channel options.
+Using this syntax with a non-supported Ably SDK means that channel params are specified for the lifetime of the `Channel` instance. In order to reference the same channel, but with different params, it is necessary to get a new `Channel` instance, using a qualified name that includes the new channel params.
 
-For example, to specify the `rewind` channel option with the value `"1"`:
+For example, to specify the `rewind` channel param with the value `"1"`:
 
 <Code>
 ```realtime_javascript

--- a/src/pages/docs/channels/options/rewind.mdx
+++ b/src/pages/docs/channels/options/rewind.mdx
@@ -128,7 +128,7 @@ channel.subscribe().listen((message) {
 </Code>
 
 <Aside data-type="note">
-If using [MQTT](/docs/protocols/mqtt) or [SSE](/docs/protocols/sse), see [Channel options without Ably SDK support](/docs/channels/options#other-sdks) for how to specify a rewind param.
+If using [MQTT](/docs/protocols/mqtt) or [SSE](/docs/protocols/sse), you can [specify channel params](/docs/channels/options#other-sdks) as a query string.
 </Aside>
 
 ### Retrieve a number of messages <a id="number"/>

--- a/src/pages/docs/channels/options/rewind.mdx
+++ b/src/pages/docs/channels/options/rewind.mdx
@@ -1,11 +1,11 @@
 ---
 title: Rewind
-meta_description: "The rewind channel option enables clients to attach to a channel and receive messages previously published on it."
+meta_description: "The rewind channel param enables clients to attach to a channel and receive messages previously published on it."
 redirect_from:
   - /docs/realtime/channels/channel-parameters/rewind
 ---
 
-The `rewind` channel option enables a client to specify where to start an attachment from, when attaching to a channel. Rewind can provide context to clients attaching to a channel by passing them previously published messages, such as in the example of a joining a chat room.
+The `rewind` channel param enables a client to specify where to start an attachment from, when attaching to a channel. Rewind can provide context to clients attaching to a channel by passing them previously published messages, such as in the example of a joining a chat room.
 
 Clients can rewind to a point in time in the past, or for a given number of messages.
 

--- a/src/pages/docs/channels/options/rewind.mdx
+++ b/src/pages/docs/channels/options/rewind.mdx
@@ -15,15 +15,7 @@ Rewind only has an effect on an initial channel attachment. Any subsequent reatt
 
 ## Subscribe with rewind <a id="subscribe"/>
 
-The `rewind` property of `params` can be set at a point in time in the past, or for a given number of messages.
-
-`rewind` can also be set by qualifying a channel name during a call to [`get()`](/docs/api/realtime-sdk/channels#get). For example, if you want to subscribe to channel `my_channel` and fetch the most recent message, you would specify the channel as `[?rewind=1]my_channel`. If the channel also contains metadata, you would apply rewind with `[some_metadata?rewind=1]my_channel`.
-
-<Aside data-type="note">
-Rewind can also be used with [MQTT](/docs/protocols/mqtt) or [SSE](/docs/protocols/sse) by qualifying the channel name to specify the rewind option.
-</Aside>
-
-A `rewind` value that is a number, `N`, is a request to attach to the channel at a position `N` messages before the present position. A `rewind` value with a time specifier is a request to attach to the channel at a point in time in the past, such as `10s` for 10 seconds, or `5m` for 5 minutes.
+The `rewind` property of `params` can be set at a point in time in the past, or for a given number of messages. A `rewind` value that is a number, `N`, is a request to attach to the channel at a position `N` messages before the present position. A `rewind` value with a time specifier is a request to attach to the channel at a point in time in the past, such as `10s` for 10 seconds, or `5m` for 5 minutes.
 
 If the attachment is successful, and one or more messages exist on the channel prior to the present position, then those messages will be delivered to the subscriber immediately after the attachment has completed, and before any subsequent messages that arise in real time.
 
@@ -134,6 +126,10 @@ channel.subscribe().listen((message) {
 });
 ```
 </Code>
+
+<Aside data-type="note">
+If using [MQTT](/docs/protocols/mqtt) or [SSE](/docs/protocols/sse), see [Channel options without Ably SDK support](/docs/channels/options#other-sdks) for how to specify a rewind param.
+</Aside>
 
 ### Retrieve a number of messages <a id="number"/>
 


### PR DESCRIPTION
It doesn't make any sense to start out by saying "rewind can **also** be set by..." and then the MQTT/SSE fallback method when we haven't told anyone the actual, main method that they should use with ably SDKs yet. Nor to have that as a top-level paragraph followed by an inset note explaining when you should use that method (for mqtt and sse), it's not at all obvious that the inset note is meant to tell you when to use the previous _not_-inset paragraph

I think this was a regression from https://github.com/ably/docs/pull/1937 

also fix a bunch of places on that page where we call it a channel option not a channel param