### PR TITLE
docs: add error code 40025 for unsupported SDK API

### DIFF
--- a/src/pages/docs/platform/errors/codes.mdx
+++ b/src/pages/docs/platform/errors/codes.mdx
@@ -154,6 +154,14 @@ Examples of this error include attempting to use [channel objects](/docs/liveobj
 Resolution: The following steps can help resolve this issue:
 * Upgrade the Ably SDK to a version that supports the requested operation.
 
+## 40025: Unsupported SDK API <a id="40025"/>
+
+This error occurs when an SDK method is called using an API shape that is no longer supported.
+
+An example of this error is calling an ably-js v2 method using the v1 Node-style callback signature. The v2 SDK is Promise-based and no longer accepts a trailing callback argument. See the [ably-js v2 migration guide](https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md) for details on migrating from v1 callbacks to Promises.
+
+Resolution: Update the call site to use the supported API for your SDK and version.
+
 ## 40030: Invalid publish request (unspecified) <a id="40030"/>
 
 This error occurs when a [publish request](/docs/pub-sub#publish) is malformed.


### PR DESCRIPTION
## Summary

- Documents the new `40025` error code introduced in [ably/ably-js#2226](https://github.com/ably/ably-js/pull/2226), thrown when an SDK method is called using an API shape that is no longer supported.
- Generic framing (the code is reusable across SDKs/APIs), with the ably-js v1 → v2 callback case given as the concrete example and a link to the v2 migration guide.
- Placed in numeric order between `40023` and `40030` in `src/pages/docs/platform/errors/codes.mdx`.

## Test plan

- [ ] Visit `/docs/platform/errors/codes#40025` in a preview build and confirm the heading anchor renders correctly
- [ ] Confirm the entry sits between 40023 and 40030 in the rendered page
- [ ] Confirm the migration guide link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)