### PR TITLE
Use semibold instead of bold for UI labels in Docs

### DIFF
--- a/src/components/Examples/ExamplesList.tsx
+++ b/src/components/Examples/ExamplesList.tsx
@@ -9,7 +9,7 @@ const ExamplesList: React.FC = () => {
         <Link
           key={example.name}
           to={example.id ? `/examples/${example.id}` : '#'}
-          className="px-4 ui-text-label1 text-neutral-1000 dark:text-neutral-300 font-bold hover:text-neutral-1300 dark:hover:text-neutral-000"
+          className="px-4 ui-text-label1 text-neutral-1000 dark:text-neutral-300 font-semibold hover:text-neutral-1300 dark:hover:text-neutral-000"
         >
           {example.name}
         </Link>

--- a/src/components/Layout/LeftSidebar.tsx
+++ b/src/components/Layout/LeftSidebar.tsx
@@ -59,7 +59,8 @@ const accordionTriggerClassName = cn(
 
 const accordionLinkClassName = 'pl-3 py-1';
 
-const sectionHeadingClassName = 'ui-text-label2 font-bold text-neutral-1300 dark:text-neutral-000 pb-2 pt-5 pl-3 pr-2';
+const sectionHeadingClassName =
+  'ui-text-label2 font-semibold text-neutral-1300 dark:text-neutral-000 pb-2 pt-5 pl-3 pr-2';
 
 const iconClassName = 'text-neutral-1300 dark:text-neutral-000 transition-transform';
 
@@ -213,7 +214,7 @@ const SectionNav = ({ content, tree }: { content: (NavProductPage | NavProductCo
               key={page.name}
               to={buildLinkWithParams(page.link, searchParams)}
               className={cn(
-                'ui-text-label2 font-bold text-neutral-1300 dark:text-neutral-000',
+                'ui-text-label2 font-semibold text-neutral-1300 dark:text-neutral-000',
                 'mt-4 flex items-center justify-between gap-2 rounded-lg py-1.5 pl-3 pr-2',
                 'hover:bg-neutral-100 dark:hover:bg-neutral-1200',
                 isSelected && 'bg-orange-100 hover:bg-orange-100',

--- a/src/components/ui/CodeSnippet.tsx
+++ b/src/components/ui/CodeSnippet.tsx
@@ -508,7 +508,9 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
             <div className="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
 
-          <div className="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">{title}</div>
+          <div className="flex-1 text-center ui-text-p3 font-semibold text-neutral-1300 dark:text-neutral-000">
+            {title}
+          </div>
 
           <div className="w-12"></div>
         </div>

--- a/src/components/ui/FeaturedLink.tsx
+++ b/src/components/ui/FeaturedLink.tsx
@@ -61,7 +61,7 @@ const FeaturedLink = ({
     <a
       {...(onClick ? {} : { href: url })}
       className={cn(
-        'font-sans font-bold block group/featured-link',
+        'font-sans font-semibold block group/featured-link',
         {
           'text-gui-disabled-light dark:text-gui-disabled-dark pointer-events-none': disabled,
         },

--- a/src/components/ui/TabMenu.tsx
+++ b/src/components/ui/TabMenu.tsx
@@ -169,7 +169,7 @@ const TabMenu: React.FC<TabMenuProps> = ({
               <Tabs.Trigger
                 key={`tab-${index}`}
                 className={cn(
-                  'lg:px-6 md:px-5 px-4 py-4 ui-text-label1 font-bold data-[state=active]:text-neutral-1300 text-neutral-1000 dark:data-[state=active]:text-neutral-000 dark:text-neutral-300 focus:outline-none focus-visible:outline-gui-focus transition-colors hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-900 dark:active:text-neutral-400 disabled:text-gui-disabled-light dark:disabled:text-gui-disabled-dark disabled:cursor-not-allowed',
+                  'lg:px-6 md:px-5 px-4 py-4 ui-text-label1 font-semibold data-[state=active]:text-neutral-1300 text-neutral-1000 dark:data-[state=active]:text-neutral-000 dark:text-neutral-300 focus:outline-none focus-visible:outline-gui-focus transition-colors hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-900 dark:active:text-neutral-400 disabled:text-gui-disabled-light dark:disabled:text-gui-disabled-dark disabled:cursor-not-allowed',
                   { 'flex-1': flexibleTabWidth },
                   { 'h-full': flexibleTabHeight },
                   tabClassName,

--- a/src/styles/ui/core/styles/buttons.css
+++ b/src/styles/ui/core/styles/buttons.css
@@ -4,19 +4,19 @@
   }
 
   .ui-button-lg-base {
-    @apply ui-button-base ui-text-label1 font-bold h-14 px-7 py-[1.0625rem] gap-3 [&>svg]:!w-6 [&>svg]:!h-6;
+    @apply ui-button-base ui-text-label1 font-semibold h-14 px-7 py-[1.0625rem] gap-3 [&>svg]:!w-6 [&>svg]:!h-6;
   }
 
   .ui-button-md-base {
-    @apply ui-button-base ui-text-label2 font-bold h-12 px-6 py-[0.8125rem] gap-2.5 [&>svg]:!w-6 [&>svg]:!h-6;
+    @apply ui-button-base ui-text-label2 font-semibold h-12 px-6 py-[0.8125rem] gap-2.5 [&>svg]:!w-6 [&>svg]:!h-6;
   }
 
   .ui-button-sm-base {
-    @apply ui-button-base ui-text-label3 font-bold h-10 px-5 py-2.5 gap-2 [&>svg]:!w-5 [&>svg]:!h-5;
+    @apply ui-button-base ui-text-label3 font-semibold h-10 px-5 py-2.5 gap-2 [&>svg]:!w-5 [&>svg]:!h-5;
   }
 
   .ui-button-xs-base {
-    @apply ui-button-base ui-text-label4 font-bold h-9 px-3 py-[0.5625rem] gap-1.5 [&>svg]:!w-4 [&>svg]:!h-4;
+    @apply ui-button-base ui-text-label4 font-semibold h-9 px-3 py-[0.5625rem] gap-1.5 [&>svg]:!w-4 [&>svg]:!h-4;
   }
 
   .ui-button-disabled-base {


### PR DESCRIPTION
## Description

Mirrors [ably/website#9079](https://github.com/ably/website/pull/9079) (`packages/ui`), which changed button, menu, and label typography from `font-bold` to `font-semibold`. This repo carries its own vendored copy of that design system, plus a few docs-specific components built on the same label typography scale (`ui-text-labelN`).

Changed:
- `src/styles/ui/core/styles/buttons.css` — all 4 label-scale button sizes
- `src/components/ui/TabMenu.tsx` — tab menu trigger
- `src/components/ui/FeaturedLink.tsx` — featured link text
- `src/components/ui/CodeSnippet.tsx` — code-window title bar
- `src/components/Layout/LeftSidebar.tsx` — section heading class, and a duplicated inline instance of the same style
- `src/components/Examples/ExamplesList.tsx` — examples-list filter link

Left alone intentionally: `src/components/ui/ProductTile/ProductLabel.tsx` — the "COMING SOON"/"Ably" wordmark identity lockup and product name stay bold.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9Qoe6FJqM6RNVsMSu9CHh)_