### PR TITLE
[DX-1070] Document last_used_at on Control API /me response

### DIFF
--- a/src/pages/docs/platform/account/control-api.mdx
+++ b/src/pages/docs/platform/account/control-api.mdx
@@ -54,7 +54,7 @@ curl -H 'Authorization: Bearer <YOUR_ACCESS_TOKEN>' ...
 
 ### Obtain token details using the Control API <a id="obtain-token"/>
 
-You can use the Control API to obtain information about your access token, such as its capabilities, expiration date, and the user and account it is assigned to. This is shown in the following request:
+You can use the Control API to obtain information about your access token, such as its capabilities, expiration date, when it was last used, and the user and account it is assigned to. This is shown in the following request:
 
 <Code>
 ```shell
@@ -83,7 +83,8 @@ Sample response:
             "write:app",
             "read:app"
         ],
-        "expires_at": "2026-04-25T00:00:00Z"
+        "expires_at": "2026-04-25T00:00:00Z",
+        "last_used_at": "2026-04-17T12:34:56Z"
     },
     "user": {
         "id": 12140,

--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -7410,11 +7410,18 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
               nullable: true
               description: The date and time at which the access token expires, in ISO 8601 format. A value of `null` indicates the token does not expire.
               example: "2026-04-25T00:00:00Z"
+            last_used_at:
+              type: string
+              format: date-time
+              nullable: true
+              description: The date and time at which the access token was last used to authenticate a Control API request, in ISO 8601 format. Updated at most once per 10-minute window. A value of `null` indicates the token has not been used since tracking began.
+              example: "2026-04-17T12:34:56Z"
           required:
           - id
           - name
           - capabilities
           - expires_at
+          - last_used_at
         user:
           type: object
           additionalProperties: false


### PR DESCRIPTION
## Summary

- Add `last_used_at` to the `me` token schema in the Control API OpenAPI spec (`static/open-specs/control-v1.yaml`), including description and `required` entry
- Update the `/v1/me` sample response and intro copy in the Control API docs page to surface the new field

Mirrors the [website PR](https://github.com/ably/website/pull/8225) that exposes `last_used_at` on the `/me` endpoint.
Jira: [DX-1070](https://ably.atlassian.net/browse/DX-1070)

## Affected URLs (review app)

- [Control API docs page](https://ably-docs-dx-1070-contr-yq3vco.herokuapp.com/docs/platform/account/control-api#obtain-token)
- [Control API reference (`/me` endpoint)](https://ably-docs-dx-1070-contr-yq3vco.herokuapp.com/docs/api/control-api#operation/getMe)

## Test plan

- [ ] Verify the Control API reference renders with the new `last_used_at` field and description
- [ ] Verify the sample response on `/docs/platform/account/control-api` renders correctly
- [ ] Confirm field description matches the behaviour (nullable, throttled to once per 10 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1070]: https://ably.atlassian.net/browse/DX-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ