### PR TITLE
docs: clarify that channels.release() is for niche use cases

### DIFF
--- a/src/pages/docs/api/realtime-sdk/channels.mdx
+++ b/src/pages/docs/api/realtime-sdk/channels.mdx
@@ -67,15 +67,15 @@ Derived channels enables you to subscribe to a filtered subset of messages on a 
 
 </If>
 
-Releases a [Channel](#properties) object, deleting it from the local SDK client instance and enabling it to be garbage collected. It also removes any listeners associated with the channel on this specific client instance.
+Releases all SDK-held references to a [Channel](#properties) object, enabling it to be garbage collected. It can be useful for applications that work with a continually changing set of channels on a single client and need to avoid unbounded memory growth; if this does not describe your application, don't call it.
 
-This method only affects the local client-side representation of the channel. The channel itself on the Ably platform is not deleted or changed, and other client instances (in the same or different processes) are unaffected. Any listeners attached through other client instances remain active.
+<Aside data-type='important'>
+This method has no guardrails: using a channel reference after `release` has been called is undefined behaviour.
+</Aside>
 
-After releasing a channel, calling `channels.get(channelName)` will create a fresh channel object with no listeners. If the channel was attached before being released, the new channel object will be in the `initialized` state, not `attached`.
+This method only affects the local client-side representation of the channel. The channel itself on the Ably platform is not deleted or changed, and other client instances (in the same or different processes) are unaffected.
 
-If using a singleton client pattern with multiple execution contexts, be cautious when calling `release` as it will affect all parts of your application using that client instance. Consider using `unsubscribe` for specific listeners instead.
-
-<If lang="javascript,nodejs">**Note**: To release a channel, the [channel state](/docs/channels/states) must be `initialized`, `detached` or `failed`.</If>
+Channels not already in the `initialized`, `detached`, or `failed` [state](/docs/channels/states) are detached before release. After release, calling `channels.get(channelName)` returns a fresh channel object in the `initialized` state.
 
 ## Channel <a id="channel-object" />
 

--- a/src/pages/docs/api/rest-sdk/channels.mdx
+++ b/src/pages/docs/api/rest-sdk/channels.mdx
@@ -56,11 +56,15 @@ Creates a new [Channel](#properties) object if none for the channel exists, or r
 
 </If>
 
-Releases a [Channel](#properties) object, deleting it from the local SDK client instance and enabling it to be garbage collected.
+Releases all SDK-held references to a [Channel](#properties) object, enabling it to be garbage collected. It can be useful for applications that work with a continually changing set of channels on a single client and need to avoid unbounded memory growth; if this does not describe your application, don't call it.
+
+<Aside data-type='important'>
+This method has no guardrails: using a channel reference after `release` has been called is undefined behaviour.
+</Aside>
 
 This method only affects the local client-side representation of the channel. The channel itself on the Ably platform is not deleted or changed, and other client instances (in the same or different processes) are unaffected.
 
-After releasing a channel, calling `channels.get(channelName)` will create a fresh channel object. If using a singleton REST client pattern with multiple execution contexts, be cautious when calling `release` as it will affect all parts of your application using that client instance. Subsequent publish operations on the same channel name will require obtaining a new channel object.
+After release, calling `channels.get(channelName)` returns a fresh channel object.
 
 ## Channel <a id="channel-object" />
 


### PR DESCRIPTION
## Summary
- Reframes the `channels.release()` docs on both the Realtime and REST API pages to match the recent [specification update](https://github.com/ably/specification/commit/f0f5022318eba512611fd064937af17aabf931fa).
- Adds an `important` admonition making clear that most applications should never call `release` — it exists for niche use cases (clients cycling through a continually changing set of channels).
- Warns that retaining and using a channel reference after `release` is undefined behaviour.
- Removes the singleton-client cautionary paragraphs, since they are subsumed by the stronger "don't use this unless you really need to" framing.

## Test plan
- [ ] Visual check of the rendered pages in a review app for both `/docs/api/realtime-sdk/channels#release` and `/docs/api/rest-sdk/channels#release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)