### PR TITLE
Adjust dark-mode orange styling for API reference signatures and property names

### DIFF
--- a/src/components/Layout/mdx/MethodSignature.tsx
+++ b/src/components/Layout/mdx/MethodSignature.tsx
@@ -48,12 +48,12 @@ export const MethodSignature: React.FC<MethodSignatureProps> = ({ children, clas
     <div ref={containerRef} className="relative pl-3 my-4">
       {/* L-shaped connector line */}
       <div
-        className="absolute left-0 w-3 border-l border-b border-orange-300 dark:border-orange-900 rounded-bl-md"
+        className="absolute left-0 w-3 border-l border-b border-orange-300 dark:border-orange-1000 rounded-bl-md"
         style={{ top: offset.top, height: offset.height }}
       />
       <code
         className={cn(
-          'bg-orange-100 dark:bg-orange-1000 border border-orange-300 dark:border-orange-900 px-3 py-1.5 rounded text-sm font-mono text-neutral-1000 dark:text-neutral-300 inline-block',
+          'bg-orange-100 dark:bg-orange-1100 border border-orange-300 dark:border-orange-1000 px-3 py-1.5 rounded text-sm font-mono text-neutral-1000 dark:text-neutral-300 inline-block',
           className,
         )}
       >

--- a/src/components/Layout/mdx/NestedTable/NestedTablePropertyRow.tsx
+++ b/src/components/Layout/mdx/NestedTable/NestedTablePropertyRow.tsx
@@ -29,7 +29,7 @@ export const NestedTablePropertyRow: React.FC<NestedTablePropertyRowProps> = ({ 
         <div className="flex items-center gap-2 flex-wrap">
           {/* Property name in monospace box - always orange */}
           {property.name && (
-            <code className="bg-orange-100 dark:bg-orange-1000 border border-orange-300 dark:border-orange-900 px-2 py-0.5 rounded text-sm font-mono text-neutral-1000 dark:text-neutral-300">
+            <code className="bg-orange-100 dark:bg-orange-1100 border border-orange-300 dark:border-orange-1000 px-2 py-0.5 rounded text-sm font-mono text-neutral-1000 dark:text-neutral-300">
               {property.name}
             </code>
           )}


### PR DESCRIPTION
## Summary

Adjusts the dark-mode orange styling used in the new-style API reference components:

- **`MethodSignature.tsx`** — method signature box background `dark:bg-orange-1000` → `dark:bg-orange-1100`, box and connector-line borders `dark:border-orange-900` → `dark:border-orange-1000`.
- **`NestedTablePropertyRow.tsx`** — property name box background `dark:bg-orange-1000` → `dark:bg-orange-1100`, border `dark:border-orange-900` → `dark:border-orange-1000`.

Light-mode styling is unchanged. Both shades are already defined in `tailwind.config.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)