### PR TITLE
fix(examples): repair filters between sm and md breakpoints (DX-1449)

### DIFF
--- a/src/components/Examples/ExamplesContent.test.tsx
+++ b/src/components/Examples/ExamplesContent.test.tsx
@@ -75,8 +75,23 @@ describe('ExamplesContent', () => {
   });
 
   it('filters examples based on product filter selection', () => {
-    // Make the screen wider than the default of 1024px as desktop filtering only works >= 1040px
+    // Desktop filter auto-commits at the `sm` breakpoint (768px) and above
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1600 });
+    window.dispatchEvent(new Event('resize'));
+
+    render(<ExamplesContent exampleImages={exampleImages} />);
+    const productFilterInput = screen.getByTestId('product-spaces');
+    fireEvent.click(productFilterInput);
+
+    expect(screen.queryByText('Online status')).not.toBeInTheDocument();
+    expect(screen.getByText('Member location')).toBeInTheDocument();
+  });
+
+  // DX-1449: between the `sm` (768px) and `md` (1040px) breakpoints the inline
+  // desktop filter renders without an Apply button, but selections previously
+  // only committed at >= 1040px, leaving the filter inert in that range.
+  it('filters examples at widths between the sm and md breakpoints', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 818 });
     window.dispatchEvent(new Event('resize'));
 
     render(<ExamplesContent exampleImages={exampleImages} />);

--- a/src/components/Examples/ExamplesFilter.tsx
+++ b/src/components/Examples/ExamplesFilter.tsx
@@ -12,6 +12,11 @@ import { useOnClickOutside } from 'src/hooks/use-on-click-outside';
 import { navigate } from 'gatsby';
 import { ProductName } from '@ably/ui/core/ProductTile/data';
 
+// Matches Tailwind's `sm` screen (768px), where the filter switches from the
+// mobile drawer (with an Apply button) to the inline desktop sidebar. Above
+// this width selections must auto-commit, since no Apply button is rendered.
+const SM_BREAKPOINT = 768;
+
 const ExamplesFilter = ({
   selected,
   setSelected,
@@ -85,7 +90,7 @@ const ExamplesFilter = ({
 
   useEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= 1040) {
+      if (window.innerWidth >= SM_BREAKPOINT) {
         setExpandFilterMenu(false);
       }
     };
@@ -95,7 +100,7 @@ const ExamplesFilter = ({
   }, []);
 
   useEffect(() => {
-    if (window.innerWidth >= 1040) {
+    if (window.innerWidth >= SM_BREAKPOINT) {
       setSelected(localSelected);
     }
   }, [expandFilterMenu, localSelected, setSelected]);


### PR DESCRIPTION
## Summary

Fixes [DX-1449](https://ably.atlassian.net/browse/DX-1449): the examples filters stop working on narrow desktop windows (reproducible at ~818px).

### Root cause

The filter UI switches from the mobile drawer to the inline desktop sidebar at Tailwind's `sm` breakpoint (**768px** in `tailwind.config.js`), where the **Apply button is hidden** (`sm:hidden`). But the auto-commit effect in `ExamplesFilter.tsx` only propagated selections to the parent at **>= 1040px** (the `md` breakpoint).

That left a dead zone between **768px and 1039px**: the desktop sidebar rendered with no Apply button, so checkbox clicks updated local state but never reached the parent — the filters appeared completely broken.

### Fix

- Align the JS breakpoint with the CSS `sm` breakpoint (768px) via a named `SM_BREAKPOINT` constant (matches the existing `MD_BREAKPOINT` convention in `Header.tsx`).
- Add a regression test exercising the filter at 818px.

## Manual testing (review app)

1. Open https://ably-docs-dx-1449-examp-pcn9th.herokuapp.com/examples
2. Resize the browser window to a width **between 768px and 1039px** (e.g. ~818px — the originally reported width). Easiest via DevTools device toolbar / responsive mode with a custom width, or just narrow the window.
3. In the inline filter sidebar on the left, tick a product filter (e.g. **Spaces**).
4. **Expected:** the example grid immediately filters to that product. No Apply button is shown at this width — selection commits on click.
5. Sanity check the boundaries:
   - **< 768px**: the sidebar collapses to a **Filter** button opening the drawer; selections commit via the **Apply** button.
   - **>= 1040px**: inline sidebar, instant filtering (unchanged behaviour).

## Tests

`yarn test src/components/Examples` — 6/6 passing, including the new 818px regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1449]: https://ably.atlassian.net/browse/DX-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ