### PR TITLE
[DX-1489] Fix embedded-token JWT requirements on the token auth page

### DIFF
--- a/src/pages/docs/auth/token/index.mdx
+++ b/src/pages/docs/auth/token/index.mdx
@@ -245,7 +245,7 @@ If you have an existing [JWT](https://jwt.io/) authentication system, you can em
 
 ### Requirements
 
-* The embedded token can be an Ably Token or an [Ably JWT](/docs/api/rest-sdk/authentication#ably-jwt).
+* The embedded token can be an [Ably JWT](/docs/api/rest-sdk/authentication#ably-jwt) or an Ably Token.
 * Include the token under the `x-ably-token` key in the [JOSE Header](https://tools.ietf.org/html/rfc7519). If the outer JWT is an unencrypted JWS, you can alternatively include it as an `x-ably-token` claim in the payload.
 * The expiry time of the embedded token must not be earlier than the outer JWT's expiry time (`exp` claim). Ably will reject any JWT if it is unencrypted and its `exp` claim is later than the expiry of the enclosed token.
 

--- a/src/pages/docs/auth/token/index.mdx
+++ b/src/pages/docs/auth/token/index.mdx
@@ -245,7 +245,7 @@ If you have an existing [JWT](https://jwt.io/) authentication system, you can em
 
 ### Requirements
 
-* The embedded token can be an Ably Token or an Ably JWT.
+* The embedded token can be an Ably Token or an [Ably JWT](/docs/api/rest-sdk/authentication#ably-jwt).
 * Include the token under the `x-ably-token` key in the [JOSE Header](https://tools.ietf.org/html/rfc7519). If the outer JWT is an unencrypted JWS, you can alternatively include it as an `x-ably-token` claim in the payload.
 * The expiry time of the embedded token must not be earlier than the outer JWT's expiry time (`exp` claim). Ably will reject any JWT if it is unencrypted and its `exp` claim is later than the expiry of the enclosed token.
 

--- a/src/pages/docs/auth/token/index.mdx
+++ b/src/pages/docs/auth/token/index.mdx
@@ -245,8 +245,8 @@ If you have an existing [JWT](https://jwt.io/) authentication system, you can em
 
 ### Requirements
 
-* The embedded token must be an Ably Token (not a JWT).
-* The embedded token is included under the `x-ably-token` key in the [JOSE Header](https://tools.ietf.org/html/rfc7519), or if using JWS, in the payload claims.
+* The embedded token can be an Ably Token or an Ably JWT.
+* Include the token under the `x-ably-token` key in the [JOSE Header](https://tools.ietf.org/html/rfc7519). If the outer JWT is an unencrypted JWS, you can alternatively include it as an `x-ably-token` claim in the payload.
 * The expiry time of the embedded token must not be earlier than the outer JWT's expiry time (`exp` claim). Ably will reject any JWT if it is unencrypted and its `exp` claim is later than the expiry of the enclosed token.
 
 ### When to use


### PR DESCRIPTION
## What

Two corrections to the **Embedded Token JWT → Requirements** list on [`/docs/auth/token#embedded`](https://ably.com/docs/auth/token#embedded):

1. **"The embedded token must be an Ably Token (not a JWT)" is factually wrong.** The service accepts an embedded Ably JWT as well as a native Ably Token: `TokenDb.get` in the realtime service unwraps `x-ably-token` and validates either form, and the realtime test suite covers it directly (`auth_external_jwt_with_ably_jwt_embedded_in_jose_header`, `auth_external_jwt_with_ably_jwt_embedded_in_payload`, `auth_external_encrypted_jwt_with_ably_jwt_embedded_in_jose_header`). The "(not a JWT)" exclusion was introduced in the #3085 rewrite — the pre-rewrite wording ("The embedded token is an Ably Token") made no such claim.

2. **The `x-ably-token` location bullet implied the JOSE header is only for the non-JWS case.** The server checks the JOSE header first for *both* JWS and JWE outer tokens, with the payload claim as an additional option for unencrypted JWS only (a JWE payload is encrypted, so Ably cannot read it). As previously worded, the bullet contradicted the code examples further down the same page, which all embed the token in the header of an HS256 JWS.

## Why

Reported as inaccurate by a reader; verified against the realtime service implementation and its test suite before rewording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)