### PR TITLE
[DX-1479] docs: simplify Ably CLI onboarding to `npx @ably/cli init`

### DIFF
--- a/src/pages/docs/chat/getting-started/android.mdx
+++ b/src/pages/docs/chat/getting-started/android.mdx
@@ -48,7 +48,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/javascript.mdx
+++ b/src/pages/docs/chat/getting-started/javascript.mdx
@@ -66,7 +66,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/jvm.mdx
+++ b/src/pages/docs/chat/getting-started/jvm.mdx
@@ -63,7 +63,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react-native.mdx
+++ b/src/pages/docs/chat/getting-started/react-native.mdx
@@ -57,7 +57,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react-ui-kit.mdx
+++ b/src/pages/docs/chat/getting-started/react-ui-kit.mdx
@@ -71,7 +71,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/react.mdx
+++ b/src/pages/docs/chat/getting-started/react.mdx
@@ -64,7 +64,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
+++ b/src/pages/docs/chat/getting-started/swift-async-sequence.mdx
@@ -29,7 +29,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/chat/getting-started/swift.mdx
+++ b/src/pages/docs/chat/getting-started/swift.mdx
@@ -29,7 +29,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/cli/init.mdx
+++ b/src/pages/docs/cli/init.mdx
@@ -27,7 +27,7 @@ You can also run `init` without installing the CLI first:
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 
@@ -89,7 +89,7 @@ Set up the CLI without installing it first:
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/dotnet.mdx
+++ b/src/pages/docs/getting-started/dotnet.mdx
@@ -45,7 +45,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/flutter.mdx
+++ b/src/pages/docs/getting-started/flutter.mdx
@@ -171,7 +171,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/go.mdx
+++ b/src/pages/docs/getting-started/go.mdx
@@ -38,7 +38,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/java.mdx
+++ b/src/pages/docs/getting-started/java.mdx
@@ -56,7 +56,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/javascript.mdx
+++ b/src/pages/docs/getting-started/javascript.mdx
@@ -30,7 +30,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/kotlin.mdx
+++ b/src/pages/docs/getting-started/kotlin.mdx
@@ -35,7 +35,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/laravel.mdx
+++ b/src/pages/docs/getting-started/laravel.mdx
@@ -54,7 +54,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/nextjs.mdx
+++ b/src/pages/docs/getting-started/nextjs.mdx
@@ -90,7 +90,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/node.mdx
+++ b/src/pages/docs/getting-started/node.mdx
@@ -48,7 +48,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/objective-c.mdx
+++ b/src/pages/docs/getting-started/objective-c.mdx
@@ -50,7 +50,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/php.mdx
+++ b/src/pages/docs/getting-started/php.mdx
@@ -48,7 +48,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/python.mdx
+++ b/src/pages/docs/getting-started/python.mdx
@@ -45,7 +45,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/react-native.mdx
+++ b/src/pages/docs/getting-started/react-native.mdx
@@ -149,7 +149,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/react.mdx
+++ b/src/pages/docs/getting-started/react.mdx
@@ -157,7 +157,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/ruby.mdx
+++ b/src/pages/docs/getting-started/ruby.mdx
@@ -43,7 +43,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/getting-started/swift.mdx
+++ b/src/pages/docs/getting-started/swift.mdx
@@ -41,7 +41,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/platform/tools/cli.mdx
+++ b/src/pages/docs/platform/tools/cli.mdx
@@ -21,7 +21,7 @@ Get started in a single command:
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/apns.mdx
+++ b/src/pages/docs/push/getting-started/apns.mdx
@@ -31,7 +31,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/fcm.mdx
+++ b/src/pages/docs/push/getting-started/fcm.mdx
@@ -30,7 +30,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/flutter.mdx
+++ b/src/pages/docs/push/getting-started/flutter.mdx
@@ -26,7 +26,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code fixed="true">
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/react-native.mdx
+++ b/src/pages/docs/push/getting-started/react-native.mdx
@@ -28,7 +28,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 

--- a/src/pages/docs/push/getting-started/web.mdx
+++ b/src/pages/docs/push/getting-started/web.mdx
@@ -30,7 +30,7 @@ Use the [Ably CLI](/docs/platform/tools/cli) as an additional client to quickly 
 
 <Code>
 ```shell
-npx -p @ably/cli ably init
+npx @ably/cli init
 ```
 </Code>
 


### PR DESCRIPTION
## What

Replaces the verbose Ably CLI onboarding command `npx -p @ably/cli ably init` with the simpler one-command form `npx @ably/cli init` across all docs.

**31 files, 32 occurrences** — the CLI docs page, the `cli/init` reference, and every getting-started guide (Pub/Sub, Chat, and Push, across all languages).

## Why

`@ably/cli` previously shipped two binaries (`ably` and `ably-interactive`). npm's resolver only auto-selects an executable when a package has a single bin, so `npx @ably/cli init` failed with *"could not determine executable to run"* and users had to fall back to the redundant `npx -p @ably/cli ably init`.

[ably/ably-cli#419](https://github.com/ably/ably-cli/pull/419) made the package single-bin, so `npx @ably/cli init` now resolves cleanly — matching what people expect from npx (`npx neonctl init`, etc.).

## Ready to merge

The single-bin fix shipped in **`@ably/cli` v1.2.1, now published to npm** (`latest` = `1.2.1`, with a single `ably` bin). `npx @ably/cli init` resolves against the published version, so this is safe to merge.

## Scope note

Pure find-and-replace of a single unambiguous string; no surrounding prose changed (none of the pages explained the `-p` flag). Verified with `git grep` that zero verbose forms remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
