### PR TITLE
docs: add guidance for modifying messages during chat moderation

### DIFF
--- a/src/pages/docs/chat/moderation/custom/index.mdx
+++ b/src/pages/docs/chat/moderation/custom/index.mdx
@@ -54,6 +54,15 @@ The request has the following JSON format.
   "action": "accept|reject",
   "rejectionDetail": {
     "key": "string"
+  },
+  "message": {
+    "text": "string",
+    "metadata": {
+      "key": "any"
+    },
+    "headers": {
+      "key": "string"
+    }
   }
 }
 ```
@@ -61,6 +70,12 @@ The request has the following JSON format.
 
 * `action`: Must be either `accept` or `reject`. `accept` means that the message will be published to the chat room, `reject` means it will be rejected.
 * `rejectionDetail`: Optional. If provided with `action: "reject"`, a map of string key-value pairs containing structured information about why the message was rejected. Both keys and values must be strings. This information may be sent back to clients via the `ErrorInfo.detail` field. The total response payload must not exceed 32 KiB in size.
+* `message`: Optional. Omit this object to publish the original message unchanged. Provide it to modify the message before it is published.
+
+When provided, the `message` object behaves as a full replacement of the original message's `text`, `metadata`, and `headers`, not a partial update:
+
+* `text` is required and cannot be empty. Moderation fails if `text` is missing or empty.
+* `metadata` and `headers` are optional. If you omit either one, it is removed from the published message. To preserve the original `metadata` or `headers`, copy them from the request `message` into the response.
 
 ### Error handling <a id="error"/>
 


### PR DESCRIPTION
## Description

Guidance in chat moderation response for custom moderation was out-of-date. You can now provide a `message` field to change in place the original message before proceeding with the publish.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
