### PR TITLE
[AIT-1138] docs(liveobjects): JS sections for `PathObject.instance()` wrapping primitives (RTPO8f)

### DIFF
--- a/src/pages/docs/liveobjects/batch.mdx
+++ b/src/pages/docs/liveobjects/batch.mdx
@@ -80,7 +80,7 @@ await rootObject.get('visits').batch((ctx) => {
 When you call `batch()` on a `PathObject`, the path is resolved to its underlying instance, and the batch context operates on that resolved instance.
 </Aside>
 
-You can only call `batch()` on an `PathObject` whose path resolves to a `LiveMap` or `LiveCounter` instance:
+You can only call `batch()` on a `PathObject` whose path resolves to a `LiveMap` or `LiveCounter` instance:
 
 <Code>
 ```javascript

--- a/src/pages/docs/liveobjects/concepts/instance.mdx
+++ b/src/pages/docs/liveobjects/concepts/instance.mdx
@@ -27,6 +27,8 @@ meta_description: "Learn about Instance, a reference to a specific LiveObject in
 
 An `Instance` represents a specific object instance within the channel object. When you call methods on an `Instance`, they operate on that specific instance regardless of where it exists in the structure or whether it has been moved.
 
+An `Instance` can also wrap a primitive value, for example when obtained from a path that resolves to a primitive. Primitive-backed instances are read-only and have no object ID.
+
 <If lang="swift">
 <Aside data-type='note'>
 `Instance` is not yet available in the Swift SDK; support is coming soon.
@@ -45,7 +47,7 @@ Obtain an `Instance` from a `PathObject` using the `instance()` method:
 const rootObject = await channel.object.get();
 
 // Get the specific Instance of a LiveCounter located at the 'visits' key
-const visits = rootObject.get('visits').instance();
+const visits = rootObject.get('visits').instance(); // undefined only if nothing exists at the path
 console.log(visits?.id); // e.g. counter:abc123@1234567890
 console.log(visits?.value()); // e.g. 5
 ```
@@ -65,7 +67,7 @@ if (visitsInstance != null) {
 </Code>
 
 <If lang="javascript">
-The `instance()` method returns `undefined` if no object exists at that path.
+The `instance()` method returns `undefined` only if nothing exists at that path. It wraps whatever value resolves there: a `LiveMap`, a `LiveCounter`, or a primitive value. A primitive-backed `Instance` is read-only: it has no `id` and exposes the primitive via `value()`.
 </If>
 <If lang="java">
 The `instance()` method returns `null` only if nothing exists at that path. It wraps whatever value resolves there: a `LiveMap` or `LiveCounter` becomes a `LiveMapInstance` or `LiveCounterInstance`, and a primitive value becomes a read-only primitive instance (for example `StringInstance`).
@@ -202,7 +204,7 @@ if (settingsInstance != null) {
 </Code>
 
 <If lang="javascript">
-The `id` getter returns the [object ID](/docs/liveobjects/concepts/objects#object-ids) of the instance, which can be used with the [REST API](/docs/liveobjects/rest-api-usage).
+The `id` getter returns the [object ID](/docs/liveobjects/concepts/objects#object-ids) of the instance, which can be used with the [REST API](/docs/liveobjects/rest-api-usage). On a primitive-backed instance, `id` returns `undefined`, because primitives have no object ID.
 </If>
 <If lang="java">
 The `getId()` method returns the [object ID](/docs/liveobjects/concepts/objects?lang=java#object-ids) of the instance, which can be used with the [REST API](/docs/liveobjects/rest-api-usage).

--- a/src/pages/docs/liveobjects/concepts/objects.mdx
+++ b/src/pages/docs/liveobjects/concepts/objects.mdx
@@ -248,7 +248,7 @@ See the [PathObject documentation](/docs/liveobjects/concepts/path-object) for d
 const rootObject = await channel.object.get();
 
 // Navigate to nested paths and get the instance
-const themeInstance = rootObject.get('settings').get('theme').instance();
+const themeInstance = rootObject.get('settings').get('theme').instance(); // undefined only if nothing exists at the path
 
 // Work directly with the instance
 await rootObject.get('visits').instance()?.increment(5);

--- a/src/pages/docs/liveobjects/concepts/path-object.mdx
+++ b/src/pages/docs/liveobjects/concepts/path-object.mdx
@@ -394,7 +394,7 @@ if (settingsInstance != null) {
 </Code>
 
 <If lang="javascript">
-If the entry at the path does not exist, or the entry does not contain a `LiveMap` or `LiveCounter` object, `instance()` returns `undefined`:
+`instance()` returns `undefined` only if the entry at the path does not exist. A primitive value is wrapped in a read-only `Instance`:
 </If>
 <If lang="java">
 In the Java SDK, `instance()` returns `null` only if the entry at the path does not exist. A primitive value is wrapped in a read-only primitive instance:
@@ -402,9 +402,15 @@ In the Java SDK, `instance()` returns `null` only if the entry at the path does 
 
 <Code>
 ```javascript
-// The 'username' entry contains a primitive, not an object
+// The 'username' entry contains a primitive string,
+// so instance() returns a read-only Instance wrapping it
 const username = rootObject.get('username').instance();
-console.log(username); // undefined
+console.log(username?.id); // undefined - primitive instances have no object id
+console.log(username?.value()); // e.g. 'alice'
+
+// instance() returns undefined only when nothing exists at the path
+const missing = rootObject.get('nonexistent').instance();
+console.log(missing); // undefined
 ```
 
 ```java

--- a/src/pages/docs/liveobjects/concepts/path-object.mdx
+++ b/src/pages/docs/liveobjects/concepts/path-object.mdx
@@ -405,7 +405,7 @@ In the Java SDK, `instance()` returns `null` only if the entry at the path does 
 // The 'username' entry contains a primitive string,
 // so instance() returns a read-only Instance wrapping it
 const username = rootObject.get('username').instance();
-console.log(username?.id); // undefined - primitive instances have no object id
+console.log(username?.id); // undefined - primitive instances have no object ID
 console.log(username?.value()); // e.g. 'alice'
 
 // instance() returns undefined only when nothing exists at the path


### PR DESCRIPTION
Fixes https://ably.atlassian.net/browse/AIT-1138

## Summary

Updates the JavaScript sections of the LiveObjects docs to reflect the new `PathObject.instance()` behaviour: it now returns an `Instance` wrapping **any** resolved value, whether a `LiveObject` or a primitive. `undefined` is returned only when the path does not resolve.

The Java sections were already updated for this behaviour; this PR brings the JavaScript sections into full parity with them.

## Why

The spec deprecated `RTPO8d` (primitive → undefined/null) in favour of `RTPO8f` (primitive → `Instance` wrapping the primitive value), and ably-js has adopted the change. A primitive-backed `Instance` is read-only: it has no `id` and exposes the primitive via `value()`.

- Spec change: ably/specification#504
- ably-js implementation: ably/ably-js#2260

## Changes

### `concepts/path-object.mdx`

- Reworded the JavaScript statement in "Obtain object instances": `instance()` returns `undefined` only if the entry at the path does not exist; a primitive value is wrapped in a read-only `Instance`.
- Replaced the JavaScript example that showed `instance()` returning `undefined` for a primitive. It now demonstrates the new behaviour (`id` is `undefined`, `value()` returns the primitive) and shows that `undefined` is returned only for a nonexistent path, mirroring the adjacent Java example.

### `concepts/instance.mdx`

- Updated the JavaScript statement under "Get an Instance" to match the Java wording: `instance()` returns `undefined` only if nothing exists at the path, and wraps whatever value resolves there.
- Added a paragraph to the page intro noting that an `Instance` can also wrap a primitive value; the previous intro described `Instance` purely as a reference to a LiveObject identified by its object ID, contradicting the behaviour documented further down the page.
- Clarified the `id` getter docs: on a primitive-backed instance, `id` returns `undefined`, because primitives have no object ID.
- Added the `// undefined only if nothing exists at the path` code comment for parity with the equivalent Java example comment.

### `concepts/objects.mdx`

- Added the same parity code comment to the JavaScript `instance()` example, mirroring the existing Java comment.

### `batch.mdx`

- Fixed a pre-existing typo ("an `PathObject`" → "a `PathObject`"). The statement itself is unchanged: `batch()` still requires the path to resolve to a `LiveMap` or `LiveCounter`, since ably-js deliberately kept the 92007 guard for non-LiveObject paths.

## Verified unaffected

All `value()`, `size()`, subscribe-restriction, and `batch()` behavioural statements across the LiveObjects docs were reviewed against the spec change and remain correct. Every `<If lang="java">` block mentioning `Instance` was cross-checked to confirm its JavaScript counterpart is now consistent.
