### PR TITLE
Support: Enterprise - Document legacy client options for custom endpoints

### DIFF
--- a/src/pages/docs/platform/account/enterprise-customization.mdx
+++ b/src/pages/docs/platform/account/enterprise-customization.mdx
@@ -123,6 +123,10 @@ Repeat this step for all fallback hosts in the `fallbackHosts` array, if provide
 
 Now that you have tested your custom endpoints, you must modify your code to instantiate the Ably client with the provided `ClientOptions`.
 
+<Aside data-type='note'>
+If you're using an older SDK that does not yet support the `endpoint` client option, use the [legacy options](#legacy-options) instead.
+</Aside>
+
 The following example demonstrates how to set up the Ably Realtime client using an [Ably subdomain:](#option-1)
 
 <Code>
@@ -152,6 +156,37 @@ const ably = new Ably.Realtime({
 You should then test that all client SDKs can connect, publish, and receive messages (where applicable) before rolling out these changes to production code.
 
 Where possible, you should also inspect your network traffic to verify that the client SDKs are calling the endpoints for your custom endpoint. Instead of connections to `realtime.ably.net` you should see connections to `[ENDPOINT].realtime.ably.net`, or your own custom CNAME domain.
+
+### Use legacy client options <a id="legacy-options"/>
+
+If your SDK version does not support the `endpoint` client option, use the following legacy options instead.
+
+The following example demonstrates how to set up the Ably Realtime client using an [Ably subdomain:](#option-1)
+
+<Code>
+```javascript
+const ably = new Ably.Realtime({
+  authUrl: '/auth', // Your authentication URL
+  environment: 'example-eu', // Replace with your custom endpoint name
+});
+```
+</Code>
+
+The following example demonstrates how to set up the Ably Realtime client using [your own subdomain:](#option-2)
+
+<Code>
+```javascript
+const ably = new Ably.Realtime({
+  authUrl: '/auth', // Your authentication URL
+  restHost: 'example.company.com',
+  realtimeHost: 'example.company.com',
+  fallbackHosts: [
+    'a.fallback.example.company.com',
+    'b.fallback.example.company.com'
+  ]
+});
+```
+</Code>
 
 ### Roll out your changes <a id="roll-out"/>
 


### PR DESCRIPTION
## Description

The enterprise customization page only shows the `endpoint` client option in its code examples. This option was introduced in certain SDKs at certain versions and is not universally available.

Customers on older SDK versions who configure a custom endpoint have no reference for the legacy approach, which can result in the option being silently ignored and traffic being routed incorrectly.

This PR:
- Adds a note to the "Modify your code" section pointing to the legacy options for customers whose SDK does not support `endpoint`
- Adds a new "Use legacy client options" section (between "Modify your code" and "Roll out your changes") with JavaScript examples for both the Ably subdomain and custom domain cases, using `environment` and `restHost`/`realtimeHost`/`fallbackHosts` respectively

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
