### PR TITLE
docs(ai-transport): add roadmap page

### DIFF
--- a/src/data/nav/aitransport.ts
+++ b/src/data/nav/aitransport.ts
@@ -189,6 +189,10 @@ export default {
           link: '/docs/ai-transport/going-to-production',
         },
         {
+          name: 'Roadmap',
+          link: '/docs/ai-transport/roadmap',
+        },
+        {
           name: 'Troubleshooting',
           link: '/docs/ai-transport/troubleshooting',
         },
@@ -325,16 +329,6 @@ export default {
         {
           name: 'Transport patterns',
           link: '/docs/ai-transport/internals/transport-patterns',
-        },
-      ],
-    },
-    {
-      name: 'Roadmap',
-      pages: [
-        {
-          name: 'Roadmap',
-          link: '/docs/ai-transport/roadmap',
-          index: true,
         },
       ],
     },

--- a/src/data/nav/aitransport.ts
+++ b/src/data/nav/aitransport.ts
@@ -328,6 +328,16 @@ export default {
         },
       ],
     },
+    {
+      name: 'Roadmap',
+      pages: [
+        {
+          name: 'Roadmap',
+          link: '/docs/ai-transport/roadmap',
+          index: true,
+        },
+      ],
+    },
   ],
   api: [],
 } satisfies NavProduct;

--- a/src/pages/docs/ai-transport/roadmap.mdx
+++ b/src/pages/docs/ai-transport/roadmap.mdx
@@ -1,0 +1,52 @@
+---
+title: "AI Transport roadmap"
+meta_description: "The AI Transport roadmap across three horizons: capabilities available now, capabilities in active development, and capabilities planned for the future."
+meta_keywords: "AI Transport, roadmap, durable sessions, AI infrastructure, token streaming, human handover, durable execution"
+intro: "AI Transport is under active development with new releases shipping regularly. What features can you expect to see next?"
+---
+
+This page shows where AI Transport is heading. The roadmap is dynamic and updated based on the feedback received from customers. The fastest way to influence this roadmap is to [contact Ably](https://ably.com/contact), explaining what you are trying to build and where AI Transport can help you.
+
+## Now <a id="now"/>
+
+Available today.
+
+| Capability | Description |
+| --- | --- |
+| [Resumable token streaming](/docs/ai-transport/features/token-streaming) | Tokens stream over a session rather than a single HTTP request, so a dropped connection resumes mid-response with nothing lost or duplicated, and a reconnecting client catches up automatically. |
+| [Connection resilience](/docs/ai-transport/features/reconnection-and-recovery) | Realtime delivery over WebSocket with automatic fallback to HTTP streaming and long-polling, so streams survive proxies, firewalls, and unreliable networks. |
+| [Multi-device session continuity](/docs/ai-transport/features/multi-device) | The same session opens on any device the user picks up, with the full conversation and current state. |
+| [Persistent history and replay](/docs/ai-transport/features/history) | Conversations survive disconnects and stay available as history, for resumption, audit, and review. |
+| Bidirectional control | Any client signals the agent through the session, so a user can [cancel generation](/docs/ai-transport/features/cancellation), [interrupt](/docs/ai-transport/features/interruption), [send again while the agent responds](/docs/ai-transport/features/double-texting), and keep interacting rather than only consuming a one-way stream. |
+| [Conversation branching](/docs/ai-transport/features/branching) | Edit and regenerate messages, with each branch kept in the session tree. |
+| Client-side tool calls and approval gates | Call [client tools](/docs/ai-transport/features/tool-calling) over the session, with [human-in-the-loop](/docs/ai-transport/features/human-in-the-loop) approval where you need it. |
+| Drop-in framework integration | A drop-in transport for the [Vercel AI SDK](/docs/ai-transport/getting-started/vercel-ai-sdk), plus the [Core SDK](/docs/ai-transport/getting-started/core-sdk) for everything else. |
+| Shared live state and presence | [Agent presence](/docs/ai-transport/features/agent-presence) and [shared session state](/docs/ai-transport/features/liveobjects) exposed directly through the SDK. |
+| Enterprise-ready platform | SOC 2 Type II and HIPAA, on Ably's realtime [infrastructure](/docs/ai-transport/concepts/infrastructure). |
+
+## Next <a id="next"/>
+
+Actively building.
+
+| Capability | Description |
+| --- | --- |
+| Durable execution support | Pair durable sessions with Temporal and Vercel WDK, so the workflow and the user experience are both crash-proof. |
+| Human and AI handover | Transfer a conversation between an AI and a human agent and back again using the AIT SDK, with live supervision and escalation. |
+| Mid-session steering | Redirect or steer the agent while it responds. |
+| Push notifications through the SDK | Reach users when they are away, including iOS Live Activities for long-running tasks. |
+| More provider codecs | Native integrations for OpenAI and Anthropic, so more of the ecosystem is a drop-in. |
+| More language SDKs | AI Transport SDK implementation in Python. |
+| Ably Chat integration | A clean path from chat use cases into AI Transport. |
+
+## Future <a id="future"/>
+
+Planned and exploring.
+
+| Capability | Description |
+| --- | --- |
+| More language SDKs | Java, Swift, Kotlin, and .NET. |
+| More framework integrations | LangChain and LangGraph, TanStack AI, AG-UI, Vue, and Svelte. |
+| More model-specific codecs | Gemini. |
+| Sub-agent orchestration | Better primitives for coordinating multiple sub-agents in a single Run. |
+| More durable-execution integrations | Inngest and trigger.dev. |
+| Multimodal | Audio and video delivery, and integrations with voice providers. |

--- a/src/pages/docs/ai-transport/roadmap.mdx
+++ b/src/pages/docs/ai-transport/roadmap.mdx
@@ -7,7 +7,7 @@ intro: "AI Transport is under active development with new releases shipping regu
 
 This page shows where AI Transport is heading. The roadmap is dynamic and updated based on the feedback received from customers. The fastest way to influence this roadmap is to [contact Ably](https://ably.com/contact), explaining what you are trying to build and where AI Transport can help you.
 
-## Now <a id="now"/>
+## Delivered <a id="delivered"/>
 
 Available today.
 
@@ -24,19 +24,26 @@ Available today.
 | Shared live state and presence | [Agent presence](/docs/ai-transport/features/agent-presence) and [shared session state](/docs/ai-transport/features/liveobjects) exposed directly through the SDK. |
 | Enterprise-ready platform | SOC 2 Type II and HIPAA, on Ably's realtime [infrastructure](/docs/ai-transport/concepts/infrastructure). |
 
-## Next <a id="next"/>
+## Now <a id="now"/>
 
 Actively building.
 
 | Capability | Description |
 | --- | --- |
-| Durable execution support | Pair durable sessions with Temporal and Vercel WDK, so the workflow and the user experience are both crash-proof. |
-| Human and AI handover | Transfer a conversation between an AI and a human agent and back again using the AIT SDK, with live supervision and escalation. |
+| Durable execution support | Pair durable sessions with [Temporal](https://temporal.io/) and [Vercel Workflow SDK](https://workflow-sdk.dev/), so the workflow and the user experience are both crash-proof. |
+| Human and AI handover | Transfer a conversation between an AI and a human agent and back again using the AI Transport SDK, with live supervision and escalation. |
 | Mid-session steering | Redirect or steer the agent while it responds. |
-| Push notifications through the SDK | Reach users when they are away, including iOS Live Activities for long-running tasks. |
-| More provider codecs | Native integrations for OpenAI and Anthropic, so more of the ecosystem is a drop-in. |
-| More language SDKs | AI Transport SDK implementation in Python. |
-| Ably Chat integration | A clean path from chat use cases into AI Transport. |
+| Increased ecosystem support | Native integrations for OpenAI and Anthropic, so more of the ecosystem is a drop-in. |
+
+## Next <a id="next"/>
+
+Ready for development.
+
+| Capability | Description |
+| --- | --- |
+| Push notifications through the AI Transport SDK | Reach users when they are away, including iOS Live Activities for long-running tasks, without using the Pub/Sub SDK. |
+| Increased language support | AI Transport SDK implementation in Python. |
+| Ably [Chat SDK](/docs/chat) integration | A clean path from chat use cases into AI Transport. |
 
 ## Future <a id="future"/>
 
@@ -44,9 +51,8 @@ Planned and exploring. If you care about one of these features then [contact Abl
 
 | Capability | Description |
 | --- | --- |
-| More language SDKs | Java, Swift, Kotlin, and .NET. |
-| More framework integrations | LangChain and LangGraph, TanStack AI, AG-UI, Vue, and Svelte. |
-| More model-specific codecs | Gemini. |
+| Increased language support | Java, Swift, Kotlin, and .NET. |
+| Expanded ecosystem support | Gemini, LangChain and LangGraph, TanStack AI, AG-UI, Vue, and Svelte. |
 | Sub-agent orchestration | Better primitives for coordinating multiple sub-agents in a single Run. |
 | More durable-execution integrations | Inngest and trigger.dev. |
 | Multimodal | Audio and video delivery, and integrations with voice providers. |

--- a/src/pages/docs/ai-transport/roadmap.mdx
+++ b/src/pages/docs/ai-transport/roadmap.mdx
@@ -37,7 +37,7 @@ Actively building.
 
 ## Next <a id="next"/>
 
-Ready for development.
+Coming up - unlikely to change.
 
 | Capability | Description |
 | --- | --- |

--- a/src/pages/docs/ai-transport/roadmap.mdx
+++ b/src/pages/docs/ai-transport/roadmap.mdx
@@ -51,8 +51,8 @@ Planned and exploring. If you care about one of these features then [contact Abl
 
 | Capability | Description |
 | --- | --- |
-| Increased language support | Java, Swift, Kotlin, and .NET. |
-| Expanded ecosystem support | Gemini, LangChain and LangGraph, TanStack AI, AG-UI, Vue, and Svelte. |
+| Increased language support | AI Transport SDK implementation in Java, Swift, Kotlin, and .NET. |
+| Expanded ecosystem support | Native integrations for Gemini, LangChain and LangGraph, TanStack AI, AG-UI, Vue, and Svelte, so more of the ecosystem is a drop-in. |
 | Sub-agent orchestration | Better primitives for coordinating multiple sub-agents in a single Run. |
 | More durable-execution integrations | Inngest and trigger.dev. |
 | Multimodal | Audio and video delivery, and integrations with voice providers. |

--- a/src/pages/docs/ai-transport/roadmap.mdx
+++ b/src/pages/docs/ai-transport/roadmap.mdx
@@ -2,7 +2,7 @@
 title: "AI Transport roadmap"
 meta_description: "The AI Transport roadmap across three horizons: capabilities available now, capabilities in active development, and capabilities planned for the future."
 meta_keywords: "AI Transport, roadmap, durable sessions, AI infrastructure, token streaming, human handover, durable execution"
-intro: "AI Transport is under active development with new releases shipping regularly. What features can you expect to see next?"
+intro: "AI Transport is under active development with new releases shipping regularly"
 ---
 
 This page shows where AI Transport is heading. The roadmap is dynamic and updated based on the feedback received from customers. The fastest way to influence this roadmap is to [contact Ably](https://ably.com/contact), explaining what you are trying to build and where AI Transport can help you.
@@ -40,7 +40,7 @@ Actively building.
 
 ## Future <a id="future"/>
 
-Planned and exploring.
+Planned and exploring. If you care about one of these features then [contact Ably](https://ably.com/contact), explaining what you are trying to build and where AI Transport can help you.
 
 | Capability | Description |
 | --- | --- |


### PR DESCRIPTION
## What

Adds a customer-facing AI Transport roadmap page (AIT-1029) to give readers an indication of where the product is going next and inviting feedback.

- New page `src/pages/docs/ai-transport/roadmap.mdx` covering three horizons — **Now**, **Next**, **Future** — as capability tables.
- "Now" capabilities link to their existing feature/concept pages (all 15 links verified to resolve).
- Opens with a short framing line inviting readers to [contact Ably](https://ably.com/contact) to influence the roadmap.
- Adds a **Roadmap** entry to the AI Transport navigation (`src/data/nav/aitransport.ts`), after the API reference and before the Internals.