### PR TITLE
Document --chat-room-filter flag for integrations create/update

### DIFF
--- a/src/pages/docs/cli/integrations/create.mdx
+++ b/src/pages/docs/cli/integrations/create.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Integrations create"
 meta_description: "Create an integration rule using the Ably CLI."
-meta_keywords: "ably cli, cli, integrations, create, rule, webhook, chat room filter, ably integrations create"
+meta_keywords: "ably cli, cli, integrations, create, rule, webhook, ably integrations create"
 ---
 
 Use the `ably integrations create` command to create an integration rule for your Ably application.

--- a/src/pages/docs/cli/integrations/create.mdx
+++ b/src/pages/docs/cli/integrations/create.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Integrations create"
 meta_description: "Create an integration rule using the Ably CLI."
-meta_keywords: "ably cli, cli, integrations, create, rule, webhook, ably integrations create"
+meta_keywords: "ably cli, cli, integrations, create, rule, webhook, chat room filter, ably integrations create"
 ---
 
 Use the `ably integrations create` command to create an integration rule for your Ably application.
@@ -22,7 +22,7 @@ The type of integration rule to create. Valid options are `http`, `amqp`, `kines
 
 ### `--source-type` <a id="source-type"/> <RequiredBadge />
 
-The source type for the integration rule. Valid options are `channel.message`, `channel.presence`, `channel.lifecycle`, or `presence.message`.
+The source type for the integration rule. Valid options are `channel.message`, `channel.presence`, `channel.lifecycle`, `presence.message`, or `chat.message`.
 
 ### `--app` <a id="app"/>
 
@@ -30,7 +30,11 @@ The app ID to create the integration rule for. If not specified, the currently s
 
 ### `--channel-filter` <a id="channel-filter"/>
 
-A channel name filter to apply to the integration rule.
+A channel name filter to apply to the integration rule. This is a regular expression, and only applies to rules with a `channel.message`, `channel.presence`, `channel.lifecycle`, or `presence.message` source type.
+
+### `--chat-room-filter` <a id="chat-room-filter"/>
+
+A chat room name filter to apply to the integration rule. This is a regular expression, and only applies to rules with a `chat.message` source type.
 
 ### `--target-url` <a id="target-url"/>
 
@@ -71,6 +75,14 @@ Create an AMQP integration with a channel filter:
 <Code>
 ```shell
 ably integrations create --rule-type amqp --source-type channel.message --channel-filter "^notifications"
+```
+</Code>
+
+Create an HTTP webhook integration for a chat room with a chat room filter:
+
+<Code>
+```shell
+ably integrations create --rule-type http --source-type chat.message --chat-room-filter "^support" --target-url https://example.com/webhook
 ```
 </Code>
 

--- a/src/pages/docs/cli/integrations/update.mdx
+++ b/src/pages/docs/cli/integrations/update.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Integrations update"
 meta_description: "Update an integration rule using the Ably CLI."
-meta_keywords: "ably cli, cli, integrations, update, rule, chat room filter, ably integrations update"
+meta_keywords: "ably cli, cli, integrations, update, rule, ably integrations update"
 ---
 
 Use the `ably integrations update` command to update an existing integration rule.

--- a/src/pages/docs/cli/integrations/update.mdx
+++ b/src/pages/docs/cli/integrations/update.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Integrations update"
 meta_description: "Update an integration rule using the Ably CLI."
-meta_keywords: "ably cli, cli, integrations, update, rule, ably integrations update"
+meta_keywords: "ably cli, cli, integrations, update, rule, chat room filter, ably integrations update"
 ---
 
 Use the `ably integrations update` command to update an existing integration rule.
@@ -28,7 +28,11 @@ The app ID that the integration rule belongs to. If not specified, the currently
 
 ### `--channel-filter` <a id="channel-filter"/>
 
-Update the channel name filter for the integration rule.
+Update the channel name filter for the integration rule. This is a regular expression, and only applies to rules with a `channel.message`, `channel.presence`, `channel.lifecycle`, or `presence.message` source type.
+
+### `--chat-room-filter` <a id="chat-room-filter"/>
+
+Update the chat room name filter for the integration rule. This is a regular expression, and only applies to rules with a `chat.message` source type.
 
 ### `--request-mode` <a id="request-mode"/>
 
@@ -77,6 +81,14 @@ Update the channel filter for an integration rule:
 <Code>
 ```shell
 ably integrations update aBcDe1 --channel-filter "^notifications"
+```
+</Code>
+
+Update the chat room filter for an integration rule:
+
+<Code>
+```shell
+ably integrations update aBcDe1 --chat-room-filter "^support"
 ```
 </Code>
 


### PR DESCRIPTION
## Description

Updates the CLI reference docs for `ably integrations create` and `ably integrations update` to reflect [ably/ably-cli#433](https://github.com/ably/ably-cli/pull/433), which adds a `--chat-room-filter` flag (and a `chat.message` source type) so chat-room-sourced integration rules can be created and updated via the CLI.

- `src/pages/docs/cli/integrations/create.mdx`: added `chat.message` to the `--source-type` options, documented the new `--chat-room-filter` flag, clarified which source types `--channel-filter` applies to, and added an example creating a chat-room-sourced webhook.
- `src/pages/docs/cli/integrations/update.mdx`: documented the new `--chat-room-filter` flag and added a matching update example.

`get`/`list` were not updated since those commands only gained new output lines (no new flags), and this reference doesn't document exact CLI output shapes.

### Checklist

- [x] Commits have been rebased.
- [ ] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).

[DX-1546]

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAApZnvNvLA89JZZzDdDb6)_

[DX-1546]: https://ably.atlassian.net/browse/DX-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ