### PR TITLE
Preserve URL fragments when persisting the language param on links

### DIFF
--- a/src/components/Markdown/MarkdownProvider.test.tsx
+++ b/src/components/Markdown/MarkdownProvider.test.tsx
@@ -96,5 +96,12 @@ describe('<Anchor/>', () => {
 
       expect(a).toHaveAttribute('href', '#');
     });
+
+    it('preserves the fragment on internal links with anchors', () => {
+      const { getByTestId } = render(<Anchor href="/docs/channels#publish">Example docs</Anchor>);
+      const a = getByTestId('link-internal');
+
+      expect(a).toHaveAttribute('href', '/docs/channels?lang=javascript#publish');
+    });
   });
 });

--- a/src/components/Markdown/MarkdownProvider.tsx
+++ b/src/components/Markdown/MarkdownProvider.tsx
@@ -89,7 +89,7 @@ export const Anchor: FC<JSX.IntrinsicElements['a']> = ({ children, href, ...prop
     }
 
     if (langParam || clientLang || agentLang) {
-      cleanHref = url.pathname + url.search;
+      cleanHref = url.pathname + url.search + url.hash;
     }
   }
 


### PR DESCRIPTION
## What

The MDX `Anchor` component carries the reader's `?lang=` (and `client_lang`/`agent_lang`) query params onto every internal link, but rebuilds the href as `url.pathname + url.search` — silently discarding `url.hash`.

## Impact

Whenever the current page URL has a language param (i.e. any time a reader has touched the language selector, or followed a `?lang=` link), **every anchored internal link on the site loses its `#fragment`** and lands at the top of the target page instead of the linked section.

## Fix

Include `url.hash` in the rebuilt href, plus a regression test pinning `/docs/channels#publish` → `/docs/channels?lang=javascript#publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)