### PR TITLE
control-v1: add missing type to conflationEnabled

### DIFF
--- a/static/open-specs/control-v1.yaml
+++ b/static/open-specs/control-v1.yaml
@@ -6852,6 +6852,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false
@@ -6918,6 +6919,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false
@@ -6995,6 +6997,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           description: If `true`, the batching interval, configurable from 20ms to 1s, temporarily holds and aggregates incoming messages. These messages are then combined and delivered as a single batch once the interval elapses or a size limit is reached (before the interval elapses).
           example: 20
         conflationEnabled:
+          type: boolean
           default: false
           description: If `true`, enables <a href="https://ably.com/docs/messages#conflation">conflation</a> for channels within this namespace. Conflation will aggregate published messages for a set period of time and evaluate them against a conflation key. Only the most recent message that satisfies the key will be sent to subscribers at the end of the conflation interval.
           example: false


### PR DESCRIPTION
I generate the Terraform provider schemas from this spec, and tfplugingen-openapi silently skips any property that has no type. `conflationEnabled` in the three namespace schemas (`namespace_post`, `namespace_patch`, `namespace_response`) has a default, description and example but no `type`, so the attribute vanishes from the generated schema without any error. I scanned the rest of the spec and these three are the only untyped properties in the file.

The Terraform provider currently carries this fix as a local patch on its vendored copy of the spec (`codegen/spec-fixes.patch`), which I can drop once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)