### PR TITLE
ait: make steps docs agnostic to durable execution framework

### DIFF
--- a/src/pages/docs/ai-transport/api/javascript/core/agent-session.mdx
+++ b/src/pages/docs/ai-transport/api/javascript/core/agent-session.mdx
@@ -499,7 +499,7 @@ unsubscribe();
 
 <MethodSignature>{`detach(): Promise<void>`}</MethodSignature>
 
-Unsubscribe from cancel messages, abort every active run's controller (firing their `abortSignal`), detach the channel this session attached, and clean up. Publishes no run terminal: any still-open run is left as-is on the session, to be resumed or cleaned up by another process. A durable in-flight activity uses this to leave a run open for the next activity to adopt mid-workflow. For a teardown that also closes open runs, use [`end`](#session-end).
+Unsubscribe from cancel messages, abort every active run's controller (firing their `abortSignal`), detach the channel this session attached, and clean up. Publishes no run terminal: any still-open run is left as-is on the session, to be resumed or cleaned up by another process. Use this when another process still needs to continue the run — see [Durable execution](/docs/ai-transport/features/durable-execution) for the cross-process pattern. For a teardown that also closes open runs, use [`end`](#session-end).
 
 The detach is best-effort: a failure (for example, the channel is already `FAILED`) is swallowed and does not reject. Idempotent.
 
@@ -519,7 +519,7 @@ await session.detach();
 
 Gracefully tear down the session. For every still-open run this session owns, close its open step (if any), then publish `ai-run-end` with `reason: 'cancelled'`, then do everything [`detach`](#detach) does. A forgotten `run.end()` on a fire-and-forget turn still closes every observer's stream this way, rather than leaving it stuck on `streaming`.
 
-An open run always ends `'cancelled'`, never `'complete'` (that would falsely mark an unfinished turn as done), `'suspend'` (that would hang observers with no resumer; preserve-for-resume is [`detach`](#detach)'s job), or `'error'`. Use `end` as the normal teardown for a non-durable agent. A durable in-flight activity uses [`detach`](#detach) instead, leaving a still-open run for the next activity to pick up without terminating it.
+An open run always ends `'cancelled'`, never `'complete'` (that would falsely mark an unfinished turn as done), `'suspend'` (that would hang observers with no resumer; preserve-for-resume is [`detach`](#detach)'s job), or `'error'`. Use `end` for the final teardown of a turn this process owns. When another process still needs to continue the run, use [`detach`](#detach) instead, leaving it open rather than terminating it.
 
 <Code>
 ```javascript


### PR DESCRIPTION
[AIT-1216](https://ably.atlassian.net/browse/AIT-1216)

Remove temporal specific language (activity) and examples from conceptual AI Transport docs

[AIT-1216]: https://ably.atlassian.net/browse/AIT-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ