### PR TITLE
chore(deps): remove unused uuid direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
     "remark-gfm": "^1.0.0",
     "typescript": "^4.6.3",
     "use-keyboard-shortcut": "^1.1.6",
-    "util": "^0.12.4",
-    "uuid": "^8.3.2"
+    "util": "^0.12.4"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
## Summary
- Remove `uuid` from `dependencies` — never imported in source (verified via grep across `src/`, `data/`, `examples/`, `gatsby-*`, `plugins/`).
- Gatsby still pulls `uuid@8.3.2` transitively, so behavior is unchanged.
- Closes #3357 — dependabot bump 8.3.2 → 14.0.0 would have been a no-op since the direct dep is unused. Removing the dep eliminates future dependabot noise on this package.

## Test plan
- [ ] `yarn install` clean
- [ ] `yarn build` succeeds
- [ ] `yarn test` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)