### PR TITLE
docs(ai-transport): remove channel-rule banner from Vercel AI SDK framework pages

### DIFF
--- a/src/pages/docs/ai-transport/frameworks/vercel-ai-sdk-core.mdx
+++ b/src/pages/docs/ai-transport/frameworks/vercel-ai-sdk-core.mdx
@@ -9,10 +9,6 @@ intro: "Vercel AI SDK Core gives you streamText for orchestrating LLMs on the se
 
 Ready to build? See [Get started with Vercel AI SDK](/docs/ai-transport/getting-started/vercel-ai-sdk).
 
-<Aside data-type='important'>
-AI Transport requires the **Message annotations, updates, deletes, and appends** [channel rule](/docs/ai-transport/getting-started/channel-rules) on the namespace your conversations live on. Enable it once per Ably app, or streaming fails with error `93002`.
-</Aside>
-
 ## What Vercel AI SDK Core brings <a id="vercel-brings"/>
 
 | Capability | Description |

--- a/src/pages/docs/ai-transport/frameworks/vercel-ai-sdk-ui.mdx
+++ b/src/pages/docs/ai-transport/frameworks/vercel-ai-sdk-ui.mdx
@@ -11,10 +11,6 @@ redirect_from:
 
 Ready to build? See [Get started with Vercel AI SDK](/docs/ai-transport/getting-started/vercel-ai-sdk).
 
-<Aside data-type='important'>
-AI Transport requires the **Message annotations, updates, deletes, and appends** [channel rule](/docs/ai-transport/getting-started/channel-rules) on the namespace your conversations live on. Enable it once per Ably app, or streaming fails with error `93002`.
-</Aside>
-
 ## What Vercel AI SDK UI brings <a id="vercel-brings"/>
 
 | Capability | Description |


### PR DESCRIPTION
## What

Removes the channel-rule setup banner (the `<Aside data-type='important'>` — "Message annotations, updates, deletes, and appends… or streaming fails with error `93002`") from the two AI Transport framework pages:

- `frameworks/vercel-ai-sdk-core.mdx`
- `frameworks/vercel-ai-sdk-ui.mdx`

## Why

The framework pages explain how AI Transport *composes* with a given technology — they answer "what is this and how does it fit my stack", not "how do I set it up". A namespace channel-rule reminder at the top of those pages is out of context: it interrupts the conceptual explanation with a one-off configuration detail that only matters once you're actually building.

The requirement isn't lost — it stays where it's actionable: the [Get started with Vercel AI SDK](/docs/ai-transport/getting-started/vercel-ai-sdk) guide and the dedicated [channel rules](/docs/ai-transport/getting-started/channel-rules) page. Both framework pages already carry a "Ready to build? See Get started with Vercel AI SDK" link immediately above the removed banner, so a reader who needs the setup step is routed straight to it. This is a pure removal, not a relocation.

Resolves [AIT-1165](https://ably.atlassian.net/browse/AIT-1165).

## Scope

Only these two framework pages carried the banner. The same note on the Getting Started, channel-rules, troubleshooting, and API error pages is deliberately left untouched — there it sits beside the instructions it describes.


[AIT-1165]: https://ably.atlassian.net/browse/AIT-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ