### PR TITLE
Support: Presence - Fix leave event timeout in trigger events table

### DIFF
--- a/src/pages/docs/presence-occupancy/presence.mdx
+++ b/src/pages/docs/presence-occupancy/presence.mdx
@@ -31,7 +31,7 @@ The following presence events are emitted:
 | Event | Description |
 |-------|-------------|
 | Enter | A new member has entered the channel |
-| Leave | A member who was present has now left the channel. This may be a result of an explicit request to leave or implicitly when detaching from the channel. Alternatively, if a member's connection is abruptly disconnected and they do not resume their connection within a minute, Ably treats this as a leave event as the client is no longer present |
+| Leave | A member who was present has now left the channel. This may be a result of an explicit request to leave or implicitly when detaching from the channel. Alternatively, if a member's connection is abruptly disconnected and they do not resume their connection within 15 seconds, Ably treats this as a leave event as the client is no longer present |
 | Update | An already present member has updated their [member data](#member-data). Being notified of member data updates can be useful, for example, it can be used to update the status of a user when they are typing a message |
 | Present | When subscribing to presence events on a channel that already has members present, this event is emitted for every member already present on the channel before the subscribe listener was registered |
 


### PR DESCRIPTION
## Description

The trigger events table stated that a leave event fires if a client
does not resume their connection "within a minute" after an abrupt
disconnect. This contradicts the "Handle unstable connections and
failures" section on the same page, which states the timeout is 15
seconds.

Corrects the table to say "within 15 seconds" to match the authoritative
description below it.

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
