### PR TITLE
AI Transport docs: auth endpoint URL and example channel namespaces

### DIFF
--- a/src/pages/docs/ai-transport/api/index.mdx
+++ b/src/pages/docs/ai-transport/api/index.mdx
@@ -18,7 +18,7 @@ A minimal client session setup using the Vercel-pre-bound factory:
 import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,

--- a/src/pages/docs/ai-transport/api/javascript/core/client-session.mdx
+++ b/src/pages/docs/ai-transport/api/javascript/core/client-session.mdx
@@ -17,7 +17,7 @@ import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,
@@ -83,7 +83,7 @@ import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,
@@ -260,7 +260,7 @@ import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,

--- a/src/pages/docs/ai-transport/api/javascript/vercel/chat-transport.mdx
+++ b/src/pages/docs/ai-transport/api/javascript/vercel/chat-transport.mdx
@@ -14,7 +14,7 @@ The Vercel entry point pre-binds the [`UIMessageCodec`](/docs/ai-transport/api/j
 import * as Ably from 'ably';
 import { createClientSession, createChatTransport } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,
@@ -40,7 +40,7 @@ A pre-bound version of the core [`createClientSession`](/docs/ai-transport/api/j
 import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,
@@ -200,7 +200,7 @@ import * as Ably from 'ably';
 import { useChat } from '@ai-sdk/react';
 import { createClientSession, createChatTransport } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,

--- a/src/pages/docs/ai-transport/api/react/core/providers.mdx
+++ b/src/pages/docs/ai-transport/api/react/core/providers.mdx
@@ -18,7 +18,7 @@ import { AblyProvider } from 'ably/react';
 import { ClientSessionProvider } from '@ably/ai-transport/react';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 function App() {
   return (
@@ -126,7 +126,7 @@ import { AblyProvider } from 'ably/react';
 import { ClientSessionProvider, useClientSession } from '@ably/ai-transport/react';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 function App() {
   return (

--- a/src/pages/docs/ai-transport/api/react/vercel/chat-transport-provider.mdx
+++ b/src/pages/docs/ai-transport/api/react/vercel/chat-transport-provider.mdx
@@ -17,7 +17,7 @@ import * as Ably from 'ably';
 import { AblyProvider } from 'ably/react';
 import { ChatTransportProvider } from '@ably/ai-transport/vercel/react';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 function App() {
   return (
@@ -117,7 +117,7 @@ function Providers({ children }) {
   const [client, setClient] = useState(null);
 
   useEffect(() => {
-    const ably = new Ably.Realtime({ authUrl: '/auth', clientId: 'user' });
+    const ably = new Ably.Realtime({ authUrl: '/api/auth/token', clientId: 'user' });
     setClient(ably);
     return () => ably.close();
   }, []);

--- a/src/pages/docs/ai-transport/concepts/connections.mdx
+++ b/src/pages/docs/ai-transport/concepts/connections.mdx
@@ -67,7 +67,7 @@ import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport';
 import { UIMessageCodec } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({
   client: ably,

--- a/src/pages/docs/ai-transport/concepts/sessions.mdx
+++ b/src/pages/docs/ai-transport/concepts/sessions.mdx
@@ -60,7 +60,7 @@ A session is materialised by attaching a client session to the channel that back
 import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 
 const session = createClientSession({ client: ably, channelName: 'conversation-42' });
 await session.connect();

--- a/src/pages/docs/ai-transport/features/token-streaming.mdx
+++ b/src/pages/docs/ai-transport/features/token-streaming.mdx
@@ -155,7 +155,7 @@ Set the rollup window for a connection using the `appendRollupWindow` [transport
 <Code>
 ```javascript
 const ably = new Ably.Realtime({
-  authUrl: '/auth',
+  authUrl: '/api/auth/token',
   transportParams: { appendRollupWindow: 100 },
 });
 ```

--- a/src/pages/docs/ai-transport/getting-started/authentication.mdx
+++ b/src/pages/docs/ai-transport/getting-started/authentication.mdx
@@ -2,7 +2,7 @@
 title: "Set up authentication"
 meta_description: "Wire AI Transport to your auth: a token-issuing endpoint that signs Ably JWTs, and an authenticated Ably client on the browser."
 meta_keywords: "AI Transport, authentication setup, Ably JWT, authCallback, token endpoint, getting started"
-intro: "AI Transport authenticates through your existing auth: your server validates the user and signs an Ably token, and the browser's Ably client fetches it through `authCallback` and refreshes it before expiry."
+intro: "AI Transport authenticates through your existing auth: your server validates the user and signs an Ably token, and the browser's Ably client fetches it through `authCallback`and refreshes it before expiry."
 ---
 
 This page is the practical setup. For the conceptual model (the three auth layers, capabilities, token lifecycle, cancel authorisation), see the [authentication concept](/docs/ai-transport/concepts/authentication).
@@ -53,7 +53,7 @@ import * as Ably from 'ably';
 const realtimeClient = new Ably.Realtime({
   authCallback: async (tokenParams, callback) => {
     try {
-      const response = await fetch('/api/ably-token', { credentials: 'include' });
+      const response = await fetch('/api/auth/token', { credentials: 'include' });
       if (!response.ok) throw new Error('Auth failed');
       const jwt = await response.text();
       callback(null, jwt);
@@ -86,7 +86,7 @@ export function Providers({ children }) {
     const ably = new Ably.Realtime({
       authCallback: async (_tokenParams, callback) => {
         try {
-          const response = await fetch('/api/ably-token', { credentials: 'include' });
+          const response = await fetch('/api/auth/token', { credentials: 'include' });
           callback(null, await response.text());
         } catch (err) {
           callback(err instanceof Error ? err.message : String(err), null);

--- a/src/pages/docs/ai-transport/getting-started/channel-rules.mdx
+++ b/src/pages/docs/ai-transport/getting-started/channel-rules.mdx
@@ -5,7 +5,7 @@ meta_keywords: "AI Transport, channel rules, mutableMessages, Ably namespace, me
 intro: "AI Transport streams tokens by appending to a single Ably channel message. That requires one channel rule on the namespace your conversations live on. This is a one-time configuration per Ably app."
 ---
 
-The *Message annotations, updates, deletes, and appends* rule (`mutableMessages: true`) is mandatory. Without it, AI Transport fails on the first token append after a stream starts; the symptom is error `93002` `Can only update/delete/append messages on channels with mutableMessages enabled`. This is the single most common AI Transport setup failure; see [troubleshooting](/docs/ai-transport/troubleshooting#namespace-not-configured) for the symptom-side detail.
+The *Message annotations, updates, deletes, and appends* rule (`mutableMessages: true`) is mandatory when using AI Transport. Without it, AI Transport fails on the first token append after a stream starts, with error `93002` `Can only update/delete/append messages on channels with mutableMessages enabled`. See [troubleshooting](/docs/ai-transport/troubleshooting#namespace-not-configured) for the symptom-side detail.
 
 <Aside data-type='important'>
 Enabling this rule causes messages in the namespace to be [persisted](/docs/storage-history/storage#all-message-persistence) regardless of whether persistence is enabled separately. [Ably charges for persisted messages](https://faqs.ably.com/how-does-ably-count-messages); account for this when picking the namespace.

--- a/src/pages/docs/ai-transport/getting-started/core-sdk.mdx
+++ b/src/pages/docs/ai-transport/getting-started/core-sdk.mdx
@@ -176,6 +176,8 @@ export function Chat() {
 
 Create `app/page.tsx`. `Providers` sets up an authenticated Ably client. [`ClientSessionProvider`](/docs/ai-transport/api/react/core/providers) wires the channel and codec into AI Transport.
 
+Update `channelName` to match a namespace with the AIT [channel rules](/docs/ai-transport/getting-started/channel-rules) configured.
+
 <Code>
 ```javascript
 'use client';
@@ -201,7 +203,7 @@ function Providers({ children }) {
 }
 
 export default function Page() {
-  const channelName = 'my-chat-session';
+  const channelName = 'conversations:my-chat-session';
   return (
     <Providers>
       <ClientSessionProvider channelName={channelName} codec={UIMessageCodec}>

--- a/src/pages/docs/ai-transport/getting-started/core-sdk.mdx
+++ b/src/pages/docs/ai-transport/getting-started/core-sdk.mdx
@@ -32,9 +32,9 @@ npm install @ably/ai-transport ably ai @ai-sdk/anthropic next react react-dom
 
 ## Set up authentication <a id="auth"/>
 
-Create an auth endpoint at `/auth` that returns an Ably JWT to the client. The endpoint validates the user and signs a token with their client ID and the channel capabilities they need. See [Set up authentication](/docs/ai-transport/getting-started/authentication) for the full setup.
+Create an auth endpoint at `/api/auth/token` that returns an Ably JWT to the client. The endpoint validates the user and signs a token with their client ID and the channel capabilities they need. See [Set up authentication](/docs/ai-transport/getting-started/authentication) for the full setup.
 
-The client below uses `authUrl: '/auth'` to fetch tokens from this endpoint.
+The client below uses `authUrl: '/api/auth/token'` to fetch tokens from this endpoint.
 
 ## Create the agent route <a id="agent-route"/>
 
@@ -191,7 +191,7 @@ function Providers({ children }) {
   const [client, setClient] = useState(null);
 
   useEffect(() => {
-    const ably = new Ably.Realtime({ authUrl: '/auth', clientId: 'user' });
+    const ably = new Ably.Realtime({ authUrl: '/api/auth/token', clientId: 'user' });
     setClient(ably);
     return () => ably.close();
   }, []);

--- a/src/pages/docs/ai-transport/getting-started/vercel-ai-sdk.mdx
+++ b/src/pages/docs/ai-transport/getting-started/vercel-ai-sdk.mdx
@@ -38,9 +38,9 @@ npm install @ably/ai-transport ably ai @ai-sdk/react @ai-sdk/anthropic next reac
 
 ## Set up authentication <a id="set-up-authentication"/>
 
-Create an auth endpoint at `/auth` that returns an Ably JWT to the client. The endpoint validates the user and signs a token with their client ID and the channel capabilities they need. See [Set up authentication](/docs/ai-transport/getting-started/authentication) for the full setup.
+Create an auth endpoint at `/api/auth/token` that returns an Ably JWT to the client. The endpoint validates the user and signs a token with their client ID and the channel capabilities they need. See [Set up authentication](/docs/ai-transport/getting-started/authentication) for the full setup.
 
-The client below uses `authUrl: '/auth'` to fetch tokens from this endpoint.
+The client below uses `authUrl: '/api/auth/token'` to fetch tokens from this endpoint.
 
 ## Create the agent route <a id="create-the-agent-route"/>
 
@@ -181,7 +181,7 @@ function Providers({ children }) {
   const [client, setClient] = useState(null);
 
   useEffect(() => {
-    const ably = new Ably.Realtime({ authUrl: '/auth', clientId: 'user-abc' });
+    const ably = new Ably.Realtime({ authUrl: '/api/auth/token', clientId: 'user-abc' });
     setClient(ably);
     return () => ably.close();
   }, []);

--- a/src/pages/docs/ai-transport/getting-started/vercel-ai-sdk.mdx
+++ b/src/pages/docs/ai-transport/getting-started/vercel-ai-sdk.mdx
@@ -166,6 +166,8 @@ export function Chat({ chatId }) {
 
 Create `app/page.tsx`. `Providers` sets up an authenticated Ably client. [`ClientSessionProvider`](/docs/ai-transport/api/react/core/providers) constructs the underlying [`ClientSession`](/docs/ai-transport/api/javascript/core/client-session) bound to the channel.
 
+Update `channelName` to match a namespace with the AIT [channel rules](/docs/ai-transport/getting-started/channel-rules) configured.
+
 <Code>
 ```javascript
 'use client';
@@ -191,7 +193,7 @@ function Providers({ children }) {
 }
 
 export default function Page() {
-  const chatId = 'my-chat-session';
+  const chatId = 'conversations:my-chat-session';
   return (
     <Providers>
       <ClientSessionProvider channelName={chatId} codec={UIMessageCodec}>

--- a/src/pages/docs/ai-transport/internals/wire-protocol.mdx
+++ b/src/pages/docs/ai-transport/internals/wire-protocol.mdx
@@ -17,13 +17,11 @@ Client publishes input event (no run-id on a fresh send)
 
 Agent publishes run-start (run-id and invocation-id minted by createRun)
   name: ai-run-start
-  extras.ai.transport: { run-id=R1, invocation-id=I1, run-client-id=user-abc, input-client-id=user-abc,
-                         input-codec-message-id=M1 }
+  extras.ai.transport: { run-id=R1, invocation-id=I1, run-client-id=user-abc, input-client-id=user-abc, input-codec-message-id=M1 }
 
 Agent publishes assistant stream create
   name: ai-output
-  extras.ai.transport: { run-id=R1, invocation-id=I1, codec-message-id=M2, role=assistant, parent=M1,
-                         input-codec-message-id=M1 }
+  extras.ai.transport: { run-id=R1, invocation-id=I1, codec-message-id=M2, role=assistant, parent=M1, input-codec-message-id=M1 }
   extras.ai.codec:     { stream=true, stream-id=S1, status=streaming }
 
 Agent appends text deltas to M2

--- a/src/pages/docs/ai-transport/why/index.mdx
+++ b/src/pages/docs/ai-transport/why/index.mdx
@@ -34,7 +34,7 @@ A minimal adoption surface:
 import * as Ably from 'ably';
 import { createClientSession } from '@ably/ai-transport/vercel';
 
-const ably = new Ably.Realtime({ authUrl: '/auth' });
+const ably = new Ably.Realtime({ authUrl: '/api/auth/token' });
 const session = createClientSession({
   client: ably,
   channelName: 'chat-123',


### PR DESCRIPTION
## Summary

Small consistency and formatting fixes to the AI Transport getting-started, reference, and internals docs.

- **Auth endpoint URL.** Normalise the token-issuing endpoint to `/api/auth/token` everywhere it appears: the `authUrl` placeholders (`'/auth'`), the "create an endpoint at" prose, and the `authCallback` fetch (`/api/ably-token`). The agent POST endpoint (`/api/chat`) is intentionally left unchanged.
- **Example channel namespaces.** Use a `conversations:` namespaced channel name in the core SDK and Vercel getting-started examples, and add a note prompting readers to match `channelName` to a namespace that has the AIT channel rules configured. Without a configured namespace the examples fail on the first token append. Also tightens the channel-rules wording around when `mutableMessages` applies.
- **Wire protocol example formatting.** Unwrap the broken `extras.ai.transport` lines in the Run sequence example so the header maps read on single lines.

## Test plan

- Docs-only change; no code or tests affected.
- Verified no stale `/auth` or `/api/ably-token` references remain in the ai-transport folder and that `/api/chat` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)