### PR TITLE
Support: Channel rules - fix link to namespace rules section in dashboard

### DIFF
--- a/src/pages/docs/channels/index.mdx
+++ b/src/pages/docs/channels/index.mdx
@@ -207,9 +207,9 @@ To set a rule:
 <Tabs>
 <Tab value="dashboard" label="Dashboard">
 
-In your app [settings](https://ably.com/accounts/any/apps/any/settings):
+In your app [settings](https://ably.com/accounts/any/apps/any/app_namespaces):
 
-1. Click **Add new rule**.
+1. Click **Create rule**.
 2. Select the channel name or namespace to apply rules to.
 3. Check the required rules.
 4. Click **Create rule** to save.


### PR DESCRIPTION
## Description

The link to create a channel namespace rule was pointing to an incorrect url https://ably.com/accounts/any/apps/any/settings when it is now https://ably.com/accounts/any/apps/any/app_namespaces

### Checklist

- [ ] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [ ] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
