### PR TITLE
[DX-1326] docs: document ably init and use it across getting-started pages

### DIFF
--- a/src/data/nav/platform.ts
+++ b/src/data/nav/platform.ts
@@ -360,6 +360,7 @@ export default {
               link: '/docs/cli',
               index: true,
             },
+            { name: 'Init', link: '/docs/cli/init' },
             { name: 'Login', link: '/docs/cli/login' },
             {
               name: 'Accounts',

--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -44,19 +44,11 @@ implementation("com.ably.chat:chat-extensions-compose:1.2.0")
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -42,9 +42,9 @@ implementation("com.ably.chat:chat-extensions-compose:1.2.0")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -44,7 +44,7 @@ implementation("com.ably.chat:chat-extensions-compose:1.2.0")
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -62,7 +62,7 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -62,19 +62,11 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -60,9 +60,9 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -57,9 +57,9 @@ implementation("org.slf4j:slf4j-nop:2.0.17")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -59,19 +59,11 @@ implementation("org.slf4j:slf4j-nop:2.0.17")
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -59,7 +59,7 @@ implementation("org.slf4j:slf4j-nop:2.0.17")
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -53,19 +53,11 @@ cd ios && pod install && cd ..
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -51,9 +51,9 @@ cd ios && pod install && cd ..
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -53,7 +53,7 @@ cd ios && pod install && cd ..
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-ui-kit.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-kit.mdx
@@ -67,7 +67,7 @@ That's all the setup you need—the kit's CSS is automatically bundled by Vite a
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-ui-kit.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-kit.mdx
@@ -65,9 +65,9 @@ That's all the setup you need—the kit's CSS is automatically bundled by Vite a
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react-ui-kit.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-kit.mdx
@@ -67,19 +67,11 @@ That's all the setup you need—the kit's CSS is automatically bundled by Vite a
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -58,9 +58,9 @@ echo "VITE_ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -60,19 +60,11 @@ echo "VITE_ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -60,7 +60,7 @@ echo "VITE_ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
+++ b/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
@@ -25,19 +25,11 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
+++ b/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
@@ -25,7 +25,7 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
+++ b/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
@@ -23,9 +23,9 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -25,19 +25,11 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -25,7 +25,7 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -23,9 +23,9 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test chat features. It can simulate other users by sending messages, entering presence, and acting as another user typing a message.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/cli/index.mdx
+++ b/src/pages/docs/cli/index.mdx
@@ -28,7 +28,7 @@ The following top-level commands are available in the Ably CLI:
 
 | Command | Description |
 | ------- | ----------- |
-| [`ably init`](/docs/cli/init) | Set up the Ably CLI in one command: install, authenticate, and install [Agent Skills](https://github.com/ably/agent-skills) into your AI coding tools |
+| [`ably init`](/docs/cli/init) | Install the CLI, authenticate, and install [Agent Skills](https://github.com/ably/agent-skills) |
 | [`ably login`](/docs/cli/login) | Log in to your Ably account (alias for "ably accounts login") |
 | [`ably accounts`](/docs/cli/accounts) | Manage Ably accounts and your configured access tokens |
 | [`ably apps`](/docs/cli/apps) | Manage Ably apps |

--- a/src/pages/docs/cli/index.mdx
+++ b/src/pages/docs/cli/index.mdx
@@ -28,6 +28,7 @@ The following top-level commands are available in the Ably CLI:
 
 | Command | Description |
 | ------- | ----------- |
+| [`ably init`](/docs/cli/init) | Set up the Ably CLI in one command: install, authenticate, and install [Agent Skills](https://github.com/ably/agent-skills) into your AI coding tools |
 | [`ably login`](/docs/cli/login) | Log in to your Ably account (alias for "ably accounts login") |
 | [`ably accounts`](/docs/cli/accounts) | Manage Ably accounts and your configured access tokens |
 | [`ably apps`](/docs/cli/apps) | Manage Ably apps |

--- a/src/pages/docs/cli/init.mdx
+++ b/src/pages/docs/cli/init.mdx
@@ -1,0 +1,108 @@
+---
+title: "Init"
+meta_description: "Set up the Ably CLI in a single command: install, authenticate, and install Agent Skills into AI coding tools."
+meta_keywords: "ably cli, cli, init, ably init, onboarding, agent skills, claude code, cursor, vs code, windsurf"
+---
+
+Use the `ably init` command to set up the Ably CLI in a single step. It installs the CLI, authenticates you with [OAuth Device Authorization](https://datatracker.ietf.org/doc/html/rfc8628), and installs the Ably [Agent Skills](https://github.com/ably/agent-skills) into any AI coding tools detected on your machine.
+
+Supported AI coding tools:
+
+* [Claude Code](https://www.anthropic.com/claude-code) - installed via the `@ably/agent-skills` Claude Code plugin.
+* [Cursor](https://cursor.com)
+* [VS Code](https://code.visualstudio.com) (GitHub Copilot)
+* [Windsurf](https://windsurf.com)
+
+For tools other than Claude Code, the skill files are copied directly into the tool's user skills directory.
+
+## Synopsis
+
+<Code>
+```shell
+ably init [options]
+```
+</Code>
+
+You can also run `init` without installing the CLI first:
+
+<Code>
+```shell
+npx -p @ably/cli ably init
+```
+</Code>
+
+## Options
+
+### `--target | -t` <a id="target"/>
+
+Target AI coding tools to install Agent Skills for. Defaults to `auto`, which detects installed tools and prompts you to choose. Repeat the flag to specify multiple tools.
+
+Supported values:
+
+* `auto` - Auto-detect installed tools (default).
+* `claude-code` - Claude Code.
+* `cursor` - Cursor.
+* `vscode` - VS Code (GitHub Copilot).
+* `windsurf` - Windsurf.
+
+`auto` cannot be combined with explicit targets.
+
+### `--json` <a id="json"/>
+
+Output results as compact JSON. Mutually exclusive with `--pretty-json`.
+
+### `--pretty-json` <a id="pretty-json"/>
+
+Output results in formatted, colorized JSON. Mutually exclusive with `--json`.
+
+### `--verbose | -v` <a id="verbose"/>
+
+Enable verbose logging. Can be combined with `--json` or `--pretty-json`.
+
+## Examples
+
+Set up the CLI with auto-detected AI coding tools:
+
+<Code>
+```shell
+ably init
+```
+</Code>
+
+Install Agent Skills for Claude Code only:
+
+<Code>
+```shell
+ably init --target claude-code
+```
+</Code>
+
+Install Agent Skills for Cursor and Windsurf:
+
+<Code>
+```shell
+ably init --target cursor --target windsurf
+```
+</Code>
+
+Set up the CLI without installing it first:
+
+<Code>
+```shell
+npx -p @ably/cli ably init
+```
+</Code>
+
+Run `init` in JSON mode for use in scripts:
+
+<Code>
+```shell
+ably init --json
+```
+</Code>
+
+## See also
+
+* [Login](/docs/cli/login) - Authenticate without installing Agent Skills.
+* [Environment variables](/docs/cli/env) - Authenticate via environment variables instead of OAuth.
+* [CLI reference](/docs/cli) - Full list of available commands.

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -39,9 +39,9 @@ dotnet add package ably.io
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -41,7 +41,7 @@ dotnet add package ably.io
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -41,19 +41,11 @@ dotnet add package ably.io
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -167,19 +167,11 @@ Initialize the Ably service at the application level to prevent it from being re
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -165,9 +165,9 @@ Initialize the Ably service at the application level to prevent it from being re
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -167,7 +167,7 @@ Initialize the Ably service at the application level to prevent it from being re
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -34,7 +34,7 @@ go get -u github.com/ably/ably-go/ably
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -34,19 +34,11 @@ go get -u github.com/ably/ably-go/ably
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -32,9 +32,9 @@ go get -u github.com/ably/ably-go/ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -52,19 +52,11 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -50,9 +50,9 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -52,7 +52,7 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -26,19 +26,11 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -24,9 +24,9 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -26,7 +26,7 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -31,7 +31,7 @@ implementation("io.ably:ably-java:<latest-version>")
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -29,9 +29,9 @@ implementation("io.ably:ably-java:<latest-version>")
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -31,19 +31,11 @@ implementation("io.ably:ably-java:<latest-version>")
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/laravel.mdx
+++ b/src/pages/docs/getting-started/laravel.mdx
@@ -48,9 +48,9 @@ npm run dev
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/laravel.mdx
+++ b/src/pages/docs/getting-started/laravel.mdx
@@ -50,7 +50,7 @@ npm run dev
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/laravel.mdx
+++ b/src/pages/docs/getting-started/laravel.mdx
@@ -50,19 +50,11 @@ npm run dev
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/nextjs.mdx
+++ b/src/pages/docs/getting-started/nextjs.mdx
@@ -86,7 +86,7 @@ npm install ably
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/nextjs.mdx
+++ b/src/pages/docs/getting-started/nextjs.mdx
@@ -86,19 +86,11 @@ npm install ably
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/nextjs.mdx
+++ b/src/pages/docs/getting-started/nextjs.mdx
@@ -84,9 +84,9 @@ npm install ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -44,19 +44,11 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -44,7 +44,7 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -42,9 +42,9 @@ echo "ABLY_API_KEY={{API_KEY}}" > .env
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -44,9 +44,9 @@ https://github.com/ably/ably-cocoa
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -46,7 +46,7 @@ https://github.com/ably/ably-cocoa
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -46,19 +46,11 @@ https://github.com/ably/ably-cocoa
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -44,19 +44,11 @@ composer require ably/ably-php
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -42,9 +42,9 @@ composer require ably/ably-php
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -44,7 +44,7 @@ composer require ably/ably-php
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -41,19 +41,11 @@ pip install ably
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -39,9 +39,9 @@ pip install ably
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -41,7 +41,7 @@ pip install ably
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -143,9 +143,9 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -145,7 +145,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -145,19 +145,11 @@ Keep the Realtime client initialization outside of any React component to preven
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -151,9 +151,9 @@ Keep the Realtime client initialization outside of any React component to preven
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -153,19 +153,11 @@ Keep the Realtime client initialization outside of any React component to preven
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -153,7 +153,7 @@ Keep the Realtime client initialization outside of any React component to preven
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -39,19 +39,11 @@ The realtime interface of the Ruby SDK must be run within an [EventMachine](http
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -37,9 +37,9 @@ The realtime interface of the Ruby SDK must be run within an [EventMachine](http
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -39,7 +39,7 @@ The realtime interface of the Ruby SDK must be run within an [EventMachine](http
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -37,7 +37,7 @@ dependencies: [
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -37,19 +37,11 @@ dependencies: [
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -35,9 +35,9 @@ dependencies: [
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features. It can simulate other clients by publishing messages, subscribing to channels, and managing presence states.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/platform/tools/cli.mdx
+++ b/src/pages/docs/platform/tools/cli.mdx
@@ -17,28 +17,34 @@ The Ably CLI interacts with:
 
 ## Installation
 
-The Ably CLI is available as an NPM package. Install it using:
+Get started in a single command:
+
+<Code>
+```shell
+npx -p @ably/cli ably init
+```
+</Code>
+
+`ably init` installs the Ably CLI globally, authenticates you, and installs the Ably [Agent Skills](https://github.com/ably/agent-skills) into any AI coding tools it detects on your machine, such as Claude Code, Cursor, VS Code, and Windsurf.
+
+If you'd rather install the CLI yourself before running `init`, the Ably CLI is published to NPM:
 
 <Code>
 ```shell
 npm install -g @ably/cli
+ably init
 ```
 </Code>
+
+<Aside data-type='note'>
+You can skip `ably init` and authenticate with [environment variables](/docs/cli/env) instead, which is useful in scripts and CI/CD pipelines.
+</Aside>
 
 ## Usage
 
-Run the following to log in to your Ably account:
+`ably init` authenticates using an [OAuth Device Authorization](https://datatracker.ietf.org/doc/html/rfc8628) flow: the CLI displays an authorization code and opens your browser to approve it. Once approved, the CLI receives an [access token](/docs/platform/account/access-tokens) that is stored locally and refreshed automatically, so there is no manual token management.
 
-<Code>
-```shell
-ably login
-```
-</Code>
-<Aside data-type='note'>
-Alternatively, you can skip interactive `ably login` and use [environment variables](/docs/cli/env) to authenticate directly in scripts and CI/CD pipelines.
-</Aside>
-
-This initiates an [OAuth Device Authorization](https://datatracker.ietf.org/doc/html/rfc8628) flow: the CLI displays an authorization code and opens your browser to approve it. Once approved, the CLI receives an [access token](/docs/platform/account/access-tokens) that is stored locally and refreshed automatically — no manual token management required.
+If you only need to authenticate, without installing Agent Skills, run [`ably login`](/docs/cli/login) instead.
 
 After you have successfully authenticated and chosen your app and API key, you're ready to interact with Ably resources directly from your terminal.
 

--- a/src/pages/docs/platform/tools/cli.mdx
+++ b/src/pages/docs/platform/tools/cli.mdx
@@ -27,7 +27,7 @@ npx -p @ably/cli ably init
 
 [`ably init`](/docs/cli/init) installs the Ably CLI globally, authenticates you, and installs the Ably [Agent Skills](https://github.com/ably/agent-skills) into any AI coding tools it detects on your machine, such as Claude Code, Cursor, VS Code, and Windsurf.
 
-If you'd rather install the CLI yourself before running `init`, the Ably CLI is published to NPM:
+To install the CLI manually first, use npm and then run `ably init`:
 
 <Code>
 ```shell
@@ -37,20 +37,18 @@ ably init
 </Code>
 
 <Aside data-type='note'>
-Alternatively, you can skip interactive `ably init` or `ably login` commands by using [environment variables](/docs/cli/env) to authenticate directly in scripts and CI/CD pipelines.
+Alternatively, you can skip the interactive `ably init` and `ably login` commands by using [environment variables](/docs/cli/env) to authenticate directly in scripts and CI/CD pipelines.
 </Aside>
 
 ## Usage
 
-`ably init` authenticates using an [OAuth Device Authorization](https://datatracker.ietf.org/doc/html/rfc8628) flow: the CLI displays an authorization code and opens your browser to approve it. Once approved, the CLI receives an [access token](/docs/platform/account/access-tokens) that is stored locally and refreshed automatically, so there is no manual token management.
+During `ably init`, the CLI authenticates using an [OAuth Device Authorization](https://datatracker.ietf.org/doc/html/rfc8628) flow: it displays an authorization code and opens your browser to approve it. Once approved, the CLI receives an [access token](/docs/platform/account/access-tokens) that is stored locally and refreshed automatically, so there is no manual token management.
 
 If you only need to authenticate, without installing Agent Skills, run [`ably login`](/docs/cli/login) instead.
 
-After you have successfully authenticated and chosen your app and API key, you're ready to interact with Ably resources directly from your terminal.
+After authenticating and selecting your app and API key, you can interact with Ably resources directly from your terminal.
 
-For example, open two terminal instances and subscribe to one, and publish messages in the other:
-
-To subscribe:
+For example, open two terminal windows. In the first, subscribe to a channel:
 
 <Code>
 ```shell
@@ -59,7 +57,7 @@ ably channels subscribe channel-1
 ```
 </Code>
 
-To publish:
+In the second, publish messages to the same channel:
 
 <Code>
 ```shell
@@ -75,7 +73,7 @@ ably channels publish --count 5 channel-1 "Message number {{.Count}}"
 ```
 </Code>
 
-For a list of all available commands, run:
+To list all available commands, run:
 
 <Code>
 ```shell

--- a/src/pages/docs/platform/tools/cli.mdx
+++ b/src/pages/docs/platform/tools/cli.mdx
@@ -25,7 +25,7 @@ npx -p @ably/cli ably init
 ```
 </Code>
 
-`ably init` installs the Ably CLI globally, authenticates you, and installs the Ably [Agent Skills](https://github.com/ably/agent-skills) into any AI coding tools it detects on your machine, such as Claude Code, Cursor, VS Code, and Windsurf.
+[`ably init`](/docs/cli/init) installs the Ably CLI globally, authenticates you, and installs the Ably [Agent Skills](https://github.com/ably/agent-skills) into any AI coding tools it detects on your machine, such as Claude Code, Cursor, VS Code, and Windsurf.
 
 If you'd rather install the CLI yourself before running `init`, the Ably CLI is published to NPM:
 

--- a/src/pages/docs/platform/tools/cli.mdx
+++ b/src/pages/docs/platform/tools/cli.mdx
@@ -37,7 +37,7 @@ ably init
 </Code>
 
 <Aside data-type='note'>
-You can skip `ably init` and authenticate with [environment variables](/docs/cli/env) instead, which is useful in scripts and CI/CD pipelines.
+Alternatively, you can skip interactive `ably init` or `ably login` commands by using [environment variables](/docs/cli/env) to authenticate directly in scripts and CI/CD pipelines.
 </Aside>
 
 ## Usage

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -25,9 +25,9 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -27,7 +27,7 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -27,19 +27,11 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -25,7 +25,7 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -25,19 +25,11 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -23,9 +23,9 @@ Using an AI coding assistant? [Teach it Ably](/docs/platform/ai-llms#agent-skill
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/flutter.mdx
+++ b/src/pages/docs/push/getting-started/flutter.mdx
@@ -20,9 +20,9 @@ You'll learn how to configure Firebase Cloud Messaging (FCM) for Android and APN
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code fixed="true">
 ```shell

--- a/src/pages/docs/push/getting-started/flutter.mdx
+++ b/src/pages/docs/push/getting-started/flutter.mdx
@@ -22,19 +22,11 @@ You'll learn how to configure Firebase Cloud Messaging (FCM) for Android and APN
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code fixed="true">
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code fixed="true">
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/flutter.mdx
+++ b/src/pages/docs/push/getting-started/flutter.mdx
@@ -22,7 +22,7 @@ You'll learn how to configure Firebase Cloud Messaging (FCM) for Android and APN
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code fixed="true">
 ```shell

--- a/src/pages/docs/push/getting-started/react-native.mdx
+++ b/src/pages/docs/push/getting-started/react-native.mdx
@@ -24,19 +24,11 @@ You'll learn how to set up your application with Firebase Cloud Messaging (FCM),
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/react-native.mdx
+++ b/src/pages/docs/push/getting-started/react-native.mdx
@@ -22,9 +22,9 @@ You'll learn how to set up your application with Firebase Cloud Messaging (FCM),
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/react-native.mdx
+++ b/src/pages/docs/push/getting-started/react-native.mdx
@@ -24,7 +24,7 @@ You'll learn how to set up your application with Firebase Cloud Messaging (FCM),
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -24,9 +24,9 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 ### (Optional) Install Ably CLI <a id="install-cli"/>
 
-Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
+Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
+Install the Ably CLI, authenticate, and set the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -26,7 +26,7 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-Install the Ably CLI, authenticate, and set the default app and API key in a single command:
+[`ably init`](/docs/cli/init) installs the Ably CLI, authenticates, and sets the default app and API key in a single command:
 
 <Code>
 ```shell

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -26,19 +26,11 @@ then enable the Push notifications option. See [rules](/docs/channels#rules) for
 
 Use the [Ably CLI](https://github.com/ably/cli) as an additional client to quickly test Pub/Sub features and push notifications.
 
-1. Install the Ably CLI:
+Install the Ably CLI, log in to your Ably account, and set the default app and API key in a single command:
 
 <Code>
 ```shell
-npm install -g @ably/cli
-```
-</Code>
-
-2. Run the following to log in to your Ably account and set the default app and API key:
-
-<Code>
-```shell
-ably login
+npx -p @ably/cli ably init
 ```
 </Code>
 


### PR DESCRIPTION
## Summary

- Add a new CLI reference page at `/docs/cli/init` for the `ably init` command, covering synopsis, options (`--target`, `--json`, `--pretty-json`, `--verbose`), examples, and supported AI coding tools (Claude Code, Cursor, VS Code, Windsurf).
- Link the new page from the CLI index table and from the platform nav.
- Replace the two-step "install CLI then `ably login`" snippet across all getting-started pages (core, chat, push) with the single `npx -p @ably/cli ably init` command.
- Update `/docs/platform/tools/cli` to lead with the one-command install and explain what `ably init` does end-to-end.

## Test plan

- [ ] `yarn develop` and confirm `/docs/cli/init` renders, appears in the platform nav, and is linked from the CLI index table.
- [ ] Spot-check a few getting-started pages (JavaScript, Python, React Native, FCM) to confirm the new single-command snippet renders correctly.
- [ ] Verify `/docs/platform/tools/cli` reads cleanly with the new lead-in and the alternative `npm install -g @ably/cli` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)