### PR TITLE
fix: SDK page in dark mode

### DIFF
--- a/src/components/SDKsPage/Card/index.tsx
+++ b/src/components/SDKsPage/Card/index.tsx
@@ -19,7 +19,7 @@ export type CardProps = {
 
 const Card = ({ githubRepoURL, setupLink, title, image, text }: CardProps) => {
   return (
-    <section className="p-6 bg-extra-light-grey rounded-lg flex-1">
+    <section className="p-6 bg-extra-light-grey dark:bg-neutral-1200 rounded-lg flex-1">
       <div className="flex items-center justify-between">
         <h3 className="ui-text-h3">{title}</h3>
         <img key={image.src} src={image.src} height="40px" width={`${image.isWide ? '68px' : '40px'}`} />

--- a/src/components/SDKsPage/MainSection/index.tsx
+++ b/src/components/SDKsPage/MainSection/index.tsx
@@ -82,7 +82,7 @@ const MainSection = ({ tab }: { tab: Tab }) => {
         <hr />
       </div>
       <div className={`${container}`}>
-        <p className="ui-text-p1 text-charcoal-grey py-[4.5rem]">{data.tabs[activeTab].text}</p>
+        <p className="ui-text-p1 py-[4.5rem]">{data.tabs[activeTab].text}</p>
       </div>
       <CardGrid currentProduct={data.tabs[activeTab].cards} />
     </div>

--- a/src/components/SDKsPage/data.ts
+++ b/src/components/SDKsPage/data.ts
@@ -2,7 +2,6 @@ import js from './images/js.svg';
 import java from './images/java.svg';
 import python from './images/python.svg';
 import react from './images/react.svg';
-import reactnative from './images/reactnative.svg';
 import csharp from './images/csharp.svg';
 import go from './images/go.svg';
 import nodejs from './images/nodejs.svg';
@@ -57,7 +56,7 @@ export const data = {
         {
           title: 'React Native',
           text: 'Ably React Native SDK.',
-          image: { src: reactnative, isWide: false },
+          image: { src: react, isWide: false },
           setupLink: 'getting-started/react-native',
         },
         {
@@ -143,12 +142,6 @@ export const data = {
           text: 'Ably SDK for NativeScript.',
           image: { src: nativescript, isWide: false },
           setupLink: 'https://github.com/ably/ably-js-nativescript#how-to-use-this-library',
-        },
-        {
-          title: 'React Native',
-          text: 'Ably SDK for React Native.',
-          image: { src: react, isWide: false },
-          setupLink: 'getting-started/react-native',
         },
         {
           title: 'Cordova',


### PR DESCRIPTION
## Description

The SDK page didn't get properly ported to dark mode in #3466. This PR addresses that. It also fixes a duplicate React Native card on Pub/Sub that was using an incorrect logo asset.

### Checklist

- [x] Commits have been rebased.
- [x] Linting has been run against the changed file(s).
- [x] The PR adheres to the [writing style guide](../blob/main/writing-style-guide.md) and [contribution guide](../blob/main/CONTRIBUTING.md).
