### PR TITLE
batching: clarify idempotency behavior in server-side batching explanation

### DIFF
--- a/src/pages/docs/messages/batch.mdx
+++ b/src/pages/docs/messages/batch.mdx
@@ -18,7 +18,7 @@ It makes messages more cost efficient in high-throughput scenarios by reducing t
 Server-side batching is effective in applications such as fan engagement platforms, where key moments in a game, such as points being scored, cause huge surges in the number of reactions and messages. It also enables a much higher number of users to be [present](/docs/presence-occupancy/presence) on a channel when it is enabled.
 
 <Aside data-type="important">
-Be aware that server-side batching doesn't support [idempotency](/docs/pub-sub/advanced#idempotency) due to how messages are grouped on the server. However, if you are explicitly setting a message ID, then these messages will be excluded from being batched.
+Be aware that server-side batching doesn't support [idempotency](/docs/pub-sub/advanced#idempotency) due to how messages are grouped on the server. Messages with an explicitly set ID are still batched, but they **won't** be deduplicated based on that ID.
 </Aside>
 
 ### Configure server-side batching <a id="configure"/>


### PR DESCRIPTION
## Description

When server side batching is enabled, setting a message ID will no longer dedupe incoming messages. Message will still be batched.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
