### PR TITLE
Support: Presence - Fix leave event timeout in trigger events table

### DIFF
--- a/src/pages/docs/presence-occupancy/presence.mdx
+++ b/src/pages/docs/presence-occupancy/presence.mdx
@@ -31,7 +31,7 @@ The following presence events are emitted:
 | Event | Description |
 |-------|-------------|
 | Enter | A new member has entered the channel |
-| Leave | A member who was present has now left the channel. This may be a result of an explicit request to leave or implicitly when detaching from the channel. Alternatively, if a member's connection is abruptly disconnected and they do not resume their connection within a minute, Ably treats this as a leave event as the client is no longer present |
+| Leave | A member who was present has now left the channel. This may be a result of an explicit request to leave or implicitly when detaching from the channel. Alternatively, if a member's connection is abruptly disconnected and they do not resume their connection within 15 seconds, Ably treats this as a leave event as the client is no longer present |
 | Update | An already present member has updated their [member data](#member-data). Being notified of member data updates can be useful, for example, it can be used to update the status of a user when they are typing a message |
 | Present | When subscribing to presence events on a channel that already has members present, this event is emitted for every member already present on the channel before the subscribe listener was registered |
 
@@ -249,7 +249,7 @@ An Ably client instance might, if on an application server for example, publish 
 
 Each unique [`clientId`](/docs/api/realtime-sdk#client-id) may only be present once when entering on behalf of another client as the unique identifier for each member in a presence set is the combined [`clientId`](/docs/api/realtime-sdk#client-id) and shared [`connectionId`](/docs/api/realtime-sdk/connection#id).
 
-A single [`clientId`](/docs/api/realtime-sdk#client-id) may be present multiple times on the same channel via different client connections. Ably considers these as different members of the presence set for the channel, however they will be differentiated by their unique connectionId. For example, if a client with ID “Sarah” is connected to a chat channel on both a desktop and a mobile device simultaneously, “Sarah” will be present twice in the presence member set with the same client ID, yet will have two unique connection IDs. A member of the presence set is therefore unique by the combination of the clientId and connectionId strings.
+A single [`clientId`](/docs/api/realtime-sdk#client-id) may be present multiple times on the same channel via different client connections. Ably considers these as different members of the presence set for the channel, however they will be differentiated by their unique connectionId. For example, if a client with ID "Sarah" is connected to a chat channel on both a desktop and a mobile device simultaneously, "Sarah" will be present twice in the presence member set with the same client ID, yet will have two unique connection IDs. A member of the presence set is therefore unique by the combination of the clientId and connectionId strings.
 
 In order to be able to publish presence changes for arbitrary client IDs, the SDK must have been instantiated either with an [API key](https://faqs.ably.com/what-is-an-app-api-key), or with a [token bound to a wildcard client ID](https://faqs.ably.com/can-a-client-emulate-any-client-id-i.e.-authenticate-using-a-wildcard-client-id).
 


### PR DESCRIPTION
The trigger events table stated that a leave event fires if a client
does not resume their connection "within a minute" after an abrupt
disconnect. This contradicts the "Handle unstable connections and
failures" section on the same page, which states the timeout is 15
seconds.

Corrects the table to say "within 15 seconds" to match the authoritative
description below it.

---
**Submitted by:** Mike Clark (mike.clark@ably.com)
**Submitted at:** 2026-06-19T13:51:43.371Z
*Created via `githubCreatePRWithFile` MCP tool*