### PR TITLE
Add message bandwidth per channel limit

### DIFF
--- a/src/pages/docs/platform/pricing/limits.mdx
+++ b/src/pages/docs/platform/pricing/limits.mdx
@@ -100,6 +100,7 @@ Therefore, to provide the realtime platform-as-a-service economically to all cus
 | **Default last message on channel TTL (days)**<p>*the default period that the last message on a channel is stored for, when enabled*</p> | 1 | 30 | 365 | 365 |
 | **Channel creation rate (per second)**<p>*the maximum rate at which channels can be created across an account*</p> | 42 | 250 | 500 | Custom |
 | **Message publish rate per channel (per second)**<p>*the maximum rate at which messages can be published for each channel*</p> | 50 | 50 | 50 | 50 |
+| **Message bandwidth per channel (per second)**<p>*the maximum total size of all messages published to a channel per second*</p> | 1024 KiB | 1024 KiB | 1024 KiB | 1024 KiB |
 | **Presence members per channel**<p>*the maximum number of clients that can be simultaneously present on a channel*</p> | 200 | 200 | 200 | 200 |
 | **Presence members per channel with [server-side batching](/docs/messages/batch#server-side) enabled**<p>*the maximum number of clients that can be simultaneously present on a channel when server-side batching is enabled*</p> | 200 | 5,000 | 10,000 | 20,000 |
 | **Total object size per channel(MB)**<p>*the maximum aggregate size of all objects on a channel*</p> | 6.5 | 6.5 | 6.5 | 6.5 |


### PR DESCRIPTION
## Summary
- Adds a new "Message bandwidth per channel (per second)" row to the channel limits table on the pricing/limits page
- Default is 1024 KiB/s across all packages (Free, Standard, Pro, Enterprise)

## Test plan
- [ ] Verify the new row renders correctly in the limits table
- [ ] Check formatting is consistent with other rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)