### PR TITLE
fix(cli-docs): add --message flag to push publish, update --channel description

### DIFF
--- a/src/pages/docs/cli/push/publish.mdx
+++ b/src/pages/docs/cli/push/publish.mdx
@@ -30,7 +30,7 @@ A raw JSON recipient object. Exclusive with `--device-id` and `--client-id`.
 
 ### `--channel` <a id="channel"/>
 
-The target channel name. Publishes a push notification via the channel using `extras.push`. Ignored if `--device-id`, `--client-id`, or `--recipient` is also provided. Use together with `--message` to provide a realtime message to push recipients.
+The target channel name. Publishes a push notification via the channel using `extras.push`. Ignored if `--device-id`, `--client-id`, or `--recipient` is also provided. Use together with `--message` to publish a realtime message on the channel alongside the push notification.
 
 ### `--message` <a id="message"/>
 

--- a/src/pages/docs/cli/push/publish.mdx
+++ b/src/pages/docs/cli/push/publish.mdx
@@ -30,7 +30,11 @@ A raw JSON recipient object. Exclusive with `--device-id` and `--client-id`.
 
 ### `--channel` <a id="channel"/>
 
-The target channel name. Publishes a push notification via the channel using `extras.push`. Ignored if `--device-id`, `--client-id`, or `--recipient` is also provided.
+The target channel name. Publishes a push notification via the channel using `extras.push`. Ignored if `--device-id`, `--client-id`, or `--recipient` is also provided. Use together with `--message` to provide a realtime message to push recipients.
+
+### `--message` <a id="message"/>
+
+Realtime message data to include alongside the push notification. Only applies when publishing via `--channel`.
 
 ### `--title` <a id="title"/>
 
@@ -168,6 +172,22 @@ Publish to a channel using a custom JSON payload:
 <Code>
 ```shell
 ably push publish --channel my-channel --payload '{"notification":{"title":"Hello","body":"World"},"data":{"key":"value"}}'
+```
+</Code>
+
+Publish a push notification to a channel with a realtime message string:
+
+<Code>
+```shell
+ably push publish --channel my-channel --title Hello --body World --message 'Hello from push'
+```
+</Code>
+
+Publish a push notification to a channel with a realtime message JSON payload:
+
+<Code>
+```shell
+ably push publish --channel my-channel --title Hello --body World --message '{"event":"push","text":"Hello"}'
 ```
 </Code>
 

--- a/src/pages/docs/cli/push/publish.mdx
+++ b/src/pages/docs/cli/push/publish.mdx
@@ -34,7 +34,7 @@ The target channel name. Publishes a push notification via the channel using `ex
 
 ### `--message` <a id="message"/>
 
-Realtime message data to include alongside the push notification. Only applies when publishing via `--channel`.
+Realtime message data to include alongside the push notification. Accepts either plain text or raw JSON, and the value is used as the realtime message `data` payload rather than a full message object. Only applies when publishing via `--channel`.
 
 ### `--title` <a id="title"/>
 


### PR DESCRIPTION
## Summary

Addresses review comment on #3307.

- Updates `--channel` flag description to mention `--message` as a companion flag
- Adds `--message` flag documentation for attaching a realtime message payload when publishing via channel
- Adds an example showing `--channel` used together with `--message`

## Test plan

- [ ] `--channel` description reads correctly with the `--message` cross-reference
- [ ] `--message` flag appears in the flags section after `--channel`
- [ ] New example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)