### PR TITLE
docs(ai-transport): add AI Transport tab to SDKs page

### DIFF
--- a/src/components/SDKsPage/MainSection/index.tsx
+++ b/src/components/SDKsPage/MainSection/index.tsx
@@ -9,6 +9,7 @@ export enum Tab {
   CHANNELS = 'channels',
   SPACES = 'spaces',
   CHAT = 'chat',
+  AITRANSPORT = 'aitransport',
   LIVEOBJECTS = 'liveobjects',
   LIVESYNC = 'livesync',
 }
@@ -40,6 +41,15 @@ const MainSection = ({ tab }: { tab: Tab }) => {
             )}
           >
             Chat
+          </Link>
+          <Link
+            to="/docs/sdks?tab=aitransport"
+            className={cn(
+              'ui-text-h3 mr-4 px-2 py-4 inline-block relative',
+              activeTab === Tab.AITRANSPORT && activeTabClasses,
+            )}
+          >
+            AI Transport
           </Link>
           <Link
             to="/docs/sdks?tab=liveobjects"

--- a/src/components/SDKsPage/data.ts
+++ b/src/components/SDKsPage/data.ts
@@ -222,6 +222,23 @@ export const data = {
         },
       ],
     },
+    aitransport: {
+      text: "Choose an SDK to start building realtime AI features with the AI Transport product. Use the Core SDK for direct access to sessions, runs, and the conversation tree, or the Vercel AI SDK integration to add durable streaming to an existing Vercel AI SDK app. Click 'Get started' for setup instructions.",
+      cards: [
+        {
+          title: 'Core SDK',
+          text: 'Ably AI Transport SDK for JavaScript.',
+          image: { src: js, isWide: false },
+          setupLink: 'ai-transport/getting-started/core-sdk',
+        },
+        {
+          title: 'Vercel AI SDK',
+          text: 'AI Transport integration for the Vercel AI SDK.',
+          image: { src: js, isWide: false },
+          setupLink: 'ai-transport/getting-started/vercel-ai-sdk',
+        },
+      ],
+    },
     liveobjects: {
       text: "LiveObjects is a plugin to the existing Pub/Sub SDKs. Choose from the following platforms to synchronize your shared state across clients at scale. Click 'Setup' for instructions on getting started, or view its source repository for a full list of the platforms it supports.",
       cards: [

--- a/src/components/SDKsPage/data.ts
+++ b/src/components/SDKsPage/data.ts
@@ -233,7 +233,7 @@ export const data = {
         },
         {
           title: 'Vercel AI SDK',
-          text: 'AI Transport integration for the Vercel AI SDK.',
+          text: 'Ably AI Transport with the Vercel AI SDK.',
           image: { src: js, isWide: false },
           setupLink: 'ai-transport/getting-started/vercel-ai-sdk',
         },


### PR DESCRIPTION
## Summary

Adds an **AI Transport** tab to the [SDKs listing page](https://ably.com/docs/sdks) so the AI Transport SDK is discoverable alongside the other products.

- New tab sits between **Chat** and **LiveObjects**, matching the site-wide product order (Pub/Sub → Chat → AI Transport → LiveObjects → Spaces → LiveSync).
- Two cards mirroring the AI Transport "By SDK" getting-started structure:
  - **Core SDK** → `/docs/ai-transport/getting-started/core-sdk`
  - **Vercel AI SDK** → `/docs/ai-transport/getting-started/vercel-ai-sdk`

## Testing

- `yarn eslint` passes on both changed files.
- Verified locally with `yarn develop`: the AI Transport tab renders on `/docs/sdks`.