### PR TITLE
Fix spelling mistake in platform index

### DIFF
--- a/src/pages/docs/platform/architecture/edge-network.mdx
+++ b/src/pages/docs/platform/architecture/edge-network.mdx
@@ -31,7 +31,7 @@ Behind CloudFront, each Ably region employs AWS Network Load Balancers to distri
 
 ### DNS organization and latency-based routing <a id="dns-routing"/>
 
-Ably uses DNS-based latency routing to direct clients to the nearest available datacenter. The primary endpoints for client connections and HTTP requests is `main.realtime.ably.net`.
+Ably uses DNS-based latency routing to direct clients to the nearest available datacenter. The primary endpoint for client connections and HTTP requests is `main.realtime.ably.net`.
 
 When a client performs a DNS lookup for this endpoint, the DNS service resolves to the closest datacenter, among those that are currently enabled, to the client's location. This latency-based routing ensures that clients connect to the datacenter with the lowest network latency, maximizing the responsiveness of the service.
 

--- a/src/pages/docs/platform/index.mdx
+++ b/src/pages/docs/platform/index.mdx
@@ -83,7 +83,7 @@ Use Ably's products and SDKs to build realtime applications for your clients. Th
 
 Ably's core [Pub/Sub](/docs/basics) product provides flexible APIs that are feature-rich and powerful. These flexible APIs are the building blocks for crafting any type of realtime experience for your customers.
 
-Ably's other products are built on top of Pub/Sub. They utilize the same platform with the some guarantees and benefits. These products can be considered abstractions, with APIs designed to simplify and build applications more quickly for the most popular use cases.
+Ably's other products are built on top of Pub/Sub. They utilize the same platform with the same guarantees and benefits. These products can be considered abstractions, with APIs designed to simplify and build applications more quickly for the most popular use cases.
 
 ### Ably Chat <a id="chat"/>
 

--- a/src/pages/docs/platform/index.mdx
+++ b/src/pages/docs/platform/index.mdx
@@ -95,7 +95,7 @@ Chat is effective for use cases such as sports and gaming live streams, 1:1 agen
 
 ### Ably Spaces <a id="spaces"/>
 
-Use the Ably [Spaces](/docs/spaces) SDKs to build multiplayer collaborative components in your applications. It provides a set of purpose-built APIs to manage the participate state of users collaborating synchronously in an application, such as their the position of their cursors, or which elements they are interacting with.
+Use the Ably [Spaces](/docs/spaces) SDKs to build multiplayer collaborative components in your applications. It provides a set of purpose-built APIs to manage the participate state of users collaborating synchronously in an application, such as the position of their cursors, or which elements they are interacting with.
 
 Spaces is an abstraction built over Ably Pub/Sub. It utilizes Ably's platform to benefit from all of the same performance guarantees and scaling potential.
 


### PR DESCRIPTION
Fix typo on line 86 of `src/pages/docs/platform/index.mdx`: 'with the some guarantees' → 'with the same guarantees'.