### PR TITLE
Clarify view vs manage permissions in Team permissions table

### DIFF
--- a/src/pages/docs/platform/account/team.mdx
+++ b/src/pages/docs/platform/account/team.mdx
@@ -21,17 +21,26 @@ The user that creates an Ably account is assigned the account owner role. An acc
 - Admin
 - Owner
 
+Developers have view-only access to all app features, including those not listed in the following table. Only admins and the account owner can create, edit, or delete app resources.
+
 | Permission | Developer | Billing | Admin | Owner |
 |---|---|---|---|---|
 | View all apps | ✓ | ✓ | ✓ | ✓ |
 | View app configuration | ✓ | - | ✓ | ✓ |
 | View app settings | ✓ | - | ✓ | ✓ |
+| View [API keys](/docs/auth) | ✓ | - | ✓ | ✓ |
+| View [integrations](/docs/platform/integrations) | ✓ | - | ✓ | ✓ |
+| View [rules](/docs/channels#rules) | ✓ | - | ✓ | ✓ |
+| View [queues](/docs/platform/integrations/queues) | ✓ | - | ✓ | ✓ |
 | View [app statistics](/docs/metadata-stats/stats#app) | ✓ | ✓ | ✓ | ✓ |
 | View [account statistics](/docs/metadata-stats/stats#account) | ✓ | ✓ | ✓ | ✓ |
 | Configure own [2FA](/docs/platform/account/2fa) | ✓ | - | ✓ | ✓ |
 | [Invite new users](#invite) | - | - | ✓ | ✓ |
 | [Remove existing users](#remove) | - | - | ✓ | ✓ |
 | Manage [API keys](/docs/auth) | - | - | ✓ | ✓ |
+| Manage [integrations](/docs/platform/integrations) | - | - | ✓ | ✓ |
+| Manage [rules](/docs/channels#rules) | - | - | ✓ | ✓ |
+| Manage [queues](/docs/platform/integrations/queues) | - | - | ✓ | ✓ |
 | Manage app configuration | - | - | ✓ | ✓ |
 | Manage app settings | - | - | ✓ | ✓ |
 | Create apps | - | - | ✓ | ✓ |


### PR DESCRIPTION
## Summary

Fixes the ambiguous "Manage API keys" row in the Team permissions table at `/docs/platform/account/team` ([DX-1547](https://ably.atlassian.net/browse/DX-1547)).

The table previously only had a "Manage API keys" row (Admin/Owner ✓), implying the Developer role cannot interact with API keys at all. Verified behaviour: Developers have **view-only** access to API keys — and to all other app features (integrations, channel rules, queues, etc.) — while only Admins and the account owner can create/edit/delete.

## Changes

- Add explicit **View** rows for API keys, integrations, channel rules, and queues (Developer ✓, Billing -, Admin ✓, Owner ✓)
- Add explicit **Manage** rows for integrations, channel rules, and queues (Admin/Owner only), alongside the existing "Manage API keys" row
- Add a catch-all sentence above the table so items not listed (message persistence, domains, connections, logs, reports, settings) don't require inference: Developers have view-only access to all app features; only admins and the account owner can create, edit, or delete app resources

## Notes for review

- Scope grew slightly beyond the ticket: integrations, channel rules, and queues were equally ambiguous, so they get the same treatment.
- The pre-existing "View/Manage app configuration" rows now overlap with the new explicit rows (channel rules etc. arguably *are* app configuration). Left in place deliberately — happy to consolidate if you'd prefer.
- Billing left as `-` for all new rows, consistent with Billing's existing access.

Resolves DX-1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DX-1547]: https://ably.atlassian.net/browse/DX-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ