### PR TITLE
Skills/docs authoring orchestrator

### DIFF
--- a/.claude/skills/docs-execute-plan/SKILL.md
+++ b/.claude/skills/docs-execute-plan/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: docs-execute-plan
+description: Write or refresh Ably docs pages (MDX) by executing a docs-plan.md from docs-plan-pr — build it commit by commit, drafting each page from the project guidance, reviewing with the docs-review-* concerns until clean, verifying, then committing with /git-commit; uses fixups for earlier commits and keeps a decision log. For multi-PR (stacked) plans it creates one branch per PR. Can also run against a direct page or directory target. Asks up front whether to checkpoint each commit, between PRs, or run to completion.
+license: proprietary
+metadata:
+  team: engineering
+  tags: docs, documentation, execute, write, mdx, commits, stacked-prs, docs-review, git-commit, fixups, workflow
+  mcp: false
+---
+
+# Execute a docs plan
+
+Take a `docs-plan.md` produced by `docs-plan-pr` and build it to completion — one
+**single-purpose commit** (a cluster of pages) at a time, each drafted, reviewed,
+verified, and committed before the next. This skill is the execution counterpart of
+`docs-plan-pr`: that skill decides *what* the commits and PRs are; this one *builds*
+them. It is the docs counterpart of `code-execute-plan`, and the write half of the
+write → review loop (the `docs-review-*` skills are the review half).
+
+The loop per commit is: **draft the pages → review with `docs-review-all` (the
+`docs-review-*` concerns) and iterate until clean → run the verification checks →
+commit with `/git-commit`**. Keep going until the plan is fully built, keeping a
+decision log as you go.
+
+## Required reading (read before drafting)
+
+Project-canonical guidance lives in folder `AGENTS.md` files, which auto-load when
+you edit pages there. Read what applies to the pages you are writing:
+
+- `src/pages/docs/AGENTS.md` — the general docs-writing guidance: structure / IA
+  principles and feature-page tiers, the per-page-type templates, the
+  API-reference standard (for `api/**` pages), the code-accuracy workflow, and the
+  verification checks.
+- `src/pages/docs/<product>/AGENTS.md` — product positioning and terminology
+  (e.g. `src/pages/docs/ai-transport/AGENTS.md`).
+- `writing-style-guide.md` (repo root) — Ably house style + the AI-fingerprint
+  list. **Load-bearing — read before writing prose.** It is the authority for prose
+  and takes precedence over anything here; flag conflicts.
+- `CLAUDE.md` (repo root) — repo conventions: MDX components, frontmatter, code
+  blocks, nav files.
+
+## Step 1: Locate and read the plan
+
+- Find the plan at the repo root: `docs-plan.md`, or `<KEY>-plan.md` (the form
+  `jira-plan-pr` writes). If the user named one, use it. If several exist or it's
+  ambiguous, ask which with **AskUserQuestion**.
+- Read it fully and extract: the **Goal**, **Source of change** and resolved
+  decisions, the **Version bump**, the ordered **PR(s)** and their **commits**
+  (intent + the page cluster each touches), the **Pages** detail, the **Glossary
+  source**, the **acceptance-criteria** checklist, and any **open questions / risks**.
+- Note whether the plan is **single-PR or multi-PR (stacked)** — this changes the
+  cadence options (Step 2) and the branching (Step 3) — and capture the **ticket
+  key** if there is one (from a `<KEY>-plan.md` filename or the plan title) for
+  branch names.
+- If the plan still has unresolved open questions that block starting, surface them
+  and resolve with **AskUserQuestion** before writing any page.
+
+**Direct target (no plan).** If invoked as `/docs-execute-plan <page or directory>`
+with no plan, treat the target as an ad-hoc single-commit plan: draft/refresh those
+pages with the same per-commit loop (Steps 2 and 4), skipping the stacked-PR
+branching. If a larger change has no plan, prefer producing one first with
+`docs-plan-pr`.
+
+## Step 2: Ask how the user wants to review (required)
+
+Before building anything, use **AskUserQuestion** to choose the review cadence.
+Which options you offer depends on whether the plan is single- or multi-PR (Step 1):
+
+- **Checkpoint each commit** — after a commit's pages are drafted, reviewed
+  (`docs-review-all`, iterated clean), and verified, **show the diff and wait for
+  the user's approval before committing**. Then move to the next commit.
+- **Checkpoint between PRs** *(offer only for multi-PR plans)* — commit through each
+  PR's commits without pausing, then **stop at each PR boundary** for the user to
+  review that whole PR before starting the next stacked PR.
+- **Run to completion** — draft, self-review, verify, and commit each commit without
+  pausing (the user has pre-approved `/git-commit`), and only stop at the very end
+  for the user to review the whole result.
+
+Remember the choice and apply it consistently in Steps 4–5.
+
+## Step 3: Set up the working branch
+
+Don't commit on the default branch. **Use one branch per PR**, named with the ticket
+key (from Step 1) where there is one so each branch is traceable:
+
+- **Naming:** `<key-lowercase>-<short-slug>`, and for a multi-PR plan include the
+  PR's position, e.g. `ait-1234-pr1-new-pages`, `ait-1234-pr2-api-sweep`. With no
+  ticket key, fall back to a descriptive slug (`pr1-new-pages`, or
+  `docs-<product>-refresh` for a single PR). Keep the slug short and drawn from the
+  PR's theme.
+- Create the branch for the plan's **first PR** now: `git switch -c <slug>`.
+- For a **stacked-PR** plan, **each later PR is its own branch stacked on the
+  previous PR's branch** — create them at each PR boundary (Step 5), not up front.
+
+## Step 4: Build the plan, commit by commit
+
+Work through the commits **in the plan's order**. Following the repo's orchestration
+pattern (see `translate-examples-to-swift`), **spawn a drafting subagent per page**
+and keep the orchestrator coordinating, not editing — even for a single page, to
+keep behaviour consistent and context isolated. For each commit:
+
+1. **Draft** the cluster's pages. For each page: identify the **page type** and read
+   the matching template in the **Page-type templates** section of
+   `src/pages/docs/AGENTS.md` (or its **API reference standard** for `api/**`
+   pages). Draft applying that template, the **Docs structure** guidance, the
+   product folder's `AGENTS.md` positioning and terminology, and the house style.
+   Verify every code snippet against the SDK per the **Code accuracy** section. Stay
+   within the commit's stated intent — resist pulling in unrelated pages.
+2. **Review** with `docs-review-all` over the commit's pages (it fans out the
+   `docs-review-*` concerns as subagents). Fix every `blocker` and `major`, then
+   re-review. Repeat until every concern returns `VERDICT: PASS`. `minor`/`nit` are
+   author's discretion. Don't commit over unresolved review findings.
+3. **Verify** — run the **Verification checks** from `src/pages/docs/AGENTS.md` (and
+   the API-reference hidden-table audit for `api/**` pages). Expect zero hits.
+   Register new or renamed pages in `src/data/nav/`, with `redirect_from` on moves.
+   If a page ships Swift variants, hand off to `translate-examples-to-swift`.
+4. **Gate on the chosen cadence (Step 2):**
+   - *Checkpoint each commit* → show the diff and a one-line summary, wait for
+     approval, apply requested changes and re-review/re-verify before committing.
+   - *Run to completion* → proceed without asking (pre-approved).
+5. **Commit** with `/git-commit`.
+6. **Fixups for earlier commits.** If, while doing a later commit, you make a change
+   that belongs to an **already-made** commit (e.g. a cross-link or nav entry for an
+   earlier cluster), create a **targeted fixup** against that commit (`/git-fixup`,
+   i.e. `git commit --fixup=<sha>`) rather than burying it. This keeps each commit
+   single-purpose, matching the plan.
+7. **Log it** (Step 6).
+
+## Step 5: PR boundaries (stacked plans)
+
+When you finish all commits for a PR in a stacked plan:
+
+- Run `docs-review-all` and the verification checks once more over that PR's
+  complete set of pages.
+- **If the cadence is _Checkpoint between PRs_** (Step 2): stop here, show the PR's
+  full diff and a summary of what it delivers, and wait for the user's approval
+  (apply any requested changes and re-check) before moving on.
+- Start the **next PR on its own branch, stacked on the current one**, using the
+  same naming as Step 3: `git switch -c <key>-pr<N>-<slug>` (created from the
+  just-completed PR's branch, not the default branch). Then continue Step 4.
+
+Pushing branches and opening PRs is outward-facing — **don't do it automatically**.
+Once the plan (or a PR within it) is complete, offer to **push the branch**
+(`git push`), then hand off **opening the PR** to the user or their PR-creation flow
+— use the `gh-pr-description` skill to write the description, referencing the
+originating ticket when the plan came from `jira-plan-pr`. For a stacked plan, each
+PR targets the previous PR's branch as its base.
+
+## Step 6: Keep a decision log
+
+Maintain a running **Decision log** as you build — append it as a
+`## Decision log` section to the plan file (`docs-plan.md` / `<KEY>-plan.md`) so the
+record sits with the plan. For each entry note: which commit/PR it relates to, any
+**deviation from the plan** and why, decisions made while drafting (terminology
+calls, IA tweaks), fixups applied, and anything a reviewer should know. Update it as
+you go, not only at the end.
+
+## Step 7: Report
+
+When the plan is fully built, tell the user: the branch(es) created, the commits
+made (and any fixups), the `docs-review-all` result and verification status, which
+acceptance criteria are now met, and a pointer to the decision log. If you stopped
+early (no plan, blocked on an open question, a review you couldn't get to PASS), say
+so plainly and what remains.

--- a/.claude/skills/docs-plan-pr/SKILL.md
+++ b/.claude/skills/docs-plan-pr/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: docs-plan-pr
+description: Plan a documentation change — given an SDK release/tag, a PR or set of PRs, specific commits, local code changes, or a described task, work out which docs pages must change and what is new, and write a docs-plan.md describing the work as a series of single-purpose commits (one or more stacked PRs). Plans; does not write the pages (hand off to `docs-execute-plan`).
+license: proprietary
+metadata:
+  team: engineering
+  tags: docs, documentation, plan, planning, scope, breakdown, commits, stacked-prs, sdk-drift, workflow
+  mcp: false
+---
+
+# Plan a docs change into commits and PRs
+
+Turn a change into a concrete, reviewable docs plan grounded in the real docs and
+the real SDK. The output is `docs-plan.md`, which describes the work as a series of
+**single-purpose commits** — each a coherent cluster of pages, with its intent and
+*why* (which delta drives it) — grouped into **one or more (stacked) PRs**. This
+plans; `docs-execute-plan` builds the pages.
+
+This skill is the docs planning engine and the change-driven entry point: it works
+backwards from an SDK change to the docs that change invalidates or requires (the
+recurring need behind most AI Transport docs PRs — drift sweeps, pre-release
+refreshes). It is invoked directly, or by a wrapper skill (e.g. `jira-plan-pr`)
+that has already gathered the brief from an external source and hands it off. It is
+the docs counterpart of `code-plan-pr`, and shares its shape.
+
+This skill plans; it does not implement. Read the docs and the SDK thoroughly so
+the plan reflects their real state, and surface genuine IA decisions to the user
+before finalising it (Step 2).
+
+## Step 0: Establish the change
+
+The brief is either a **code change** to document or a **described task**.
+
+- **Code change** — resolve it with the shared **`code-resolve-changes`** skill
+  (load via the Ably MCP: `skillGet({ id: "code-resolve-changes" })`). It accepts a
+  release/tag, a PR or set of PRs, specific commits, or local working-tree changes,
+  and returns the before→after states and the changed files; with nothing specified
+  it defaults to the latest release of the SDK repo the docs document. Read its
+  result rather than re-deriving the diff.
+- **Described task** ("add a roadmap page", "split the auth guide") — if a brief was
+  handed to you (e.g. by `jira-plan-pr`), use it. If the request is thin, use
+  **AskUserQuestion** to pin the goal before reading the docs. Don't invent scope.
+
+Capture the intended end state — it anchors the plan and its acceptance criteria.
+
+## Step 1: Read the SDK surface and the docs, and map the deltas to pages
+
+Confirm the change concerns **these** docs before planning how to document it.
+
+- Find the version the docs currently target in
+  `src/data/languages/languageData.ts` (the version badge reads from it).
+- Read the SDK type declarations at the change's after-state (npm for a published
+  release; `git show <ref>:<path>` or the local tree otherwise) and capture the
+  surface deltas across every entry point. See the **Code accuracy** section of
+  `src/pages/docs/AGENTS.md`.
+- List the affected product's pages and grep each changed symbol (old and new name)
+  across them so nothing drifts silently.
+- **If the change is not for these docs** — it documents a different product, or
+  nothing it references exists in these pages — **stop and tell the user.** Say
+  which docs you're in and why it doesn't match. Do not write a plan.
+
+Map each delta to the pages it drives, using the **Docs structure** section of
+`src/pages/docs/AGENTS.md` for where pages sit in the IA:
+
+| Delta | Page(s) | Type |
+|---|---|---|
+| New capability users call | new/expanded feature; maybe a concept | feature, concept |
+| Signature / option / return change | API reference + snippet sweep on calling pages | api-reference |
+| Renamed factory / type / enum | breaking sweep + `redirect_from` on renamed pages | all affected |
+| New / changed error or terminal reason | API errors page + troubleshooting (literal code/text) | api-reference, troubleshooting |
+| New framework / adapter / codec | framework guide, aligned with siblings | framework |
+| Behaviour change, no surface change | prose + edge-cases on the feature/concept page | feature, concept |
+| Config / channel-rule / capability change | getting-started + going-to-production | getting-started |
+
+## Step 2: Reach a shared understanding before finalising
+
+The goal is not just to fill gaps — it is to make sure you and the user **agree on
+the shape of the change** before it's written into a plan. Reading the SDK and the
+docs in Step 1 will have turned the brief into a concrete set of page changes with
+real trade-offs; replay that back and confirm it matches what they want.
+
+Surface, don't bury:
+
+- **Restate the shape** you've landed on — which pages change, what's net-new, the
+  version bump — so the user can correct a wrong mental model before it's baked in.
+- **Flag the IA decisions** the work forces: new page vs expand an existing one,
+  renames and their `redirect_from`s, a terminology choice the glossary does not
+  settle, where a net-new capability lives in the IA, scope deliberately left out.
+- **Spell out the implications**: ripple effects into sibling pages, pre-release
+  gating if the target version isn't on npm yet, redirects needed for moved slugs.
+
+Use **AskUserQuestion** to resolve anything that is genuinely the user's call — a
+real IA decision, an ambiguous goal, a trade-off with no obvious winner. Don't
+silently pick a direction that should be theirs; equally, don't ask about things
+the docs, the SDK, or sensible defaults already settle. Record the resulting
+decisions and their rationale in the plan so the shared understanding is captured.
+
+## Step 3: Decide single PR vs stacked PRs, and order the commits
+
+Design the change as a sequence of **single-purpose commits**: each commit is a
+coherent cluster of pages (e.g. "the core API reference for the new run model",
+"the feature-page sweep"), fully updated for every delta that touches it, so a page
+is touched in exactly one commit. Order them so net-new and foundational work lands
+first (the version bump, then new pages other pages cross-link to), then the
+cross-cutting symbol sweep cluster by cluster.
+
+Then judge whether the whole change lands as **one PR a reviewer can reasonably
+review**:
+
+- **Fits one PR** → the plan is one PR containing the ordered commits.
+- **Too large** → split into a series of **stacked PRs**, each built on the
+  previous branch, each independently reviewable with a clear theme (e.g. PR1: new
+  pages + version bump; PR2: API-reference sweep; PR3: feature/concept sweep). Make
+  the stacking order and the dependency between PRs explicit.
+
+## Step 4: Write docs-plan.md
+
+Write the plan to `docs-plan.md` at the repo root (use `<KEY>-plan.md` when called
+from `jira-plan-pr` so it's tied to the ticket). Markdown, this shape:
+
+```markdown
+# <title> — docs plan
+
+## Goal
+What the reader can do/understand after this change.
+
+## Source of change
+How it was specified (release/tag, PR(s), commits, local, or default latest
+release), the resolved before→after states, the key deltas, and the decisions
+resolved with the user in Step 2 (with rationale).
+
+## Version bump
+Bump the product in languageData.ts from <from> to <to>. Note pre-release gating
+if <to> is not yet on npm.
+
+## Plan
+<!-- If one PR: a single ## PR section. If stacked: one ## PR section each, in order. -->
+
+### PR 1 — <theme>  (base: <branch>)
+Intent of this PR and why it's a reviewable unit.
+
+1. **<commit intent>** — the page cluster it updates and the motivation. Name the
+   pages it touches, not the line-by-line edits.
+2. **<commit intent>** — ...
+
+### PR 2 — <theme>  (base: PR 1's branch)
+...
+
+## Pages
+### <path/to/page.mdx> — <page type> — <create | update>
+Intent: what this page must say after the change.
+Why: which delta drives it.
+Renames/redirects: <old slug → new slug> (if any).
+
+## Glossary source
+<for terminology review — e.g. Confluence 4865097761 for AI Transport>
+
+## Acceptance criteria
+- [ ] languageData.ts bumped
+- [ ] all affected pages updated; no stale symbols remain
+- [ ] new/renamed pages registered in nav, with redirect_from on moves
+- [ ] docs-review-all passes (style, structure, code-accuracy, terminology, links)
+
+## Open questions / risks
+Anything still unresolved or worth flagging to reviewers.
+```
+
+Keep commit and PR entries at the level of **intent and motivation** — the *what
+and why*. The **Pages** section carries the per-page detail behind those commits;
+the implementation comes later in `docs-execute-plan`.
+
+## Step 5: Report
+
+Say where the plan was written, summarise the shape (commits, single PR vs how many
+stacked PRs and their themes, pages create vs update, the version bump, renames),
+list decisions resolved or still open, and point at `docs-execute-plan` to build it. If
+the change is not for these docs, say so and do not write a plan.

--- a/.claude/skills/docs-review-all/SKILL.md
+++ b/.claude/skills/docs-review-all/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: docs-review-all
+description: Run a full review of a docs change — fan out every relevant review concern (docs-review-style, docs-review-structure, docs-review-code-accuracy, docs-review-terminology, docs-review-links) across independent subagents and synthesise one consolidated report with a single verdict. Read-only; never edits the docs.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review docs (all concerns)
+
+Runs every docs review concern over a change and produces one combined report.
+Read-only — it reports; it does not edit. Fixing is the author's job, or the
+`docs-execute-plan` skill's loop. This is the docs analogue of `code-review-all`.
+
+## Step 1 — resolve scope once
+
+Resolve the scope via the shared **`review-conventions`** contract (load via the
+Ably MCP: `skillGet({ id: "review-conventions" })`) — honour any `$ARGUMENTS`
+override, otherwise the changed `.mdx` pages on this branch vs its base plus
+working-tree changes. State the scope once and pass the same scope to every
+concern so they review the same pages.
+
+## Step 2 — fan out the concerns
+
+Run all five concern skills over the scope. **Prefer parallel subagents** (one
+`Task` per concern) so they run concurrently and independently:
+
+- `docs-review-style`
+- `docs-review-structure`
+- `docs-review-code-accuracy`
+- `docs-review-terminology` (pass the glossary source)
+- `docs-review-links`
+
+Each returns a report ending in `VERDICT: PASS | CHANGES_REQUESTED`.
+
+## Step 3 — synthesise
+
+Merge the five reports into one: a single findings table sorted by severity then
+page, each finding tagged with its concern; de-duplicate where two concerns flag
+the same line (keep the higher severity). Overall verdict is
+`CHANGES_REQUESTED` if any concern returned it, else `PASS`. Emit the combined
+report in the `review-conventions` format with the overall `VERDICT:` last, and
+note in the Notes which concerns passed and which requested changes.
+
+## When to use
+
+- **Directly** — a quick "is this docs change ready?" check on the branch.
+- **In the `docs-execute-plan` loop** — `docs-execute-plan` calls this per page and iterates until the
+  verdict is `PASS` before moving on.

--- a/.claude/skills/docs-review-code-accuracy/SKILL.md
+++ b/.claude/skills/docs-review-code-accuracy/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: docs-review-code-accuracy
+description: Audit the code samples on a docs page against the SDK they target — factory and method names, option shapes, return shapes, enum values, import surfaces verified against the SDK .d.ts at the version the docs target, plus no API keys in client code. Read-only; produces a conformance report and never edits the page.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review: code accuracy
+
+Check that every code sample matches the SDK it targets. Prior docs drift; the
+SDK is the source of truth. This is the concern where a confidently-wrong sample
+does the most damage.
+
+## Step 1 — scope & contract
+
+Invoke the `review-conventions` skill via the Ably MCP
+(`skillGet({ id: "review-conventions" })`) — report-only rule, scope resolution
+(honouring `$ARGUMENTS`), severity scale, report format. Use
+**concern = `code-accuracy`**, **surface = docs**. The method is in
+the **Code accuracy** section of `src/pages/docs/AGENTS.md` (auto-loaded when editing docs). Apply the criteria below, then emit the report.
+
+## Step 2 — establish the SDK state, then read it
+
+1. **Resolve the state to verify against** with the shared **`code-resolve-changes`**
+   skill (load via the Ably MCP: `skillGet({ id: "code-resolve-changes" })`). If
+   the docs-change plan names a source of change, pass it; otherwise default to the
+   version the docs target (`src/data/languages/languageData.ts`), and failing that
+   the latest release of the SDK repo.
+2. **Badge check.** A sample written against a different version than the
+   `languageData.ts` badge is a finding.
+3. **Read the type declarations** from the resolved state to cross-check snippets —
+   `npm pack <package>@<version>` for a published release, or `git show <ref>:<path>`
+   / the local working tree for a state not on npm (read-only; do not mutate).
+4. Use the entry point the sample's audience uses (core vs framework-bound).
+
+## Step 3 — what to look for
+
+For every snippet, cross-check against the `.d.ts`:
+
+- **Factory / constructor names** exist and are spelled as written. (`blocker`)
+- **Method locations** — the method is on the object the sample calls it on. (`blocker`)
+- **Option / parameter shapes** — keys exist, types match, required present. (`major`–`blocker`)
+- **Return shapes** — the sample uses what the method returns. (`major`)
+- **Enum / literal values** match the SDK. (`major`)
+- **Import surfaces** — one consistent import per file; symbol exported by that path. (`minor`–`major`)
+- **No API keys in client code** — `authUrl: '/auth'` placeholder only. A literal key is a `blocker`.
+
+After reading the SDK, re-grep the page for old patterns it no longer supports
+(renamed factories, moved methods, removed hooks, renamed option keys).
+
+## Step 4 — severity notes
+
+Verify before flagging — read the actual `.d.ts`, not memory or prior docs. A
+sample that won't compile/run as written is a `blocker`; deprecated-but-runs is
+`major`; a real key in client code is always a `blocker`. When you cannot fetch
+the SDK, say so and mark affected snippets unverified rather than guessing.

--- a/.claude/skills/docs-review-links/SKILL.md
+++ b/.claude/skills/docs-review-links/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: docs-review-links
+description: Audit a docs page for mechanics and integrity — H2 anchors, internal link resolution, frontmatter completeness, nav registration, redirects, the API-reference hidden-table audit, and literal error codes in troubleshooting for searchability. Read-only; produces a conformance report and never edits the page.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review: links & mechanics
+
+Audit the mechanical integrity that breaks pages silently — anchors, links,
+frontmatter, navigation, redirects, and the API-reference table wiring.
+
+## Step 1 — scope & contract
+
+Invoke the `review-conventions` skill via the Ably MCP
+(`skillGet({ id: "review-conventions" })`) — report-only rule, scope resolution
+(honouring `$ARGUMENTS`), severity scale, report format. Use
+**concern = `links`**, **surface = docs**. The checks are the **Verification
+checks** section of `src/pages/docs/AGENTS.md` (and its **API reference standard**
+section for the hidden-table audit). Run them from the repo root against the
+scoped pages; each hit is a finding. Emit the report.
+
+## Step 2 — what to look for
+
+- **H2 anchors** — every `## Heading` carries `<a id="slug"/>`. Missing anchors
+  break the page nav. (`major`)
+- **Internal link resolution** — every internal link resolves; no links to a URL
+  that exists only in another page's `redirect_from`. (`major`–`blocker`)
+- **Frontmatter completeness** — `title`, `meta_description`, `meta_keywords`,
+  `intro`, and `redirect_from` where the page moved. Per-interface API-reference
+  pages **omit** `intro:`; navigational API pages keep it. (`major`)
+- **Navigation registration** — new pages added to `src/data/nav/`; renamed slugs
+  updated everywhere. (`major`)
+- **Redirects on moves** — renamed/merged pages carry `redirect_from`. (`blocker` if the old URL was live)
+- **Troubleshooting searchability** — each entry includes the **literal error
+  code and text** so search finds it. (`major`)
+- **API-reference hidden-table audit** — every `<Table id='X' hidden>` has an
+  inline `<Table id='X'/>` reference and vice versa (run the Node audit in
+  `api-reference.md`). (`major`)
+- **Heading levels** — no skipped levels (H2→H4). (`minor`)
+- **Asides** — `<Aside>` only when load-bearing. (`minor`)
+
+## Step 3 — severity notes
+
+Run the greps and the Node hidden-table audit rather than eyeballing — these are
+binary. A broken internal link or missing redirect on a moved page is
+`blocker`/`major`. Missing frontmatter and unanchored H2s are `major`. Quote the
+exact path and line for each hit.

--- a/.claude/skills/docs-review-structure/SKILL.md
+++ b/.claude/skills/docs-review-structure/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: docs-review-structure
+description: Audit a docs page for page-type conformance — benefit-led opening and the understand/implement/detail tiers, section order against the page-type template, mechanism-first feature pages, one-code-proof concept pages, intentional-design framing on framework pages, edge-cases and FAQ presence, visual placement, and diagram-type match. Read-only; produces a conformance report and never edits the page.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review: structure
+
+Audit whether each page is the right shape for its type and follows the project's
+structure principles.
+
+## Step 1 — scope & contract
+
+Invoke the `review-conventions` skill via the Ably MCP
+(`skillGet({ id: "review-conventions" })`) — report-only rule, scope resolution
+(honouring `$ARGUMENTS`), severity scale, report format. Use
+**concern = `structure`**, **surface = docs**. The authorities are
+the **Docs structure** and **Page-type templates** sections of `src/pages/docs/AGENTS.md`. For each
+page, identify the page type and audit against that template, then emit the report.
+
+## Step 2 — what to look for
+
+**Every page** (from `structure.md`):
+
+- **Benefit-led opening with problem woven in** — leads with what the feature
+  gives you, not a standalone problem section; stands alone for the buying
+  decision. (`major`)
+- **Three tiers — understand → implement → detail** — result first, code fast,
+  detail later; an evaluator/returning dev shouldn't scroll past edge cases to
+  see what it does. (`major`)
+- **Visual placement** — demo/GIF/diagram prominent (at or near the top for
+  feature pages), not tucked below the code. (`minor`–`major`)
+- **One focus per page, structured by developer intent** — atomic, not bundled
+  conditional logic; default to the most common choice rather than presenting
+  equal options. (`minor`–`major`)
+- **Variants are toggles, not page splits** — no per-variant copies of a page. (`major`)
+- **Diagram type matches** — UX/interaction visuals on feature pages; architectural/
+  flow/state diagrams on concept/internals pages. A mismatch is a finding. (`major`)
+
+**By page type** (from `page-types.md`):
+
+- **Feature** — mechanism-led, minimal "this is all you write" snippet in tier 1;
+  full implementation in tier 2; **edge-cases/FAQ** and related features in tier 3.
+  Missing edge-cases or a real FAQ is `major`.
+- **Concept** — mental model; **one** code-proof sample; no method-by-method API
+  teaching. (`major` if it drifts into API teaching.)
+- **Framework** — capability tables; **intentional-design framing** ("the
+  framework intentionally doesn't do X", never "can't"); sibling-page alignment
+  where capabilities overlap, without forced parity. "can't" framing is `major`.
+- **Positioning** — may open problem-first but must pivot to capability by mid-page.
+- **Getting-started** — clear "working app" milestone, everything after it additive;
+  `authUrl: '/auth'` placeholder only.
+- **Troubleshooting** — symptom-named; Issue → Cause → Solution.
+- **API reference** — defer mechanics to `docs-review-links`/`docs-review-code-accuracy`;
+  here check only the API-reference *shape*.
+
+## Step 3 — severity notes
+
+Read the whole page before judging order — section intent matters more than
+literal heading text. A missing required tier/section (edge-cases, FAQ,
+benefit-led opening, capability pivot) is `major`. Out-of-order is `minor` unless
+it breaks the reader's path. Diagram-type mismatch is `major`. Don't flag a
+deliberate, template-noted divergence (`structure.md` allows visual-first or
+code-first leads).

--- a/.claude/skills/docs-review-style/SKILL.md
+++ b/.claude/skills/docs-review-style/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: docs-review-style
+description: Audit a docs page for writing style — AI-generated-content fingerprints (the "de-claudeify" concern), house-style violations, em dashes, bold-prefix bullets, Latin abbreviations, "we" as subject, vague modals, blog-style openers, gift-wrapped endings. Read-only; produces a conformance report and never edits the page.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review: style
+
+Audit the prose for the patterns that get docs sent back in review — AI tone
+first ("reads like Claude in smartarse mode"; "reads like an intro to a blog
+post"), then house-style violations.
+
+## Step 1 — scope & contract
+
+Invoke the `review-conventions` skill via the Ably MCP
+(`skillGet({ id: "review-conventions" })`). It defines the report-only rule,
+scope resolution (honouring any `$ARGUMENTS` override), the severity scale, and
+the report format. Use **concern = `style`**, **surface = docs**. The authority
+is `../../../writing-style-guide.md` (repo root) — read it, apply its rules, and
+emit the report.
+
+## Step 2 — what to look for
+
+The "Avoid AI-generated content fingerprints" section of the style guide is the
+checklist. Flag, with the offending line quoted:
+
+- **Corrective antithesis** — "Not X. It's Y." setups. (`major`)
+- **Dramatic pivots** — "But here's the thing", "Here's the catch". (`major`)
+- **Soft hedging** — "It's worth noting", "This is where X really shines". (`major`)
+- **Throat-clearing intros** — "Let's dive in", "First, let's understand". (`major`)
+- **Gift-wrapped endings / mid-page summary scaffolds** — "In summary", "These properties combine to give you…". (`major`)
+- **Blog-style problem windups** where the page should open with the benefit/mechanism (see `structure.md`: benefit-led, problem woven in). (`major`)
+- **Editorial nouns the product does not use** — e.g. "problem surface", "ambient" sync. (`minor`–`major`)
+- **Generic examples** — "imagine a chat app" with no concrete behaviour. (`minor`)
+- **Overexplaining the obvious** to a developer audience (defining `await`, a JWT). (`minor`)
+- **Staccato runs** and **copy-paste metaphors** reused more than twice. (`minor`)
+
+House-style binaries (grep the scoped pages — each hit is a finding):
+
+- Em dashes `—` (`blocker`). Bold-prefix bullets `* **Label:** …` (`blocker`).
+- Latin abbreviations `e.g.`/`i.e.`/`etc.` (`major`). "we" as subject (`major`).
+- Vague modals — would/should/might/maybe (`minor`–`major`). Slang (`minor`).
+
+Respect the style guide's "Patterns to keep" — fragments, occasional
+sentence-initial "And"/"But", a comma splice that reads well are not findings.
+Judge tone like a human editor, not a regex.
+
+## Step 3 — severity notes
+
+Quote the exact line for every finding. Tone findings are `major` — they are the
+notes reviewers reliably catch. Banned-syntax hits (em dash, bold-prefix bullet)
+are `blocker`. Taste calls are `nit`.

--- a/.claude/skills/docs-review-terminology/SKILL.md
+++ b/.claude/skills/docs-review-terminology/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: docs-review-terminology
+description: Audit a docs page for product-vocabulary correctness against the canonical glossary — wrong or deprecated terms, conflated terms, and internal jargon leaking into public docs. Glossary source is configurable (AI Transport Terminology Reference by default). Read-only; produces a conformance report and never edits the page.
+license: proprietary
+metadata:
+  team: engineering
+---
+
+# Review: terminology
+
+Check that every product term matches the canonical glossary. Wrong or
+internal-only vocabulary is a reliable review rejection — it confuses readers and
+contradicts other pages.
+
+## Step 1 — scope & contract
+
+Invoke the `review-conventions` skill via the Ably MCP
+(`skillGet({ id: "review-conventions" })`) — report-only rule, scope resolution
+(honouring `$ARGUMENTS`), severity scale, report format. Use
+**concern = `terminology`**, **surface = docs**. Apply the criteria below and emit
+the report.
+
+## Step 2 — load the glossary (fetch at runtime)
+
+Determine the glossary source: an explicit one in `$ARGUMENTS` or the docs-change
+plan; otherwise the product's positioning file the product folder AGENTS.md (e.g. `src/pages/docs/ai-transport/AGENTS.md`)
+(e.g. `ai-transport.md`) plus the product glossary. For **AI Transport** the
+canonical glossary is the **AI Transport Terminology Reference**, Confluence page
+`4865097761` — fetch it (`confluenceGetPage({ pageId: "4865097761" })` if the
+Confluence tool is available). Never embed a copy; fetch each run.
+
+## Step 3 — what to look for
+
+- **Deprecated / renamed terms** — old nouns the product moved away from. For AIT:
+  `Transport`→`Session`, `Turn`→`Run`. (`blocker`)
+- **Internal jargon in public docs** — for AIT, **`root`** is not public; write
+  "an object on a channel" (`const myObject = await channel.object.get();`). (`blocker`)
+- **Conflated terms** — for AIT, **barge-in is voice-specific; interruption is
+  the general term** — don't rename or merge. (`major`–`blocker`)
+- **Inconsistent term** within the page or across the section. (`major`)
+- **Wrong-primitive claims** — for AIT, branching is anchored on `codecMessageId`,
+  not `runId`. (`major`)
+- **Capitalisation/spelling** of product and tech names (JavaScript, GitHub, macOS). (`minor`)
+
+## Step 4 — severity notes
+
+Check each term against the glossary you fetched — don't rely on memory. A
+deprecated term or internal jargon in public docs is a `blocker`; an
+inconsistent-but-valid term is `major`. When a term is missing or ambiguous in
+the glossary, flag it as a `minor` for the product owner to confirm rather than
+inventing a ruling.

--- a/src/pages/docs/AGENTS.md
+++ b/src/pages/docs/AGENTS.md
@@ -1,59 +1,116 @@
+# Writing and reviewing Ably docs pages
+
+Guidance for any agent creating, refreshing, or reviewing documentation pages
+under `src/pages/docs/`. This file is auto-loaded when you edit pages here. For
+MDX mechanics, navigation, and SDK versions see the repo-root `CLAUDE.md`; for
+prose style see `writing-style-guide.md`. The `docs-execute-plan`, `docs-plan-pr`,
+and `docs-review-*` skills apply and check this guidance.
+
+
+## Docs Structure Guidance
+
+## Why structure matters
+
+Developers use docs to answer three questions, roughly in this order:
+
+1. **Should I use this?** They need to understand what the product does and why it matters to them -- from the docs alone, without a landing page or sales conversation.
+2. **How do I do the thing I came here to do?** They're looking for a page that matches their intent ("cancel a stream", "set up auth"), not one that matches our internal feature taxonomy.
+3. **How do I handle this specific detail?** They need to go deep on one topic without wading through others.
+
+Docs structure should serve all three. Navigation organised by developer intent, pages scoped to a single focus, and variant handling that doesn't multiply pages are the main tools for doing that.
+
 ---
-name: write-docs
-description: Write or refresh an Ably documentation page in this repo. Use when creating a new MDX page, rewriting an existing one, or applying the page-design principles to docs work. Captures the principles, page-type templates, writing standards, and code-accuracy checks distilled from the April 2026 wireframe workings used for the AI Transport refresh.
+
+## Principles
+
+### 1. Docs stand alone for the buying decision
+
+A developer arriving anywhere in the docs should understand why the product exists, what it enables, and be able to decide to use it. Don't assume they've seen a landing page, blog post, or demo. Technical explanation and value proposition are the same thing -- showing how something works IS the sales pitch.
+
+### 2. Lead with what Ably guarantees
+
+Ably's core value is infrastructure-level guarantees that developers would otherwise have to build themselves: low-latency delivery, guaranteed delivery (no silent message loss), and guaranteed ordering. These aren't background features -- they're the reason developers choose Ably over rolling their own. Every product page should make clear which of these guarantees apply and how the product upholds them. Don't bury them in a footnote or assume the reader already knows.
+
+### 3. Simplicity is the product
+
+Every page should reinforce that the product makes things simpler. The framing is always "you have this problem, and it disappears." The guarantees above are a key part of that: complexity the developer no longer has to handle.
+
+### 4. One focus per page, structured by developer intent
+
+Each page answers one question a developer actually asks: "how do I do X?", "how does Y work?", "what happens when Z?". Keep pages atomic -- don't bundle multiple concepts with conditional logic ("if you want X then do Y"). Separate pages are simpler, more findable, and easier to maintain.
+
+A flat list of focused, atomic pages is a feature of the IA, not a problem to be solved by grouping. Resist the urge to nest pages into deep hierarchies -- if pages are well-titled and scoped to a single intent, a long flat list is more navigable than a deep tree. Some duplication across atomic pages is fine and expected; don't try to eliminate it by bundling or replacing content with cross-references.
+
+At every decision point, default to the most common choice. Never present two equal options where one should be the default.
+
+### 5. Variants are toggles, not navigation splits
+
+Feature pages are variant-agnostic. Code examples adapt via client-side language, server-side language, and framework toggles. Don't create per-variant copies of feature pages -- this causes duplication and drift.
+
+### 6. Self-contained product sections
+
+Docs for a product should work without constantly navigating to other sections. Developers should be able to learn about pricing, limits, authentication, and key concepts within the product's docs section. Link out for deep dives where appropriate, but don't require it for core understanding.
+
+### 7. Concepts before action, internals at the end
+
+Developers need a mental model to make sense of features. Foundational concepts (how sessions work, what a turn is, how auth fits in) sit above getting-started and feature pages in the nav. Implementation internals (wire protocols, transport patterns) sit at the bottom for curious engineers. The ordering is: concepts → getting started → features → deep internals.
+
+### 8. Inbound through excellence, not pollution
+
+Docs serve the developer who has arrived. Don't distort page structure to rank for search terms. Problem-first inbound content (blog posts, tutorials) lives outside docs and drives developers to them.
+
+### 9. Ship and iterate
+
+Publishing and showing direction is more important than polish. Be explicit about what's shipped, what's partial, and what's planned. Stub pages are fine if they're honest about being stubs.
+
 ---
 
-## How to use this skill
+## Page structure for feature pages
 
-This skill is the distilled rulebook for writing Ably docs in this repo. Read it before starting a draft. Apply the per-page-type template to your draft. Run the verification checks before review.
+The organising principle is **result first, code fast, detail later**. Pages use progressive disclosure in three tiers: understand → implement → detail. Developers who just need to see what the feature does and how to use it shouldn't have to scroll past implementation detail or edge cases.
 
-The principles are aimed at the human reader first and the AI agent second. The writing standards are aimed at not sounding like AI.
+### Tier 1: Understand (above the fold)
 
-## Required reading
+1. **Benefit statement with problem framing** -- one or two sentences. Lead with what the feature gives you; weave in what breaks or what's hard without it. This replaces a standalone "problem framing" section.
+2. **Visual / demo** -- embedded GIF, interactive sandbox, or diagram showing the feature in action. Place it prominently -- at or near the top, not tucked below the code.
+3. **Minimal code snippet** -- the "this is all you write" TL;DR. 3-10 lines with framework/language toggles. This serves evaluators ("is this simple?") and returning developers ("remind me of the API").
 
-Read these in-repo references before you draft. The skill **does not duplicate them**.
+### Tier 2: Implement (one scroll down)
 
-- [`CLAUDE.md`](../../../CLAUDE.md) — repository conventions: MDX components, frontmatter, code blocks, `<Aside>`, `<Tiles>`, `<Table>`, language toggles, nav files. The "Content Formatting (MDX)" and "Writing Style" sections are load-bearing.
-- [`writing-style-guide.md`](../../../writing-style-guide.md) — Ably house style: International English, present tense, active voice, second person, imperative headings, sentence case, no em dashes, no bold-prefix bullets, no Latin abbreviations, no subjective phrases, no vague modals, no slang, no pricing detail in technical docs.
+4. **Full implementation guide** -- server setup, client setup, and any integration steps. Working code for each supported language/framework with variant toggles.
+5. **Customisation options** -- optional configuration, modes, and parameters.
 
-When this skill conflicts with `CLAUDE.md` or `writing-style-guide.md`, those win. Flag the conflict.
+### Tier 3: Detail (progressive disclosure)
 
-## Principles (read these once; apply them every time)
+6. **How it works** -- brief explanation of underlying mechanics. If a feature depends on another concept (e.g. turns, sessions), give a 1-2 sentence inline explanation with a link -- don't treat it as a prerequisite the reader must go and read first.
+7. **Edge cases and FAQ** -- what happens in unusual scenarios, collapsible where possible.
+8. **Related features** -- 1-2 line comparisons with links to similar or complementary features.
+9. **API reference link**
 
-Eighteen principles govern Ably docs pages, distilled from the AI Transport wireframe workings (April 2026). Three groups: general (apply to every page), page-specific (depend on page type), and mechanical (binary checks).
+### Template flexibility
 
-### General
+This is the default structure. Some features are best explained by a demo (visual-first -- lead with the demo above the benefit statement) and others by a one-liner code sample (code-first -- lead with the snippet). Use the default unless the content clearly calls for a different lead. The three tiers and their ordering should stay consistent regardless of which element leads.
 
-1. **Humans first, agents second.** Narrative and outcome up top; technical detail and API specifics lower on the page where agents still find them.
-2. **Progressive disclosure.** Each page has clear tiers — Understand → See it → Build it → Go deep. A reader can stop at any tier and have gotten value.
-3. **Minimal first code sample.** Contrived, no setup boilerplate, no auth scaffolding. Demonstrate the one capability. Runnable implementation comes later.
-4. **Link to concepts, don't require them.** Reference concepts inline with one or two lines of explanation plus a "learn more" link. A reader should not need to leave the page to understand it.
-5. **Primary audience: developers and senior engineers.** Product readers are secondary — accessible enough to evaluate, written for engineers.
-6. **We enable user experience.** Show what the API makes possible for end users, not just what the API exposes. Avoid pure feature-listing.
-7. **Visual type matches page type.** Feature pages use UX interaction sketches. Concept, positioning, and infrastructure pages use architectural/flow/state diagrams. UX visuals on a concept page read as marketing and undermine credibility.
+Problem framing is woven into each feature page. There is no separate "Problems" section in the docs.
 
-### Page-specific
+---
 
-8. **Feature pages lead with the mechanism.** The first heading is "How it works", not "the problem with X". Lead with how Ably solves the job; problem framing is a lightweight aside or lives on the concept page.
-9. **Concept pages convey what the layer requires.** The pattern is *problem → model → what this layer requires → code proof*. Name the technical properties (ordering, persistence, accumulation, fan-out, presence) and why each matters.
-10. **Concept pages do not teach features.** One minimal code-proof sample max. No API surface walkthrough. If a concept page drifts into method-by-method content, it stops being a concept page and the feature pages around it feel thin.
-11. **Features map to jobs to be done.** Each feature page maps to what a developer is trying to accomplish ("barge-in" = "let my users change direction mid-response"). Page names and intros use the JTBD framing.
-12. **Framework pages: intentional design framing, not "missing features".** Frame the framework's scope as a deliberate boundary the framework chose, and Ably as the layer that fills the gap. Never "the framework can't do X" — always "the framework intentionally doesn't do X". Sibling framework pages (for example UI vs Core) use verbatim-aligned capability bullets.
-13. **Positioning pages: open problem-first, turn positive.** "Why X" pages may lead with the problem, but must pivot to the capability section by mid-page. Pages that stay defensive end-to-end become gripe lists, not pitches.
+## Developer journeys to keep in mind
 
-### Mechanical (binary, agent-checkable)
+When writing a page, consider which journey the reader is on:
 
-14. **Layer 0 hook in the first 5 seconds.** Every page opens with a hook that answers "what is this, why should I care?". The `intro:` frontmatter feeds the auto-generated PageHeader; the body's first paragraph reinforces it. On feature pages, the hook is two sentences: outcome first ("Your users can change direction mid-response"), mechanism second ("AI Transport's session layer lets a client cancel and re-prompt without breaking the stream"). **Per-interface API reference pages are the one exception**: they drop `intro:` and let the opening paragraph carry the hook. Navigational API pages (the API reference hub, the errors page) keep `intro:` like every other page type. See the `## API reference pages` section for the full standard.
-15. **Cover unhappy paths.** Every feature page has an edge-cases section. Race conditions, timeouts, network drops, capability-missing failures, what happens when the LLM errors. This is what separates trusted docs from marketing.
-16. **FAQ with three to five real entries on feature pages.** Surface what developers actually ask. Do not pad to meet a count.
-17. **No API keys in client code.** Ever. Use `authUrl: '/auth'` as the placeholder and link out to `concepts/authentication` (or the equivalent setup page) once.
-18. **Visual rhythm.** Diagram, code block, card layout, or icon table every few paragraphs. No walls of text.
+| Journey | Typical path |
+|---------|-------------|
+| Evaluating ("What is this?") | Overview -> Why this product -> How it works -> Get started |
+| Stack-first ("I use framework X, why do I need this?") | Framework guide -> Get started with that framework -> Features |
+| Problem-first ("My X keeps breaking") | Why this product -> How it works -> Relevant feature page -> Get started |
+| Use-case-first ("I'm building X") | Use case guide -> Relevant feature pages -> Get started |
+| Returning developer ("I need to add feature Y") | Feature page -> API reference -> done |
 
-### Cross-product orientation
-
-AI Transport is the testbed for the new principles. Other Ably products will align over time. Diverge from Chat / LiveObjects / Pub-Sub patterns where these principles demand it; do not contort an AIT page to match an older Pub-Sub convention. Note the divergence in the PR description so the wider docs can track.
 
 ## Page-type templates
+
+Pick the template that matches the page you are writing. Templates describe *structure*, not literal headings — adapt each section heading to the specific page (see the writing-style guidance). These are distilled from the April 2026 wireframe workings used for the AI Transport refresh.
 
 Pick the template that matches the page you are writing.
 
@@ -154,7 +211,7 @@ A single checklist page. Items inline. Cross-cutting only.
 
 ### API reference page
 
-API reference pages have their own complete standard — they do not follow the other page-type templates. See the `## API reference pages` section below for the full rules: frontmatter, page structure, anchor convention, visible-vs-hidden type tables, React hook sub-template, and verification.
+API reference pages have their own complete standard — they do not follow the other page-type templates. See the "API reference standard" section below for the full rules: frontmatter, page structure, anchor convention, visible-vs-hidden type tables, React hook sub-template, and verification.
 
 ### Internals page
 
@@ -165,7 +222,138 @@ For curious senior engineers. Register: precise, technical, no hand-holding. Dia
 3. **Mechanism walkthrough.**
 4. **Cross-references** to the wire-protocol or codec reference where applicable.
 
-## API reference pages
+
+
+## Code accuracy: verify against the SDK, not prior docs
+
+Prior docs drift. The SDK is the source of truth.
+
+### Workflow before writing any code snippet
+
+1. Find the SDK version this docs page targets in `src/data/languages/languageData.ts`. That file is the canonical version registry, keyed by product and language. Use that exact version, not whatever npm currently labels `latest`. The page header reads from the same registry, so the code samples and the version badge stay aligned.
+2. Pull the package at that version: `npm pack <package>@<version>` into a temp dir, extract, read the `.d.ts` files.
+3. Cross-check the signatures, option shapes, and return types your snippet uses.
+4. Where the SDK exposes both a core and a framework-bound entry point (for example `@ably/ai-transport` and `@ably/ai-transport/vercel`), pick the entry point your snippet's audience uses and follow its option shape.
+5. After drafting, re-grep your file for any old patterns the SDK no longer supports.
+
+### Documenting a pre-release SDK
+
+If the docs page targets an SDK version that is not yet on npm:
+
+1. Bump the version in `src/data/languages/languageData.ts` to the upcoming release.
+2. Read the `.d.ts` files straight from the SDK repo. Check out the matching git tag or release branch (or use a local checkout if one is on disk), then read `dist/` or `src/`.
+3. Write the docs against that source.
+4. Flag the PR as gated on the SDK release. Merge only once the SDK version exists on npm and `languageData.ts` matches.
+
+### Common drift patterns to check
+
+Whenever an SDK has had a major refactor, sweep the docs for these patterns:
+
+- Renamed factories (for example `createTransport` → `createClientTransport`).
+- Hooks that changed from factory to context reader (for example `useClientTransport` going from `(options) => Transport` to `(options) => { transport, transportError }`).
+- Methods that moved between objects (for example `transport.send` → `view.send`).
+- Removed convenience hooks (for example `useEdit`/`useRegenerate`/`useSend` consolidated into methods on a `ViewHandle` returned by `useView`).
+- Renamed option keys (for example `id` → `chatId`).
+- Renamed enum/literal values (for example `TurnEndReason` going from `'completed' | 'failed' | 'cancelled'` to `'complete' | 'error' | 'cancelled'`).
+
+
+
+## Verification checks
+
+Run these from the repo root against the page(s) you changed before review. Expected result is zero hits on each. The review concern skills run the subset relevant to their dimension.
+
+These greps cover the standards. Replace `<your-path>` with the page or section you wrote. The expected result is zero hits on each.
+
+```bash
+P=<your-path>  # e.g. src/pages/docs/ai-transport/features/
+
+# Frontmatter completeness (no output = clean)
+for field in title meta_description meta_keywords intro; do
+  echo "Pages missing $field:"
+  find "$P" -name "*.mdx" -exec grep -L "^$field:" {} \;
+done
+
+# No API keys in client code (excluding authUrl)
+grep -rn -E "key\s*:\s*['\"][^'\"]+['\"]" "$P" | grep -v authUrl
+
+# No "docs under construction" / WIP markers
+grep -rni "under construction\|coming soon\|todo:\|wip\b" "$P"
+
+# Every H2 carries an inline anchor (CLAUDE.md convention: `## Heading <a id="slug"/>`)
+for f in "$P"/*.mdx; do
+  total=$(grep -c "^## " "$f")
+  anchored=$(grep -cE '^## .* <a id="[^"]+"' "$f")
+  [ "$total" != "$anchored" ] && echo "$f: $anchored/$total H2s anchored"
+done
+
+# No em dashes (style guide forbids)
+grep -rn "—" "$P"
+
+# No bold-prefix bullets
+grep -rnE "^\s*[\*\-]\s+\*\*[^*]+:\*\*" "$P"
+
+# No "we" pronoun in prose
+grep -rnE "\bwe\b" "$P" | grep -v "code\|//"
+
+# No Latin abbreviations
+grep -rnE "\b(e\.g\.|i\.e\.|etc\.)" "$P"
+
+# No subjective phrases or vague modals
+grep -rniE "easily|simple to|it's as easy|fire up" "$P"
+
+# Internal link integrity (catches stale paths if you renamed any pages)
+# Replace OLD_PATH with the old URL you replaced; expect zero hits outside redirect_from frontmatter.
+grep -rn "OLD_PATH" "$P" | grep -v redirect_from
+
+# FAQ count on feature pages (each should report 3-5)
+for f in "$P"/*.mdx; do
+  count=$(awk '/^## FAQ/,/^## /' "$f" | grep -c "^### ")
+  echo "$f: $count FAQ entries"
+done
+```
+
+For **API reference pages only**, run these additional checks:
+
+```bash
+A=<api-ref-path>  # e.g. src/pages/docs/ai-transport/api-reference/
+
+# Per-interface API ref pages must NOT have intro: (navigational pages can)
+# Edit the exclusion list to match the navigational pages in your product.
+for f in "$A"/*.mdx; do
+  case "$(basename $f)" in
+    index.mdx|errors.mdx) continue ;;  # navigational pages
+  esac
+  if grep -q "^intro:" "$f"; then
+    echo "$f: per-interface API ref page should not have intro:"
+  fi
+done
+
+# Every hidden table must be referenced; every reference must have a definition
+node -e "
+const fs = require('fs'), path = require('path');
+const dir = process.env.A;
+for (const f of fs.readdirSync(dir)) {
+  if (!f.endsWith('.mdx')) continue;
+  const content = fs.readFileSync(path.join(dir, f), 'utf8');
+  const hidden = [...content.matchAll(/<Table id='([^']+)' hidden>/g)].map(m => m[1]);
+  const visible = [...content.matchAll(/<Table id='([^']+)'>/g)].map(m => m[1]);
+  const refs = [...content.matchAll(/<Table id='([^']+)'\\/>/g)].map(m => m[1]);
+  for (const h of hidden) if (!refs.includes(h)) console.log(f + ': hidden ' + h + ' unreferenced');
+  for (const r of refs) if (!hidden.includes(r) && !visible.includes(r)) console.log(f + ': ' + r + ' undefined');
+}" 2>/dev/null
+
+# Method headings should be verb phrases, not bare names like "## methodName"
+# Flag suspiciously bare H2s (single camelCase or lowercase token):
+grep -rnE "^## [a-z][a-zA-Z0-9]*\s*<" "$A"
+
+# Returns sections that mention ErrorInfo without linking to its canonical home
+# (replace 'errors#errorinfo' with the actual canonical anchor for your product)
+grep -rn "ErrorInfo" "$A" | grep -v "errors#errorinfo" | grep -v errors.mdx
+```
+
+
+
+## API reference standard
 
 API reference pages have their own complete standard, distinct from every other page type. The rules in this section apply **only** to API reference pages — they do not modify feature, concept, framework, positioning, getting-started, guide, troubleshooting, or internals pages. Those page types keep their templates exactly as written above.
 
@@ -316,191 +504,3 @@ Expected: zero output. A hidden table with no inline reference renders nothing. 
 
 Multi-language API references use a per-language sub-tree in the nav (`JavaScript`, `React`, `Kotlin`) with plain `{ name, link }` entries. Do not add a `languages: [...]` array — those are only used by the legacy multi-language section. For products with multiple SDK variants (Realtime vs REST), the nav uses `JavaScript (Realtime)`, `JavaScript (REST)`, etc. as the sub-tree labels.
 
-## Code accuracy: verify against the SDK, not against prior docs
-
-Prior docs drift. The SDK is the source of truth.
-
-### Workflow before writing any code snippet
-
-1. Find the SDK version this docs page targets in `src/data/languages/languageData.ts`. That file is the canonical version registry, keyed by product and language. Use that exact version, not whatever npm currently labels `latest`. The page header reads from the same registry, so the code samples and the version badge stay aligned.
-2. Pull the package at that version: `npm pack <package>@<version>` into a temp dir, extract, read the `.d.ts` files.
-3. Cross-check the signatures, option shapes, and return types your snippet uses.
-4. Where the SDK exposes both a core and a framework-bound entry point (for example `@ably/ai-transport` and `@ably/ai-transport/vercel`), pick the entry point your snippet's audience uses and follow its option shape.
-5. After drafting, re-grep your file for any old patterns the SDK no longer supports.
-
-### Documenting a pre-release SDK
-
-If the docs page targets an SDK version that is not yet on npm:
-
-1. Bump the version in `src/data/languages/languageData.ts` to the upcoming release.
-2. Read the `.d.ts` files straight from the SDK repo. Check out the matching git tag or release branch (or use a local checkout if one is on disk), then read `dist/` or `src/`.
-3. Write the docs against that source.
-4. Flag the PR as gated on the SDK release. Merge only once the SDK version exists on npm and `languageData.ts` matches.
-
-### Common drift patterns to check
-
-Whenever an SDK has had a major refactor, sweep the docs for these patterns:
-
-- Renamed factories (for example `createTransport` → `createClientTransport`).
-- Hooks that changed from factory to context reader (for example `useClientTransport` going from `(options) => Transport` to `(options) => { transport, transportError }`).
-- Methods that moved between objects (for example `transport.send` → `view.send`).
-- Removed convenience hooks (for example `useEdit`/`useRegenerate`/`useSend` consolidated into methods on a `ViewHandle` returned by `useView`).
-- Renamed option keys (for example `id` → `chatId`).
-- Renamed enum/literal values (for example `TurnEndReason` going from `'completed' | 'failed' | 'cancelled'` to `'complete' | 'error' | 'cancelled'`).
-
-## Writing standards
-
-The canonical source is [`writing-style-guide.md`](../../../writing-style-guide.md). **You must read it before making any changes to the docs.** It covers International English, present tense, active voice, second person, imperative headings, sentence case, banned patterns (em dashes, bold-prefix bullets, Latin abbreviations, subjective phrases, vague modals, slang, "we" as subject, pricing detail, API keys in client code), the Layer-0 hook pattern, MDX asides, AI-fingerprint patterns to strip from drafts, and the counter-rules to keep.
-
-The style guide takes precedence over anything else in this skill. If a rule here ever conflicts with the style guide, the style guide wins.
-
-## Per-page workflow
-
-1. **Identify the page type.** Pick the matching template above.
-2. **Draft the prose against the template.** Keep it tight.
-3. **Verify every code snippet against the actual SDK.** See the code-accuracy section.
-4. **Strip AI-writing patterns.** Re-read against the "Avoid AI-generated content fingerprints" section of [`writing-style-guide.md`](../../../writing-style-guide.md).
-5. **Self-check against the verification greps below.**
-6. **Open the PR.** Reviewer (not the writer) reviews against this skill and the writing-style guide.
-
-## Verification (run from the repo root before review)
-
-These greps cover the standards. Replace `<your-path>` with the page or section you wrote. The expected result is zero hits on each.
-
-```bash
-P=<your-path>  # e.g. src/pages/docs/ai-transport/features/
-
-# Frontmatter completeness (no output = clean)
-for field in title meta_description meta_keywords intro; do
-  echo "Pages missing $field:"
-  find "$P" -name "*.mdx" -exec grep -L "^$field:" {} \;
-done
-
-# No API keys in client code (excluding authUrl)
-grep -rn -E "key\s*:\s*['\"][^'\"]+['\"]" "$P" | grep -v authUrl
-
-# No "docs under construction" / WIP markers
-grep -rni "under construction\|coming soon\|todo:\|wip\b" "$P"
-
-# Every H2 carries an inline anchor (CLAUDE.md convention: `## Heading <a id="slug"/>`)
-for f in "$P"/*.mdx; do
-  total=$(grep -c "^## " "$f")
-  anchored=$(grep -cE '^## .* <a id="[^"]+"' "$f")
-  [ "$total" != "$anchored" ] && echo "$f: $anchored/$total H2s anchored"
-done
-
-# No em dashes (style guide forbids)
-grep -rn "—" "$P"
-
-# No bold-prefix bullets
-grep -rnE "^\s*[\*\-]\s+\*\*[^*]+:\*\*" "$P"
-
-# No "we" pronoun in prose
-grep -rnE "\bwe\b" "$P" | grep -v "code\|//"
-
-# No Latin abbreviations
-grep -rnE "\b(e\.g\.|i\.e\.|etc\.)" "$P"
-
-# No subjective phrases or vague modals
-grep -rniE "easily|simple to|it's as easy|fire up" "$P"
-
-# Internal link integrity (catches stale paths if you renamed any pages)
-# Replace OLD_PATH with the old URL you replaced; expect zero hits outside redirect_from frontmatter.
-grep -rn "OLD_PATH" "$P" | grep -v redirect_from
-
-# FAQ count on feature pages (each should report 3-5)
-for f in "$P"/*.mdx; do
-  count=$(awk '/^## FAQ/,/^## /' "$f" | grep -c "^### ")
-  echo "$f: $count FAQ entries"
-done
-```
-
-For **API reference pages only**, run these additional checks:
-
-```bash
-A=<api-ref-path>  # e.g. src/pages/docs/ai-transport/api-reference/
-
-# Per-interface API ref pages must NOT have intro: (navigational pages can)
-# Edit the exclusion list to match the navigational pages in your product.
-for f in "$A"/*.mdx; do
-  case "$(basename $f)" in
-    index.mdx|errors.mdx) continue ;;  # navigational pages
-  esac
-  if grep -q "^intro:" "$f"; then
-    echo "$f: per-interface API ref page should not have intro:"
-  fi
-done
-
-# Every hidden table must be referenced; every reference must have a definition
-node -e "
-const fs = require('fs'), path = require('path');
-const dir = process.env.A;
-for (const f of fs.readdirSync(dir)) {
-  if (!f.endsWith('.mdx')) continue;
-  const content = fs.readFileSync(path.join(dir, f), 'utf8');
-  const hidden = [...content.matchAll(/<Table id='([^']+)' hidden>/g)].map(m => m[1]);
-  const visible = [...content.matchAll(/<Table id='([^']+)'>/g)].map(m => m[1]);
-  const refs = [...content.matchAll(/<Table id='([^']+)'\\/>/g)].map(m => m[1]);
-  for (const h of hidden) if (!refs.includes(h)) console.log(f + ': hidden ' + h + ' unreferenced');
-  for (const r of refs) if (!hidden.includes(r) && !visible.includes(r)) console.log(f + ': ' + r + ' undefined');
-}" 2>/dev/null
-
-# Method headings should be verb phrases, not bare names like "## methodName"
-# Flag suspiciously bare H2s (single camelCase or lowercase token):
-grep -rnE "^## [a-z][a-zA-Z0-9]*\s*<" "$A"
-
-# Returns sections that mention ErrorInfo without linking to its canonical home
-# (replace 'errors#errorinfo' with the actual canonical anchor for your product)
-grep -rn "ErrorInfo" "$A" | grep -v "errors#errorinfo" | grep -v errors.mdx
-```
-
-## Reviewer checklist
-
-When reviewing someone else's docs PR (or your own at PR time), walk this list. Each item is a yes/no check.
-
-**Page shape**
-
-1. The page type is identifiable from the structure (feature / concept / framework / positioning / getting-started / guide / troubleshooting / API reference / internals).
-2. Layer-0 hook present and not Mad Libs.
-3. `intro` frontmatter present and matches the page-header sentence — except on per-interface API reference pages, which drop `intro:`.
-4. Section order matches the template for this page type.
-5. Edge cases / unhappy paths section present (feature pages).
-6. FAQ has three to five real questions (feature pages).
-7. Concept page shows at most one code-proof sample and does not drift into API teaching.
-8. Visual rhythm — diagram, code, or card every few paragraphs. No walls of text.
-
-**Writing standards**
-
-9. Page complies with the rules in [`writing-style-guide.md`](../../../writing-style-guide.md). Use the verification greps above to spot the common violations (em dashes, bold-prefix bullets, Latin abbreviations, subjective phrases, vague modals, "we" as the subject, AI-fingerprint patterns).
-10. Author ran `/deslop` (or equivalent AI-pattern check).
-
-**Code accuracy**
-
-11. Every code snippet matches the actual SDK at the latest tagged release (factory names, option shapes, return shapes, method locations, enum values).
-12. No API keys in client code.
-13. `authUrl: '/auth'` used for the placeholder where auth is referenced.
-
-**Mechanics**
-
-14. Frontmatter complete: `title`, `meta_description`, `meta_keywords`, `intro`, `redirect_from` where the page moved or merged. (Per-interface API reference pages omit `intro`.)
-15. Every H2 carries an inline anchor — `## Heading <a id="slug"/>`, per the CLAUDE.md convention. Use the H2-anchor grep above.
-16. Section headings are descriptive imperatives or noun phrases tied to the specific content, not template labels copied verbatim (no `## The model`, `## The problem X solves`, `## Code proof`).
-17. New page added to the relevant nav file under `src/data/nav/`.
-18. `<Aside>` used sparingly and load-bearing. No decorative asides.
-19. Internal links resolve. No references to URLs that only exist in `redirect_from` frontmatter.
-
-**API reference pages only** (additional checks)
-
-20. Method H2s use descriptive verb phrases (`## Create a client transport`), not bare method names. Anchor is JS-canonical kebab-case.
-21. Every method H2 is followed by `<MethodSignature>{` … `}</MethodSignature>` (template-literal form for signatures with `<` or `>`).
-22. Every method with parameters has `### Parameters <a id="{slug}-params"/>` with a 4-column `Parameter | Required | Description | Type` table.
-23. Every method has `### Returns <a id="{slug}-returns"/>` unless it returns `void`/`Unit`.
-24. Type tables default to hidden (`<Table id='X' hidden>`) referenced via `<Table id='X'/>`. Visible types only when they meet one of the four promotion criteria.
-25. Hidden table audit passes. Every hidden has at least one inline reference; every reference has a definition.
-26. Error type referenced via cross-page link to its canonical home (lowercase `#errorinfo` anchor).
-27. Page ends with `## Example` showing end-to-end usage.
-28. No same-page markdown anchor links to type anchors (`[X](#X)`). Type names in prose are backticked; cross-page references go to the type's own page.
-
-## When the SDK or product changes shape
-
-When a major SDK change lands (renamed factories, moved methods, removed hooks, changed enum values), do a sweep across the relevant docs section using the patterns in the code-accuracy section above. Drift is the single biggest source of incorrect docs.

--- a/src/pages/docs/ai-transport/AGENTS.md
+++ b/src/pages/docs/ai-transport/AGENTS.md
@@ -1,0 +1,62 @@
+# AI Transport docs
+
+Positioning and terminology for AI Transport documentation pages under this
+folder, auto-loaded when you edit them. Apply it alongside the general docs
+guidance in `src/pages/docs/AGENTS.md`.
+
+## Terminology
+
+Use the canonical product vocabulary (the AI Transport Terminology Reference,
+Confluence page 4865097761, is the source of truth):
+
+- **Session / Run** — not Transport / Turn.
+- **An object on a channel** — not `root`; e.g. `const myObject = await channel.object.get();`.
+- **Barge-in is voice-specific; interruption is the general term** — do not conflate them.
+- Branch selection is anchored on `codecMessageId`, not `runId`.
+
+
+## AI Transport — Value Proposition
+
+## One-line pitch
+
+AI Transport is a drop-in infrastructure layer that gives AI applications durable, multi-device sessions so token streams survive disconnections, work across devices, and support bidirectional control — without building custom infrastructure.
+
+## The problem
+
+Most AI frameworks connect clients to agents with HTTP streaming. This works for simple demos but breaks in production:
+
+- **Streams die on disconnection.** A network blip, tab refresh, or device switch kills the response. Tokens the LLM is still generating have nowhere to go.
+- **Sessions are single-device.** The stream exists only for the client that started it. A second tab or phone can't access it.
+- **The connection is exclusive.** The HTTP stream only exists between the client that initiated the request and the agent. Other clients — a second tab, a phone, a colleague — have no visibility of live activity and no way to send signals to the agent.
+- **Multi-agent systems lack shared visibility.** When agents communicate through point-to-point connections, clients can't see granular live activity from all agents without centralised coordination or custom plumbing.
+
+The transport layer is the most underinvested part of the AI stack. Teams end up building custom buffering, sequence numbering, resume handlers, and signalling layers instead of focusing on their product.
+
+## What AI Transport does
+
+AI Transport decouples the conversation from the connection by implementing a durable session pattern on top of Ably channels. The session outlives any individual socket — the agent writes to the channel; clients independently subscribe. The session persists across disconnects, device switches, and agent restarts.
+
+**Core capabilities:**
+
+- **Durable token streaming.** Streams survive tab changes, page refreshes, device switches, and network loss. Append rollup batches high-rate token output into fewer messages, keeping costs efficient.
+- **Automatic reconnection and recovery.** Clients reconnect and resume from exactly where they left off — no lost tokens, no manual retry logic.
+- **Multi-device sessions.** Any device that subscribes to the channel sees every message in real time. Start on laptop, continue on phone.
+- **Bidirectional control.** Cancel, interrupt, or steer the agent mid-response through the same session. Control signals are scoped to individual turns.
+
+## How it's different
+
+| Direct HTTP streaming | AI Transport |
+| --- | --- |
+| Stream dies on disconnect | Stream survives — client resumes automatically |
+| Single-device, single-connection | Any device subscribes to the same session |
+| Client can only cancel (loses resume) | Client sends cancel/steer signals; session persists |
+| Multi-agent updates proxied through orchestrator | Each agent publishes directly to the session |
+| Custom infra needed for recovery, history, multi-device | Built in — zero application code for recovery |
+
+## Framework and model agnostic
+
+AI Transport works with any AI model or framework: OpenAI, Anthropic, Vercel AI SDK, LangChain, and others. A pluggable codec bridges framework-specific event types to Ably messages.
+
+## Who it's for
+
+Engineering teams building production AI applications who need their agent interactions to be reliable, multi-device, and controllable — without investing months building custom realtime infrastructure.


### PR DESCRIPTION
## What

Brings the plan → write → review-loop orchestrator pattern to the docs,
decomposes the `write-docs` monolith, and moves the docs-writing guidance into
folder `AGENTS.md` files. Skill names mirror `ably-ai-transport-js`
(`docs-review-all` + `docs-review-*`, like `code-review-all` + `code-review-*`).
The shared review contract (`review-conventions`) and change resolver
(`code-resolve-changes`) load from ably-os over the Ably MCP (ably/ably-os#1608).

## Guidance → folder AGENTS.md

The 506-line `write-docs/SKILL.md` is retired; its guidance now lives with the
content it governs and auto-loads when an agent edits those pages:

- `src/pages/docs/AGENTS.md` — structure/IA principles, feature-page tiers,
  page-type templates, the API-reference standard, code-accuracy, verification.
- `src/pages/docs/ai-transport/AGENTS.md` — AI Transport positioning + terminology.

Skills no longer vendor guidance; `docs-write` applies the folder `AGENTS.md`, and
the `docs-review-*` concerns read it to check against.

## Skills

| Skill | Role |
|---|---|
| `docs-plan` | change (SDK release/PR/commits/local, via `code-resolve-changes`) → `docs-plan.md` of single-purpose page units |
| `docs-write` | executor/orchestrator: draft per the folder `AGENTS.md` → review loop → PASS |
| `docs-review-all` | fan out the concerns across subagents → one verdict (docs analogue of `code-review-all`) |
| `docs-review-{style,structure,code-accuracy,terminology,links}` | read-only concerns, each loading `review-conventions` via MCP |

The concerns derive from the last 2 months of docs PR feedback: de-claudeify
(`style`), mechanism-first / concept-ordering / diagram-type (`structure`), SDK
drift + pre-release (`code-accuracy`), `root`→object & barge-in vs interruption
(`terminology`), error-code searchability (`links`).

## Removed

- `.claude/skills/write-docs/SKILL.md` — content relocated to the `AGENTS.md` files.
