### PR TITLE
Reorder docs homepage product icons

### DIFF
--- a/src/data/content/homepage.ts
+++ b/src/data/content/homepage.ts
@@ -27,6 +27,10 @@ export default {
         link: '/docs/chat',
       },
       {
+        name: 'aiTransport',
+        link: '/docs/ai-transport',
+      },
+      {
         name: 'spaces',
         link: '/docs/spaces',
       },
@@ -37,10 +41,6 @@ export default {
       {
         name: 'liveSync',
         link: '/docs/livesync',
-      },
-      {
-        name: 'aiTransport',
-        link: '/docs/ai-transport',
       },
     ],
   },


### PR DESCRIPTION
## Why

The docs landing page product grid ordering didn't reflect how we want to present the products. This adjusts the order so the most prominent products lead, while keeping the double-row Platform card in place.

## What

Reorders the `productCards` array in `src/data/content/homepage.ts` so the grid reads:

- **Row 1:** Platform (double-row card), Pub/Sub, Chat, AI Transport
- **Row 2:** Spaces, LiveObjects, LiveSync

No other changes — this is purely a presentation ordering tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)