### PR TITLE
Protocols & adapters: decision guide and page pattern revamp

### DIFF
--- a/src/components/Icon/glyphs/icon-tech-amqp.tsx
+++ b/src/components/Icon/glyphs/icon-tech-amqp.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechAmqp = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={15} fontWeight={700} letterSpacing={-0.5} textAnchor="middle" dominantBaseline="central">AMQP</text></svg>;
+const ForwardRef = forwardRef(IconTechAmqp);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/icon-tech-mqtt.tsx
+++ b/src/components/Icon/glyphs/icon-tech-mqtt.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechMqtt = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={15} fontWeight={700} letterSpacing={-0.5} textAnchor="middle" dominantBaseline="central">MQTT</text></svg>;
+const ForwardRef = forwardRef(IconTechMqtt);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/icon-tech-pubnub.tsx
+++ b/src/components/Icon/glyphs/icon-tech-pubnub.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechPubnub = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={20} fontWeight={700} textAnchor="middle" dominantBaseline="central">PN</text></svg>;
+const ForwardRef = forwardRef(IconTechPubnub);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/icon-tech-pusher.tsx
+++ b/src/components/Icon/glyphs/icon-tech-pusher.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechPusher = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={26} fontWeight={700} textAnchor="middle" dominantBaseline="central">P</text></svg>;
+const ForwardRef = forwardRef(IconTechPusher);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/icon-tech-sse.tsx
+++ b/src/components/Icon/glyphs/icon-tech-sse.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechSse = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={17} fontWeight={700} textAnchor="middle" dominantBaseline="central">SSE</text></svg>;
+const ForwardRef = forwardRef(IconTechSse);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/icon-tech-stomp.tsx
+++ b/src/components/Icon/glyphs/icon-tech-stomp.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const IconTechStomp = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps, ref: Ref<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} fill="none" viewBox="0 0 48 48" ref={ref} aria-labelledby={titleId} {...props}>{title ? <title id={titleId}>{title}</title> : null}<text x={24} y={25} fill="currentColor" fontFamily="inherit" fontSize={13} fontWeight={700} letterSpacing={-0.3} textAnchor="middle" dominantBaseline="central">STOMP</text></svg>;
+const ForwardRef = forwardRef(IconTechStomp);
+export default ForwardRef;

--- a/src/components/Icon/glyphs/index.ts
+++ b/src/components/Icon/glyphs/index.ts
@@ -34,6 +34,7 @@ import IconSocialLinkedinMono from "./icon-social-linkedin-mono";
 import IconSocialStackoverflowMono from "./icon-social-stackoverflow-mono";
 import IconSocialXMono from "./icon-social-x-mono";
 import IconSocialYoutubeMono from "./icon-social-youtube-mono";
+import IconTechAmqp from "./icon-tech-amqp";
 import IconTechAndroidFull from "./icon-tech-android-full";
 import IconTechClaudeMono from "./icon-tech-claude-mono";
 import IconTechCsharp from "./icon-tech-csharp";
@@ -44,16 +45,21 @@ import IconTechJavascript from "./icon-tech-javascript";
 import IconTechJson from "./icon-tech-json";
 import IconTechKotlin from "./icon-tech-kotlin";
 import IconTechLaravelBroadcast from "./icon-tech-laravel-broadcast";
+import IconTechMqtt from "./icon-tech-mqtt";
 import IconTechNextjs from "./icon-tech-nextjs";
 import IconTechNodejs from "./icon-tech-nodejs";
 import IconTechObjectivec from "./icon-tech-objectivec";
 import IconTechOpenai from "./icon-tech-openai";
 import IconTechPhp from "./icon-tech-php";
 import IconTechPostgres from "./icon-tech-postgres";
+import IconTechPubnub from "./icon-tech-pubnub";
+import IconTechPusher from "./icon-tech-pusher";
 import IconTechPython from "./icon-tech-python";
 import IconTechReact from "./icon-tech-react";
 import IconTechReactnative from "./icon-tech-reactnative";
 import IconTechRuby from "./icon-tech-ruby";
+import IconTechSse from "./icon-tech-sse";
+import IconTechStomp from "./icon-tech-stomp";
 import IconTechSwift from "./icon-tech-swift";
 import IconTechTypescript from "./icon-tech-typescript";
 import IconTechVercel from "./icon-tech-vercel";
@@ -99,6 +105,7 @@ export const glyphs = {
   "icon-social-stackoverflow-mono": IconSocialStackoverflowMono,
   "icon-social-x-mono": IconSocialXMono,
   "icon-social-youtube-mono": IconSocialYoutubeMono,
+  "icon-tech-amqp": IconTechAmqp,
   "icon-tech-android-full": IconTechAndroidFull,
   "icon-tech-claude-mono": IconTechClaudeMono,
   "icon-tech-csharp": IconTechCsharp,
@@ -109,16 +116,21 @@ export const glyphs = {
   "icon-tech-json": IconTechJson,
   "icon-tech-kotlin": IconTechKotlin,
   "icon-tech-laravel-broadcast": IconTechLaravelBroadcast,
+  "icon-tech-mqtt": IconTechMqtt,
   "icon-tech-nextjs": IconTechNextjs,
   "icon-tech-nodejs": IconTechNodejs,
   "icon-tech-objectivec": IconTechObjectivec,
   "icon-tech-openai": IconTechOpenai,
   "icon-tech-php": IconTechPhp,
   "icon-tech-postgres": IconTechPostgres,
+  "icon-tech-pubnub": IconTechPubnub,
+  "icon-tech-pusher": IconTechPusher,
   "icon-tech-python": IconTechPython,
   "icon-tech-react": IconTechReact,
   "icon-tech-reactnative": IconTechReactnative,
   "icon-tech-ruby": IconTechRuby,
+  "icon-tech-sse": IconTechSse,
+  "icon-tech-stomp": IconTechStomp,
   "icon-tech-swift": IconTechSwift,
   "icon-tech-typescript": IconTechTypescript,
   "icon-tech-vercel": IconTechVercel,

--- a/src/data/nav/pubsub.ts
+++ b/src/data/nav/pubsub.ts
@@ -326,7 +326,7 @@ export default {
       ],
     },
     {
-      name: 'Supported protocols',
+      name: 'Protocols & adapters',
       pages: [
         {
           name: 'Overview',
@@ -334,12 +334,17 @@ export default {
           index: true,
         },
         {
-          name: 'Server-Sent Events (SSE)',
-          link: '/docs/protocols/sse',
+          name: 'Ably SDKs (native protocol)',
+          link: '/docs/sdks',
+          external: true,
         },
         {
           name: 'MQTT',
           link: '/docs/protocols/mqtt',
+        },
+        {
+          name: 'Server-Sent Events (SSE)',
+          link: '/docs/protocols/sse',
         },
         {
           name: 'Pusher Adapter',
@@ -348,6 +353,14 @@ export default {
         {
           name: 'PubNub Adapter',
           link: '/docs/protocols/pubnub',
+        },
+        {
+          name: 'AMQP',
+          link: '/docs/protocols/amqp',
+        },
+        {
+          name: 'STOMP',
+          link: '/docs/protocols/stomp',
         },
       ],
     },

--- a/src/pages/docs/protocols/amqp.mdx
+++ b/src/pages/docs/protocols/amqp.mdx
@@ -1,0 +1,57 @@
+---
+title: AMQP
+meta_description: "AMQP is used to consume messages from Ably queues. Use an AMQP client to have worker processes pull messages from Ably for asynchronous processing."
+meta_keywords: "AMQP, Ably queues, message queue, consume messages, worker"
+intro: "AMQP lets worker processes consume messages from Ably queues for asynchronous processing. Unlike MQTT, SSE, or the vendor adapters, it does not connect clients directly to channels."
+---
+
+AMQP (Advanced Message Queuing Protocol) is a message queuing protocol supported by [Ably queues](/docs/platform/integrations/queues). It gives worker processes a reliable way to pull messages from Ably and process them asynchronously, with acknowledgement and at-least-once delivery.
+
+## Understand how AMQP works with Ably <a id="how-it-works"/>
+
+AMQP does not connect a client directly to an Ably [channel](/docs/channels), unlike the [MQTT](/docs/protocols/mqtt), [SSE](/docs/protocols/sse), [Pusher](/docs/protocols/pusher), and [PubNub](/docs/protocols/pubnub) protocols. Instead, you publish messages to a channel, a [queue rule](/docs/platform/integrations/queues#config) copies matching messages into a queue, and an AMQP client consumes them from that queue.
+
+Ably queues use AMQP 0.9.1. Queues are pre-provisioned and routing is handled by queue rules, so you subscribe directly to a queue rather than binding to an exchange or declaring a queue. Attempts to bind to an exchange or declare a queue are rejected.
+
+## When to use AMQP <a id="when-to-use"/>
+
+Use AMQP when you want to consume realtime data from Ably on your servers as a work queue, rather than maintain realtime connections on clients. This suits workloads where each message represents a unit of work, where you want to scale consumers horizontally, retain a backlog if consumers fall behind, and guarantee that each message is delivered to only one consumer.
+
+To stream data continuously into your own queueing or streaming service instead, see [outbound streaming](/docs/platform/integrations/streaming). To connect clients directly to Ably, use an [Ably SDK](/docs/sdks) or one of the other [protocols](/docs/protocols).
+
+## Connection details <a id="connection-details"/>
+
+Consuming from an Ably queue over AMQP requires the following values, most of which are shown in the **Queues** tab of your app [dashboard](https://ably.com/dashboard):
+
+| Value | Description |
+| --- | --- |
+| Queue name | Your app ID and the queue name, for example `UATwBQ:example-queue`. |
+| Host | The regional server endpoint for the queue, for example `us-east-1-a-queue.ably.io`. |
+| Port | 5671, the TLS-only port supported for secure AMQP consumption. |
+| Vhost | Always `shared`. |
+| Username | The part of your API key before the colon. |
+| Password | The part of your API key after the colon. |
+| Client | Any AMQP 0.9.1 compatible client that supports TLS. |
+
+For example, connecting from Node.js:
+
+<Code>
+```nodejs
+const url = 'amqps://APPID.KEYID:SECRET@us-east-1-a-queue.ably.io/shared';
+amqp.connect(url, (err, conn) => {
+  /* subscribe directly to the queue and consume messages */
+});
+```
+</Code>
+
+For a complete worked example, including decoding message envelopes and acknowledging deliveries, see [consume messages using AMQP](/docs/platform/integrations/queues#amqp).
+
+<Aside data-type='note'>
+AMQP connections may disconnect during routine maintenance. Most AMQP clients automatically reconnect and retry with backoff. If your client does not handle reconnection, implement this logic in your application code.
+</Aside>
+
+## Read next <a id="read-next"/>
+
+* [Ably queues](/docs/platform/integrations/queues): provisioning, queue rules, envelopes, and the dead letter queue.
+* [STOMP](/docs/protocols/stomp): the text-based alternative for consuming from queues.
+* [Outbound streaming](/docs/platform/integrations/streaming): stream data into your own Kafka, Kinesis, or AMQP infrastructure instead.

--- a/src/pages/docs/protocols/index.mdx
+++ b/src/pages/docs/protocols/index.mdx
@@ -1,93 +1,147 @@
 ---
-title: Protocols
-meta_description: "Clients can use the Ably network protocol adapters. This is especially useful where an Ably SDK is not available for your language of choice, or where platform resource constraints prohibit use of an SDK."
+title: Protocols and adapters
+meta_description: "Ably SDKs and the native protocol are the recommended way to connect. When an SDK is not available you can connect using MQTT, SSE, AMQP or STOMP, or migrate from Pusher or PubNub using a protocol adapter."
+meta_keywords: "protocols, protocol adapters, MQTT, SSE, Pusher adapter, PubNub adapter, AMQP, STOMP, migrate to Ably"
+intro: "Ably SDKs and the native protocol are the recommended way to connect and give you the full Ably feature set. When an SDK is not an option, Ably also speaks other protocols and can emulate Pusher and PubNub, so you can connect from any platform or move an existing application onto Ably without a rewrite."
 redirect_from:
   - /docs/protocol-adapters
 ---
 
-Ably SDKs are the recommended method for connecting to Ably because they offer support for a comprehensive set of Ably features, such as automatic [connection management](/docs/connect), [authentication token renewal](/docs/auth/token) and [presence](/docs/presence-occupancy).
+Ably SDKs connect using Ably's native protocol. They give you the full feature set, the strongest delivery guarantees, and automatic connection recovery across regions, and are the recommended way to connect to Ably.
 
-Protocol adapters offer an alternative method for connecting to Ably. The advantage to protocol adapters is that they require fewer resources in terms of memory and network overhead such as in smaller footprint devices, or on a platform where an Ably SDK isn't available such as an Arduino-based IoT wearable. The potential drawback to consider when evaluating protocol adapters is that they do not support the full set of Ably features, for example the MQTT protocol adapter does not support presence, and the SSE protocol adapter does not support automatic token renewal.
+Some platforms cannot run an SDK, and some applications already speak another protocol. For those cases Ably also speaks MQTT, SSE, AMQP and STOMP, and provides adapters for the Pusher and PubNub protocols. Every connection reaches the same Ably network, whichever protocol it uses.
 
-## Migrate to Ably <a id="migration-support"/>
+## Available protocols and adapters <a id="available-adapters"/>
 
-Ably helps customers migrate from other data streaming networks including PubNub and Pusher. Protocol adapters facilitate risk-free migration by allowing you to use existing protocols and client libraries while transitioning to Ably SDKs over time.
+Choose a connection method to read its documentation:
 
-Protocol adapters ensure interoperability between different protocols. For example, you can publish sensor data from an MQTT device, subscribe to that data using a Pusher client library for dashboard display, support mobile apps using Ably SDKs, and process data using AMQP worker queues - all within the same system.
+<Tiles>
+{[
+  {
+    title: 'Ably SDKs',
+    description: 'The recommended way to connect. The native protocol with the full feature set and the strongest guarantees.',
+    image: 'icon-product-pubsub',
+    link: '/docs/sdks',
+  },
+  {
+    title: 'MQTT',
+    description: 'Lightweight publish/subscribe for IoT hardware and constrained devices without an SDK.',
+    image: 'icon-tech-mqtt',
+    link: '/docs/protocols/mqtt',
+  },
+  {
+    title: 'SSE',
+    description: 'Subscribe-only event streams over HTTP through the browser EventSource API.',
+    image: 'icon-tech-sse',
+    link: '/docs/protocols/sse',
+  },
+  {
+    title: 'Pusher Adapter',
+    description: 'Connect existing Pusher clients to Ably by changing an API key and endpoint.',
+    image: 'icon-tech-pusher',
+    link: '/docs/protocols/pusher',
+  },
+  {
+    title: 'PubNub Adapter',
+    description: 'Connect existing PubNub clients to Ably by changing an API key and endpoint.',
+    image: 'icon-tech-pubnub',
+    link: '/docs/protocols/pubnub',
+  },
+  {
+    title: 'AMQP',
+    description: 'Consume messages from Ably queues with worker processes on your servers.',
+    image: 'icon-tech-amqp',
+    link: '/docs/protocols/amqp',
+  },
+  {
+    title: 'STOMP',
+    description: 'Consume messages from Ably queues with any STOMP client.',
+    image: 'icon-tech-stomp',
+    link: '/docs/protocols/stomp',
+  },
+]}
+</Tiles>
 
-Migration times typically range from a few hours (using protocol adapters) to a week, depending on your migration strategy and whether you choose to adopt Ably's native SDKs immediately or transition gradually.
+## Connect with the native protocol <a id="native"/>
 
-A full list of Ably SDKs can be found on the [SDK page](/docs/sdks).
+An [Ably SDK](/docs/sdks) is available for most platforms and languages. SDKs use Ably's native protocol, which supports the complete feature set, including [presence](/docs/presence-occupancy), [message history](/docs/storage-history/history), [push notifications](/docs/push), automatic [token renewal](/docs/auth/token), and [connection recovery](/docs/platform/architecture/connection-recovery) that fails over between regions without losing messages.
 
-## Available Protocol Adapters <a id="available-adapters"/>
+Use an Ably SDK whenever one is available for your platform. Compared to any other protocol it gives you richer features, higher availability, and more efficient use of the network. To understand what the native protocol provides, see [Ably basics](/docs/basics).
 
-Ably supports multiple protocols in addition to the native WebSockets-based one:
+## Choose a protocol or adapter <a id="choose"/>
 
-* [MQTT](#mqtt)
-* [SSE](#sse)
-* [AMQP](#amqp)
-* [STOMP](#stomp)
-* [Pusher](#pusher)
-* [PubNub](#pubnub)
+A protocol adapter translates another protocol into Ably's native protocol at the edge of the network. Your client keeps speaking its own protocol and Ably handles the translation, so you get Ably's routing, scale and message ordering, together with the features that both protocols share. Capabilities that the other protocol cannot express, such as message continuity across a dropped connection, are available only through an Ably SDK.
 
-### MQTT <a id="mqtt"/>
+Match your situation to a starting point:
 
-MQTT (MQ Telemetry Transport) is a publish/subscribe, lightweight messaging protocol designed for constrained devices and low-bandwidth networks. One of the major uses of MQTT is with IoT (Internet of Things), where these principles are key to having effective communication between various devices.
+| Your situation | Start with |
+| --- | --- |
+| An Ably SDK is available for your platform | An [Ably SDK](/docs/sdks). This is the recommended path. |
+| You have an existing Pusher or PubNub application | The [Pusher](/docs/protocols/pusher) or [PubNub](/docs/protocols/pubnub) adapter, to move onto Ably without a rewrite. |
+| Your platform cannot run an SDK | [MQTT](/docs/protocols/mqtt) for devices, or [SSE](/docs/protocols/sse) for subscribe-only browser streams. |
+| Your servers consume messages as a work queue | [AMQP](/docs/protocols/amqp) or [STOMP](/docs/protocols/stomp) with Ably [queues](/docs/platform/integrations/queues). |
 
-MQTT can also be used with Ably as a basic event broker or if an SDK is not available for your target platform. However, without an SDK you don't get access to the full range of platform features and data guarantees.
+### Migration and reach compared <a id="migrate"/>
 
-Read more in the [MQTT section](/docs/protocols/mqtt).
+Adapters and protocols serve two different jobs. The Pusher and PubNub adapters move an existing application onto Ably; MQTT and SSE reach platforms an SDK cannot:
 
-### SSE <a id="sse"/>
+| | Migrate from another vendor | Reach platforms without an SDK |
+| --- | --- | --- |
+| Protocols | [Pusher](/docs/protocols/pusher), [PubNub](/docs/protocols/pubnub) | [MQTT](/docs/protocols/mqtt), [SSE](/docs/protocols/sse) |
+| What it solves | Moves an existing application onto Ably's network in hours, by changing an API key and endpoint | Connects constrained IoT devices, and browsers that need a subscribe-only stream |
+| How long you use it | A bridge with no time limit. Migrate to an Ably SDK when you want the full feature set, at your own pace | Often the right permanent choice for the platform |
+| Feature set | The features the vendor protocol shares with Ably; broader features such as presence are included | Lightweight publish/subscribe with MQTT; subscribe-only with SSE |
 
-SSE is a push technology commonly used to send unidirectional message updates or continuous data streams to a browser client. SSE aims to enhance native, cross-browser server-to-client streaming through a JavaScript API called EventSource, standardized as part of HTML5 by the World Wide Web Consortium (W3C).
+During a migration you can run adapter clients and Ably SDK clients against the same channels, because every protocol reaches the same Ably network. For example, you can publish from a Pusher client and subscribe from an Ably SDK on the same channel, then move each app to an SDK one at a time.
 
-The Ably SSE and raw HTTP streaming API provides a way to get a realtime stream of events from Ably in circumstances where using a full Ably Pub/Sub SDK, or even an MQTT library, is impractical.
+### Compare capabilities <a id="compare"/>
 
-Read more in the [SSE section](/docs/protocols/sse).
+Every connection to Ably uses the same network, whichever protocol it speaks. An Ably SDK adds the capabilities that other protocols cannot express:
 
-### AMQP <a id="amqp"/>
+| Capability | Adapters and protocols | Ably SDKs |
+| --- | --- | --- |
+| Routing to the nearest datacenter | Yes | Yes |
+| Elastic scaling of messages and connections | Yes | Yes |
+| Consistent message ordering within a region | Yes | Yes |
+| Interoperability with other protocols on the same channels | Yes | Yes |
+| Connection recovery with multi-region failover and no message loss | No | Yes |
+| Idempotent publishing that prevents duplicate messages | No | Yes |
+| Presence, history and push notifications | Depends on the protocol | Yes |
+| Automatic token renewal | No | Yes |
 
-The AMQP protocol provides a rich set of functionality to amongst other things bind to exchanges, provision queues and configure routing. The functionality exists so that queues can be dynamically provisioned by clients and messages can be routed to these queues as required.
-
-Read more in the [queues section](/docs/platform/integrations/queues).
-
-### STOMP <a id="stomp"/>
-
-STOMP is a simple text-based messaging protocol, typically used for communication between message brokers. It provides an interoperable wire format so that STOMP clients can communicate with any message broker that supports the STOMP protocol and as such is a good fit for use with Ably queues.
-
-Read more in the [queues section](/docs/platform/integrations/queues).
-
-### Pusher <a id="pusher"/>
-
-Ably is the only cloud vendor that supports the Pusher protocol. It's simple to migrate to Ably, or use Ably as a failover for Pusher in hours instead of months.
-
-Seamlessly migrate from Pusher by connecting your existing clients to the Ably network with practically zero changes to your code.
-
-Read more in the [Pusher Adapter section](/docs/protocols/pusher).
-
-### PubNub <a id="pubnub"/>
-
-Ably is the only cloud vendor that supports the PubNub protocol. It's simple to migrate to Ably, or improve resilience with failover options in hours instead of months.
-
-Seamlessly migrate from PubNub by connecting to the Ably network using the PubNub protocol.
-
-Read more in the [PubNub Adapter section](/docs/protocols/pubnub).
+Individual protocols support different subsets of these features. Each protocol page lists what it supports and what it does not.
 
 ## How protocol adapters work <a id="how-they-work"/>
 
 The Ably platform is available at the endpoint `realtime.ably.io` for socket connections and `rest.ably.io` for REST-based requests and HTTP fallbacks for devices not supporting sockets. Ably client libraries always communicate directly with the Ably platform through those endpoints, and Ably ensures those endpoints route users to the closest available datacenter.
 
-Protocol adapters use different endpoints from the default Ably endpoints and route users to a protocol adapter layer that also runs in each of our datacenters. For example, if a client uses MQTT, the endpoint is `mqtt.ably.io`. Ably's latency-based DNS ensures that the client connecting to `mqtt.ably.io` is routed to the closest datacenter, and when the routing layer receives the request, it identifies which protocol the request is destined for based on the hostname. The router then routes the request to a local frontend designed to process data for that protocol.
+Protocol adapters use different endpoints from the default Ably endpoints and route users to a protocol adapter layer that also runs in each of Ably's datacenters. For example, if a client uses MQTT, the endpoint is `mqtt.ably.io`. Ably's latency-based DNS ensures that the client connecting to `mqtt.ably.io` is routed to the closest datacenter, and when the routing layer receives the request, it identifies which protocol the request is destined for based on the hostname. The router then routes the request to a local frontend designed to process data for that protocol.
 
 Protocol adapters run as middleware between the routers and the rest of the Ably service, ensuring that all incoming requests are transformed into the Ably protocol and sent to the Ably service, and all data received from Ably is transformed back to the client's protocol. The adapters are stateful, maintaining connections similar to how Ably provides connection state recovery. The routers ensure that requests are routed to the correct adapter handling each connection for each request.
 
-Protocol adapters provide a seamless way to connect using different protocols to Ably without having to worry about the complexities of ensuring interoperability between protocols.
+Each protocol connects through its own endpoint:
+
+| Protocol | Endpoint |
+| --- | --- |
+| MQTT | `main.mqtt.ably.net` |
+| SSE | `https://main.realtime.ably.net/sse` |
+| Pusher | `main.pusher.ably.net` |
+| PubNub | `main.pubnub.ably.net` |
+| AMQP and STOMP | Regional queue endpoints, for example `us-east-1-a-queue.ably.io` |
 
 ## Pricing <a id="pricing"/>
 
-Use of protocol adapters carries no additional charge. You are charged for the total number of peak connections and messages sent as if you were using Ably's native protocol. See the [pricing](/docs/platform/pricing) page for more details.
+Use of protocol adapters carries no additional charge. You are charged for the total number of peak connections and messages sent as if you were using Ably's native protocol. See [Pub/Sub pricing](/docs/pub-sub/pricing) for how operations count towards your message total, and [platform pricing](/docs/platform/pricing) for plans.
 
-## Getting started with protocol adapters <a id="getting-started"/>
+## Get started <a id="getting-started"/>
 
-If you are interested in using our protocol adapters to assist with migration from another service, or would like to use another protocol not listed here with Ably, then please [get in touch](https://ably.com/contact).
+Each protocol page shows how to configure a client and connect:
+
+* [Configure an MQTT client](/docs/protocols/mqtt#config)
+* [Configure an SSE connection](/docs/protocols/sse#config)
+* [Configure a Pusher SDK](/docs/protocols/pusher#configure)
+* [Configure a PubNub SDK](/docs/protocols/pubnub#configure)
+* [Consume messages using AMQP](/docs/platform/integrations/queues#amqp)
+* [Consume messages using STOMP](/docs/platform/integrations/queues#stomp)
+
+To use a protocol not listed here with Ably, [get in touch](https://ably.com/contact).

--- a/src/pages/docs/protocols/mqtt.mdx
+++ b/src/pages/docs/protocols/mqtt.mdx
@@ -1,6 +1,8 @@
 ---
 title: MQTT
 meta_description: "Any MQTT-enabled client can communicate with the Ably service through the Ably MQTT protocol adapter. This is especially useful where an Ably SDK is not available for your language of choice."
+meta_keywords: "MQTT, MQTT adapter, IoT, publish subscribe, constrained devices, Ably"
+intro: "The MQTT adapter connects constrained devices and platforms without an Ably SDK, such as IoT hardware, to Ably. MQTT is a lightweight publish/subscribe protocol built for low-bandwidth networks."
 languages:
  - javascript
  - nodejs
@@ -8,17 +10,26 @@ redirect_from:
   - /docs/mqtt
 ---
 
-The Ably MQTT protocol adapter is able to translate back and forth between [MQTT](https://mqtt.org/) and Ably's own protocol, allowing for seamless integration of any systems you may have. MQTT (MQ Telemetry Transport) is a [publish/subscribe](https://ably.com/topic/pub-sub), lightweight messaging protocol designed for constrained devices and low-bandwidth networks. One of the major uses of MQTT is with IoT (Internet of Things), where these principles are key to having effective communication between various devices.
+The Ably MQTT protocol adapter translates back and forth between [MQTT](https://mqtt.org/) and Ably's own protocol, allowing integration with your existing systems. MQTT (MQ Telemetry Transport) is a [publish/subscribe](https://ably.com/topic/pub-sub), lightweight messaging protocol designed for constrained devices and low-bandwidth networks. One of the major uses of MQTT is with IoT (Internet of Things), where these principles are key to having effective communication between various devices.
 
 ## When to use the MQTT adapter <a id="when-to-use"/>
 
-The MQTT adapter is our recommended way of interacting with Ably from devices which do not have a native Ably SDK, such as Arduino platforms, C/C++ applications, and so on. Anyone who has previously been using Pubnub or Pusher SDKs for this purpose may want to consider switching to MQTT. Compared to the Pubnub protocol, using MQTT will result in better performance with lower latency. The MQTT adapter typically adds only 1-10ms of latency. Compared to the Pusher protocol, MQTT will give you connection state recovery.
+The MQTT adapter is the recommended way of interacting with Ably from devices which do not have a native Ably SDK, such as Arduino platforms and C/C++ applications, when a lightweight publish/subscribe feature set fits your needs. MQTT is a lightweight, fast protocol with connection state recovery, and the adapter typically adds only 1-10ms of latency.
+
+MQTT supports a smaller feature set than the [Pusher](/docs/protocols/pusher) and [PubNub](/docs/protocols/pubnub) protocols, which include broader features such as presence. Choose the protocol that matches the features you need. For features beyond what these protocols support, use an [Ably SDK](/docs/sdks).
 
 Behind the scenes, the adapter just uses the normal Ably service, so there is no problem with using MQTT and Ably SDKs side by side. You can mix and match as you like; for example, using MQTT on your IoT devices, but using the Ably Pub/Sub SDK on your servers.
 
 MQTT is recommended to interact with Ably when:
 
 * Bandwidth is limited and you want to keep network traffic to a minimum
+* A simple publish/subscribe feature set is all you need
+
+For devices that cannot run an SDK, MQTT is often the right long-term choice rather than a temporary one.
+
+<Aside data-type='note'>
+An Ably SDK is the recommended way to connect when one is available for your platform. To decide between the native protocol, this adapter, and other protocols, see [choosing a protocol or adapter](/docs/protocols#choose).
+</Aside>
 
 ## Known limitations <a id="limitations"/>
 
@@ -26,14 +37,16 @@ Using the MQTT adapter will be a little slower than using an Ably SDK, as an ada
 
 While the adapter can be useful for devices which need to use MQTT, there are many benefits to using an Ably SDK, such as continuity guarantees, fallback host support, history and presence. As a result, if an Ably SDK is available for your platform, it is recommended you consider using it instead of the protocol adapter.
 
-Our MQTT adapter only supports features supported by both the MQTT protocol and the Ably platform:
+The MQTT adapter supports only the features supported by both the MQTT protocol and the Ably platform:
 
-* Only supports MQTT 3.1.1 clients only, connection attempts using earlier protocol versions will be rejected
-* Publishing supports QoS 0 or 1
-* Subscribing only supports QoS 0
-* Session resumption is supported within the usual [Ably time limit of two minutes](/docs/storage-history/storage#default-persistence)
-* Doesn't support any MQTT features that aren't normally supported by Ably, such as `WILL` messages, the `RETAIN` flag or [wildcard channel subscriptions](/docs/channels)
-* Doesn't support Ably features that aren't supported by the MQTT protocol, such as presence, history and push notifications, though you can use the Ably REST API in conjunction with the adapter to access features available over REST
+| Area | Support |
+| --- | --- |
+| Protocol version | MQTT 3.1.1 only. Connection attempts using earlier versions are rejected. |
+| Publishing | QoS 0 or 1. |
+| Subscribing | QoS 0 only. |
+| Session resumption | Supported within the usual [Ably time limit of two minutes](/docs/storage-history/storage#default-persistence). |
+| `WILL` messages, `RETAIN` flag, [wildcard subscriptions](/docs/channels) | Not supported, as Ably does not normally support them. |
+| Presence, history and push notifications | Not supported over MQTT. Use the [Ably REST API](/docs/api/rest-api) alongside the adapter to access features available over REST. |
 
 <Aside data-type='usp'>
 Consistent regional message ordering.
@@ -46,8 +59,8 @@ Within a single region, all MQTT subscribers will observe messages in the [same 
 To use the Ably MQTT protocol adapter, you'll need to ensure you correctly configure your MQTT client as follows:
 
 * Set the host to "main.mqtt.ably.net"
-* Set SSL / TLS to true and the port to 8883. (If your MQTT client does not support SSL, you should instead use port 1883, but in this case Ably disallows api-key auth—see [SSL usage note](#ssl) below)
-* Set the keep alive time to somewhere between 15 and 60 seconds. (60s will maximize battery life, 15s will maximize responsiveness to network issues. It must not be any higher than 60s to avoid our load balancer terminating the TCP socket for inactivity)
+* Set SSL / TLS to true and the port to 8883. (If your MQTT client does not support SSL, you should instead use port 1883, but in this case Ably disallows api-key auth, see the [SSL usage note](#ssl-tls) below)
+* Set the keep alive time to somewhere between 15 and 60 seconds. (60s will maximize battery life, 15s will maximize responsiveness to network issues. It must not be any higher than 60s to avoid Ably's load balancer terminating the TCP socket for inactivity)
 * If using an API key, set the username to the part of the API key before the colon, and the password to the part after the colon
 * If using a token, set the username to the token, and leave the password blank
 
@@ -66,9 +79,9 @@ var client = mqtt.connect('mqtts:main.mqtt.ably.net', options);
 ```
 </Code>
 
-### Token Authentication <a id="token-auth"/>
+### Token authentication <a id="token-auth"/>
 
-Ably recommends that you always make use of [token Authentication over basic Authentication](/docs/auth) when trying to connect from devices you may not trust. In addition, if you're using Basic Authentication you'll be required to use SSL to connect to our adapter to ensure the API key cannot be accessed by someone listening in.
+Ably recommends that you always make use of [token authentication over basic authentication](/docs/auth) when trying to connect from devices you may not trust. In addition, if you're using Basic Authentication you'll be required to use SSL to connect to the Ably adapter to ensure the API key cannot be accessed by someone listening in.
 
 For Token Authentication you'll be required to [create a token from your own servers](/docs/auth/token). Once you have the token, you can simply pass it through when trying to connect to Ably as the connection's `username`, leaving the `password` empty.
 
@@ -166,7 +179,7 @@ In the above example, `command` will now contain the message in its original str
 
 ## SSL/TLS <a id="ssl-tls"/>
 
-Ably supports both SSL and non-SSL connections (the latter uses a different port, see above), but strongly recommends using SSL wherever possible. If you are not using SSL, note that the same restrictions apply as if you were using an Ably client without SSL. That is, [connection attempts using Basic Authentication (i.e. an API key) are disallowed](/docs/auth/basic), and any [namespaces which you've enabled 'require TLS' on](/docs/channels) will be inaccessible. [Contact us](https://ably.com/support) if this is a problem for you.
+Ably supports both SSL and non-SSL connections (the latter uses a different port, see above), but strongly recommends using SSL wherever possible. If you are not using SSL, note that the same restrictions apply as if you were using an Ably client without SSL. That is, [connection attempts using Basic Authentication (that is, an API key) are disallowed](/docs/auth/basic), and any [namespaces which you've enabled 'require TLS' on](/docs/channels) will be inaccessible. [Contact us](https://ably.com/support) if this is a problem for you.
 
 ## Channel options <a id="channel-options"/>
 
@@ -187,6 +200,8 @@ In order to assist applications that use these transports, `vcdiff` decoder libr
 Read more in the [delta section](/docs/channels/options/deltas).
 
 #### Delta example <a id="delta-example"/>
+
+The following example decodes delta messages received over MQTT:
 
 <Code>
 ```javascript
@@ -233,6 +248,8 @@ Read more in the [Rewind section.](/docs/channels/options/rewind).
 
 #### Rewind example <a id="rewind-example"/>
 
+The following example subscribes to a channel with the `rewind` channel option:
+
 <Code>
 ```javascript
 var mqtt = require('mqtt');
@@ -251,3 +268,18 @@ client.on('message', (topic, message) => {
 });
 ```
 </Code>
+
+## Edge cases <a id="edge-cases"/>
+
+Be aware of the following behavior when running production traffic through the adapter:
+
+* When a token is about to expire, the adapter sends a single warning message on the `[mqtt]tokenevents` topic 30 seconds before expiry. If the client does not reconnect with a new token, the server abruptly disconnects the connection when the token expires. See [token authentication](#token-auth).
+* Keep alive times above 60 seconds cause the load balancer to terminate the TCP socket for inactivity. Set the keep alive between 15 and 60 seconds. See [configuration](#config).
+* All payloads sent and received through the adapter are binary, because MQTT is a binary protocol. Decode received messages before use. See [decode messages](#decode-messages).
+* Connections without SSL cannot use basic authentication, and cannot access namespaces with **Require TLS** enabled. See [SSL/TLS](#ssl-tls).
+
+## Read next <a id="read-next"/>
+
+* [Choose a protocol or adapter](/docs/protocols#choose): the decision guide for all connection methods.
+* [SSE](/docs/protocols/sse): the subscribe-only alternative for browsers and HTTP streaming.
+* [Ably SDKs](/docs/sdks): the native protocol, for when you want the full feature set.

--- a/src/pages/docs/protocols/pubnub.mdx
+++ b/src/pages/docs/protocols/pubnub.mdx
@@ -1,20 +1,30 @@
 ---
 title: PubNub Adapter
-meta_description: "Use the PubNub Adapter to migrate from PubNub to Ably by only changing your API key."
+meta_description: "Use the PubNub adapter to migrate from PubNub to Ably by changing your API key and endpoint, or to add failover options."
+meta_keywords: "PubNub adapter, PubNub protocol, migrate from PubNub, PubNub failover, Ably"
+intro: "The PubNub adapter connects your existing PubNub application to Ably by changing an API key and endpoint. Use it to migrate off PubNub, or to add failover options, without rewriting your application."
 languages:
   - javascript
   - ruby
 ---
 
-Ably enables migration from PubNub to Ably using its PubNub Adapter. The protocol adapter handles all background translation and only requires an API key change.
+The PubNub adapter connects an existing PubNub application to Ably. It translates between the PubNub protocol and Ably's native protocol, and only requires a change to your API key and endpoint. Ably is the only cloud vendor that supports the PubNub protocol.
 
-Using an adapter introduces some latency and is slower than using an Ably SDK. The PubNub adapter can have more variable latency than other adapters because PubNub's protocol is inherently long-polling based, which creates an impedance mismatch with Ably's WebSocket-based architecture. Some operations are quick with PubNub, but slower or impossible with Ably, and vice versa.
+## When to use the PubNub adapter <a id="when-to-use"/>
 
-Many of the advantages associated with using Ably, such as the use of WebSockets rather than long polling, [continuity guarantees](https://ably.com/four-pillars-of-dependability), and fallback host support are only available when using an Ably SDK. If an [Ably SDK](/docs/sdks) is available in your chosen platform, it is recommended you use that, or plan to transition to it eventually.
+Use the PubNub adapter to move onto Ably's network without changing your application logic. Your existing PubNub client and server libraries keep working, so you can migrate off PubNub, or add failover options, incrementally.
 
-You can use PuBNub and and an Ably SDK side-by-side as they are interoperable, with the exception of a few features.
+The adapter is a bridge onto Ably. Several Ably advantages are available only when you connect with an [Ably SDK](/docs/sdks), including the use of WebSockets rather than long polling, [continuity guarantees](https://ably.com/four-pillars-of-dependability) with multi-region fallback, and fallback host support.
 
-For a detailed comparison of Ably and PubNub features, see [Ably vs PubNub](https://ably.com/compare/ably-vs-pubnub).
+There is no time limit on connecting through the adapter. Migrate to an Ably SDK when you want the full feature set and the strongest guarantees, at whatever pace suits you.
+
+The PubNub adapter can have more variable latency than other adapters. PubNub's protocol is long-polling based, which creates an impedance mismatch with Ably's WebSocket-based architecture, so some operations take longer through the adapter and some PubNub features are unavailable.
+
+You can run PubNub clients and an Ably SDK side by side, as they are interoperable with the exception of a few features. For a detailed comparison of Ably and PubNub features, see [Ably vs PubNub](https://ably.com/compare/ably-vs-pubnub).
+
+<Aside data-type='note'>
+An Ably SDK is the recommended way to connect when one is available for your platform. To decide between the native protocol, this adapter, and other protocols, see [choosing a protocol or adapter](/docs/protocols#choose).
+</Aside>
 
 <Aside data-type='usp'>
 Automatic connection recovery and message continuity.
@@ -35,24 +45,21 @@ A typical migration from PubNub to Ably follows these steps:
 
 ## Supported features <a id="features"/>
 
-The following PubNub features are supported using the adapter:
+The adapter supports the following PubNub features:
 
-* Publish
-* Subscribe
-* Presence
-* History
-* getState
-* setState
-* hereNow
-* Global hereNow
-
-The following PubNub features are not supported using the adapter:
-
-* PAM
-* whereNow
-* Channel groups
-* Backfill subscribes
-* Stream filters
+| PubNub feature | Support |
+| --- | --- |
+| Publish | Yes |
+| Subscribe | Yes |
+| Presence | Yes |
+| History | Yes |
+| getState and setState | Yes |
+| hereNow and global hereNow | Yes |
+| PAM | No. Manage access through Ably [capabilities](/docs/auth/capabilities) instead. |
+| whereNow | No |
+| Channel groups | No |
+| Backfill subscribes | No |
+| Stream filters | No |
 
 ## Configure a PubNub SDK <a id="configure"/>
 
@@ -128,3 +135,43 @@ Some PubNub API requests are mapped to multiple Ably requests and will count as 
 
 * A global hereNow request is mapped to a request for a list of active channels, followed by a presence request for each channel. This is a total of *n+1* requests for *n* channels.
 * A mismatch exists between how Ably and PubNub paginate history requests. For example, any PubNub history requests that would result in Ably providing a paginated result will involve two Ably API requests.
+
+## Edge cases <a id="edge-cases"/>
+
+Be aware of the following behavior when running production traffic through the adapter:
+
+* The adapter provides at least two minutes of message continuity over client disconnections. After two minutes without a subscribe poll the adapter disconnects from Ably, any presence members entered by that connection leave, and further subscribe polls are treated as a new connection.
+* On reconnection, clients receive the last 100 messages for each channel they are subscribed to. The PubNub protocol has no way to signal whether this covers all missed messages. Use an Ably SDK if you need to be notified of [continuity losses](/docs/channels/states#non-fatal-errors).
+* Each UUID, for a given API key in a given region, counts as a separate connection. Generating a new UUID on every page refresh, for example with the `unique_uuid` option, inflates connection counts quickly because each connection stays alive for at least two minutes.
+* Ably channels with commas in their names cannot be accessed through the adapter, because PubNub uses commas as delimiters.
+* Some PubNub API requests map to multiple Ably requests and count as such for rate limits. See [REST requests](#rest).
+
+## FAQ <a id="faq"/>
+
+The following questions come up most often when teams evaluate the adapter:
+
+### How much latency does the adapter add? <a id="faq-latency"/>
+
+More than the other adapters, and more variably. PubNub's long-polling protocol creates an impedance mismatch with Ably's WebSocket-based architecture, so some operations take longer through the adapter. Use an Ably SDK for the lowest and most consistent latency.
+
+### Can PubNub clients and Ably SDKs run at the same time? <a id="faq-interop"/>
+
+Yes. They are interoperable on the same channels, with the exception of a few features, so you can migrate one app at a time. See the [migration process](#migration-process).
+
+### What happens when a client briefly disconnects? <a id="faq-disconnect"/>
+
+The adapter provides at least two minutes of message continuity, and clients receive the last 100 messages per channel on reconnection. The PubNub protocol cannot signal whether those 100 messages cover everything that was missed. An Ably SDK notifies clients of continuity losses explicitly.
+
+### Why is the connection count higher than expected? <a id="faq-connections"/>
+
+Each UUID for a given API key in a given region counts as a separate connection, and each connection stays alive for at least two minutes after its last subscribe poll. Reuse UUIDs across page refreshes to keep counts accurate.
+
+### Is PAM supported? <a id="faq-pam"/>
+
+No. Manage access through Ably API key and token [capabilities](/docs/auth/capabilities) instead.
+
+## Read next <a id="read-next"/>
+
+* [Choose a protocol or adapter](/docs/protocols#choose): the decision guide for all connection methods.
+* [Pusher adapter](/docs/protocols/pusher): the equivalent migration path from Pusher.
+* [Ably SDKs](/docs/sdks): the native protocol, for when you want the full feature set.

--- a/src/pages/docs/protocols/pusher.mdx
+++ b/src/pages/docs/protocols/pusher.mdx
@@ -1,15 +1,27 @@
 ---
 title: Pusher Adapter
-meta_description: "Use the Pusher Adapter to migrate from Pusher to Ably by only changing your API key."
+meta_description: "Use the Pusher adapter to migrate from Pusher to Ably by changing your API key and endpoint, or to run Ably as a failover for Pusher."
+meta_keywords: "Pusher adapter, Pusher protocol, migrate from Pusher, Pusher failover, Ably"
+intro: "The Pusher adapter connects your existing Pusher application to Ably by changing an API key and endpoint. Use it to migrate off Pusher, or to run Ably as a failover, without rewriting your application."
 languages:
   - javascript
 ---
 
-Ably enables migration from Pusher to Ably using its Pusher Adapter. The protocol adapter handles all background translation and only requires an API key change.
+The Pusher adapter connects an existing Pusher application to Ably. It translates between the Pusher protocol and Ably's native protocol, and only requires a change to your API key and endpoint. Ably is the only cloud vendor that supports the Pusher protocol.
 
-Using an adapter introduces some latency and is slower than using an Ably SDK, however the impact is typically 1-10ms. It will also be slightly slower than using Pusher natively, but only if you are close to whichever Pusher data center used. If you aren't close to the Pusher data center you've chosen, then the extra latency from using the adapter should be more than compensated for by being able to use a data center that is close to you. This is because Ably automatically connects clients to the data center closest to them.
+## When to use the Pusher adapter <a id="when-to-use"/>
 
-The Pusher Adapter provides some of the advantages of Ably, such as inter-regional message federation, however others, such as [continuity guarantees](https://ably.com/four-pillars-of-dependability), fallback host support, and [message history](/docs/storage-history/history) are only available when using an Ably SDK. If an [Ably SDK](/docs/sdks) is available in your chosen platform, it is recommended you use that, or plan to transition to it eventually.
+Use the Pusher adapter to move onto Ably's network quickly, without changing your application logic. Your existing Pusher client and server libraries keep working, so you can migrate off Pusher, or run Ably as a failover for Pusher, in hours rather than months.
+
+The adapter is a bridge onto Ably. It provides Ably advantages such as inter-regional message federation and automatic routing to the nearest datacenter, but the Pusher protocol cannot express some of Ably's capabilities. [Continuity guarantees](https://ably.com/four-pillars-of-dependability) with multi-region fallback, fallback host support, [message history](/docs/storage-history/history), and idempotent publishing are available only when you connect with an [Ably SDK](/docs/sdks).
+
+There is no time limit on connecting through the adapter. Migrate to an Ably SDK when you want the full feature set and the strongest guarantees, at whatever pace suits you.
+
+Using the adapter introduces some latency compared to an Ably SDK, though the impact is typically 1-10ms. It is also slightly slower than using Pusher natively if you are close to your chosen Pusher datacenter. If you are not close to it, the extra latency from the adapter is more than compensated for by Ably connecting clients to the nearest datacenter.
+
+<Aside data-type='note'>
+An Ably SDK is the recommended way to connect when one is available for your platform. To decide between the native protocol, this adapter, and other protocols, see [choosing a protocol or adapter](/docs/protocols#choose).
+</Aside>
 
 <Aside data-type='usp'>
 Automatic routing to the closest datacenter.
@@ -29,7 +41,7 @@ The following Pusher features are supported using the adapter:
 * REST get presence set
 * REST get user count
 
-## Enable the Pusher Adapter <a id="enable"/>
+## Enable the Pusher adapter <a id="enable"/>
 
 The Pusher protocol is not supported by default in Ably apps. This is due to security reasons associated with the use of public channels.
 
@@ -123,7 +135,7 @@ Channel names are mapped when using the adapter as follows:
 * Pusher public channels will use the `public:` namespace.
 * Pusher private channels will use the `private:` namespace.
 * Pusher presence channels will use the `presence:` namespace.
-* Channels not in any of the above namespaces were receive a `private-ablyroot-` prefix.
+* Channels not in any of the above namespaces receive a `private-ablyroot-` prefix.
 
 Colons are not permitted in Pusher channel names, but are used as namespace separators in Ably. Because of this, the adapter maps semicolons to colons in Ably channel names and colons to semicolons in Pusher channel names. This means that you will be unable to access any Ably channels with semicolons in their name.
 
@@ -144,3 +156,42 @@ Both user count and subscriber count currently only work on presence channels.
 
 * User count returns the size of the presence set once it has been made unique by `clientId`.
 * Subscriber count returns the raw size of the presence set.
+
+## Edge cases <a id="edge-cases"/>
+
+Be aware of the following behavior when running production traffic through the adapter:
+
+* When a connection is interrupted, the adapter retries in the normal Ably way and reconnects to the nearest region. The Pusher protocol requires a new connection to be created, so messages published while the client reconnects can be lost. A native Ably client fails over to an alternative region on the existing connection with no loss of messages.
+* When a client publishes a message, is unsure whether the publish succeeded, and retries, the message can be delivered twice. The Pusher protocol cannot carry the unique message ID that Ably SDKs assign to each publish to prevent duplication.
+* Ably channels with semicolons in their names cannot be accessed through the adapter, because the adapter maps semicolons to colons. See [channel mapping](#mapping).
+* Error code `40160` means **Require identification** is enabled on a namespace the adapter needs. See [enable the Pusher adapter](#enable).
+
+## FAQ <a id="faq"/>
+
+The following questions come up most often when teams evaluate the adapter:
+
+### Does the adapter route clients to the nearest datacenter? <a id="faq-routing"/>
+
+Yes. A client connects to the Ably Pusher endpoint and is routed to the nearest datacenter by [latency-based DNS](/docs/platform/architecture/edge-network#dns-organization-and-latency-based-routing), the same as a native connection.
+
+### How much latency does the adapter add? <a id="faq-latency"/>
+
+One extra network hop within Ably's infrastructure, typically 1-10ms. There is no materially significant increase compared to a native connection.
+
+### Are messages delivered in the order they were published? <a id="faq-ordering"/>
+
+Yes. Messages published over a WebSocket connection are delivered to subscribers in the order they were published, within a region. See [message ordering](/docs/platform/architecture/message-ordering).
+
+### Can a message be delivered more than once? <a id="faq-duplicates"/>
+
+Only if a publisher retries a publish that it is unsure succeeded, because the Pusher protocol cannot carry the unique message ID that prevents duplication with an Ably SDK. All other message deliveries behave the same as the core Ably platform.
+
+### Does the adapter limit how far an application can scale? <a id="faq-scaling"/>
+
+No. Ably's scaling of connections, channels and messages applies to adapter traffic as normal.
+
+## Read next <a id="read-next"/>
+
+* [Choose a protocol or adapter](/docs/protocols#choose): the decision guide for all connection methods.
+* [PubNub adapter](/docs/protocols/pubnub): the equivalent migration path from PubNub.
+* [Ably SDKs](/docs/sdks): the native protocol, for when you want the full feature set.

--- a/src/pages/docs/protocols/sse.mdx
+++ b/src/pages/docs/protocols/sse.mdx
@@ -1,6 +1,8 @@
 ---
 title: SSE
 meta_description: "Ably provides support for Server-Sent Events (SSE). This is useful for where browser clients support SSE, and the use case does not require or support the resources used by an Ably SDK."
+meta_keywords: "SSE, Server-Sent Events, EventSource, subscribe-only, HTTP streaming, Ably"
+intro: "The SSE adapter provides a subscribe-only realtime stream over HTTP, without a full SDK. Use it in memory-limited environments and on platforms where an Ably SDK is impractical."
 languages:
   - javascript
 redirect_from:
@@ -8,9 +10,9 @@ redirect_from:
   - /docs/sse/versions/v1.1
 ---
 
-The Ably SSE (Server-Sent Events) API provides realtime event streams without needing a full SDK or an [MQTT](/docs/protocols/mqtt) library. [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) is a lightweight streaming layer over HTTP, primarily accessed through the [EventSource API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) in modern web browsers — the preferred method to harness SSE.
+The Ably SSE (Server-Sent Events) API provides realtime event streams without needing a full SDK or an [MQTT](/docs/protocols/mqtt) library. [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) is a lightweight streaming layer over HTTP, primarily accessed through the [EventSource API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) in modern web browsers, the preferred way to use SSE.
 
-With HTTP streaming, servers can maintain client requests and transmit data without repetitive requests, offering efficiency akin to WebSockets.
+With HTTP streaming, servers can maintain client requests and transmit data without repetitive requests, with efficiency similar to WebSockets.
 
 SSE allows subscribe-only functionality. This means you can't:
 
@@ -19,24 +21,32 @@ SSE allows subscribe-only functionality. This means you can't:
 * Query the existing presence set
 * Attach and detach from channels without restarting the stream.
 
-Ably advise SSE for simplified, subscribe-only streams on platforms. Its status as an open standard eliminates the need for client-side SDKs. However, the [Ably SDK](/docs/sdks) is recommended overall for its [expanded features and superior reliability](/docs/basics).
+Ably recommends SSE for subscribe-only streams on platforms where a full SDK is impractical. Its status as an open standard removes the need for client-side SDKs. For most other cases the [Ably SDK](/docs/sdks) is recommended overall for its [expanded features and superior reliability](/docs/basics).
+
+<Aside data-type='note'>
+An Ably SDK is the recommended way to connect when one is available for your platform. To decide between the native protocol, this adapter, and other protocols, see [choosing a protocol or adapter](/docs/protocols#choose).
+</Aside>
 
 ## When to use the SSE adapter <a id="when-to-use"/>
 
-SSE is an excellent alternative to Ably SDK in memory-limited environments.
+SSE is an alternative to the Ably SDK in memory-limited environments. For platforms that cannot run an SDK, SSE is often the right long-term choice rather than a temporary one.
 
 ### Applicability of SSE <a id="Applicability-of-SSE"/>
 
+Use SSE in the following situations:
+
 * When operating under severe memory constraints
 * Where no Ably native library is available for your desired platform
-* When Ably provides only a REST SDK for your designated platform, but a realtime client interface is requisite
+* When Ably provides only a REST SDK for your designated platform, but a realtime client interface is required
 * Where the sole operation is the subscription to channel events
 
 ### Advantages of Ably SDKs and Realtime Protocol <a id="Advantages-of-Ably-SDKs-and-Realtime-Protocol"/>
 
-* Assured high service quality and resilience, particularly in DNS (Domain Name System) disruptions or network partitioning scenarios.
-* Access to a comprehensive range of features including, but not limited to, [publishing](/docs/pub-sub#publish), [presence](/docs/presence-occupancy/presence), [history](/docs/storage-history/history), [push notifications](/docs/push), [automatic payload encoding](/docs/channels/options/encryption), and [symmetric encryption](/docs/channels/options/encryption).
-* Optimal compatibility with browsers via the WebSocket protocol.
+An Ably SDK provides the following advantages over SSE:
+
+* Guaranteed service quality and resilience, particularly in DNS (Domain Name System) disruptions or network partitioning scenarios.
+* Access to a range of features including [publishing](/docs/pub-sub#publish), [presence](/docs/presence-occupancy/presence), [history](/docs/storage-history/history), [push notifications](/docs/push), [automatic payload encoding](/docs/channels/options/encryption), and [symmetric encryption](/docs/channels/options/encryption).
+* Compatibility with browsers using the WebSocket protocol.
 
 <Aside data-type="note">
 If you are streaming LLM responses to users, [AI Transport](/docs/ai-transport) provides purpose-built token streaming with resumable sessions and multi-device continuity, addressing the limitations of HTTP-based streaming.
@@ -75,9 +85,9 @@ If using basic auth, you can use a querystring parameter of `key` or an `Authori
 
 Note that [connection state](/docs/connect) is only retained for two minutes.
 
-The SSE protocol and EventSource API seamlessly resume dropped connections. The client reconnects, supplying a `lastEventId` parameter, ensuring no event is missed from the previous connection's endpoint. Ably uses this feature to resume channels from where they left off.
+The SSE protocol and EventSource API resume dropped connections automatically. The client reconnects, supplying a `lastEventId` parameter, ensuring no event is missed from the previous connection's endpoint. Ably uses this feature to resume channels from where they left off.
 
-At the point of token expiration, the connection terminates. The default EventSource reconnection won't function due to the expired credentials embedded in the connection URL. The solution is initiating a new connection with an updated `accessToken`, ensuring continuity by providing the right `lastEventId` for a seamless transition from the previous connection's endpoint.
+At the point of token expiration, the connection terminates. The default EventSource reconnection won't function due to the expired credentials embedded in the connection URL. The solution is initiating a new connection with an updated `accessToken`, ensuring continuity by providing the right `lastEventId` to carry on from the previous connection's endpoint.
 
 ### Implementing message continuity with token auth <a id="message-continuity-token-auth"/>
 
@@ -106,7 +116,7 @@ const connectToAbly = () => {
 
   // establish a connection with that token
   const lastEventParam = lastEvent ? ('&lastEvent=' + lastEvent) : '';
-  eventSource = new EventSource(`https://main.realtime.ably.net/sse?v=1.1&accessToken=${token}&channels=${channel}${lastEventParam}`);
+  eventSource = new EventSource(`https://main.realtime.ably.net/sse?v=1.2&accessToken=${token}&channels=${channel}${lastEventParam}`);
 
   // handle incoming messages
   eventSource.onmessage = msg => {
@@ -172,7 +182,7 @@ You can subscribe to messages in delta mode, using the SSE transport, as follows
   var key = '{{API_KEY}}';
   var channel = '{{RANDOM_CHANNEL_NAME}}';
   var baseUrl = 'https://main.realtime.ably.net/event-stream';
-  var urlParams = `?channels=${channel}&v=1.1&key=${key}&delta=vcdiff`;
+  var urlParams = `?channels=${channel}&v=1.2&key=${key}&delta=vcdiff`;
   var url = baseUrl + urlParams;
   var eventSource = new EventSource(url);
   var channelDecoder = new DeltaCodec.CheckedVcdiffDecoder();
@@ -213,7 +223,7 @@ For more information on enveloped and unenveloped SSE, please see the [SSE API](
   var key = '{{API_KEY}}';
   var channel = 'sample-app-sse';
   var baseUrl = 'https://main.realtime.ably.net/event-stream';
-  var urlParams = `?channels=${channel}&v=1.1&key=${key}&delta=vcdiff&enveloped=false`;
+  var urlParams = `?channels=${channel}&v=1.2&key=${key}&delta=vcdiff&enveloped=false`;
   var url = baseUrl + urlParams;
   var eventSource = new EventSource(url);
   var channelDecoder = new DeltaCodec.VcdiffDecoder();
@@ -256,7 +266,7 @@ Or to specify the same parameter but only applying to one channel of two, using 
   var channelOne = encodeURIComponent('[?rewind=1]channel1');
   var channelTwo = 'channel2';
   var channels = channelOne + ',' + channelTwo;
-  var querystring = 'v=1.2&key={{API_KEY}}&channels=' + channels';
+  var querystring = 'v=1.2&key={{API_KEY}}&channels=' + channels;
   var eventSource = new EventSource('https://main.realtime.ably.net/event-stream?' + querystring);
 ```
 </Code>
@@ -317,3 +327,18 @@ The following is an example curl command subscribing to `[meta]stats:minute` wit
 curl -s -u "{{API_KEY}}" "https://main.realtime.ably.net/sse?channel=[meta]stats:minute&v=1.2&rewind=1"
 ```
 </Code>
+
+## Edge cases <a id="edge-cases"/>
+
+Be aware of the following behavior when running production traffic over SSE:
+
+* When a token expires, the connection terminates and the default EventSource reconnection fails, because the expired credentials are embedded in the connection URL. Start a new connection with a fresh token and the last `lastEventId` to resume without missing messages. See [authentication](#auth).
+* Close the previous `EventSource` with `eventSource.close()` before reconnecting with a new token. Re-subscribing without closing creates two active subscriptions, one of which errors continually.
+* Connection state is retained for two minutes. A client that reconnects after longer than that starts a fresh stream and misses any messages sent in between.
+* Channels cannot be attached or detached without restarting the stream, because the channel set is fixed in the connection URL.
+
+## Read next <a id="read-next"/>
+
+* [Choose a protocol or adapter](/docs/protocols#choose): the decision guide for all connection methods.
+* [SSE API reference](/docs/api/sse): endpoints, enveloped and unenveloped modes, and request parameters.
+* [Ably SDKs](/docs/sdks): the native protocol, for when you want the full feature set.

--- a/src/pages/docs/protocols/stomp.mdx
+++ b/src/pages/docs/protocols/stomp.mdx
@@ -1,0 +1,43 @@
+---
+title: STOMP
+meta_description: "STOMP is a simple text-based protocol used to consume messages from Ably queues. Use a STOMP client to pull messages from Ably for asynchronous processing."
+meta_keywords: "STOMP, Ably queues, message queue, consume messages, worker"
+intro: "STOMP lets a STOMP client consume messages from Ably queues. Unlike MQTT, SSE, or the vendor adapters, it does not connect clients directly to channels."
+---
+
+STOMP (Simple Text Oriented Messaging Protocol) is a text-based messaging protocol supported by [Ably queues](/docs/platform/integrations/queues). It provides an interoperable wire format, so a STOMP client can consume messages from Ably in the same way it would from any compatible message broker.
+
+## Understand how STOMP works with Ably <a id="how-it-works"/>
+
+STOMP does not connect a client directly to an Ably [channel](/docs/channels), unlike the [MQTT](/docs/protocols/mqtt), [SSE](/docs/protocols/sse), [Pusher](/docs/protocols/pusher), and [PubNub](/docs/protocols/pubnub) protocols. Instead, you publish messages to a channel, a [queue rule](/docs/platform/integrations/queues#config) copies matching messages into a queue, and a STOMP client consumes them from that queue.
+
+## When to use STOMP <a id="when-to-use"/>
+
+Use STOMP where you already have a STOMP client and want it to consume realtime data from Ably as a work queue. This gives each message delivery to a single consumer, with acknowledgement and at-least-once delivery.
+
+To connect clients directly to Ably, use an [Ably SDK](/docs/sdks) or one of the other [protocols](/docs/protocols).
+
+## Connection details <a id="connection-details"/>
+
+Consuming from an Ably queue over STOMP requires the following values, most of which are shown in the **Queues** tab of your app [dashboard](https://ably.com/dashboard):
+
+| Value | Description |
+| --- | --- |
+| Queue name | Your app ID and the queue name, for example `UATwBQ:example-queue`. |
+| Destination | The queue name with the `/amq/queue/` prefix, for example `/amq/queue/UATwBQ:example-queue`. |
+| Host | The regional server endpoint for the queue, for example `us-east-1-a-queue.ably.io`. |
+| Port | 61614, the TLS-only STOMP port. This differs from the AMQP port. |
+| Vhost | Always `shared`. |
+| Username | The part of your API key before the colon. |
+| Password | The part of your API key after the colon. |
+| Client | Any STOMP client that supports TLS. |
+
+Subscribe with the `client-individual` acknowledgement mode, so that each message is removed from the queue only when your code confirms it has been processed. STOMP is a text-based protocol, so decode message bodies as UTF-8 strings before parsing.
+
+For a complete worked example, including decoding message envelopes and acknowledging deliveries, see [consume messages using STOMP](/docs/platform/integrations/queues#stomp).
+
+## Read next <a id="read-next"/>
+
+* [Ably queues](/docs/platform/integrations/queues): provisioning, queue rules, envelopes, and the dead letter queue.
+* [AMQP](/docs/protocols/amqp): the richer binary alternative for consuming from queues.
+* [Outbound streaming](/docs/platform/integrations/streaming): stream data into your own Kafka, Kinesis, or AMQP infrastructure instead.


### PR DESCRIPTION
## Why this PR exists

Sales and solutions engineers field the same customer questions about the protocol adapters over and over — particularly the Pusher adapter: when to use it, when not to, and why moving to the Ably SDKs is worth it in the long term. Today those answers live in people's heads and get repeated call by call; they are not written down anywhere a customer can find them.

Ably is a product-led growth business, and the belief behind this PR is that the docs should do that job first. An evaluating team should be able to self-serve the adapter-vs-SDK decision entirely from the docs. Solutions engineers can still jump on calls to add depth, but the call should end with a link to the docs as the source of truth — and the docs should keep improving as each conversation teaches us something new.

It is also worth restating why the protocol adapters exist at all, because it shapes the whole story: they were built to drive adoption. They are an on-ramp that removes the migration friction for teams already running on Pusher or PubNub — a hook to get people onto Ably with practically zero code changes. They were never intended to be the long-term way to use the platform; the native SDKs are the destination. The docs in this PR tell that story positively in both directions: the adapter is a legitimate, fully supported bridge with no deadline, and the SDK is where the full value is.

## How this should land

This PR is a starting point, not a finished product, and it is not expected to land as-is. The intent:

- The sales team takes this over as the owners of the customer conversation, and works with the DevEx team to shape and land it.
- Once landed, solutions engineers refer to these pages on calls rather than re-explaining from scratch.
- The pages are maintained as a living asset: when a customer conversation surfaces a new question or a better answer, it flows back into the docs (the Pusher FAQ in this PR was built exactly that way, from the questions an evaluating customer actually asked).

## The framework

Every page in the section now tells one consistent story:

- **Ably SDKs (native protocol) are the recommended path** — richer features, higher availability, more efficient — stated up front everywhere.
- **The Pusher and PubNub adapters are a migration bridge with no deadline.** They move an existing application onto Ably in hours by changing an API key and endpoint. Teams migrate to the native SDK when they want the full feature set, at their own pace. Never framed as a lesser choice — framed as a deliberate one.
- **MQTT and SSE are reach protocols.** For constrained devices and subscribe-only browser streams they are often the right *permanent* choice, not a temporary one.
- **AMQP and STOMP are queue protocols** — they consume from Ably queues rather than connecting clients to channels, and now have honest standalone pages saying exactly that.
- Trade-offs are disclosed plainly on every page: what every protocol keeps (nearest-datacenter routing, elastic scale, regional ordering, interop on shared channels) and what only the native SDK provides (connection recovery with no message loss, idempotent publish, full feature set, automatic token renewal).

## Page pattern (proposed as the exemplar for protocol-style pages)

Hook → when to use (+ callout to the decision guide) → how it works → configuration (tables + code) → **edge cases** → **FAQ (only where real questions exist)** → read next.

The Pusher page is the fullest example: its FAQ answers the questions evaluating teams actually ask (routing, latency, ordering, duplicates, scaling), and its edge-cases section discloses the unhappy paths (reconnection semantics, duplicate publishes) rather than leaving them to be discovered.

## Overview page

Rebuilt from a wall of text into: a protocol card grid (with new monogram glyphs), a "match your situation" chooser table, a migration-vs-reach side-by-side, a capability matrix, and an endpoint table. Benchmarked against comparable docs (Centrifugo's transports overview is the pattern target: a visual element every 3-4 paragraphs; deliberately not the marketing-dense end of the spectrum).

## Navigation

- Section renamed **Supported protocols → Protocols & adapters**
- **Ably SDKs (native protocol)** listed first with the jump-out indicator, so the recommended path is visible in the section rather than implied
- AMQP and STOMP added

## Also fixed along the way

- Broken JS in the SSE rewind sample (stray quote)
- Dead `#ssl` anchor on the MQTT page
- Stale `v=1.1` API versions in SSE samples
- Pricing link now points at Pub/Sub pricing (message counting) rather than platform plans
- Style-guide violations across the section (em dashes, first-person, Latin abbreviations, subjective phrasing, typos)

## Deliberately deferred

- An Ably-style architecture diagram for "How protocol adapters work" (the endpoint table is the interim visual anchor)
- A richer interactive decision component for the overview
- Collapsible nav sections (site-wide behaviour change; the section listing doubles as the protocol showcase, so left expanded)

## Review notes

- `review-app` label added for a deployed preview
- Feedback wanted on: the page pattern itself (edge cases + FAQ + read next as the standard closing sections), the monogram icon approach, and whether the overview's table density is right

🤖 Generated with [Claude Code](https://claude.com/claude-code)