### PR TITLE
[DX-1417] fix(nav): render top-level pricing nav links as clickable links

### DIFF
--- a/src/components/Layout/LeftSidebar.test.tsx
+++ b/src/components/Layout/LeftSidebar.test.tsx
@@ -126,4 +126,25 @@ describe('LeftSidebar', () => {
     // Should not be inside an accordion trigger button
     expect(sectionHeading.closest('button')).toBeNull();
   });
+
+  it('renders a top-level entry with a link but no child pages as a clickable link', () => {
+    mockUseLayoutContext.mockReturnValue({
+      activePage: {
+        page: { name: 'Postgres database connector', link: '/docs/livesync/postgres' },
+        tree: [{ index: 6, page: { name: 'Ably LiveSync', link: '/docs/livesync' } }],
+        languages: [],
+        language: 'javascript',
+        product: 'liveSync',
+        template: null,
+        hasProductBar: false,
+      },
+    });
+
+    render(<LeftSidebar />);
+
+    // "LiveSync pricing" is a top-level link, so it should render as an anchor, not a heading
+    const pricingLink = screen.getByText('LiveSync pricing').closest('a');
+    expect(pricingLink).not.toBeNull();
+    expect(pricingLink).toHaveAttribute('href', '/docs/livesync/pricing');
+  });
 });

--- a/src/components/Layout/LeftSidebar.tsx
+++ b/src/components/Layout/LeftSidebar.tsx
@@ -58,6 +58,8 @@ const accordionTriggerClassName = cn(
 
 const accordionLinkClassName = 'pl-3 py-1';
 
+const sectionHeadingClassName = 'ui-text-label2 font-bold text-neutral-1300 dark:text-neutral-000 pb-2 pt-5 pl-3 pr-2';
+
 const iconClassName = 'text-neutral-1300 dark:text-neutral-000 transition-transform';
 
 const ChildAccordion = ({ content, tree }: { content: (NavProductPage | NavProductContent)[]; tree: number[] }) => {
@@ -193,16 +195,47 @@ const ChildAccordion = ({ content, tree }: { content: (NavProductPage | NavProdu
 
 /** Render top-level nav sections as static headings with their content always expanded. */
 const SectionNav = ({ content, tree }: { content: (NavProductPage | NavProductContent)[]; tree: number[] }) => {
+  const { activePage } = useLayoutContext();
+  const location = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+
   return (
     <div className="p-3">
       {content.map((page, index) => {
         const hasDeeperLayer = 'pages' in page && page.pages;
 
+        // A top-level entry with a link but no child pages (e.g. a product's pricing page)
+        // is a destination, not a section, so render it as a clickable link rather than a
+        // static heading.
+        if (!hasDeeperLayer && 'link' in page && page.link) {
+          const isSelected = page.link === activePage.page.link;
+
+          return (
+            <Link
+              key={page.name}
+              to={buildLinkWithParams(page.link, searchParams)}
+              className={cn(
+                'ui-text-label2 font-bold text-neutral-1300 dark:text-neutral-000',
+                'mt-4 flex items-center justify-between gap-2 rounded-lg py-1.5 pl-3 pr-2',
+                'hover:bg-neutral-100 dark:hover:bg-neutral-1200',
+                isSelected && 'bg-orange-100 hover:bg-orange-100',
+              )}
+              {...(page.external && {
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              })}
+            >
+              <span>{page.name}</span>
+              {page.external && (
+                <Icon name="icon-gui-arrow-top-right-on-square-outline" additionalCSS={iconClassName} size="16px" />
+              )}
+            </Link>
+          );
+        }
+
         return (
           <div key={page.name}>
-            <div className="ui-text-label2 font-bold text-neutral-1300 dark:text-neutral-000 pb-2 pt-5 pl-3 pr-2">
-              {page.name}
-            </div>
+            <div className={sectionHeadingClassName}>{page.name}</div>
             {hasDeeperLayer && <ChildAccordion content={page.pages} tree={[...tree, index]} />}
           </div>
         );


### PR DESCRIPTION
## What

Top-level nav entries that are plain links (a `link` with no child `pages`) now render as clickable links in the left sidebar instead of static headings.

Resolves [DX-1417](https://ably.atlassian.net/browse/DX-1417).

## Why

`SectionNav` in `LeftSidebar.tsx` rendered every top-level nav entry as a bold heading and only rendered anything interactive when the entry had a `pages` array. The per-product pricing pages were added to the nav as top-level link-only entries, so they showed as dead headings with no way to reach the page.

This affected all five products that added a top-level pricing link in the recent nav refactor:

- Pub/Sub — `/docs/pub-sub/pricing`
- Chat — `/docs/chat/pricing`
- Spaces — `/docs/spaces/pricing`
- LiveObjects — `/docs/liveobjects/pricing`
- LiveSync — `/docs/livesync/pricing`

Originally spotted as the empty "LiveSync pricing" header on https://ably.com/docs/livesync/postgres.

## How

In `SectionNav`, a top-level entry with a `link` and no `pages` now renders as a `Link` with active-page highlighting and the existing language-param preservation (`buildLinkWithParams`), reusing the same patterns as the child nav links. One renderer change fixes all five products at once — no nav data changes needed.

## Testing

- Added a unit test asserting a top-level link entry renders as an anchor with the correct `href`.
- `yarn jest src/components/Layout/LeftSidebar.test.tsx` — all pass.
- `yarn lint` — clean.

On the review app, the "… pricing" entry in the left sidebar should now be clickable for each afflicted product:

- [Pub/Sub pricing](https://ably-docs-dx-1417-sideb-2flaij.herokuapp.com/docs/pub-sub/pricing)
- [Chat pricing](https://ably-docs-dx-1417-sideb-2flaij.herokuapp.com/docs/chat/pricing)
- [Spaces pricing](https://ably-docs-dx-1417-sideb-2flaij.herokuapp.com/docs/spaces/pricing)
- [LiveObjects pricing](https://ably-docs-dx-1417-sideb-2flaij.herokuapp.com/docs/liveobjects/pricing)
- [LiveSync pricing](https://ably-docs-dx-1417-sideb-2flaij.herokuapp.com/docs/livesync/pricing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1417]: https://ably.atlassian.net/browse/DX-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ