### PR TITLE
Support: Billing - Update payment and invoices navigation steps

### DIFF
--- a/src/pages/docs/platform/pricing/billing.mdx
+++ b/src/pages/docs/platform/pricing/billing.mdx
@@ -32,11 +32,13 @@ The following details will appear on your credit card or bank statement when pay
 To update your billing details:
 
 1. Ensure you are the account owner or have the billing [role](/docs/platform/account/team).
-2. Log in to your [account](https://ably.com/login) and select *Billing* from the *Account* menu.
+2. Log in to your [account](https://ably.com/login) and select *Payment* from the *Billing* section of the account sidebar.
 
-You can update your payment details and view your invoices in this screen.
+You can update your payment details on this screen.
 
-It's also possible to have your invoices sent to an accounts department by filling in the *Optional billing email address*.
+To view your invoices, select *Invoices* from the *Billing* section of the account sidebar.
+
+It's also possible to have your invoices sent to an accounts department by filling in the *Billing email* field.
 
 ## Billing alerts <a id="alerts"/>
 


### PR DESCRIPTION
Updates the billing details section on the Billing page to reflect the current account UI.

Changes:
- Payment details are now managed on a dedicated *Payment* page under the *Billing* section of the account sidebar, not a single *Billing* menu item.
- Invoices are now on a separate *Invoices* page rather than the same screen as payment details.
- The billing email field is now labelled *Billing email*, not *Optional billing email address*.

---
**Submitted by:** Mike Clark (mike.clark@ably.com)
**Submitted at:** 2026-07-02T11:49:43.339Z
*Created via `githubCreatePRWithFile` MCP tool*