### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled, unlabeled, closed]
 
+permissions: {}
+
 jobs:
   manage-review-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -19,13 +19,13 @@ jobs:
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'review-app'))
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Check if user is an Ably organization member
         if: github.event.action == 'labeled' && github.event.label.name == 'review-app'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.ABLY_ORG_TOKEN }}
           script: |
@@ -60,7 +60,7 @@ jobs:
             }
 
       - name: Manage Heroku Review App
-        uses: fastruby/manage-heroku-review-app@v1.3
+        uses: fastruby/manage-heroku-review-app@9fa49f0320460f278c3687bc348dd0cbb18555dc # v1.3
         with:
           action: ${{ (github.event.action == 'labeled' && github.event.label.name == 'review-app' && 'create') || 'destroy' }}
         env:

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check if user is an Ably organization member
         if: github.event.action == 'labeled' && github.event.label.name == 'review-app'


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on actions/checkout so the default GITHUB_TOKEN is not left in the local git config after checkout.
- Add a top-level permissions: {} so the GITHUB_TOKEN is granted no scopes by default; the job continues to declare only the contents/deployments/pull-requests scopes it actually
needs.
- Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended - the workflow runs the same checks against the same inputs.